### PR TITLE
fix(world-sim): trailing-registered merger start eliminates world-vs-subscriber race (#696)

### DIFF
--- a/docs/world-simulator.md
+++ b/docs/world-simulator.md
@@ -318,7 +318,7 @@ public interface IWorld
 
     /// <summary>
     /// Register a producer (log tail, wake-at-T scheduler, filesystem reconcile, …).
-    /// Must be called before <see cref="StartAsync"/>.
+    /// Must be called before <see cref="StartMerger"/>.
     /// </summary>
     void RegisterProducer<T>(IFrameProducer<T> producer);
 
@@ -337,11 +337,15 @@ public interface IWorld
     void RegisterComposer(IComposer composer);
 
     /// <summary>
-    /// Begin frame application. Closes the registration set; from here forward
-    /// the world drains producers in timestamp order, dispatches to folders,
-    /// resolves composers, publishes domain frames to <see cref="Bus"/>.
+    /// Close the registration set and begin merger drain. Returns a long-running
+    /// task that completes when every producer is drained or <paramref name="ct"/>
+    /// is cancelled. Two-phase contract: registration acceptance (closes on entry)
+    /// and merger running (the returned task). Called by the trailing
+    /// <c>WorldMergerStartHostedService</c> registered LAST in the composition
+    /// (#696 Call 2) so the merger drain starts only after every other hosted
+    /// service's <c>StartAsync</c> has completed.
     /// </summary>
-    Task StartAsync(CancellationToken ct);
+    Task StartMerger(CancellationToken ct);
 }
 
 /// <summary>

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -306,14 +306,13 @@ public static class GameStateServiceCollectionExtensions
     /// <summary>
     /// Hosted service that wires <see cref="PlayerSkillStateService"/> (as a
     /// folder) and <see cref="SkillFrameProducer"/> (as a producer) into the
