### PR TITLE
chore(arwen): post-#608 cleanup sweep — retire FavorDelta + refresh docs (#689 #690 #691)

### DIFF
--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -152,9 +152,12 @@ channel rule, and this strategic principle):
   *Known anti-pattern instances — audit landed as
   [#579](https://github.com/moumantai-gg/mithril/issues/579) on 2026-05-21,
   surfacing four Class A migrations (Gandalf `LootBracketTracker.AddItemRx`,
-  Smaug CivicPride, Samwise GardeningXp, Arwen ItemDeleted) plus one Class C
-  design discussion (Samwise `ProcessUpdateItemCode` needs a new
-  `InventoryEvent.CodeChanged` event kind on `IInventoryService`).
+  Smaug CivicPride, Samwise GardeningXp, Arwen `ItemDeleted` — Arwen
+  resolved via [#608](https://github.com/moumantai-gg/mithril/pull/608) by
+  lifting the gift-detection FSM into the Tier-2 `IGiftSignalService`; see
+  [`world-sim-migration-audit.md`](world-sim-migration-audit.md) §Arwen)
+  plus one Class C design discussion (Samwise `ProcessUpdateItemCode` needs
+  a new `InventoryEvent.CodeChanged` event kind on `IInventoryService`).
   Each filed as its own retiring-PR issue.
 
 - **GameState services translate log events into a developer-facing domain

--- a/docs/module-signal-map.md
+++ b/docs/module-signal-map.md
@@ -327,11 +327,10 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 **Charter:** NPC favor + gift-rate calibration ([`module-charters.md`](module-charters.md)).
 
 **Inputs**
-- Log: `LocalPlayer` pipe via `FavorIngestionService` — three event types parsed by `FavorLogParser`:
-  - `FavorUpdate` — `StartInteraction` marker; sets active NPC
-  - `ItemDeleted` — `instanceId` only; needs Inventory resolve
-  - `FavorDelta` — delta favor for active NPC
-- GameState: `IInventoryService.TryResolve(instanceId)` — **synchronous cross-FSM peek** mid-transition
+- Log: `LocalPlayer` pipe via `FavorIngestionService` — one event type parsed by `FavorLogParser`:
+  - `FavorUpdate` — `ProcessStartInteraction` marker; absolute favor snapshot for the active NPC
+- GameState: `IGiftSignalService` (Tier-2 signal service in `Mithril.GameState.Gifting`) — React-channel `Subscribe` for `GiftAccepted`. The signal service owns a single L1 subscription with its own `ProcessAddItem`-fed `instanceId → InternalName` map, correlates the `ProcessStartInteraction` / `ProcessDeleteItem` / `ProcessDeltaFavor` verb triple on its own pump, and emits a fully-resolved `GiftAccepted` with `InternalName` baked in. The React channel atomically replays the in-session event log to late subscribers (#585 contract).
+- GameState: `IInventoryService.TryGetStackSize` — same-source read against the view's composed map (sim-coherent under Player.log dispatch order, encapsulated inside the view layer per principle 4).
 - GameState: `IGameSessionService` (SessionId for record stamps + dedup key)
 - Reference: `IReferenceDataService` items.json, NPC data, gift preferences
 - Settings: `ArwenSettings`, `CalibrationSettings`
@@ -340,7 +339,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 
 **State machines**
 - `FavorStateService` — per-character NPC favor snapshots; `SetExactFavor` is an absolute (not delta) last-write-wins upsert
-- `CalibrationService` — gift-detection mini-FSM: hand-rolled 2-slot pending correlator (`_pendingDeletedItem` ⊕ `_pendingDelta` paired in either arrival order, cleared by next `StartInteraction`). Tier-1-shaped, **same-source** (all three signals on `LocalPlayer` pipe). Persists observations; derives per-(NPC,item) / per-(NPC,signature) / per-NPC / per-keyword rates.
+- `CalibrationService` — calibration aggregator. Production gift events arrive via `OnGiftAccepted(GiftAccepted)` from the `IGiftSignalService` React channel — already resolved (`InternalName` + `NpcKey` + delta), so this entry point goes straight to `RecordObservation`. Persists observations; derives per-(NPC,item) / per-(NPC,signature) / per-NPC / per-keyword rates. (Legacy hand-rolled 2-slot correlator FSM — `_pendingDeletedItem` ⊕ `_pendingDelta` — remains only to exercise pre-#608 transitions in unit tests; the production path bypasses it.)
 - `PendingGiftObservation` queue — TTL-bounded list of gifts awaiting user confirmation of stack size
 
 **Outputs**
@@ -350,7 +349,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 - Community export: sanitized rate aggregates only (no per-observation timestamps / NPC favor snapshots)
 - UI: favor dashboard, gift scanner, observations editor, calibration tab
 
-⚠️ The `_inventory.TryResolve` peek is the canonical Rule-1 violation discussed in the world-simulator design notes — works in live play (Add lands long before Delete), races on replay-from-session-start where both consumers drain the backlog in parallel.
+**Cross-source posture.** Resolved post-#608 — the historical `IInventoryService.TryResolve` cross-FSM peek (the canonical Rule-1 violation cited in earlier revisions of the world-simulator design notes) was eliminated by lifting the gift-detection FSM into the Tier-2 `IGiftSignalService`. The signal service does all three verbs on a single L1 pump and emits resolved events; Arwen consumes only same-source signals (its own L1 favor pipe + the React channel). No cross-pump race on subscribe-late. See [`world-sim-migration-audit.md`](world-sim-migration-audit.md) §Arwen for the full narrative.
 
 ---
 

--- a/src/Arwen.Module/Parsing/FavorLogParser.cs
+++ b/src/Arwen.Module/Parsing/FavorLogParser.cs
@@ -7,17 +7,14 @@ public abstract record FavorEvent(DateTime Timestamp);
 /// <summary>Exact absolute favor captured when the player talks to an NPC.</summary>
 public sealed record FavorUpdate(DateTime Timestamp, string NpcKey, double AbsoluteFavor) : FavorEvent(Timestamp);
 
-/// <summary>Favor delta after a gift, quest, or hang-out.</summary>
-public sealed record FavorDelta(DateTime Timestamp, string NpcKey, double Delta) : FavorEvent(Timestamp);
-
 /// <summary>
-/// Parses Player.log lines for NPC favor events. The gift-detection FSM is
-/// lifted into <c>Mithril.GameState.Gifting.IGiftSignalService</c> (Tier-2
-/// signal service in <c>Mithril.GameState.Gifting</c>); the signal service
-/// owns its own <c>LocalPlayerLogLine</c> subscription and parses
-/// <c>ProcessDeleteItem</c> there. This parser handles only the two
-/// favor-side verbs that drive Arwen's <c>ArwenFavorState</c> snapshot
-/// (<see cref="FavorUpdate"/>, <see cref="FavorDelta"/>).
+/// Parses Player.log lines for the <c>ProcessStartInteraction</c>
+/// (→ <see cref="FavorUpdate"/>) verb that drives Arwen's
+/// <c>ArwenFavorState</c> snapshot. The gift-detection FSM that
+/// historically consumed <c>ProcessDeltaFavor</c> is lifted into
+/// <c>Mithril.GameState.Gifting.IGiftSignalService</c> (Tier-2 signal
+/// service), which owns its own <c>LocalPlayerLogLine</c> subscription
+/// and parses that verb (plus <c>ProcessDeleteItem</c>) on its own pump.
 ///
 /// <para>Active-character tracking lives in <c>ActiveCharacterLogSynchronizer</c> —
 /// this parser does not handle <c>ProcessAddPlayer</c>.</para>
@@ -28,19 +25,11 @@ public sealed partial class FavorLogParser
     [GeneratedRegex(@"ProcessStartInteraction\((\d+),\s*\d+,\s*([\d.-]+),\s*\w+,\s*""(NPC_\w+)""\)", RegexOptions.CultureInvariant)]
     private static partial Regex StartInteractionRx();
 
-    // ProcessDeltaFavor(0, "NPC_Key", delta, True)
-    [GeneratedRegex(@"ProcessDeltaFavor\(\d+,\s*""(NPC_\w+)"",\s*([\d.-]+),\s*\w+\)", RegexOptions.CultureInvariant)]
-    private static partial Regex DeltaFavorRx();
-
     public FavorEvent? TryParse(string line, DateTime timestamp)
     {
         var m = StartInteractionRx().Match(line);
         if (m.Success && double.TryParse(m.Groups[2].ValueSpan, out var favor))
             return new FavorUpdate(timestamp, m.Groups[3].Value, favor);
-
-        m = DeltaFavorRx().Match(line);
-        if (m.Success && double.TryParse(m.Groups[2].ValueSpan, out var delta))
-            return new FavorDelta(timestamp, m.Groups[1].Value, delta);
 
         return null;
     }

--- a/src/Arwen.Module/State/FavorIngestionService.cs
+++ b/src/Arwen.Module/State/FavorIngestionService.cs
@@ -167,13 +167,11 @@ public sealed class FavorIngestionService : BackgroundService
                         _state.OnFavorUpdated(update.NpcKey);
                     }
                 }
-                // FavorDelta and ProcessDeleteItem are intentionally not
-                // consumed here. IGiftSignalService owns the verb-triple
+                // ProcessDeltaFavor and ProcessDeleteItem are intentionally
+                // not consumed here. IGiftSignalService owns the verb-triple
                 // correlation on its own single L1 pump; production gifts
                 // arrive at calibration via OnGiftAccepted on the React
-                // channel. FavorLogParser still emits FavorDelta for its
-                // own unit-test coverage; nothing on the ingestion path
-                // consumes it.
+                // channel.
                 return ValueTask.CompletedTask;
             },
             new LogSubscriptionOptions
