### PR TITLE
fix(world-sim): WorldEventBus.Subscription.Dispose removes entry from per-type list (#638)

### DIFF
--- a/src/Mithril.WorldSim.Chat/Internal/WorldEventBus.cs
+++ b/src/Mithril.WorldSim.Chat/Internal/WorldEventBus.cs
@@ -20,7 +20,7 @@ internal sealed class WorldEventBus : IWorldEventBus
     {
         ArgumentNullException.ThrowIfNull(handler);
 
-        var subscription = new Subscription(typeof(T), boxed =>
+        var subscription = new Subscription(this, typeof(T), boxed =>
         {
             // The bus stores handlers as Action<IFrame> wrappers (post-cast to
             // the concrete generic Frame<T>) so a single dictionary covers all
@@ -35,6 +35,42 @@ internal sealed class WorldEventBus : IWorldEventBus
             list.Add(subscription);
         }
         return subscription;
+    }
+
+    /// <summary>
+    /// Remove a disposed subscription from its per-type list. Tolerant of
+    /// double-dispose — calls past the first are a no-op because the entry is
+    /// already gone. Hot path is publish, not dispose, so the List.Remove cost
+    /// is acceptable.
+    /// </summary>
+    private void RemoveSubscription(Subscription subscription)
+    {
+        if (!_subscriptions.TryGetValue(subscription.PayloadType, out var list))
+        {
+            return;
+        }
+        lock (_mutationLock)
+        {
+            list.Remove(subscription);
+        }
+    }
+
+    /// <summary>
+    /// Test-only accessor for the subscriber-list count of a given payload
+    /// type. Exposed via <c>InternalsVisibleTo</c> so the dispose-leak test
+    /// can assert the list shrinks back to zero. Returns 0 when no subscriber
+    /// has ever registered for <typeparamref name="T"/>.
+    /// </summary>
+    internal int SubscriberCountForTesting<T>()
+    {
+        if (!_subscriptions.TryGetValue(typeof(T), out var list))
+        {
+            return 0;
+        }
+        lock (_mutationLock)
+        {
+            return list.Count;
+        }
     }
 
     /// <summary>
@@ -95,19 +131,27 @@ internal sealed class WorldEventBus : IWorldEventBus
 
     private sealed class Subscription : IDisposable
     {
-        private readonly Type _payloadType;
+        private readonly WorldEventBus _owner;
         private readonly Action<IFrame> _handler;
 
-        public Subscription(Type payloadType, Action<IFrame> handler)
+        public Subscription(WorldEventBus owner, Type payloadType, Action<IFrame> handler)
         {
-            _payloadType = payloadType;
+            _owner = owner;
+            PayloadType = payloadType;
             _handler = handler;
         }
+
+        public Type PayloadType { get; }
 
         public bool IsDisposed { get; private set; }
 
         public void Invoke(IFrame frame) => _handler(frame);
 
-        public void Dispose() => IsDisposed = true;
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+            IsDisposed = true;
+            _owner.RemoveSubscription(this);
+        }
     }
 }

--- a/src/Mithril.WorldSim.Player/Internal/WorldEventBus.cs
+++ b/src/Mithril.WorldSim.Player/Internal/WorldEventBus.cs
@@ -24,7 +24,7 @@ internal sealed class WorldEventBus : IWorldEventBus
     {
         ArgumentNullException.ThrowIfNull(handler);
 
-        var subscription = new Subscription(typeof(T), boxed =>
+        var subscription = new Subscription(this, typeof(T), boxed =>
         {
             // The bus stores handlers as Action<IFrame> wrappers (post-cast to
             // the concrete generic Frame<T>) so a single dictionary covers all
@@ -39,6 +39,42 @@ internal sealed class WorldEventBus : IWorldEventBus
             list.Add(subscription);
         }
         return subscription;
+    }
+
+    /// <summary>
+    /// Remove a disposed subscription from its per-type list. Tolerant of
+    /// double-dispose — calls past the first are a no-op because the entry is
+    /// already gone. Hot path is publish, not dispose, so the List.Remove cost
+    /// is acceptable.
+    /// </summary>
+    private void RemoveSubscription(Subscription subscription)
+    {
+        if (!_subscriptions.TryGetValue(subscription.PayloadType, out var list))
+        {
+            return;
+        }
+        lock (_mutationLock)
+        {
+            list.Remove(subscription);
+        }
+    }
+
+    /// <summary>
+    /// Test-only accessor for the subscriber-list count of a given payload
+    /// type. Exposed via <c>InternalsVisibleTo</c> so the dispose-leak test
+    /// can assert the list shrinks back to zero. Returns 0 when no subscriber
+    /// has ever registered for <typeparamref name="T"/>.
+    /// </summary>
+    internal int SubscriberCountForTesting<T>()
+    {
+        if (!_subscriptions.TryGetValue(typeof(T), out var list))
+        {
+            return 0;
+        }
+        lock (_mutationLock)
+        {
+            return list.Count;
+        }
     }
 
     /// <summary>
@@ -125,14 +161,17 @@ internal sealed class WorldEventBus : IWorldEventBus
 
     private sealed class Subscription : IDisposable
     {
-        private readonly Type _payloadType;
+        private readonly WorldEventBus _owner;
         private readonly Action<IFrame> _handler;
 
-        public Subscription(Type payloadType, Action<IFrame> handler)
+        public Subscription(WorldEventBus owner, Type payloadType, Action<IFrame> handler)
         {
-            _payloadType = payloadType;
+            _owner = owner;
+            PayloadType = payloadType;
             _handler = handler;
         }
+
+        public Type PayloadType { get; }
 
         public bool IsDisposed { get; private set; }
 
@@ -145,6 +184,11 @@ internal sealed class WorldEventBus : IWorldEventBus
             _handler(frame);
         }
 
-        public void Dispose() => IsDisposed = true;
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+            IsDisposed = true;
+            _owner.RemoveSubscription(this);
+        }
     }
 }