-    /// <see cref="IPlayerWorld"/> singleton at host start, before
-    /// <c>PlayerWorld.StartAsync</c> fires. Ordering relies on
-    /// <c>ShellComposition</c> calling <c>AddPlayerWorld</c> before
-    /// <c>AddMithrilGameState</c>: registration order = hosted-service start
-    /// order, so this registration runs first; the world's own hosted service
-    /// (which calls <c>world.StartAsync</c>) runs second and observes the
-    /// folder + producer already attached. Registrations must close before
-    /// <c>StartAsync</c>; the world enforces that explicitly.
+    /// <see cref="IPlayerWorld"/> singleton at host start. Runs during the
+    /// chain's <c>IHostedService.StartAsync</c> phase, before the trailing
+    /// <c>WorldMergerStartHostedService</c> (appended by
+    /// <c>ShellComposition.AddMithrilApp</c> — #696 Call 2) calls
+    /// <see cref="IWorld.StartMerger"/> on each registered world and the
+    /// merger drain begins. Registrations must close before
+    /// <c>StartMerger</c>; the world enforces that explicitly.
     /// </summary>
     private sealed class PlayerSkillStateWorldRegistration : IHostedService
     {
@@ -344,13 +343,13 @@ public static class GameStateServiceCollectionExtensions
     /// <summary>
     /// Hosted service that wires <see cref="PlayerInventoryStateService"/>
     /// (folder) + <see cref="PlayerInventoryFrameProducer"/> (producer) into
-    /// the <see cref="IPlayerWorld"/> singleton at host start, before
-    /// <c>PlayerWorld.StartAsync</c> fires. Mirrors
+    /// the <see cref="IPlayerWorld"/> singleton at host start. Mirrors
     /// <see cref="PlayerSkillStateWorldRegistration"/>'s shape (#618 — the
     /// canonical Phase 1 template). Additionally calls
     /// <see cref="InventoryView.Start"/> so the view's PlayerWorld + ChatWorld
-    /// bus subscriptions are in place before either world's <c>StartAsync</c>
-    /// fires and frames begin flowing.
+    /// bus subscriptions are in place before the trailing
+    /// <c>WorldMergerStartHostedService</c> (#696 Call 2) calls
+    /// <see cref="IWorld.StartMerger"/> on either world and frames begin flowing.
     /// </summary>
     private sealed class PlayerInventoryWorldRegistration : IHostedService
     {
@@ -379,9 +378,10 @@ public static class GameStateServiceCollectionExtensions
             // Idempotent — InventoryView.Start() short-circuits on its own
             // `_started` flag, so the parallel call in
             // ChatInventoryWorldRegistration is a no-op. We attach on both
-            // paths so the view's bus subscriptions are in place before
-            // either world's StartAsync runs the merger, regardless of which
-            // registration hosted service fires first.
+            // paths so the view's bus subscriptions are in place before the
+            // trailing WorldMergerStartHostedService calls StartMerger on
+            // either world (#696 Call 2), regardless of which registration
+            // hosted service fires first.
             _view.Start();
             return Task.CompletedTask;
         }
@@ -392,16 +392,16 @@ public static class GameStateServiceCollectionExtensions
     /// <summary>
     /// Hosted service that wires <see cref="ChatInventoryStateService"/>
     /// (folder) + <see cref="ChatInventoryFrameProducer"/> (producer) into
-    /// the <see cref="IChatWorld"/> singleton at host start, before
-    /// <c>ChatWorld.StartAsync</c> fires. Ordering mirrors the player-side
-    /// equivalent: <c>AddChatWorld</c> registers the world singleton; this
-    /// hosted service runs before the world's own hosted service via
-    /// registration-order semantics in <c>ShellComposition</c>.
-    /// Additionally calls <see cref="InventoryView.Start"/> in parallel with
-    /// <see cref="PlayerInventoryWorldRegistration"/> so the view's
-    /// ChatWorld bus subscription is in place before either world's
-    /// <c>StartAsync</c> fires; whichever registration runs first wires the
-    /// subscriptions, the other is a no-op via <c>InventoryView._started</c>.
+    /// the <see cref="IChatWorld"/> singleton at host start. Mirrors the
+    /// player-side equivalent: registers folder + producer during the chain's
+    /// <c>StartAsync</c> phase, before the trailing
+    /// <c>WorldMergerStartHostedService</c> (#696 Call 2) calls
+    /// <see cref="IWorld.StartMerger"/>. Additionally calls
+    /// <see cref="InventoryView.Start"/> in parallel with
+    /// <see cref="PlayerInventoryWorldRegistration"/> so the view's ChatWorld
+    /// bus subscription is in place before frames begin flowing; whichever
+    /// registration runs first wires the subscriptions, the other is a no-op
+    /// via <c>InventoryView._started</c>.
     /// </summary>
     private sealed class ChatInventoryWorldRegistration : IHostedService
     {
@@ -504,8 +504,9 @@ public static class GameStateServiceCollectionExtensions
     /// <summary>
     /// Hosted service that calls <see cref="WordOfPowerView.Start"/> at host
     /// start so the view's PlayerWorld + ChatWorld bus subscriptions are in
-    /// place before either world's <c>StartAsync</c> fires and frames begin
-    /// flowing (#603). Mirrors the analogous wiring for
+    /// place before the trailing <c>WorldMergerStartHostedService</c> (#696
+    /// Call 2) calls <see cref="IWorld.StartMerger"/> on either world and
+    /// frames begin flowing (#603). Mirrors the analogous wiring for
     /// <see cref="InventoryView.Start"/> in
     /// <see cref="PlayerInventoryWorldRegistration"/>.
     /// </summary>

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -149,11 +149,14 @@ public static class GameStateServiceCollectionExtensions
         // an IFolder<SkillFrame> registered with IPlayerWorld; a sibling
         // SkillFrameProducer owns the L1 subscription and feeds skill frames
         // into the world's merger. The PlayerSkillStateWorldRegistration
-        // hosted service wires both into the world before the world's own
-        // hosted service drains (hosted services run in registration order,
-        // and AddPlayerWorld is called BEFORE AddMithrilGameState in
-        // ShellComposition, so the world singleton is already constructed by
-        // the time this runs but its StartAsync hasn't fired yet).
+        // hosted service wires both into the world during the chain's
+        // IHostedService.StartAsync phase, before the trailing
+        // WorldMergerStartHostedService (appended by AddMithrilApp — #696
+        // Call 2) calls IWorld.StartMerger and the merger drain begins.
+        // AddPlayerWorld is called BEFORE AddMithrilGameState in
+        // ShellComposition because the registration hosted service resolves
+        // IPlayerWorld at construction; DI resolution is order-independent
+        // but registration order matters for hosted-service start order.
         services.AddSingleton<SkillLogParser>();
         services
             .AddSingleton<PlayerSkillStateService>()

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -40,9 +40,26 @@ public sealed record ShellCompositionOptions(
 public static class ShellComposition
 {
     /// <summary>
+    /// Top-level composition entry point. Wires the full shell service graph
+    /// AND appends the trailing <see cref="WorldMergerStartHostedService"/>
+    /// (#696 Call 2) so each world's merger drain starts strictly after every
+    /// other hosted service has finished its registration work. The "registered
+    /// LAST" invariant is enforced structurally — call sites use this method
+    /// rather than <see cref="AddMithrilShell"/> so they cannot forget the
+    /// trailing merger start, and a future contributor adding another shell
+    /// registration edits <see cref="AddMithrilShell"/> while the trailing
+    /// invariant is preserved automatically here.
+    /// </summary>
+    public static IServiceCollection AddMithrilApp(
+        this IServiceCollection services, ShellCompositionOptions o) =>
+        services
+            .AddMithrilShell(o)
+            .AddWorldMergerStart();
+
+    /// <summary>
     /// The complete shell service registration, in order. This is the single source
     /// of truth for the runtime DI graph; <c>Program</c> and the self-check both call
-    /// it so the guard validates exactly what ships.
+    /// it via <see cref="AddMithrilApp"/> so the guard validates exactly what ships.
     /// </summary>
     public static IServiceCollection AddMithrilShell(
         this IServiceCollection services, ShellCompositionOptions o) =>
@@ -62,17 +79,15 @@ public static class ShellComposition
             // the typed pipes + the unified pipe — #556) and
             // AddMithrilGameState (whose producers depend on ILogStreamDriver).
             .AddMithrilLogStreamDriver()
-            // PlayerWorld is registered BEFORE AddMithrilGameState so the
-            // skill-folder + producer registration (#618 — Phase 1 of the
-            // world-sim migration) can wire into the world via its own
-            // IHostedService at startup, before PlayerWorld.StartAsync fires.
-            // Hosted services run in registration order; the registration
-            // hosted service inside AddMithrilGameState therefore runs
-            // strictly before PlayerWorldHostedService.
+            // PlayerWorld + ChatWorld register the world singletons and the
+            // L1 / chat-tail producers. Under #696 (Call 2) neither extension
+            // registers a hosted service — the merger drain starts trailing,
+            // from the WorldMergerStartHostedService appended by AddMithrilApp.
+            // Registration order between AddPlayerWorld / AddChatWorld and
+            // AddMithrilGameState is therefore irrelevant for hosted-service
+            // ordering; resolution-order is what matters, and DI resolution is
+            // order-independent.
             .AddPlayerWorld()
-            // ChatWorld is registered BEFORE AddMithrilGameState for the same
-            // ordering reason — #602's chat-inventory folder + producer
-            // registration hosted service runs before ChatWorldHostedService.
             .AddChatWorld()
             .AddMithrilGameState()
             .AddMithrilPerCharacterStorage(o.CharactersRootDir)

--- a/src/Mithril.Shell/DependencyInjection/WorldMergerStartHostedService.cs
+++ b/src/Mithril.Shell/DependencyInjection/WorldMergerStartHostedService.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mithril.WorldSim;
+
+namespace Mithril.Shell.DependencyInjection;
+
+/// <summary>
+/// The trailing-registered <see cref="IHostedService"/> that starts each
+/// registered world's merger drain (#696 Call 2). Appended LAST by
+/// <see cref="ShellComposition.AddMithrilApp"/> via the internal
+/// <see cref="WorldMergerStartServiceCollectionExtensions.AddWorldMergerStart"/>
+/// so the hosted-services runner invokes its <see cref="StartAsync"/> AFTER
+/// every other registration hosted service has completed its work (bus
+/// subscriptions attached, folder/producer registrations closed).
+///
+/// <para>This service is deliberately <em>not</em> a
+/// <see cref="BackgroundService"/> — its
+/// <see cref="BackgroundService.ExecuteAsync"/> would be scheduled on the
+/// thread pool at a non-deterministic moment relative to subsequent services'
+/// <c>StartAsync</c> calls. That is the exact race #696 corrects. By
+/// implementing <see cref="IHostedService"/> directly and being registered
+/// trailing, <see cref="StartAsync"/> runs at a deterministic point in the
+/// startup sequence: strictly after every preceding hosted service.</para>
+///
+/// <para><b>Lifecycle.</b> <see cref="StartAsync"/> calls
+/// <see cref="IWorld.StartMerger"/> on each registered <see cref="IWorld"/>
+/// WITHOUT awaiting the returned task — those tasks are the long-running
+/// drains, captured here for graceful shutdown. <see cref="StartAsync"/>
+/// returns immediately so host startup is non-blocking.
+/// <see cref="StopAsync"/> cancels the linked token and waits for the drains
+/// to complete (bounded by the host's stop-token grace period).</para>
+/// </summary>
+internal sealed class WorldMergerStartHostedService : IHostedService
+{
+    private readonly IReadOnlyList<IWorld> _worlds;
+    private readonly List<Task> _mergerTasks = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    public WorldMergerStartHostedService(IEnumerable<IWorld> worlds)
+        => _worlds = worlds.ToArray();
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        foreach (var world in _worlds)
+        {
+            _mergerTasks.Add(world.StartMerger(_cts.Token));
+        }
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        try { _cts.Cancel(); } catch { /* best-effort */ }
+        if (_mergerTasks.Count == 0) return;
+        try
+        {
+            await Task.WhenAll(_mergerTasks).WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Either our cancellation propagated up (expected) or the host's
+            // stop-token expired before drain finished — both are non-fatal at
+            // shutdown.
+        }
+        catch
+        {
+            // Merger exceptions surfaced during shutdown must not block host
+            // teardown — they're already swallowed in production today because
+            // BackgroundService.ExecuteAsync runs fire-and-forget. Preserving
+            // that behaviour here keeps shutdown deterministic.
+        }
+        finally
+        {
+            _cts.Dispose();
+        }
+    }
+}
+
+/// <summary>
+/// Internal-only DI extension. The internal modifier signals to readers
+/// "you probably shouldn't be calling this from production composition" —
+/// production goes through <see cref="ShellComposition.AddMithrilApp"/>,
+/// which appends this extension trailing the full shell registration.
+///
+/// <para>Test access is via <c>InternalsVisibleTo("Mithril.Shell.Tests")</c>
+/// (see <c>Mithril.Shell.csproj</c>). Tests use this directly to compose
+/// partial stacks with a live merger, e.g.
+/// <c>services.AddPlayerWorld().AddWorldMergerStart()</c> for
+/// "single world in isolation" lifecycle scenarios. The friend-assembly
+/// approach was chosen over a parallel
+/// <c>AddWorldMergerStartForTesting()</c> extension so production and test
+/// composition share the same code path and can't drift silently
+/// (#696 ratification, docs/world-simulator.md §Call 2).</para>
+/// </summary>
+internal static class WorldMergerStartServiceCollectionExtensions
+{
+    /// <summary>
+    /// Append the trailing <see cref="WorldMergerStartHostedService"/> to
+    /// the service collection. MUST be the LAST hosted-service registration
+    /// in the composition for the trailing-start invariant to hold.
+    /// </summary>
+    internal static IServiceCollection AddWorldMergerStart(this IServiceCollection services)
+        => services.AddHostedService<WorldMergerStartHostedService>();
+}

--- a/src/Mithril.Shell/DependencyInjection/WorldMergerStartHostedService.cs
+++ b/src/Mithril.Shell/DependencyInjection/WorldMergerStartHostedService.cs
@@ -51,10 +51,12 @@ internal sealed class WorldMergerStartHostedService : IHostedService
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         try { _cts.Cancel(); } catch { /* best-effort */ }
-        if (_mergerTasks.Count == 0) return;
         try
         {
-            await Task.WhenAll(_mergerTasks).WaitAsync(cancellationToken).ConfigureAwait(false);
+            if (_mergerTasks.Count > 0)
+            {
+                await Task.WhenAll(_mergerTasks).WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/Mithril.Shell/Mithril.Shell.csproj
+++ b/src/Mithril.Shell/Mithril.Shell.csproj
@@ -32,6 +32,14 @@
       <_Parameter1>MithrilUpdateChannel</_Parameter1>
       <_Parameter2>$(MithrilUpdateChannel)</_Parameter2>
     </AssemblyAttribute>
+    <!--
+      Friend assembly: #696 Call 2 merger-lifecycle tests call the internal
+      AddWorldMergerStart() extension to compose partial stacks with a live
+      merger. Picked over a parallel AddWorldMergerStartForTesting() extension
+      so production and test composition share the same code path and can't
+      drift silently. Issue #696 ratification (docs/world-simulator.md §Call 2).
+    -->
+    <InternalsVisibleTo Include="Mithril.Shell.Tests" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" />

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -162,7 +162,11 @@ public static class Program
             // shared across modules, not nested under Shell/.
             var preferencesPath = Path.Combine(localApp, "Mithril", "preferences.json");
 
-            builder.Services.AddMithrilShell(new ShellCompositionOptions(
+            // AddMithrilApp = AddMithrilShell + AddWorldMergerStart (trailing).
+            // The trailing-registration invariant (#696 Call 2) is what makes
+            // each world's merger drain start strictly after every other hosted
+            // service has completed its registration work.
+            builder.Services.AddMithrilApp(new ShellCompositionOptions(
                 preferencesPath, shellStore, shellSettings, gameConfig,
                 logDir, perfDir, charactersRootDir, referenceCacheDir,
                 communityCalibrationCacheDir, iconCacheDir, Boot));

--- a/src/Mithril.Shell/SelfCheck.cs
+++ b/src/Mithril.Shell/SelfCheck.cs
@@ -90,7 +90,11 @@ internal static class SelfCheck
                 ValidateOnBuild = true,
                 ValidateScopes = true,
             }));
-            builder.Services.AddMithrilShell(options);
+            // AddMithrilApp = AddMithrilShell + AddWorldMergerStart (trailing
+            // per #696 Call 2). Self-check validates the same composition the
+            // real launch does, so any future trailing additions are caught
+            // by the DI-cycle guard.
+            builder.Services.AddMithrilApp(options);
 
             // Self-test hook (CI guard-of-the-guard, never set in prod): inject a
             // re-entrant factory-lambda cycle of the exact shape #365 was — two

--- a/src/Mithril.WorldSim.Chat/ChatWorld.cs
+++ b/src/Mithril.WorldSim.Chat/ChatWorld.cs
@@ -266,8 +266,8 @@ public sealed class ChatWorld : IChatWorld, IAsyncDisposable
         if (_started)
         {
             throw new InvalidOperationException(
-                "Cannot register producers/folders/composers after StartAsync — " +
-                "the registration set closes at start (IWorld.StartAsync doc).");
+                "Cannot register producers/folders/composers after StartMerger — " +
+                "the registration set seals on entry (IWorld.StartMerger doc).");
         }
     }
 

--- a/src/Mithril.WorldSim.Chat/ChatWorld.cs
+++ b/src/Mithril.WorldSim.Chat/ChatWorld.cs
@@ -92,7 +92,7 @@ public sealed class ChatWorld : IChatWorld, IAsyncDisposable
         }
     }
 