@@ -182,9 +180,11 @@ public sealed class FavorIngestionService : BackgroundService
                 DeliveryContext = delivery,
                 DiagnosticCategory = "Arwen.Ingestion",
                 // No SkipProcessedHighWater — CalibrationService owns
-                // per-key dedup at the sink layer; an L1 high-water filter
-                // would suppress the in-session DeleteItem/DeltaFavor pair
-                // that calibration must see on replay. See type doc.
+                // per-key dedup at the sink layer; the L1 subscription
+                // consumes only FavorUpdate (ProcessStartInteraction), so
+                // a high-water filter is unnecessary for correctness here.
+                // Gift events arrive separately via IGiftSignalService's
+                // React channel. See type doc.
             });
 
         try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -90,17 +90,6 @@
         { "name": "npcKey", "group": 3, "type": "string" }
       ]
     },
-    "arwen.FavorLogParser.DeltaFavorRx": {
-      "pattern": "ProcessDeltaFavor\\(\\d+,\\s*\"(NPC_\\w+)\",\\s*([\\d.-]+),\\s*\\w+\\)",
-      "source": "player",
-      "module": "arwen",
-      "csharp": { "type": "Arwen.Parsing.FavorLogParser", "method": "DeltaFavorRx" },
-      "eventType": "arwen.FavorDelta",
-      "fields": [
-        { "name": "npcKey", "group": 1, "type": "string" },
-        { "name": "delta", "group": 2, "type": "double" }
-      ]
-    },
     "inventory.PlayerInventoryFrameProducer.DeleteItemRx": {
       "pattern": "ProcessDeleteItem\\((\\d+)\\)",
       "source": "player",

--- a/tests/Arwen.Tests/FavorLogParserTests.cs
+++ b/tests/Arwen.Tests/FavorLogParserTests.cs
@@ -33,25 +33,25 @@ public sealed class FavorLogParserTests
     }
 
     [Fact]
