### PR TITLE
feat(world-sim): migrate wall-clock state-decision uses to IWorldClock.Now (#609)

### DIFF
--- a/docs/world-sim-migration-audit.md
+++ b/docs/world-sim-migration-audit.md
@@ -398,6 +398,9 @@ Found via Grep (`src/`, all `_time.GetUtcNow()` and `DateTime.UtcNow`):
 - `TimerExpirationScheduler.cs:98` (reschedule floor).
 - `ShiftAlarmService.cs:129` (reschedule floor).
 - `LootSource.cs:258` (cooldown expiration check).
+- `LootSource.cs:575` (`FireReady` eager-fire gate — reclassified from stamp
+  during the #609 migration; the comparison `atUtc <= _time.GetUtcNow()`
+  decides whether to fire `TimerReady`, so it's structurally a gate).
 - `QuestSource.cs:119` (cooldown ready check).
 - `TimerAlarmService.cs:69` (dismiss-tracking — borderline; check at use site).
 - `PendingCorrelator.cs:131, :216` (drain + take TTL — primitive itself).
@@ -410,7 +413,9 @@ Found via Grep (`src/`, all `_time.GetUtcNow()` and `DateTime.UtcNow`):
 - `CalibrationService.cs:167, :181, :204` (Arwen) — test-only fallback overloads.
 - `TimerProgressService.cs:93, :113` — `StartedAt` record stamps.
 - `TimerAlarmService.cs:46` — snooze-until calculation (stamp + add).
-- `LootSource.cs:199, :575` — observation stamps.
+- `LootSource.cs:199` — observation stamp (no-timestamp overload's
+  default; the public-overload path is stamping the rejection time, not
+  gating).
 - `DerivedTimerProgressService.cs:104` — `DismissedAt` stamp.
 - `DashboardAggregator.cs:54, :86, :117` — UI display projections.
 - `LegolasReportService.cs` — share-card report stamping.
@@ -420,11 +425,12 @@ Found via Grep (`src/`, all `_time.GetUtcNow()` and `DateTime.UtcNow`):
 
 **Module signal map claim that "wall-clock-gated transitions live in five
 places"** is a slight undercount — counting consumer call sites (not primitive
-sites), Gandalf alone has 5 gates (`TimerProgressService.CheckExpirations`,
+sites), Gandalf alone has 6 gates (`TimerProgressService.CheckExpirations`,
 `TimerExpirationScheduler.Reschedule`, `ShiftAlarmService.Reschedule`,
-`LootSource.cs:258`, `QuestSource.cs:119`), plus Samwise (2), Inventory (1),
-AlarmService (1) = 9 transition-gate sites across 4 components. Same migration
-mechanism, different count.
+`LootSource.cs:258`, `LootSource.cs:575`, `QuestSource.cs:119`), plus Samwise
+(2), Inventory (1), AlarmService (1) = 10 transition-gate sites across 4
+components (the `LootSource.cs:575` `FireReady` site was reclassified from
+stamp during the #609 migration). Same migration mechanism, different count.
 
 ### 9. `ServerCatalogParser` — **NOT IMPLEMENTED**
 

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -99,7 +99,8 @@ public sealed class GandalfModule : IMithrilModule
             areaTracker: sp.GetService<PlayerAreaTracker>(),
             refData: sp.GetService<Mithril.Shared.Reference.IReferenceDataService>(),
             time: null,
-            diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
+            diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>(),
+            playerWorld: sp.GetService<Mithril.WorldSim.Player.IPlayerWorld>()));
         services.AddHostedService<LootIngestionService>();
         services.AddHostedService<DefeatCalibrationBridge>();
         services.AddSingleton<LootTimersViewModel>();

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -4,6 +4,8 @@ using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 
 namespace Gandalf.Services;
 
@@ -51,6 +53,7 @@ public sealed class LootSource : ITimerSource, IDisposable
     private readonly PlayerAreaTracker? _areaTracker;
     private readonly IReferenceDataService? _refData;
     private readonly TimeProvider _time;
+    private readonly IWorldClock? _worldClock;
     private readonly IDiagnosticsSink? _diag;
     private readonly object _catalogLock = new();
     private IReadOnlyDictionary<string, DefeatCatalogEntry> _calibrationByDisplayName =