-    public async Task StartAsync(CancellationToken ct)
+    public async Task StartMerger(CancellationToken ct)
     {
         EnsureNotStarted();
         _started = true;

--- a/src/Mithril.WorldSim.Chat/DependencyInjection/ChatWorldServiceCollectionExtensions.cs
+++ b/src/Mithril.WorldSim.Chat/DependencyInjection/ChatWorldServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Mithril.WorldSim.Chat.Internal;
 using Mithril.WorldSim.Chat.Producers;
 
@@ -8,11 +7,18 @@ namespace Mithril.WorldSim.Chat.DependencyInjection;
 /// <summary>
 /// DI registration for the Phase 0 ChatWorld shell (issue #617, sibling of
 /// <c>AddPlayerWorld</c> from #616). Registers the world singleton, the
-/// chat-replay source + producer, the session service, and a
-/// <see cref="BackgroundService"/> shim that calls <see cref="IWorld.StartAsync"/>
-/// once the host boots. Per-folder migrations (#602 chat-inventory, #603
-/// chat-WoP) wire their folder / composer registrations against the same
-/// world singleton.
+/// chat-replay source + producer, and the session service. Per-folder
+/// migrations (#602 chat-inventory, #603 chat-WoP) wire their folder /
+/// composer registrations against the same world singleton.
+///
+/// <para><b>Merger start is OUT of this extension</b> (#696 Call 2). The
+/// merger drain is started trailing the entire shell composition by
+/// <c>Mithril.Shell.DependencyInjection.WorldMergerStartHostedService</c>,
+/// appended LAST by <c>ShellComposition.AddMithrilApp</c>. That hosted
+/// service resolves <see cref="IEnumerable{IWorld}"/> and calls
+/// <see cref="IWorld.StartMerger"/> on each registered world, which is why
+/// this extension registers the concrete world AS <see cref="IWorld"/> as
+/// well as <see cref="IChatWorld"/>.</para>
 /// </summary>
 public static class ChatWorldServiceCollectionExtensions
 {
@@ -42,18 +48,11 @@ public static class ChatWorldServiceCollectionExtensions
                 return world;
             })
             .AddSingleton<IChatWorld>(sp => sp.GetRequiredService<ChatWorld>())
-            .AddHostedService<ChatWorldHostedService>();
+            // Also register as IWorld so the trailing
+            // WorldMergerStartHostedService (#696 Call 2) can resolve every
+            // registered world via IEnumerable<IWorld>.
+            .AddSingleton<IWorld>(sp => sp.GetRequiredService<ChatWorld>());
 
         return services;
-    }
-
-    private sealed class ChatWorldHostedService : BackgroundService
-    {
-        private readonly ChatWorld _world;
-
-        public ChatWorldHostedService(ChatWorld world) => _world = world;
-
-        protected override Task ExecuteAsync(CancellationToken stoppingToken)
-            => _world.StartAsync(stoppingToken);
     }
 }