-    public void ParsesDeltaFavor()
-    {
-        var line = "[18:14:21] LocalPlayer: ProcessDeltaFavor(0, \"NPC_Fainor\", 23, True)";
-        var evt = _parser.TryParse(line, DateTime.UtcNow);
-
-        evt.Should().BeOfType<FavorDelta>();
-        var delta = (FavorDelta)evt!;
-        delta.NpcKey.Should().Be("NPC_Fainor");
-        delta.Delta.Should().Be(23);
-    }
-
-    [Fact]
     public void ReturnsNull_ForDeleteItem_PostMigration()
     {
         // Post-#608 the parser no longer consumes ProcessDeleteItem — the
-        // gift-detection FSM receives Removes via the PlayerWorld bus
-        // (PlayerInventoryRemoved). The parser must skip these lines without
-        // emitting any event.
+        // gift-detection FSM is lifted into
+        // Mithril.GameState.Gifting.IGiftSignalService (Tier-2 signal service),
+        // which owns its own L1 subscription and parses this verb there.
+        // The parser must skip these lines without emitting any event.
         var line = "[18:17:59] LocalPlayer: ProcessDeleteItem(98931165)";
+        _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
+    }
+
+    [Fact]
+    public void ReturnsNull_ForDeltaFavor_PostMigration()
+    {
+        // Post-#691 the parser no longer consumes ProcessDeltaFavor — the
+        // gift-detection FSM owns the verb-triple correlation on its own L1
+        // pump inside IGiftSignalService. The parser must skip these lines
+        // without emitting any event.
+        var line = "[18:14:21] LocalPlayer: ProcessDeltaFavor(0, \"NPC_Fainor\", 23, True)";
         _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
     }
 