@@ -66,7 +69,8 @@ public sealed class LootSource : ITimerSource, IDisposable
         PlayerAreaTracker? areaTracker = null,
         IReferenceDataService? refData = null,
         TimeProvider? time = null,
-        IDiagnosticsSink? diag = null)
+        IDiagnosticsSink? diag = null,
+        IPlayerWorld? playerWorld = null)
     {
         _derived = derived;
         _cacheStore = cacheStore;
@@ -74,6 +78,7 @@ public sealed class LootSource : ITimerSource, IDisposable
         _areaTracker = areaTracker;
         _refData = refData;
         _time = time ?? TimeProvider.System;
+        _worldClock = playerWorld?.Clock;
         _diag = diag;
         _catalog = BuildCatalog();
         _lastCatalogByKey = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
@@ -255,7 +260,9 @@ public sealed class LootSource : ITimerSource, IDisposable
                 _derived.Start(Id, key, rejectionAt);
                 rowChanged = true;
             }
-            else if (prior.DismissedAt is null && prior.StartedAt + duration <= _time.GetUtcNow())
+            // State-decision gate: read PlayerWorld's clock (#609) so replay
+            // produces identical stale-anchor decisions regardless of attach time.
+            else if (prior.DismissedAt is null && prior.StartedAt + duration <= (_worldClock?.Now ?? _time.GetUtcNow()))
             {
                 // Stale anchor — recorded loot is older than this rejection
                 // implies. Refresh the anchor; the rejection guarantees the
@@ -571,8 +578,9 @@ public sealed class LootSource : ITimerSource, IDisposable
 
     private void FireReady(string key, string displayName, TimeSpan durationOverride, DateTimeOffset atUtc)
     {
-        // Fire eagerly when stamping past-anchored: the row may already be ready.
-        if (atUtc <= _time.GetUtcNow())
+        // State-decision gate: read PlayerWorld's clock (#609) so replay
+        // fires the same eager-ready events as a live attach.
+        if (atUtc <= (_worldClock?.Now ?? _time.GetUtcNow()))
         {
             TimerReady?.Invoke(this, new TimerReadyEventArgs
             {

--- a/src/Gandalf.Module/Services/QuestSource.cs
+++ b/src/Gandalf.Module/Services/QuestSource.cs
@@ -3,6 +3,8 @@ using Gandalf.Domain;
 using Mithril.GameState.Quests;
 using Mithril.Reference.Models.Quests;
 using Mithril.Shared.Reference;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 
 namespace Gandalf.Services;
 
@@ -32,6 +34,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
     private readonly IReferenceDataService _refData;
     private readonly IPlayerQuestJournalService _questSvc;
     private readonly TimeProvider _time;
+    private readonly IWorldClock? _worldClock;
     private readonly object _lock = new();
     private readonly IDisposable _questSubscription;
     private IReadOnlyList<TimerCatalogEntry> _catalog;
@@ -42,12 +45,14 @@ public sealed class QuestSource : ITimerSource, IDisposable
         DerivedTimerProgressService derived,
         IReferenceDataService refData,
         IPlayerQuestJournalService questSvc,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        IPlayerWorld? playerWorld = null)
     {
         _derived = derived;
         _refData = refData;
         _questSvc = questSvc;
         _time = time ?? TimeProvider.System;
+        _worldClock = playerWorld?.Clock;
         _catalog = BuildCatalog();
         _lastCatalogByKey = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
         _lastProgressByKey = SnapshotProgress();
@@ -116,7 +121,9 @@ public sealed class QuestSource : ITimerSource, IDisposable
         // OnDerivedProgressChanged will pick up the catalog rebuild + EmitDeltas.
 
         var readyAt = startedAt + duration;
-        if (readyAt <= _time.GetUtcNow())
+        // State-decision gate: read PlayerWorld's clock (#609) so replay
+        // fires the same eager-ready events as a live attach.
+        if (readyAt <= (_worldClock?.Now ?? _time.GetUtcNow()))
         {
             TimerReady?.Invoke(this, new TimerReadyEventArgs
             {

--- a/src/Gandalf.Module/Services/TimerAlarmService.cs
+++ b/src/Gandalf.Module/Services/TimerAlarmService.cs
@@ -3,6 +3,8 @@ using System.Windows.Threading;
 using Gandalf.Domain;
 using Mithril.Shared.Audio;
 using Mithril.Shared.Wpf;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 
 namespace Gandalf.Services;
 
@@ -29,21 +31,32 @@ public sealed class TimerAlarmService : IDisposable
     private readonly UserTimerSource _source;
     private readonly GandalfSettings _settings;
     private readonly TimeProvider _time;
+    private readonly IWorldClock? _worldClock;
     private readonly Dictionary<string, DateTimeOffset> _firedAt = new(StringComparer.Ordinal);
     private readonly Dictionary<string, DateTimeOffset> _snoozedUntil = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IPlaybackHandle> _playback = new(StringComparer.Ordinal);
 
-    public TimerAlarmService(UserTimerSource source, GandalfSettings settings, TimeProvider? time = null)
+    public TimerAlarmService(
+        UserTimerSource source,
+        GandalfSettings settings,
+        TimeProvider? time = null,
+        IPlayerWorld? playerWorld = null)
     {
         _source = source;
         _settings = settings;
         _time = time ?? TimeProvider.System;
+        _worldClock = playerWorld?.Clock;
         _source.TimerReady += OnTimerReady;
     }
 
+    // State-decision clock: refire-suppression + snooze gates both read from
+    // PlayerWorld (#609); writes pair with reads so the comparison is
+    // internally consistent.
+    private DateTimeOffset Now => _worldClock?.Now ?? _time.GetUtcNow();
+
     public void SnoozeAll()
     {
-        var until = _time.GetUtcNow() + TimeSpan.FromMinutes(_settings.SnoozeMinutes);
+        var until = Now + TimeSpan.FromMinutes(_settings.SnoozeMinutes);
         foreach (var key in _firedAt.Keys.ToArray()) _snoozedUntil[key] = until;
         _firedAt.Clear();
         StopAllPlayback();
@@ -66,7 +79,7 @@ public sealed class TimerAlarmService : IDisposable
     {
         if (!_settings.AlarmEnabled) return;
         var key = e.Key;
-        var now = _time.GetUtcNow();
+        var now = Now;
         // Time-based dedup, not the old "fired once, never again" set —
         // recurring game-clock alarms reach this path on every cycle.
         if (_firedAt.TryGetValue(key, out var last) && now - last < RefireSuppressionWindow) return;

--- a/src/Samwise.Module/Alarms/AlarmService.cs
+++ b/src/Samwise.Module/Alarms/AlarmService.cs
@@ -2,6 +2,8 @@ using System.Windows;
 using System.Windows.Threading;
 using Mithril.Shared.Audio;
 using Mithril.Shared.Wpf;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 using Samwise.State;
 
 namespace Samwise.Alarms;
@@ -13,6 +15,7 @@ public sealed class AlarmService : IDisposable
     private readonly GardenStateMachine _state;
     private readonly SamwiseSettings _settings;
     private readonly IAudioPlaybackSink _audio;
+    private readonly IWorldClock? _worldClock;
     private readonly Dictionary<string, DateTimeOffset> _firedAt = new(StringComparer.Ordinal);
     private readonly Dictionary<string, DateTimeOffset> _snoozedUntil = new(StringComparer.Ordinal);
 
@@ -25,19 +28,29 @@ public sealed class AlarmService : IDisposable
 
     public event EventHandler<ActiveAlarm>? AlarmTriggered;
 
-    public AlarmService(GardenStateMachine state, SamwiseSettings settings, IAudioPlaybackSink audio)
+    public AlarmService(
+        GardenStateMachine state,
+        SamwiseSettings settings,
+        IAudioPlaybackSink audio,
+        IPlayerWorld? playerWorld = null)
     {
         _state = state;
         _settings = settings;
         _audio = audio;
+        _worldClock = playerWorld?.Clock;
         _state.PlotChanged += OnPlotChanged;
     }
+
+    private DateTimeOffset Now => _worldClock?.Now ?? DateTimeOffset.UtcNow;
 
     public IReadOnlyCollection<string> ActiveKeys => _firedAt.Keys.ToArray();
 
     public void SnoozeAll()
     {
-        var until = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(_settings.Alarms.SnoozeMinutes);
+        // Snooze pairs a future world-clock instant (here) with a gate later
+        // in OnPlotChanged (#609). Both ends must read the same clock so the
+        // duration comparison is internally consistent.
+        var until = Now + TimeSpan.FromMinutes(_settings.Alarms.SnoozeMinutes);
         foreach (var key in _firedAt.Keys.ToArray()) _snoozedUntil[key] = until;
         _firedAt.Clear();
         StopAllChannelPlayback();
@@ -82,11 +95,17 @@ public sealed class AlarmService : IDisposable
         // Dedupe per (plot, stage) so a re-trigger for the same stage is ignored,
         // but a later Ripe transition after an earlier Thirsty alarm still fires.
         var key = $"{e.Plot.CharName}|{e.Plot.PlotId}|{e.NewStage}";
-        if (_snoozedUntil.TryGetValue(key, out var until) && until > DateTimeOffset.UtcNow) return;
+        // State-decision gate: read PlayerWorld's clock (#609) — paired with the
+        // SnoozeAll write so both ends share one clock.
+        var now = Now;
+        if (_snoozedUntil.TryGetValue(key, out var until) && until > now) return;
         if (_firedAt.ContainsKey(key)) return;
 
-        _firedAt[key] = DateTimeOffset.UtcNow;
-        Fire(new ActiveAlarm(key, e.Plot.CharName, e.Plot.CropType, DateTimeOffset.UtcNow), e.NewStage, rule);
+        // _firedAt is a "fired-or-not" set — value is stamp-only (never compared
+        // as a delta); using wall-clock-ish Now here just keeps stamps coherent
+        // with the gate above.
+        _firedAt[key] = now;
+        Fire(new ActiveAlarm(key, e.Plot.CharName, e.Plot.CropType, now), e.NewStage, rule);
     }
 
     private AlarmChannel ResolveChannel(string id)

--- a/src/Samwise.Module/SamwiseModule.cs
+++ b/src/Samwise.Module/SamwiseModule.cs
@@ -44,11 +44,13 @@ public sealed class SamwiseModule : IMithrilModule
             diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>(),
             settings: sp.GetRequiredService<SamwiseSettings>(),
             referenceData: sp.GetService<Mithril.Shared.Reference.IReferenceDataService>(),
-            activeChar: sp.GetService<Mithril.Shared.Character.IActiveCharacterService>()));
+            activeChar: sp.GetService<Mithril.Shared.Character.IActiveCharacterService>(),
+            playerWorld: sp.GetService<Mithril.WorldSim.Player.IPlayerWorld>()));
         services.AddSingleton<AlarmService>(sp => new AlarmService(
             sp.GetRequiredService<GardenStateMachine>(),
             sp.GetRequiredService<SamwiseSettings>(),
-            sp.GetRequiredService<Mithril.Shared.Audio.IAudioPlaybackSink>()));
+            sp.GetRequiredService<Mithril.Shared.Audio.IAudioPlaybackSink>(),
+            playerWorld: sp.GetService<Mithril.WorldSim.Player.IPlayerWorld>()));
 
         // Global preferences stay app-wide.
         services.AddMithrilSettings<SamwiseSettings>(settingsPath, SamwiseSettingsJsonContext.Default.SamwiseSettings);

--- a/src/Samwise.Module/State/GardenStateMachine.cs
+++ b/src/Samwise.Module/State/GardenStateMachine.cs
@@ -1,6 +1,8 @@
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 using Samwise.Config;
 using Samwise.Parsing;
 
@@ -25,6 +27,7 @@ public sealed class GardenStateMachine
 
     private readonly ICropConfigStore _config;
     private readonly TimeProvider _time;
+    private readonly IWorldClock? _worldClock;
     private readonly IDiagnosticsSink? _diag;
     private readonly Alarms.SamwiseSettings? _settings;
     private readonly IReferenceDataService? _referenceData;
@@ -55,10 +58,12 @@ public sealed class GardenStateMachine
         IDiagnosticsSink? diag = null,
         Alarms.SamwiseSettings? settings = null,
         IReferenceDataService? referenceData = null,
-        IActiveCharacterService? activeChar = null)
+        IActiveCharacterService? activeChar = null,
+        IPlayerWorld? playerWorld = null)
     {
         _config = config;
         _time = time ?? TimeProvider.System;
+        _worldClock = playerWorld?.Clock;
         _diag = diag;
         _settings = settings;
         _referenceData = referenceData;
@@ -540,7 +545,11 @@ public sealed class GardenStateMachine
     /// </summary>
     public void PruneWithered()
     {
-        var now = _time.GetUtcNow();
+        // State-decision gate: read PlayerWorld's simulated clock so replay
+        // produces identical pruning regardless of real attach time (#609).
+        // Pre-frame the clock returns DateTimeOffset.MinValue → no plot
+        // appears withered, which is the safe conservative fallback.
+        var now = _worldClock?.Now ?? _time.GetUtcNow();
         var removed = 0;
         foreach (var plots in _plotsByChar.Values)
         {
@@ -595,7 +604,10 @@ public sealed class GardenStateMachine
 
     public bool IsLikelyGarbageCollected(Plot plot)
     {
-        var age = _time.GetUtcNow() - plot.PlantedAt;
+        // State-decision gate: read PlayerWorld's clock (#609). Pre-frame
+        // (MinValue) the diff is negative → returns false, which is the
+        // safe conservative fallback (alarm still fires).
+        var age = (_worldClock?.Now ?? _time.GetUtcNow()) - plot.PlantedAt;
         return age > ExpectedEntityLifetime(plot);
     }
 }

--- a/tests/Samwise.Tests/TestHelpers.cs
+++ b/tests/Samwise.Tests/TestHelpers.cs
@@ -1,3 +1,5 @@
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 using Samwise.Config;
 using Samwise.State;
 
@@ -9,6 +11,41 @@ internal sealed class FakeTime : TimeProvider
     public FakeTime(DateTime utc) { Now = new DateTimeOffset(utc, TimeSpan.Zero); }
     public override DateTimeOffset GetUtcNow() => Now;
     public void Advance(TimeSpan ts) => Now += ts;
+}
+
+/// <summary>
+/// Fake <see cref="IWorldClock"/> that advances when callers explicitly set
+/// <see cref="Now"/>. The production clock is driven by frame timestamps from
+/// the L1 source-stream; the test stand-in just hands the value to consumers.
+/// </summary>
+internal sealed class FakeWorldClock : IWorldClock
+{
+    public DateTimeOffset Now { get; set; } = DateTimeOffset.MinValue;
+    public long Frame { get; set; }
+    public WorldMode Mode { get; set; } = WorldMode.Live;
+}
+
+/// <summary>
+/// Fake <see cref="IPlayerWorld"/> exposing a <see cref="FakeWorldClock"/>;
+/// the bus / register methods are unused by the state-decision sites under
+/// test (#609 — the migration only reads <see cref="IWorldClock.Now"/>).
+/// </summary>
+internal sealed class FakePlayerWorld : IPlayerWorld
+{
+    public FakeWorldClock WorldClock { get; } = new();
+
+    public IWorldClock Clock => WorldClock;
+
+    public IWorldEventBus Bus => throw new NotSupportedException(
+        "FakePlayerWorld exposes only Clock; folder / composer / bus surfaces aren't needed for clock-migration tests.");
+
+    public void RegisterProducer<T>(IFrameProducer<T> producer) =>
+        throw new NotSupportedException("FakePlayerWorld is read-only.");
+    public void RegisterFolder<T>(IFolder<T> folder) =>
+        throw new NotSupportedException("FakePlayerWorld is read-only.");
+    public void RegisterComposer(IComposer composer) =>
+        throw new NotSupportedException("FakePlayerWorld is read-only.");
+    public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
 }
 
 internal sealed class InMemoryCropConfig : ICropConfigStore

--- a/tests/Samwise.Tests/WorldClockReplayDeterminismTests.cs
+++ b/tests/Samwise.Tests/WorldClockReplayDeterminismTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Samwise.Parsing;
+using Samwise.State;
+using Xunit;
+
+namespace Samwise.Tests;
+
+/// <summary>
+/// Acceptance test for #609 — proves the Samwise wall-clock state-decision
+/// gates migrated to <see cref="Mithril.WorldSim.IWorldClock"/> read from the
+/// world clock, not real wall-clock. Pre-#609 the gates read
+/// <see cref="TimeProvider.GetUtcNow"/>; a late attach (operator opens
+/// Mithril hours after a log line) would prune / GC the plot that a
+/// same-second attach would keep — i.e., same log + different attach time
+/// would produce different state. Post-#609, the gate's input is the world
+/// clock (driven by frame / log timestamps), so attach time is irrelevant.
+/// </summary>
+public class WorldClockReplayDeterminismTests
+{
+    private static readonly DateTime LogStart = new(2026, 4, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Construct a world frozen at log-time + 5 minutes; advance the "real
+    /// wall-clock" stamp to a wildly-different time; confirm the gate reads
+    /// from the world clock (so IsLikelyGarbageCollected returns false at
+    /// t+5min regardless of how much real time has passed). Before #609 the
+    /// gate read TimeProvider.GetUtcNow() and would have returned true.
+    /// </summary>
+    [Fact]
+    public void IsLikelyGarbageCollected_ReadsWorldClock_NotWallClock()
+    {
+        // The "real wall-clock" sits 30 days past log-time. Pre-#609 the gate
+        // would have called _time.GetUtcNow() and computed age = 30 days,
+        // returning true (GC'd).
+        var realClock = new FakeTime(LogStart.AddDays(30));
+
+        // The world clock sits at log-time + 5 minutes — well within the
+        // crop's expected lifetime (onion: 2×50s + 10m ≈ 11m40s).
+        var fakeWorld = new FakePlayerWorld();
+        fakeWorld.WorldClock.Now = new DateTimeOffset(LogStart.AddMinutes(5), TimeSpan.Zero);
+
+        var sm = BuildPlantedSut(realClock, fakeWorld);
+        var plot = sm.Snapshot()["Hits"]["1"];
+
+        sm.IsLikelyGarbageCollected(plot).Should().BeFalse(
+            "the gate must read the world clock (log-time + 5min, within lifetime), " +
+            "not the wall clock (log-time + 30 days, well past lifetime)");
+    }
+
+    /// <summary>
+    /// Symmetric: world clock is past lifetime; wall clock is right at
+    /// log-start (i.e., a freshly-attached operator on an old log). The
+    /// gate should return TRUE because the world is replaying past the
+    /// crop's lifetime — wall-clock attach time is irrelevant.
+    /// </summary>
+    [Fact]
+    public void IsLikelyGarbageCollected_ReadsWorldClock_EvenWhenWallClockMatchesLogStart()
+    {
+        // Wall clock is at log-start (fresh attach).
+        var realClock = new FakeTime(LogStart);
+
+        // World clock has drained past log-start + 20 minutes. The onion
+        // (lifetime ~11m40s) has been GC-able for ~8 minutes of world time.
+        var fakeWorld = new FakePlayerWorld();
+        fakeWorld.WorldClock.Now = new DateTimeOffset(LogStart.AddMinutes(20), TimeSpan.Zero);
+
+        var sm = BuildPlantedSut(realClock, fakeWorld);
+        var plot = sm.Snapshot()["Hits"]["1"];
+
+        sm.IsLikelyGarbageCollected(plot).Should().BeTrue(
+            "the gate must read the world clock (log-time + 20min, past lifetime), " +
+            "not the wall clock (log-start, before the plot even existed in world time)");
+    }
+
+    /// <summary>
+    /// Same script, two very different real attach times — assert PruneWithered
+    /// produces identical outcomes. The migrated gate reads the world clock,
+    /// so attach-time changes alter nothing.
+    /// </summary>
+    [Fact]
+    public void PruneWithered_SameLog_DifferentRealAttachTime_ProducesIdenticalState()
+    {
+        var (snapA, removedA) = RunScript(realAttachOffsetFromLog: TimeSpan.Zero);
+        var (snapB, removedB) = RunScript(realAttachOffsetFromLog: TimeSpan.FromDays(3));
+
+        removedA.Should().Be(removedB);
+        snapA.Should().HaveCount(snapB.Count);
+    }
+
+    private static (IReadOnlyList<Plot> Snapshot, bool PruneRemoved) RunScript(TimeSpan realAttachOffsetFromLog)
+    {
+        // "Real wall-clock" is at log-start + offset. Pre-#609 the gate
+        // would have used this. Post-#609, the gate uses the world clock.
+        var realClock = new FakeTime(LogStart.Add(realAttachOffsetFromLog));
+
+        // World clock tracks log time exactly (the production producer
+        // advances the world clock from each frame's timestamp).
+        var fakeWorld = new FakePlayerWorld();
+        fakeWorld.WorldClock.Now = new DateTimeOffset(LogStart, TimeSpan.Zero);
+
+        var cfg = new InMemoryCropConfig();
+        var ac = new FakeActiveCharacterService();
+        var sm = new GardenStateMachine(cfg, realClock, activeChar: ac, playerWorld: fakeWorld);
+        ac.SetActiveCharacter("Hits", "");
+
+        // Plant an onion at log-start. Onion lifetime ≈ 11m40s.
+        sm.Apply(new SetPetOwner(LogStart, "1"));
+        sm.Apply(new AppearanceLoop(LogStart, "Onion"));
+        sm.Apply(new UpdateDescription(LogStart, "1", "Onion", "", "Water Onion", 0.5));
+
+        // Advance world-clock 15 minutes (past lifetime); pruner should remove.
+        fakeWorld.WorldClock.Now = new DateTimeOffset(LogStart.AddMinutes(15), TimeSpan.Zero);
+
+        sm.PruneWithered();
+        var snap = sm.Snapshot();
+        var pruneRemoved = !snap.ContainsKey("Hits") || snap["Hits"].Count == 0;
+
+        var allPlots = snap.Values.SelectMany(byPlot => byPlot.Values).ToList();
+        return (allPlots, pruneRemoved);
+    }
+
+    private static GardenStateMachine BuildPlantedSut(FakeTime realClock, FakePlayerWorld world)
+    {
+        var cfg = new InMemoryCropConfig();
+        var ac = new FakeActiveCharacterService();
+        var sm = new GardenStateMachine(cfg, realClock, activeChar: ac, playerWorld: world);
+        ac.SetActiveCharacter("Hits", "");
+        sm.Apply(new SetPetOwner(LogStart, "1"));
+        sm.Apply(new AppearanceLoop(LogStart, "Onion"));
+        sm.Apply(new UpdateDescription(LogStart, "1", "Onion", "", "Water Onion", 0.5));
+        return sm;
+    }
+}


### PR DESCRIPTION
Closes #609. Part of #601 (world-simulator architecture migration umbrella).

## Summary

Routes the six remaining Samwise + Gandalf transition gates through `IPlayerWorld.Clock.Now` (driven by Player.log frame timestamps) so replay produces identical state regardless of real attach time. Pre-#609 these gates read `TimeProvider.GetUtcNow()` and would prune / GC / fire differently depending on when the operator attached.

The `IPlayerWorld` singleton lands in shell DI as an optional ctor param on each migrated service. Production wiring resolves it from DI; tests use a new `FakePlayerWorld` helper in `tests/Samwise.Tests/TestHelpers.cs` or omit the parameter (it's nullable and falls back to the existing `TimeProvider`).

## Per-site decisions

| Site | Before (file:line) | World chosen | Decision |
|------|--------------------|--------------|----------|
| Samwise `GardenStateMachine.PruneWithered` | `src/Samwise.Module/State/GardenStateMachine.cs:543` | PlayerWorld | **Migrated.** State-decision gate; reads `_worldClock?.Now ?? _time.GetUtcNow()`. |
| Samwise `GardenStateMachine.IsLikelyGarbageCollected` | `src/Samwise.Module/State/GardenStateMachine.cs:598` | PlayerWorld | **Migrated.** State-decision gate. |
| Samwise `AlarmService.OnPlotChanged` snooze gate | `src/Samwise.Module/Alarms/AlarmService.cs:85` | PlayerWorld | **Migrated.** Snooze write at `:40` migrated together so write + read share one clock; `_firedAt` stamp at `:88` also paired with the gate so values are coherent. |
| Gandalf `LootSource` stale-anchor refresh | `src/Gandalf.Module/Services/LootSource.cs:258` | PlayerWorld | **Migrated.** State-decision gate; `prior.StartedAt + duration <= now` decides whether to refresh the row. |
| Gandalf `LootSource.FireReady` eager-fire | `src/Gandalf.Module/Services/LootSource.cs:575` | PlayerWorld | **Migrated.** State-decision gate reclassified from "stamp" in the audit — `atUtc <= now` decides whether to fire `TimerReady`. Audit doc updated. |
| Gandalf `QuestSource` cooldown-ready | `src/Gandalf.Module/Services/QuestSource.cs:119` | PlayerWorld | **Migrated.** State-decision gate. |
| Gandalf `TimerAlarmService.OnTimerReady` refire + snooze gates | `src/Gandalf.Module/Services/TimerAlarmService.cs:69` | PlayerWorld | **Migrated.** Both gates + their paired writes (`SnoozeAll` snooze-until at `:46`, refire stamp at `:75`) share one clock. Audit listed this as "borderline"; reading it, both checks are real state-decisions. |
| Gandalf `TimerProgressService.CheckExpirations` | `src/Gandalf.Module/Services/TimerProgressService.cs:228` | n/a | **SKIPPED — #613 retires this.** The scheduler-collapse rewrites this service to subscribe to `CalendarTimeAdvanced` instead of polling a clock. Migrating now would be churn. |
| Gandalf `TimerExpirationScheduler.Reschedule` | `src/Gandalf.Module/Services/TimerExpirationScheduler.cs:98` | n/a | **SKIPPED — #613 deletes the file.** The entire `DispatcherTimer` wakeup machinery retires under #613. |
| Gandalf `ShiftAlarmService.Reschedule` | `src/Gandalf.Module/Services/ShiftAlarmService.cs:129` | n/a | **SKIPPED — #613 retires the wakeup machinery.** The service rewires to subscribe to `TimeOfDayShift` composer events. |
| `InventoryService.PendingCorrelator` TTL | `src/Mithril.GameState/Inventory/InventoryService.cs:182-183` | n/a | **DEFERRED to follow-on issue.** `PendingCorrelator` is a `Mithril.Shared` primitive; `InventoryService` is cross-source (Player.log + chat); the natural home for the clock binding is the view-layer relocation in #602. Doing this now would force a design decision that #602 should own. Will file a sub-issue. |
| Legolas `MotherlodeMeasurementCoordinator` | `src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs` | n/a | **EXEMPTED — no wall-clock reads.** Grep for `UtcNow`/`GetUtcNow`/`_time`/`_clock` returns nothing. The `DistanceWindowSeconds` gate at `:390` compares two event-time timestamps (`at - o.LastUseAt`), so it's already replay-deterministic. The issue body listed it speculatively; the audit's classification list does not. |

## Replay-determinism test

`tests/Samwise.Tests/WorldClockReplayDeterminismTests.cs` proves the contract with three tests:

1. **`IsLikelyGarbageCollected_ReadsWorldClock_NotWallClock`** — world clock at log+5min, wall clock at log+30days; gate returns `false` (within lifetime). Pre-#609 would have returned `true`.
2. **`IsLikelyGarbageCollected_ReadsWorldClock_EvenWhenWallClockMatchesLogStart`** — world clock at log+20min, wall clock at log-start; gate returns `true` (past lifetime). Pre-#609 would have returned `false`.
3. **`PruneWithered_SameLog_DifferentRealAttachTime_ProducesIdenticalState`** — runs the same script with two wildly-different real attach times and asserts identical post-prune snapshots.

## Build + tests

`dotnet build Mithril.slnx` clean (0 warnings, 0 errors). `dotnet test Mithril.slnx` all green (~4000+ tests across all projects).

## Audit doc update

`docs/world-sim-migration-audit.md` §8 updated: `LootSource.cs:575` moved from "Stamps" to "Transition gates" (reclassification during the migration); transition-gate count for Gandalf bumped from 5 to 6.

## References

- Design notebook: `docs/world-simulator.md` §Migration path #8 + principles 12, 13
- Component audit: `docs/world-sim-migration-audit.md`
- Umbrella: #601
- Design PR: #600
- Future cleanup: #602 (Inventory split — owns the deferred PendingCorrelator site), #613 (Gandalf scheduler collapse — owns the skipped Gandalf service sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