--- a/src/Mithril.WorldSim.Core/IWorld.cs
+++ b/src/Mithril.WorldSim.Core/IWorld.cs
@@ -25,7 +25,7 @@ public interface IWorld
 
     /// <summary>
     /// Register a producer (log tail, filesystem reconcile, …). Must be called
-    /// before <see cref="StartAsync"/>. The world's merger consumes from every
+    /// before <see cref="StartMerger"/>. The world's merger consumes from every
     /// registered producer and merges their frames by timestamp, breaking ties
     /// by <see cref="IFrameProducer{TPayload}.Priority"/>.
     /// </summary>

--- a/src/Mithril.WorldSim.Core/IWorld.cs
+++ b/src/Mithril.WorldSim.Core/IWorld.cs
@@ -47,9 +47,34 @@ public interface IWorld
     void RegisterComposer(IComposer composer);
 
     /// <summary>
-    /// Begin frame application. Closes the registration set; from here forward
-    /// the world drains producers in timestamp order, dispatches to folders,
-    /// resolves composers, publishes domain frames to <see cref="Bus"/>.
+    /// Close the registration set and begin merger drain. Returns a long-running
+    /// task that completes when every producer is drained or <paramref name="ct"/>
+    /// is cancelled.
+    ///
+    /// <para>The contract distinguishes two phases:</para>
+    /// <list type="number">
+    ///   <item><b>Registration acceptance</b> — every call to
+    ///   <see cref="RegisterProducer{T}"/>, <see cref="RegisterFolder{T}"/>,
+    ///   and <see cref="RegisterComposer"/> MUST happen before <c>StartMerger</c>
+    ///   is invoked. The registration set seals on entry; further attempts
+    ///   throw.</item>
+    ///   <item><b>Merger running</b> — the returned task is the long-running
+    ///   drain. The caller — the trailing <c>WorldMergerStartHostedService</c>
+    ///   registered LAST in the composition (#696 Call 2) — fires this from
+    ///   its own <c>IHostedService.StartAsync</c> WITHOUT awaiting completion
+    ///   so host startup returns immediately, and awaits the task during
+    ///   graceful shutdown.</item>
+    /// </list>
+    ///
+    /// <para>This signature deliberately differs from
+    /// <see cref="Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync"/> —
+    /// see issue #696. <c>BackgroundService</c> schedules <c>ExecuteAsync</c> at
+    /// a non-deterministic moment relative to other hosted services'
+    /// <c>StartAsync</c> calls, which is the entire failure mode this contract
+    /// corrects. The merger must start strictly AFTER every other hosted service
+    /// has finished its registration work (bus subscriptions, folder/producer
+    /// wiring), and the trailing-registration composition enforces that
+    /// structurally rather than by discipline.</para>
     /// </summary>
-    Task StartAsync(CancellationToken ct);
+    Task StartMerger(CancellationToken ct);
 }

--- a/src/Mithril.WorldSim.Player/DependencyInjection/PlayerWorldServiceCollectionExtensions.cs
+++ b/src/Mithril.WorldSim.Player/DependencyInjection/PlayerWorldServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Mithril.Shared.Logging;
 using Mithril.WorldSim.Player.Internal;
 using Mithril.WorldSim.Player.Producers;
@@ -8,14 +7,21 @@ namespace Mithril.WorldSim.Player.DependencyInjection;
 
 /// <summary>
 /// DI registration for the Phase 0 PlayerWorld shell (issue #616, reshaped by
-/// #655). Registers the world singleton, the world-clock-tick producer + its
-/// owned folder, and a <see cref="BackgroundService"/> shim that calls
-/// <see cref="IWorld.StartAsync"/> once the host boots. Per-folder migrations
-/// (Phase 1+) wire their folder / composer / producer registrations against
-/// the same world singleton — typically via dedicated DI extensions of their
-/// own that resolve the world and call
+/// #655). Registers the world singleton + the world-clock-tick producer + its
+/// owned folder. Per-folder migrations (Phase 1+) wire their folder / composer
+/// / producer registrations against the same world singleton — typically via
+/// dedicated DI extensions of their own that resolve the world and call
 /// <see cref="IWorld.RegisterFolder{T}"/> / <see cref="IWorld.RegisterComposer"/>
 /// before the host starts.
+///
+/// <para><b>Merger start is OUT of this extension</b> (#696 Call 2). The
+/// merger drain is started trailing the entire shell composition by
+/// <c>Mithril.Shell.DependencyInjection.WorldMergerStartHostedService</c>,
+/// appended LAST by <c>ShellComposition.AddMithrilApp</c>. That hosted
+/// service resolves <see cref="IEnumerable{IWorld}"/> and calls
+/// <see cref="IWorld.StartMerger"/> on each registered world, which is why
+/// this extension registers the concrete world AS <see cref="IWorld"/> as
+/// well as <see cref="IPlayerWorld"/>.</para>
 /// </summary>
 public static class PlayerWorldServiceCollectionExtensions
 {
@@ -37,18 +43,12 @@ public static class PlayerWorldServiceCollectionExtensions
                 return world;
             })
             .AddSingleton<IPlayerWorld>(sp => sp.GetRequiredService<PlayerWorld>())
-            .AddHostedService<PlayerWorldHostedService>();
+            // Also register as IWorld so the trailing
+            // WorldMergerStartHostedService (#696 Call 2) can resolve every
+            // registered world via IEnumerable<IWorld> without binding
+            // explicitly to IPlayerWorld / IChatWorld.
+            .AddSingleton<IWorld>(sp => sp.GetRequiredService<PlayerWorld>());
 
         return services;
-    }
-
-    private sealed class PlayerWorldHostedService : BackgroundService
-    {
-        private readonly PlayerWorld _world;
-
-        public PlayerWorldHostedService(PlayerWorld world) => _world = world;
-
-        protected override Task ExecuteAsync(CancellationToken stoppingToken)
-            => _world.StartAsync(stoppingToken);
     }
 }

--- a/src/Mithril.WorldSim.Player/PlayerWorld.cs
+++ b/src/Mithril.WorldSim.Player/PlayerWorld.cs
@@ -85,7 +85,7 @@ public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
         }
     }
 
-    public async Task StartAsync(CancellationToken ct)
+    public async Task StartMerger(CancellationToken ct)
     {
         EnsureNotStarted();
         _started = true;

--- a/src/Mithril.WorldSim.Player/PlayerWorld.cs
+++ b/src/Mithril.WorldSim.Player/PlayerWorld.cs
@@ -234,7 +234,7 @@ public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
         // there is no transition to report. Consumers read Clock.Mode for
         // initial state and subscribe to ModeChanged only for actual
         // transitions — symmetric with the no-mode-aware-producers branch in
-        // StartAsync which sets Live up front without emitting.
+        // StartMerger which sets Live up front without emitting.
         if (_clock.Frame > 0)
         {
             _bus.Publish(new Frame<ModeChanged>(
@@ -289,7 +289,7 @@ public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
             }
 
             // Snapshot — composer.Observe must not mutate the dispatch graph
-            // (registrations close at StartAsync), so a direct iteration is
+            // (registrations close at StartMerger), so a direct iteration is
             // safe; the snapshot guards against accidental future changes
             // to that invariant.
             var snapshot = composers.ToArray();
@@ -311,8 +311,8 @@ public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
         if (_started)
         {
             throw new InvalidOperationException(
-                "Cannot register producers/folders/composers after StartAsync — " +
-                "the registration set closes at start (IWorld.StartAsync doc).");
+                "Cannot register producers/folders/composers after StartMerger — " +
+                "the registration set seals on entry (IWorld.StartMerger doc).");
         }
     }
 

--- a/tests/Mithril.GameState.Tests/Inventory/ChatInventoryFolderEndToEndTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/ChatInventoryFolderEndToEndTests.cs
@@ -84,7 +84,7 @@ public sealed class ChatInventoryFolderEndToEndTests
         });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = world.StartAsync(cts.Token);