--- a/tests/Mithril.WorldSim.Chat.Tests/Internal/WorldEventBusSubscriptionDisposeTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/Internal/WorldEventBusSubscriptionDisposeTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Mithril.WorldSim.Chat.Internal;
+using Xunit;
+
+namespace Mithril.WorldSim.Chat.Tests.Internal;
+
+public sealed class WorldEventBusSubscriptionDisposeTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 1, 1, 12, 0, sec, TimeSpan.Zero);
+
+    private sealed record Ping(string Tag);
+    private sealed record Pong(string Tag);
+
+    [Fact]
+    public void Dispose_removes_subscription_from_per_type_list_and_handler_stops_firing()
+    {
+        var bus = new WorldEventBus();
+        var observed = new List<Ping>();
+        var sub = bus.Subscribe<Ping>(f => observed.Add(f.Payload));
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(1);
+
+        sub.Dispose();
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(0);
+
+        bus.Publish(new Frame<Ping>(Ts(1), new Ping("after-dispose")));
+
+        observed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispose_is_idempotent_under_double_dispose()
+    {
+        var bus = new WorldEventBus();
+        var sub = bus.Subscribe<Ping>(_ => { });
+
+        sub.Dispose();
+        var act = () => sub.Dispose();
+
+        act.Should().NotThrow();
+        bus.SubscriberCountForTesting<Ping>().Should().Be(0);
+    }
+
+    [Fact]
+    public void Disposing_one_of_many_subscriptions_leaves_the_others_intact()
+    {
+        var bus = new WorldEventBus();
+        var a = new List<Ping>();
+        var b = new List<Ping>();
+        var c = new List<Ping>();
+
+        var subA = bus.Subscribe<Ping>(f => a.Add(f.Payload));
+        var subB = bus.Subscribe<Ping>(f => b.Add(f.Payload));
+        var subC = bus.Subscribe<Ping>(f => c.Add(f.Payload));
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(3);
+
+        subB.Dispose();
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(2);
+
+        bus.Publish(new Frame<Ping>(Ts(1), new Ping("x")));
+
+        a.Should().Equal(new Ping("x"));
+        b.Should().BeEmpty();
+        c.Should().Equal(new Ping("x"));
+    }
+
+    [Fact]
+    public void Dispose_only_affects_the_disposed_subscriptions_payload_type()
+    {
+        var bus = new WorldEventBus();
+        var pingSub = bus.Subscribe<Ping>(_ => { });
+        var pongSub = bus.Subscribe<Pong>(_ => { });
+
+        pingSub.Dispose();
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(0);
+        bus.SubscriberCountForTesting<Pong>().Should().Be(1);
+
+        pongSub.Dispose();
+    }
+}

