### PR TITLE
feat(world-sim): merge ChatLogReplaySource live-poll output by timestamp across files

### DIFF
--- a/src/Mithril.WorldSim.Chat/Producers/ChatLogReplaySource.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/ChatLogReplaySource.cs
@@ -205,13 +205,21 @@ public sealed class ChatLogReplaySource : IChatLogReplaySource
 
         // 6. Live phase — poll the same tailers. They've already advanced their
         //    offsets past the replay batch, so ReadNew() now returns appended
-        //    content only.
+        //    content only. Per #640, drain each tailer into a per-poll buffer
+        //    then merge-sort by timestamp before yielding, mirroring the
+        //    replay-phase pattern at step 5 so concurrent appends across
+        //    multiple files emit in deterministic timestamp order rather than
+        //    in file-enumeration order. N (files) is typically ≤ ~10, so a
+        //    List.Sort per poll is fine; promote to a heap if profiling ever
+        //    shows this as a hotspot.
         var pollInterval = TimeSpan.FromSeconds(Math.Max(0.25, _config.PollIntervalSeconds));
+        var pollBuffer = new List<RawLogLine>();
         while (!ct.IsCancellationRequested)
         {
             try { await Task.Delay(pollInterval, _time, ct).ConfigureAwait(false); }
             catch (OperationCanceledException) { yield break; }
 
+            pollBuffer.Clear();
             foreach (var (_, tailer, _) in tailers)
             {
                 IReadOnlyList<RawLogLine> appended;
@@ -228,10 +236,14 @@ public sealed class ChatLogReplaySource : IChatLogReplaySource
                     continue;
                 }
 
-                foreach (var line in appended)
-                {
-                    yield return new LogEnvelope<RawLogLine>(line, IsReplay: false);
-                }
+                if (appended.Count > 0) pollBuffer.AddRange(appended);
+            }
+
+            if (pollBuffer.Count == 0) continue;
+            pollBuffer.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+            foreach (var line in pollBuffer)
+            {
+                yield return new LogEnvelope<RawLogLine>(line, IsReplay: false);
             }
         }
     }

--- a/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogReplaySourceTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogReplaySourceTests.cs
@@ -204,6 +204,92 @@ public sealed class ChatLogReplaySourceTests : IDisposable
         replayLines[4].Should().Contain("a-at-5");
     }
 