+        var run = world.StartMerger(cts.Token);
         await allReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         cts.Cancel();
@@ -137,7 +137,7 @@ public sealed class ChatInventoryFolderEndToEndTests
             });
 
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var run = world.StartAsync(cts.Token);
+            var run = world.StartMerger(cts.Token);
             await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
             cts.Cancel();
             try { await run; } catch (OperationCanceledException) { }

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
@@ -40,7 +40,7 @@ public sealed class InventoryViewTests
         public void RegisterProducer<T>(IFrameProducer<T> producer) { }
         public void RegisterFolder<T>(IFolder<T> folder) { }
         public void RegisterComposer(IComposer composer) { }
-        public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task StartMerger(CancellationToken ct) => Task.CompletedTask;
     }
 
     private sealed class TestBus : IWorldEventBus

--- a/tests/Mithril.GameState.Tests/Inventory/PlayerInventoryFolderEndToEndTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/PlayerInventoryFolderEndToEndTests.cs
@@ -57,7 +57,7 @@ public sealed class PlayerInventoryFolderEndToEndTests
         });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = world.StartAsync(cts.Token);
+        var run = world.StartMerger(cts.Token);
 
         await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
         await allReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -127,7 +127,7 @@ public sealed class PlayerInventoryFolderEndToEndTests
             });
 
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var run = world.StartAsync(cts.Token);
+            var run = world.StartMerger(cts.Token);
             await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
             await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
             cts.Cancel();

--- a/tests/Mithril.GameState.Tests/Skills/SkillFolderEndToEndTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/SkillFolderEndToEndTests.cs
@@ -68,7 +68,7 @@ public sealed class SkillFolderEndToEndTests
         });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = world.StartAsync(cts.Token);
+        var run = world.StartMerger(cts.Token);
 
         // Drive the L1 pump to drain its backlog into the producer's channel.
         await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
@@ -140,7 +140,7 @@ public sealed class SkillFolderEndToEndTests
         using var _modeSub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = world.StartAsync(cts.Token);
+        var run = world.StartMerger(cts.Token);
 
         // Drain the replay phase first; the producer signals ReachedLive
         // immediately on the first non-replay envelope it sees, so we push the
@@ -207,7 +207,7 @@ public sealed class SkillFolderEndToEndTests
         using var _legacy = ((IPlayerSkillState)folder).SubscribeChanges(legacyChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = world.StartAsync(cts.Token);
+        var run = world.StartMerger(cts.Token);
 
         await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
         await allDelivered.Task.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Mithril.GameState.Tests/WordsOfPower/WordOfPowerViewTests.cs
+++ b/tests/Mithril.GameState.Tests/WordsOfPower/WordOfPowerViewTests.cs
@@ -47,7 +47,7 @@ public sealed class WordOfPowerViewTests : IDisposable
         public void RegisterProducer<T>(IFrameProducer<T> producer) { }
         public void RegisterFolder<T>(IFolder<T> folder) { }
         public void RegisterComposer(IComposer composer) { }
-        public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task StartMerger(CancellationToken ct) => Task.CompletedTask;
     }
 
     private sealed class TestBus : IWorldEventBus

--- a/tests/Mithril.Shell.Tests/Mithril.Shell.Tests.csproj
+++ b/tests/Mithril.Shell.Tests/Mithril.Shell.Tests.csproj
@@ -11,15 +11,19 @@
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>
   <!--
