### PR TITLE
chore(gamestate): make ChatInventoryWorldRegistration call InventoryView.Start() for symmetry (#682)

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -376,11 +376,12 @@ public static class GameStateServiceCollectionExtensions
             _world.RegisterProducer(_producer);
             _world.RegisterFolder(_folder);
             // View subscribes to both world buses + seeds export reconcile.
-            // Idempotent — the ChatInventoryWorldRegistration calls Start()
-            // too, and only the first call actually wires; the second is a
-            // no-op. We attach here (on the Player-side path) so the bus
-            // subscription is in place before PlayerWorld.StartAsync runs
-            // the merger.
+            // Idempotent — InventoryView.Start() short-circuits on its own
+            // `_started` flag, so the parallel call in
+            // ChatInventoryWorldRegistration is a no-op. We attach on both
+            // paths so the view's bus subscriptions are in place before
+            // either world's StartAsync runs the merger, regardless of which
+            // registration hosted service fires first.
             _view.Start();
             return Task.CompletedTask;
         }
@@ -396,27 +397,41 @@ public static class GameStateServiceCollectionExtensions
     /// equivalent: <c>AddChatWorld</c> registers the world singleton; this
     /// hosted service runs before the world's own hosted service via
     /// registration-order semantics in <c>ShellComposition</c>.
+    /// Additionally calls <see cref="InventoryView.Start"/> in parallel with
+    /// <see cref="PlayerInventoryWorldRegistration"/> so the view's
+    /// ChatWorld bus subscription is in place before either world's
+    /// <c>StartAsync</c> fires; whichever registration runs first wires the
+    /// subscriptions, the other is a no-op via <c>InventoryView._started</c>.
     /// </summary>
     private sealed class ChatInventoryWorldRegistration : IHostedService
     {
         private readonly IChatWorld _world;
         private readonly IFolder<ChatInventoryObservationFrame> _folder;
         private readonly ChatInventoryFrameProducer _producer;
+        private readonly InventoryView _view;
 
         public ChatInventoryWorldRegistration(
             IChatWorld world,
             IFolder<ChatInventoryObservationFrame> folder,
-            ChatInventoryFrameProducer producer)
+            ChatInventoryFrameProducer producer,
+            InventoryView view)
         {
             _world = world;
             _folder = folder;
             _producer = producer;
+            _view = view;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _world.RegisterProducer(_producer);
             _world.RegisterFolder(_folder);
+            // Paired with the Player-side registration via
+            // InventoryView._started; whichever runs first wires the
+            // subscriptions, the second is a no-op. Attaching on both paths
+            // keeps the view's bus subscriptions resilient to
+            // registration-order reorders.
+            _view.Start();
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
## Summary

Closes #682.

The doc-comment in `PlayerInventoryWorldRegistration.StartAsync` claimed that `ChatInventoryWorldRegistration` also called `Start()` and that whichever ran first wired the view's bus subscriptions — but the chat-side registration never actually called `Start()`. The Player-side was the only path that wired the view; the documented invariant ("view's subscriptions in place before either world's `StartAsync` fires") was silently load-bearing on Player-side registration always running first.

## Fix (option 2 from the issue — author's stated preference)

Made the chat registration also call `_view.Start()`:

- `ChatInventoryWorldRegistration` now takes an `InventoryView view` constructor parameter, stores `_view`, and calls `_view.Start()` after `RegisterFolder` / `RegisterProducer`.
- `InventoryView.Start()` is already idempotent via its `_started` flag (`src/Mithril.GameState/Inventory/InventoryView.cs:196-214`), so whichever hosted service runs first wires the subscriptions and the other is a no-op.
- DI changes: none. `InventoryView` is already a singleton (line 102) and resolves for both registrations.

## Doc-comment updates

- `ChatInventoryWorldRegistration` class-level XML doc — added a sentence noting the parallel `Start()` call and the `_started` idempotency.
- `PlayerInventoryWorldRegistration.StartAsync` inline comment — reworded to match reality (mentions the `_started` short-circuit, not the no-longer-aspirational "second is a no-op").

The class-level XML doc on `PlayerInventoryWorldRegistration` ("view's PlayerWorld + ChatWorld bus subscriptions are in place before either world's `StartAsync` fires") stays correct — option 2 makes it factually defended by both paths instead of brittle to reorders.

## Why option 2 over option 1

`InventoryView.Start()` is what subscribes to BOTH `_playerWorld.Bus` and `_chatWorld.Bus`. If a future change reorders the registrations (or splits them across composition extensions), option 1 leaves the invariant silently broken. Option 2 enforces it from both sides at the cost of one extra constructor parameter and one extra (no-op) method call.

## Tests

Skipped a new test per the brief's steer. The behavioural surface added is "`ChatInventoryWorldRegistration.StartAsync` also calls `InventoryView.Start()`"; the `_started` idempotency is already exercised by every consumer of `InventoryView.Start()`, and a regression test would require new test-only surface (exposing `_started`) for the size of the change. The DI graph still resolving (build clean + full test suite green) is the load-bearing check.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — full suite green; `Mithril.GameState.Tests` 409/409.