+    // ── #640: live-poll merge orders appended frames across files ─────
+
+    [Fact]
+    public async Task Live_phase_merges_appended_lines_across_files_by_timestamp()
+    {
+        // Two files exist at attach (both with the same banner). After the
+        // source enters live mode, both files receive appends with
+        // interleaved timestamps before the next poll. The subscriber must
+        // see the appended frames in strictly non-decreasing timestamp
+        // order, not in file-enumeration order. Pre-#640 the iteration was
+        // foreach(tailers) → emit-each-tailer's-batch, which leaked
+        // filesystem-listing order.
+        Write("chat-A.log",
+            "26-05-19 21:00:00\t**** Logged In As Em. Server Laeth. Timezone Offset 01:00:00.\n");
+        Write("chat-B.log",
+            "26-05-19 21:00:00\t**** Logged In As Em. Server Laeth. Timezone Offset 01:00:00.\n");
+
+        var source = new ChatLogReplaySource(Config(pollSeconds: 0.25));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(2000));
+        var collector = CollectAsync(source, cts.Token);
+
+        // Let the source enter live mode before appending.
+        await Task.Delay(500);
+
+        // Interleave appends across two files. File A gets t=10 and t=30;
+        // file B gets t=20 and t=40. With the bug, the subscriber sees
+        // 10,30,20,40 (A drained, then B drained). With the fix, the
+        // subscriber sees 10,20,30,40.
+        Append("chat-A.log", "26-05-19 21:00:10\t[A] a-at-10\n");
+        Append("chat-B.log", "26-05-19 21:00:20\t[B] b-at-20\n");
+        Append("chat-A.log", "26-05-19 21:00:30\t[A] a-at-30\n");
+        Append("chat-B.log", "26-05-19 21:00:40\t[B] b-at-40\n");
+
+        var envelopes = await collector;
+        var liveTimestamps = envelopes
+            .Where(e => !e.IsReplay)
+            .Select(e => e.Payload.Timestamp)
+            .ToList();
+
+        liveTimestamps.Should().HaveCountGreaterThanOrEqualTo(4,
+            "all four appended lines should have been observed within the cancellation window");
+
+        // Strictly non-decreasing across the full live stream — the merge
+        // step must order across files within each poll cycle.
+        for (var i = 1; i < liveTimestamps.Count; i++)
+        {
+            liveTimestamps[i].Should().BeOnOrAfter(liveTimestamps[i - 1],
+                $"live-phase output must be timestamp-ordered, but index {i} ({liveTimestamps[i]:O}) precedes index {i - 1} ({liveTimestamps[i - 1]:O})");
+        }
+
+        var liveLines = envelopes.Where(e => !e.IsReplay)
+            .Select(e => e.Payload.Line).ToList();
+        liveLines.Should().Contain(l => l.Contains("a-at-10"));
+        liveLines.Should().Contain(l => l.Contains("b-at-20"));
+        liveLines.Should().Contain(l => l.Contains("a-at-30"));
+        liveLines.Should().Contain(l => l.Contains("b-at-40"));
+    }
+
+    [Fact]
+    public async Task Live_phase_single_file_emits_appends_in_write_order()
+    {
+        // Single-file steady state: the merge step must not perturb the
+        // write order when there is only one tailer.
+        Write("chat-Status.log",
+            "26-05-19 21:00:00\t**** Logged In As Em. Server Laeth. Timezone Offset 01:00:00.\n");
+
+        var source = new ChatLogReplaySource(Config(pollSeconds: 0.25));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1500));
+        var collector = CollectAsync(source, cts.Token);
+
+        await Task.Delay(500);
+        Append("chat-Status.log",
+            "26-05-19 21:00:10\t[Status] first\n" +
+            "26-05-19 21:00:20\t[Status] second\n" +
+            "26-05-19 21:00:30\t[Status] third\n");
+
+        var envelopes = await collector;
+        var liveLines = envelopes.Where(e => !e.IsReplay)
+            .Select(e => e.Payload.Line).ToList();
+
+        liveLines.Should().HaveCount(3);
+        liveLines[0].Should().Contain("first");
+        liveLines[1].Should().Contain("second");
+        liveLines[2].Should().Contain("third");
+    }
+
     // ── #639: session-shared clock offset across files ────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

The live-poll loop in `ChatLogReplaySource` iterated tailers in filesystem-listing order and yielded each tailer's appended batch immediately, so when multiple files in a session produced events between polls the bus emitted them in file-enumeration order rather than timestamp order. The replay phase already merges-and-sorts across files (step 5); the live phase now mirrors that pattern.

**Fix:** per-poll buffer + `List.Sort` by `Timestamp.CompareTo`, then yield in order. N (files) is typically ≤ ~10 so the per-poll sort cost is negligible; a heap can come later if profiling shows otherwise.

Surfaced in the [#636 review](https://github.com/moumantai-gg/mithril/pull/636#issuecomment-4513972987) and blocks #602 / #603 (multi-file chat ingestion) per principle 9 (deterministic replay).

## Verification

- New test `Live_phase_merges_appended_lines_across_files_by_timestamp` — two files, interleaved appends across them between polls (A@10, B@20, A@30, B@40), asserts strictly non-decreasing timestamps over the full live stream.
- New test `Live_phase_single_file_emits_appends_in_write_order` — regression check that single-tailer steady state still emits in write order.
- Existing test `Replay_envelopes_are_deterministic_across_runs_for_identical_input` covers replay-side determinism; the live-phase merge preserves the same property within each poll cycle for downstream determinism arguments.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — all tests pass (Mithril.WorldSim.Chat.Tests: 31/31, full slnx green)

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