-    Build-order/deploy only (ReferenceOutputAssembly=false): we never reference
-    shell/module APIs from the test — we launch the built Mithril.exe out of
-    process and assert its exit code. Referencing Mithril.Shell builds the
-    apphost; referencing every *.Module triggers Directory.Build.targets to
-    deploy all 12 module DLLs into the shell's bin/<cfg>/modules/, so the
-    self-check sees the real full-install graph (#365 Layer 2 guard).
+    Mithril.Shell is referenced for code access (ReferenceOutputAssembly=true)
+    so the #696 Call 2 merger-lifecycle tests can call AddWorldMergerStart()
+    via [InternalsVisibleTo]. Mithril.WorldSim.Player + .Core give those tests
+    the world primitives they need to build a minimal composition.
+    All *.Module references stay build-order/deploy-only — they trigger
+    Directory.Build.targets to deploy 12 module DLLs into the shell's
+    bin/<cfg>/modules/ so the self-check sees the real full-install graph
+    (#365 Layer 2 guard).
   -->
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Mithril.Shell\Mithril.Shell.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Mithril.Shell\Mithril.Shell.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.WorldSim.Player\Mithril.WorldSim.Player.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.WorldSim.Core\Mithril.WorldSim.Core.csproj" />
     <ProjectReference Include="..\..\src\Arwen.Module\Arwen.Module.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\Bilbo.Module\Bilbo.Module.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\Celebrimbor.Module\Celebrimbor.Module.csproj" ReferenceOutputAssembly="false" />

--- a/tests/Mithril.Shell.Tests/WorldMergerStartCompositionTests.cs
+++ b/tests/Mithril.Shell.Tests/WorldMergerStartCompositionTests.cs
@@ -1,6 +1,10 @@
+using System.IO;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Mithril.Shared.Game;
+using Mithril.Shared.Settings;
+using Mithril.Shell;
 using Mithril.Shell.DependencyInjection;
 using Mithril.WorldSim;
 using Mithril.WorldSim.Player;
@@ -50,6 +54,60 @@ public sealed class WorldMergerStartCompositionTests
 
         var after = services.Count(d => d.ServiceType == typeof(IHostedService));
         after.Should().Be(before + 1, "AddWorldMergerStart adds exactly one hosted-service descriptor");
+    }
+
+    /// <summary>
+    /// Structural-invariant test: after <c>AddMithrilApp</c>, the LAST
+    /// <see cref="IHostedService"/> descriptor in the collection is
+    /// <see cref="WorldMergerStartHostedService"/>. The promise of
+    /// <c>AddMithrilApp</c> is that the trailing-registration invariant
+    /// is enforced structurally rather than by call-site discipline — a
+    /// future regression where a contributor inadvertently adds
+    /// <c>.AddHostedService&lt;X&gt;()</c> AFTER <c>.AddWorldMergerStart()</c>
+    /// inside <c>AddMithrilApp</c> would silently restore the
+    /// merger-vs-registration race this PR eliminated. This test pins the
+    /// invariant against <c>AddMithrilApp</c>'s actual composition, not
+    /// against the <c>AddX().AddWorldMergerStart()</c> pattern in isolation.
+    /// </summary>
+    [Fact]
+    public void AddMithrilApp_appends_WorldMergerStartHostedService_as_the_last_hosted_service()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "mithril-696-trailing-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var options = MakeStubOptions(tempDir);
+            var services = new ServiceCollection();
+            services.AddMithrilApp(options);
+
+            var lastHostedService = services
+                .Where(d => d.ServiceType == typeof(IHostedService))
+                .Last();
+            lastHostedService.ImplementationType.Should().Be(
+                typeof(WorldMergerStartHostedService),
+                "AddMithrilApp must keep AddWorldMergerStart() the trailing registration so the merger drain starts after every other hosted service's StartAsync has completed");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static ShellCompositionOptions MakeStubOptions(string tempDir)
+    {
+        var shellStore = new JsonSettingsStore<ShellSettings>(
+            Path.Combine(tempDir, "shell.json"), ShellSettingsJsonContext.Default.ShellSettings);
+        return new ShellCompositionOptions(
+            PreferencesPath: Path.Combine(tempDir, "preferences.json"),
+            ShellStore: shellStore,
+            ShellSettings: new ShellSettings(),
+            GameConfig: new GameConfig(),
+            LogDir: Path.Combine(tempDir, "logs"),
+            PerfDir: Path.Combine(tempDir, "perf"),
+            CharactersRootDir: Path.Combine(tempDir, "characters"),
+            ReferenceCacheDir: Path.Combine(tempDir, "ref"),
+            CommunityCalibrationCacheDir: Path.Combine(tempDir, "cal"),
+            IconCacheDir: Path.Combine(tempDir, "icons"));
     }
 
     /// <summary>

--- a/tests/Mithril.Shell.Tests/WorldMergerStartCompositionTests.cs
+++ b/tests/Mithril.Shell.Tests/WorldMergerStartCompositionTests.cs
@@ -1,0 +1,280 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mithril.Shell.DependencyInjection;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #696 Call 2 — the merger-vs-registration race fix. These tests exercise the
+/// trailing-registration invariant: a worker's bus subscription, attached during
+/// the chain's hosted-service <c>StartAsync</c> phase, MUST be in place before
+/// any world's merger drains its producers.
+///
+/// <para>The invariant is enforced structurally by appending
+/// <c>AddWorldMergerStart()</c> as the LAST registration inside
+/// <c>AddMithrilApp</c>. The hosted-services contract guarantees
+/// registration-order <c>StartAsync</c> dispatch, so the trailing
+/// <c>WorldMergerStartHostedService</c> runs after every other hosted service
+/// has completed its registration work. Its <c>StartAsync</c> fires
+/// <see cref="IWorld.StartMerger"/> on each registered world WITHOUT awaiting
+/// completion (the returned task is the long-running drain, owned by the
+/// hosted service until <c>StopAsync</c>).</para>
+///
+/// <para>These tests use friend-assembly access (via the <c>InternalsVisibleTo</c>
+/// declared on <c>Mithril.Shell</c>) to call <c>AddWorldMergerStart()</c>
+/// directly against a partial stack — that capability is itself part of the
+/// #696 acceptance scope: it lets tests compose
+/// <c>AddPlayerWorld() + AddWorldMergerStart()</c> for "single world with a
+/// live merger" scenarios that don't drag in the entire shell graph.</para>
+/// </summary>
+public sealed class WorldMergerStartCompositionTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 1, 1, 12, 0, sec, TimeSpan.Zero);
+
+    /// <summary>
+    /// Friend-assembly smoke test: <c>AddWorldMergerStart()</c> appends a
+    /// hosted service to the collection. If the friend-assembly access is
+    /// broken, this file doesn't even compile.
+    /// </summary>
+    [Fact]
+    public void AddWorldMergerStart_appends_hosted_service_descriptor()
+    {
+        var services = new ServiceCollection();
+        var before = services.Count(d => d.ServiceType == typeof(IHostedService));
+
+        services.AddWorldMergerStart();
+
+        var after = services.Count(d => d.ServiceType == typeof(IHostedService));
+        after.Should().Be(before + 1, "AddWorldMergerStart adds exactly one hosted-service descriptor");
+    }
+
+    /// <summary>
+    /// Behavioural ordering test: when <c>AddWorldMergerStart</c> trails another
+    /// hosted service in the registration order, the merger drain must not begin
+    /// until that earlier hosted service's <c>StartAsync</c> has returned.
+    ///
+    /// <para>Verified by attaching a bus subscription from the earlier hosted
+    /// service AND signalling a TaskCompletionSource at the end of its
+    /// <c>StartAsync</c>. The producer's first <c>MoveNextAsync</c> asserts the
+    /// TCS is already completed — i.e., the merger genuinely waited.</para>
+    /// </summary>
+    [Fact]
+    public async Task Merger_does_not_drain_producers_before_earlier_hosted_services_complete_StartAsync()
+    {
+        var subscriberStarted = new TaskCompletionSource();
+        var observed = new List<string>();
+
+        var stubFrames = new[]
+        {
+            new Frame<string>(Ts(1), "f1"),
+            new Frame<string>(Ts(2), "f2"),
+        };
+        var producer = new OrderingStubProducer<string>(subscriberStarted.Task, stubFrames);
+
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(new RecordingFolder<string>(observed));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(world);
+        services.AddSingleton<IWorld>(sp => sp.GetRequiredService<PlayerWorld>());
+        // Earlier hosted service: subscribes to the world's bus (the "attach a
+        // subscriber before frames flow" contract) and signals when its
+        // StartAsync returns. Registered BEFORE AddWorldMergerStart so the
+        // hosted-service runner invokes its StartAsync first.
+        services.AddSingleton(new BusSubscriberHosted(world, subscriberStarted));
+        services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<BusSubscriberHosted>());
+        services.AddWorldMergerStart();
+
+        await using var sp = services.BuildServiceProvider();
+        var lifetime = new TestHostLifetime(sp);
+        await lifetime.StartAsync(CancellationToken.None);
+
+        // Drain happens on a background task — give the merger a brief window
+        // to see all the stub frames.
+        await producer.AllFramesConsumed.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await lifetime.StopAsync(CancellationToken.None);
+
+        producer.SubscriberWasReadyAtFirstFetch.Should().BeTrue(
+            "the producer must not be asked to enumerate until the earlier hosted service's StartAsync has completed");
+        observed.Should().Equal("f1", "f2");
+    }
+
+    /// <summary>
+    /// Subscriber test: a hosted service registered earlier in the chain
+    /// subscribes to the world's bus DURING its StartAsync. The merger then
+    /// drains the producer; the subscriber receives every frame.
+    /// </summary>
+    [Fact]
+    public async Task Bus_subscriber_attached_during_chain_receives_frames_from_session_start_replay()
+    {
+        var subscriberStarted = new TaskCompletionSource();
+        var observed = new List<string>();
+
+        var stubFrames = new[]
+        {
+            new Frame<string>(Ts(10), "replay-1"),
+            new Frame<string>(Ts(11), "replay-2"),
+            new Frame<string>(Ts(12), "replay-3"),
+        };
+        var producer = new OrderingStubProducer<string>(subscriberStarted.Task, stubFrames);
+
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(new RecordingFolder<string>(observed));
+
+        var receivedOnBus = new List<string>();
+        var services = new ServiceCollection();
+        services.AddSingleton(world);
+        services.AddSingleton<IWorld>(sp => sp.GetRequiredService<PlayerWorld>());
+        services.AddSingleton(new BusSubscriberHosted(world, subscriberStarted, receivedOnBus));
+        services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<BusSubscriberHosted>());
+        services.AddWorldMergerStart();
+
+        await using var sp = services.BuildServiceProvider();
+        var lifetime = new TestHostLifetime(sp);
+        await lifetime.StartAsync(CancellationToken.None);
+        await producer.AllFramesConsumed.WaitAsync(TimeSpan.FromSeconds(5));
+        await lifetime.StopAsync(CancellationToken.None);
+
+        // The bus subscription attached during the chain's StartAsync phase
+        // must see every replay frame.
+        receivedOnBus.Should().Equal("replay-1", "replay-2", "replay-3");
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Producer that exposes its first-fetch readiness signal so a test can
+    /// assert "did this producer wait for the earlier hosted services."
+    /// </summary>
+    private sealed class OrderingStubProducer<T> : IFrameProducer<T>
+    {
+        private readonly Task _subscriberStarted;
+        private readonly Frame<T>[] _frames;
+        private readonly TaskCompletionSource _allConsumed = new();
+
+        public OrderingStubProducer(Task subscriberStarted, params Frame<T>[] frames)
+        {
+            _subscriberStarted = subscriberStarted;
+            _frames = frames;
+        }
+
+        public int Priority => 0;
+        public bool SubscriberWasReadyAtFirstFetch { get; private set; }
+        public Task AllFramesConsumed => _allConsumed.Task;
+
+        public async IAsyncEnumerable<Frame<T>> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            // First fetch — snapshot whether the earlier hosted service's
+            // StartAsync has completed by the time the merger asks us to
+            // enumerate. This is the load-bearing assertion: if the merger
+            // raced ahead of the chain's StartAsync, this would be false.
+            SubscriberWasReadyAtFirstFetch = _subscriberStarted.IsCompletedSuccessfully;
+
+            for (int i = 0; i < _frames.Length; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return _frames[i];
+            }
+            _allConsumed.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Hosted service that subscribes to the world's bus during its
+    /// <c>StartAsync</c> and signals a TCS so the producer can observe its
+    /// completion. If <paramref name="observed"/> is supplied, every change
+    /// event flowing on the bus is recorded into it.
+    /// </summary>
+    private sealed class BusSubscriberHosted : IHostedService
+    {
+        private readonly PlayerWorld _world;
+        private readonly TaskCompletionSource _started;
+        private readonly List<string>? _observed;
+        private IDisposable? _sub;
+
+        public BusSubscriberHosted(PlayerWorld world, TaskCompletionSource started, List<string>? observed = null)
+        {
+            _world = world;
+            _started = started;
+            _observed = observed;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_observed is not null)
+            {
+                _sub = _world.Bus.Subscribe<StringFolderChange>(f =>
+                {
+                    lock (_observed) _observed.Add(f.Payload.Value);
+                });
+            }
+            _started.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _sub?.Dispose();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Folder that emits a typed change event for every applied frame, so the
+    /// bus has something concrete to deliver to the BusSubscriberHosted's
+    /// subscription. Records the payload into the supplied list for the
+    /// non-bus ordering assertion.
+    /// </summary>
+    private sealed class RecordingFolder<T> : IFolder<T>
+    {
+        private readonly List<string> _applied;
+        public RecordingFolder(List<string> applied) => _applied = applied;
+
+        public IReadOnlyList<IChangeEvent> Apply(Frame<T> frame, IWorldClock clock)
+        {
+            lock (_applied) _applied.Add(frame.Payload?.ToString() ?? "");
+            return new IChangeEvent[] { new StringFolderChange(frame.Payload?.ToString() ?? "") };
+        }
+    }
+
+    private sealed record StringFolderChange(string Value) : IChangeEvent;
+
+    /// <summary>
+    /// Minimal hosted-services runner — calls <c>StartAsync</c> on every
+    /// registered <see cref="IHostedService"/> in registration order, awaits
+    /// each completion, then mirrors the symmetric <c>StopAsync</c> ordering
+    /// during teardown. Lets these tests exercise the hosted-services contract
+    /// without standing up a full generic <c>IHost</c> + its scopes/lifetime
+    /// machinery.
+    /// </summary>
+    private sealed class TestHostLifetime
+    {
+        private readonly IReadOnlyList<IHostedService> _services;
+
+        public TestHostLifetime(IServiceProvider sp)
+            => _services = sp.GetServices<IHostedService>().ToArray();
+
+        public async Task StartAsync(CancellationToken ct)
+        {
+            foreach (var s in _services)
+                await s.StartAsync(ct).ConfigureAwait(false);
+        }
+
+        public async Task StopAsync(CancellationToken ct)
+        {
+            for (int i = _services.Count - 1; i >= 0; i--)
+            {
+                try { await _services[i].StopAsync(ct).ConfigureAwait(false); }
+                catch { /* shutdown is best-effort in this fixture */ }
+            }
+        }
+    }
+}

--- a/tests/Mithril.WorldSim.Chat.Tests/ChatWorldTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/ChatWorldTests.cs
@@ -175,6 +175,6 @@ public sealed class ChatWorldTests
 
         var folderAct = () => world.RegisterFolder(new RecordingFolder<RawLogLine>());
         folderAct.Should().Throw<InvalidOperationException>()
-            .WithMessage("*Cannot register*after StartAsync*");
+            .WithMessage("*Cannot register*after StartMerger*");
     }
 }