--- a/tools/MithrilLogMcp/test/player-parser.test.ts
+++ b/tools/MithrilLogMcp/test/player-parser.test.ts
@@ -46,14 +46,6 @@ describe('PlayerLineParser', () => {
     assert.equal(smaug!.data.npcKey, 'NPC_Marna');
   });
 
-  it('parses arwen.FavorDelta from ProcessDeltaFavor', () => {
-    const events = parse('ProcessDeltaFavor(0, "NPC_Marna", 50.0, True)');
-    const e = events.find((x) => x.type === 'arwen.FavorDelta');
-    assert.ok(e);
-    assert.equal(e!.data.npcKey, 'NPC_Marna');
-    assert.equal(e!.data.delta, 50.0);
-  });
-
   it('parses smaug.VendorItemSold', () => {
     const events = parse('ProcessVendorAddItem(420, RustyDagger(987654), True)');
     const e = events.find((x) => x.type === 'smaug.VendorItemSold');

--- a/tools/MithrilLogMcp/test/query-events.test.ts
+++ b/tools/MithrilLogMcp/test/query-events.test.ts
@@ -22,10 +22,9 @@ function fixturePath(): string {
     '[12:00:01] LocalPlayer: ProcessSetPetOwner(11111, 22222)',
     '[12:00:02] Download appearance loop @Carrot(scale=1.0)',
     '[12:00:03] ProcessStartInteraction(900, 1, 100.5, True, "NPC_Marna")',
-    '[12:00:04] ProcessDeltaFavor(0, "NPC_Marna", 25.0, True)',
-    '[12:00:05] ProcessVendorAddItem(50, RustyDagger(101), True)',
-    '[12:00:06] ProcessVendorAddItem(75, RustyDagger(102), True)',
-    '[12:00:07] ProcessStartInteraction(901, 1, 200.5, True, "NPC_Velkort")',
+    '[12:00:04] ProcessVendorAddItem(50, RustyDagger(101), True)',
+    '[12:00:05] ProcessVendorAddItem(75, RustyDagger(102), True)',
+    '[12:00:06] ProcessStartInteraction(901, 1, 200.5, True, "NPC_Velkort")',
   ];
   fs.writeFileSync(p, lines.join('\n') + '\n');
   // Anchor mtime to yesterday so line `[HH:MM:SS]` stamps land safely before
@@ -47,7 +46,7 @@ describe('runQueryEvents', () => {
         limit: 100,
       });
       const result = await runQueryEvents(args, makeConfig(p), stubCursorStore());
-      assert.ok(result.summary.scannedLines >= 8);
+      assert.ok(result.summary.scannedLines >= 7);
       assert.equal(result.events.length, 2);
       assert.ok(result.events.every((e) => e.type === 'arwen.FavorUpdate'));
     } finally { fs.unlinkSync(p); }
@@ -103,11 +102,11 @@ describe('runAggregate', () => {
       const result = await runAggregate(args, makeConfig(p), stubCursorStore());
       assert.equal(result.buckets.length, 1);
       assert.equal(result.buckets[0]?.key, 'count');
-      // 8 lines, but ProcessStartInteraction matches twice (arwen + smaug).
+      // 7 lines, but ProcessStartInteraction matches twice (arwen + smaug).
       // 1 (SetPetOwner) + 1 (AppearanceLoop) + 2 (interaction A: arwen+smaug) +
-      // 1 (DeltaFavor) + 1 (VendorAddItem) + 1 (VendorAddItem) +
-      // 2 (interaction B: arwen+smaug) + 1 (ProcessAddPlayer) = 10
-      assert.equal(result.buckets[0]?.count, 10);
+      // 1 (VendorAddItem) + 1 (VendorAddItem) +
+      // 2 (interaction B: arwen+smaug) + 1 (ProcessAddPlayer) = 9
+      assert.equal(result.buckets[0]?.count, 9);
     } finally { fs.unlinkSync(p); }
   });
 