--- a/tests/Mithril.WorldSim.Player.Tests/Internal/WorldEventBusSubscriptionDisposeTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/Internal/WorldEventBusSubscriptionDisposeTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Mithril.WorldSim.Player.Internal;
+using Xunit;
+
+namespace Mithril.WorldSim.Player.Tests.Internal;
+
+public sealed class WorldEventBusSubscriptionDisposeTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 1, 1, 12, 0, sec, TimeSpan.Zero);
+
+    private sealed record Ping(string Tag);
+    private sealed record Pong(string Tag);
+
+    [Fact]
+    public void Dispose_removes_subscription_from_per_type_list_and_handler_stops_firing()
+    {
+        var bus = new WorldEventBus();
+        var observed = new List<Ping>();
+        var sub = bus.Subscribe<Ping>(f => observed.Add(f.Payload));
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(1);
+
+        sub.Dispose();
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(0);
+
+        bus.Publish(new Frame<Ping>(Ts(1), new Ping("after-dispose")));
+
+        observed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispose_is_idempotent_under_double_dispose()
+    {
+        var bus = new WorldEventBus();
+        var sub = bus.Subscribe<Ping>(_ => { });
+
+        sub.Dispose();
+        var act = () => sub.Dispose();
+
+        act.Should().NotThrow();
+        bus.SubscriberCountForTesting<Ping>().Should().Be(0);
+    }
+
+    [Fact]
+    public void Disposing_one_of_many_subscriptions_leaves_the_others_intact()
+    {
+        var bus = new WorldEventBus();
+        var a = new List<Ping>();
+        var b = new List<Ping>();
+        var c = new List<Ping>();
+
+        var subA = bus.Subscribe<Ping>(f => a.Add(f.Payload));
+        var subB = bus.Subscribe<Ping>(f => b.Add(f.Payload));
+        var subC = bus.Subscribe<Ping>(f => c.Add(f.Payload));
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(3);
+
+        subB.Dispose();
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(2);
+
+        bus.Publish(new Frame<Ping>(Ts(1), new Ping("x")));
+
+        a.Should().Equal(new Ping("x"));
+        b.Should().BeEmpty();
+        c.Should().Equal(new Ping("x"));
+    }
+
+    [Fact]
+    public void Dispose_only_affects_the_disposed_subscriptions_payload_type()
+    {
+        var bus = new WorldEventBus();
+        var pingSub = bus.Subscribe<Ping>(_ => { });
+        var pongSub = bus.Subscribe<Pong>(_ => { });
+
+        pingSub.Dispose();
+
+        bus.SubscriberCountForTesting<Ping>().Should().Be(0);
+        bus.SubscriberCountForTesting<Pong>().Should().Be(1);
+
+        pongSub.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #638.

`WorldEventBus.Subscription.Dispose()` previously only flipped `IsDisposed = true` — the entry stayed in the per-type `List<Subscription>` forever. `Publish` short-circuited via the flag, but the list itself grew unbounded across the session as modules subscribed/unsubscribed through gates, hotkey rebinds, and live calibration. #602 / #603 will make the leak load-bearing (chat-folder + per-character session subscribers re-subscribe on every login banner).

## Fix

On `Subscription.Dispose()`:
1. Short-circuit on `IsDisposed` for double-dispose tolerance.
2. Set `IsDisposed = true`.
3. Call back into the bus's `RemoveSubscription`, which `lock (_mutationLock)`s and removes `this` from the per-type list.

`Subscription` now holds a reference to its owning bus (constructor param) and exposes `PayloadType` so the bus can locate the right list.

Mirrored byte-equivalent into the chat-side bus per principle 2 (no shared abstractions across world shells). The two files are otherwise identical to before, just two copies of the same mechanical change.

## Tests

New `WorldEventBusSubscriptionDisposeTests.cs` in both:
- `tests/Mithril.WorldSim.Player.Tests/Internal/`
- `tests/Mithril.WorldSim.Chat.Tests/Internal/`

Each suite covers:
- subscribe → dispose → publish → handler NOT invoked AND list count is back to 0
- double-dispose is a no-op (no throw, count stays 0)
- dispose one of N subscriptions removes only that one; others still fire
- dispose only affects the disposed subscription's payload type

List-count assertion uses a new `internal int SubscriberCountForTesting<T>()` on each bus, exposed via the existing `InternalsVisibleTo` in `AssemblyInfo.cs`. Smallest surface I could give the tests — no reflection, no extra plumbing.

## Out of scope (per brief)

- No structural refactor of `WorldEventBus`; the two copies stay separate.
- No change to the public `IPlayerWorld.Subscribe` / `IChatWorld.Subscribe` contracts. (The public `IWorldEventBus.Subscribe` doc-comment already promised this behaviour — the fix brings the implementation in line with the documented contract.)

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — full suite green; `Mithril.WorldSim.Player.Tests` 30/30, `Mithril.WorldSim.Chat.Tests` 35/35.