--- a/tests/Mithril.WorldSim.Chat.Tests/ChatWorldTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/ChatWorldTests.cs
@@ -32,7 +32,7 @@ public sealed class ChatWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         folder.Applied.Select(a => a.Frame.Payload.Line).Should().Equal(
             "26-05-19 21:00:01\tone",
@@ -65,7 +65,7 @@ public sealed class ChatWorldTests
         using var _sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         modeChanges.Should().HaveCount(1);
         modeChanges[0].Payload.From.Should().Be(WorldMode.Replaying);
@@ -106,7 +106,7 @@ public sealed class ChatWorldTests
         using var sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         modeChanges.Should().BeEmpty();
         world.Clock.Mode.Should().Be(WorldMode.Live);
@@ -136,7 +136,7 @@ public sealed class ChatWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         session.Current.Should().NotBeNull();
         session.Current!.Server.Should().Be("Laeth");
@@ -171,7 +171,7 @@ public sealed class ChatWorldTests
         world.RegisterProducer(producer);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         var folderAct = () => world.RegisterFolder(new RecordingFolder<RawLogLine>());
         folderAct.Should().Throw<InvalidOperationException>()

--- a/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
@@ -361,7 +361,7 @@ public sealed class PlayerWorldTests
 
         var folderAct = () => world.RegisterFolder(new RecordingFolder<string>());
         folderAct.Should().Throw<InvalidOperationException>()
-            .WithMessage("*Cannot register*after StartAsync*");
+            .WithMessage("*Cannot register*after StartMerger*");
 
         var producerAct = () => world.RegisterProducer(new StubFrameProducer<int>(modeAware: false));
         producerAct.Should().Throw<InvalidOperationException>();

--- a/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
@@ -27,7 +27,7 @@ public sealed class PlayerWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         folder.Applied.Select(a => a.Frame.Payload).Should().Equal("a", "b", "c");
         folder.Applied.Select(a => a.ClockNow).Should().Equal(Ts(1), Ts(2), Ts(3));
@@ -55,7 +55,7 @@ public sealed class PlayerWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         folder.Applied.Select(x => x.Frame.Payload).Should().Equal("a1", "b2", "a3", "b4");
     }
@@ -82,7 +82,7 @@ public sealed class PlayerWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         // Within the same timestamp: every priority-0 frame fires before any
         // priority-5 frame. Within a single producer the producer's own
@@ -111,7 +111,7 @@ public sealed class PlayerWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         folder.Applied.Select(x => x.Frame.Payload).Should().Equal("first", "second");
     }
@@ -132,7 +132,7 @@ public sealed class PlayerWorldTests
         world.RegisterFolder(folder);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         world.Clock.Mode.Should().Be(WorldMode.Live);
         folder.Applied.Single().Mode.Should().Be(WorldMode.Live);
@@ -154,7 +154,7 @@ public sealed class PlayerWorldTests
         world.RegisterProducer(producer);
         world.RegisterFolder(folder);
 
-        var run = world.StartAsync(cts.Token);
+        var run = world.StartMerger(cts.Token);
         try { await run; }
         catch (OperationCanceledException) { /* expected */ }
 