### PR DESCRIPTION
## Summary

Bundled post-#608 cleanup for the three `orchestrator-followup` issues surfaced by PR #688's review. File-level overlap (especially `FavorLogParser.cs` and the test file) made bundling cleaner than three separate PRs.

- **#691** — retire the `FavorDelta` dead emission path. `FavorLogParser` still emitted `FavorDelta` records from a parallel `ProcessDeltaFavor` regex that no production code consumed post-#608 (`Mithril.GameState.Gifting.GiftSignalService` owns the canonical parse on its single L1 pump). Delete the record, the regex, the parser test, and the `arwen.FavorLogParser.DeltaFavorRx` `log-patterns.json` catalog entry; clean up the matching MithrilLogMcp test and fixture count.
- **#689** — sweep stale doc-strings missed in PR #688's iter-3. Rewrite `FavorLogParser`'s summary (the `<see cref="FavorDelta"/>` cref is gone with the record, and the surrounding prose was structured around "two favor-side verbs"). Refresh the `FavorIngestionService` body and inline comments that still referred to FavorDelta's continued emission and to a "DeleteItem/DeltaFavor pair" the L1 sub no longer sees. Update the `FavorLogParserTests.ReturnsNull_ForDeleteItem_PostMigration` comment that still described the iter-1 PlayerWorld-bus narrative.
- **#690** — refresh `docs/module-signal-map.md` and `docs/module-charters.md` for the post-#608 Arwen architecture. The signal-map Arwen section still listed `ItemDeleted`, `FavorDelta`, and `IInventoryService.TryResolve` as inputs and ended with a ⚠️ "canonical Rule-1 violation" warning; rewrite to describe consumption of `IGiftSignalService.GiftAccepted` (Tier-2 signal service, single L1 pump, fully-resolved events) and replace the warning with a "Cross-source posture" note pointing at `world-sim-migration-audit.md` §Arwen. Mark Arwen `ItemDeleted` as resolved in the `module-charters.md` #579 audit bullet.

Mirrors the post-#608 tone already established in `world-sim-migration-audit.md` §Arwen.

## Commit structure

1. `refactor(arwen): retire FavorDelta + post-#608 doc-string refresh (#689) (#691)` — bundles #691 (code/JSON/test deletions) with #689 (cascading doc-string rewrites in the same files; the `FavorLogParser` cref change is forced by the record deletion).
2. `docs(world-sim): update module-signal-map + module-charters for post-#608 Arwen (#690)` — docs-only.

## Out of scope

- `IGiftSignalService` and other Tier-2 signal service code — #608 is merged and that work is settled.
- Legolas chat retirement — owned by #606.
- `[Obsolete] IInventoryService` per-consumer migration — owned by #659.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings (warnings-as-errors).
- [x] `dotnet test Mithril.slnx` — clean across all 13 test projects.
- [x] `dotnet test tests/Arwen.Tests` — 86/86 (net same: -1 `ParsesDeltaFavor`, +1 `ReturnsNull_ForDeltaFavor_PostMigration`).
- [ ] MithrilLogMcp `npm test` — not run locally (npm not on PATH in this worktree); CI will validate.

Closes #689
Closes #690
Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)