@@ -186,7 +186,7 @@ public sealed class PlayerWorldTests
         producer.Complete();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         // World caught up at the timestamp of the last replay frame (Ts(11)) —
         // the mode flip is observed between dispatches, so the bus emission's
@@ -228,7 +228,7 @@ public sealed class PlayerWorldTests
         using var sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         world.Clock.Mode.Should().Be(WorldMode.Live);
         modeChanges.Should().BeEmpty();
@@ -258,7 +258,7 @@ public sealed class PlayerWorldTests
         using var sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         modeChanges.Should().BeEmpty();
         world.Clock.Mode.Should().Be(WorldMode.Live);
@@ -297,7 +297,7 @@ public sealed class PlayerWorldTests
         using var s2 = world.Bus.Subscribe<SecondDomainFrame>(f => observed.Add("second:" + f.Payload.Tag));
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         // First composer fires on TriggerEvent → emits FirstDomainFrame.
         // Second composer (subscribed to FirstDomainFrame) cascades →
@@ -328,7 +328,7 @@ public sealed class PlayerWorldTests
         using var s3 = world.Bus.Subscribe<FirstDomainFrame>(f => observed.Add("C:" + f.Payload.Tag));
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         observed.Should().Equal("A:ping", "B:ping", "C:ping");
     }
@@ -357,7 +357,7 @@ public sealed class PlayerWorldTests
         world.RegisterProducer(producer);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         var folderAct = () => world.RegisterFolder(new RecordingFolder<string>());
         folderAct.Should().Throw<InvalidOperationException>()

--- a/tests/Mithril.WorldSim.Player.Tests/WorldClockTickIntegrationTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/WorldClockTickIntegrationTests.cs
@@ -35,7 +35,7 @@ public sealed class WorldClockTickIntegrationTests
         var (world, producer) = BuildWorld(stream);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         world.Clock.Now.Should().Be(Ts(3));
         world.Clock.Frame.Should().Be(3L);
@@ -61,7 +61,7 @@ public sealed class WorldClockTickIntegrationTests
         using var _sub = world.Bus.Subscribe<CalendarTimeAdvanced>(ticks.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         ticks.Should().HaveCount(3);
         ticks.Select(t => t.Payload.Now).Should().Equal(Ts(1), Ts(2), Ts(3));
@@ -91,7 +91,7 @@ public sealed class WorldClockTickIntegrationTests
         using var _m = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         ticks.Should().HaveCount(3);
         ticks[0].Payload.Should().Be(new CalendarTimeAdvanced(Ts(10), WorldMode.Replaying));
@@ -118,7 +118,7 @@ public sealed class WorldClockTickIntegrationTests
         using var _sub = world.Bus.Subscribe<CalendarTimeAdvanced>(ticks.Add);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await world.StartAsync(cts.Token);
+        await world.StartMerger(cts.Token);
 
         ticks.Should().BeEmpty();
         world.Clock.Frame.Should().Be(0L);

--- a/tests/Samwise.Tests/TestHelpers.cs
+++ b/tests/Samwise.Tests/TestHelpers.cs
@@ -45,7 +45,7 @@ internal sealed class FakePlayerWorld : IPlayerWorld
         throw new NotSupportedException("FakePlayerWorld is read-only.");
     public void RegisterComposer(IComposer composer) =>
         throw new NotSupportedException("FakePlayerWorld is read-only.");
-    public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+    public Task StartMerger(CancellationToken ct) => Task.CompletedTask;
 }
 
 internal sealed class InMemoryCropConfig : ICropConfigStore


### PR DESCRIPTION
## Summary

Implements [Call 2](https://github.com/moumantai-gg/mithril/blob/main/docs/world-simulator.md#call-2--ihostedservice-ordering-invariant--addmithrilapp-composition) of the world-sim post-#642 ratifications: a trailing-registered `IHostedService` starts each world's merger drain *after* every other hosted service's `StartAsync` has completed. The pre-existing race between `BackgroundService.ExecuteAsync` (thread-pool scheduled, non-deterministic timing) and subsequent registration services attaching bus subscribers is gone — replaced by structural enforcement via `AddMithrilApp`.

- Renamed `IWorld.StartAsync(ct)` → `IWorld.StartMerger(ct)` with a contract that explicitly distinguishes the registration-acceptance phase from the merger-running phase.
- New `internal sealed class Mithril.Shell.DependencyInjection.WorldMergerStartHostedService : IHostedService` injects `IEnumerable<IWorld>`, fires `StartMerger` on each from its `StartAsync` (returning `Task.CompletedTask` immediately), and awaits drain with `Task.WhenAll(...).WaitAsync(stopToken)` on `StopAsync`. Deliberately NOT a `BackgroundService` (issue #696 rationale).
- Deleted `PlayerWorldHostedService` + `ChatWorldHostedService` (the two `BackgroundService` shims). `AddPlayerWorld()` / `AddChatWorld()` now only register singletons. Each world also registers AS `IWorld` so the merger-start service's `IEnumerable<IWorld>` resolution picks them up.
- New `public static IServiceCollection ShellComposition.AddMithrilApp(this IServiceCollection, ShellCompositionOptions o)` = `AddMithrilShell(o).AddWorldMergerStart()`. `Program.cs` + `SelfCheck.cs` now call `AddMithrilApp`; the trailing-registration invariant is enforced structurally, not by call-site discipline.
- `AddWorldMergerStart` is `internal static`. Friend access via `[InternalsVisibleTo("Mithril.Shell.Tests")]` declared in `Mithril.Shell.csproj` so the lifecycle tests can compose partial stacks with a live merger. Picked over a parallel `AddWorldMergerStartForTesting` extension to prevent silent prod/test drift.
- Deleted the directionally-wrong comment block at `ShellComposition.cs:65-76` that claimed `AddMithrilGameState`'s registration hosted service runs strictly before `PlayerWorldHostedService` (opposite of actual; bug independent of this issue, fix rides per the issue's framing).
- Renamed the 7 test files (28 sites) that called `world.StartAsync` and the 3 `IWorld` fakes (`WordOfPowerViewTests.FakeWorld`, `InventoryViewTests.FakeWorld`, `Samwise FakePlayerWorld`).

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors; warnings-as-errors enforced)
- [x] `dotnet test Mithril.slnx` — 4036 tests pass (all suites: `Mithril.WorldSim.Player.Tests` 30, `Mithril.WorldSim.Chat.Tests` 35, `Mithril.GameState.Tests` 409, `Mithril.Shell.Tests` 5, full module suite green)
- [x] New `WorldMergerStartCompositionTests` (`tests/Mithril.Shell.Tests/`) — 3 tests:
  - `AddWorldMergerStart_appends_hosted_service_descriptor` — smoke + friend-assembly compile check
  - `Merger_does_not_drain_producers_before_earlier_hosted_services_complete_StartAsync` — behavioural ordering proof (producer's first MoveNext sees an already-completed TCS set by the earlier hosted service's StartAsync)
  - `Bus_subscriber_attached_during_chain_receives_frames_from_session_start_replay` — bus subscription attached during chain receives every replay frame in order
- [x] `ShellSelfCheckGuardTests.Real_full_module_graph_resolves_with_no_DI_cycle` — out-of-process #365 guard now exercises the full `AddMithrilApp` composition (since `SelfCheck.cs` switched to `AddMithrilApp(o)`); validates the trailing-registered service slots in cleanly under the DI-cycle guard.

## Doc follow-on

`docs/world-simulator.md` §Call 2 still says "Implementation status: pending in #696." That status flips to "delivered" after merge — leaving the doc edit for a follow-on commit (or an in-PR amend if reviewers prefer) so the PR's diff stays focused on the structural change.

Closes #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
