### PR TITLE
feat(world-sim): eager-always state subscription + mode-gated sinks (Call 1 + Call 3)

### DIFF
--- a/src/Arwen.Module/State/FavorIngestionService.cs
+++ b/src/Arwen.Module/State/FavorIngestionService.cs
@@ -6,7 +6,6 @@ using Mithril.GameState.Gifting;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
-using Mithril.Shared.Modules;
 using Mithril.Shared.Settings;
 using Microsoft.Extensions.Hosting;
 

--- a/src/Arwen.Module/State/FavorIngestionService.cs
+++ b/src/Arwen.Module/State/FavorIngestionService.cs
@@ -91,7 +91,6 @@ public sealed class FavorIngestionService : BackgroundService
     private readonly IActiveCharacterService _activeChar;
     private readonly IGiftSignalService _giftSignal;
     private readonly IDiagnosticsSink? _diag;
-    private readonly ModuleGate _gate;
     private ILogSubscription? _subscription;
     private IDisposable? _giftSubscription;
     private Dispatcher? _dispatcher;
@@ -104,7 +103,6 @@ public sealed class FavorIngestionService : BackgroundService
         PerCharacterView<ArwenFavorState> favorView,
         IActiveCharacterService activeChar,
         SettingsAutoSaver<ArwenSettings> autoSaver,
-        ModuleGates gates,
         IGiftSignalService giftSignal,
         IDiagnosticsSink? diag = null)
     {
@@ -117,32 +115,36 @@ public sealed class FavorIngestionService : BackgroundService
         _giftSignal = giftSignal;
         _diag = diag;
         _ = autoSaver; // keep alive for PropertyChanged subscription
-        _gate = gates.For("arwen");
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Eager subscription attach per Call 1 / principle eager-always (#695):
+    /// both the L1 LocalPlayer pipe and the <see cref="IGiftSignalService"/>
+    /// React channel are wired up during the IHostedService chain's
+    /// <c>StartAsync</c>, before the trailing world-merger drain starts
+    /// (#702 / Call 2 ordering invariant). The Arwen module gate no longer
+    /// gates state subscription — gate-driven UI hydration remains
+    /// Arwen's own concern (today: none; Arwen tabs hydrate lazily from
+    /// the per-character view + L1-driven FavorState).
+    /// </summary>
+    public override Task StartAsync(CancellationToken cancellationToken)
     {
-        _diag?.Info("Arwen.Ingestion", "Waiting for module gate…");
-        await _gate.WaitAsync(stoppingToken).ConfigureAwait(false);
         _diag?.Info("Arwen.Ingestion",
-            "Gate opened — subscribing to L1 LocalPlayer pipe (favor snapshot verbs) and "
+            "Subscribing to L1 LocalPlayer pipe (favor snapshot verbs) and "
             + "IGiftSignalService (resolved gift events) for calibration");
 
         // Resolve UI dispatcher once. Headless/test contexts (no WPF App
-        // running) get Inline delivery — the production path always has a
-        // dispatcher because Arwen is Eager and the shell wires App before
-        // any module gate opens.
+        // running) get Inline delivery.
         _dispatcher = Application.Current?.Dispatcher;
         var delivery = _dispatcher is null
             ? DeliveryContext.Inline
             : DeliveryContext.Marshaled(_dispatcher);
 
         // GiftSignalService.Subscribe replays the full in-session event log
-        // to the new handler atomically under its own lock (#585 contract);
-        // attach order vs the L1 driver is therefore irrelevant. The handler
-        // fires on the signal service's L1 pump thread — we marshal onto
-        // the dispatcher so calibration mutations land on the same thread
-        // the L1 favor-snapshot path uses.
+        // to the new handler atomically under its own lock (#585 contract).
+        // The handler fires on the signal service's L1 pump thread — we
+        // marshal onto the dispatcher so calibration mutations land on the
+        // same thread the L1 favor-snapshot path uses.
         _giftSubscription = _giftSignal.Subscribe(OnGiftAccepted);
 
         _subscription = _driver.Subscribe<LocalPlayerLogLine>(
@@ -187,6 +189,11 @@ public sealed class FavorIngestionService : BackgroundService
                 // React channel. See type doc.
             });
 
+        return base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
         try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
         catch (OperationCanceledException) { /* expected on host stop */ }
         finally

--- a/src/Gandalf.Module/Services/TimerAlarmService.cs
+++ b/src/Gandalf.Module/Services/TimerAlarmService.cs
@@ -30,6 +30,7 @@ public sealed class TimerAlarmService : IDisposable
 
     private readonly UserTimerSource _source;
     private readonly GandalfSettings _settings;
+    private readonly IAudioPlaybackSink _audio;
     private readonly TimeProvider _time;
     private readonly IWorldClock? _worldClock;
     private readonly Dictionary<string, DateTimeOffset> _firedAt = new(StringComparer.Ordinal);
@@ -39,11 +40,13 @@ public sealed class TimerAlarmService : IDisposable
     public TimerAlarmService(
         UserTimerSource source,
         GandalfSettings settings,
+        IAudioPlaybackSink audio,
         TimeProvider? time = null,
         IPlayerWorld? playerWorld = null)
     {
         _source = source;
         _settings = settings;
+        _audio = audio;
         _time = time ?? TimeProvider.System;
         _worldClock = playerWorld?.Clock;
         _source.TimerReady += OnTimerReady;
@@ -75,7 +78,9 @@ public sealed class TimerAlarmService : IDisposable
             handle.Stop();
     }
 
-    private void OnTimerReady(object? sender, TimerReadyEventArgs e)
+    // internal for tests (Gandalf.Tests has InternalsVisibleTo); production
+    // dispatch goes through UserTimerSource.TimerReady subscribed in the ctor.
+    internal void OnTimerReady(object? sender, TimerReadyEventArgs e)
     {
         if (!_settings.AlarmEnabled) return;
         var key = e.Key;
@@ -86,10 +91,17 @@ public sealed class TimerAlarmService : IDisposable
         if (_snoozedUntil.TryGetValue(key, out var until) && until > now) return;
 
         _firedAt[key] = now;
+
+        // Call 3 / principle 12 — mode-gate the user-facing projection (audio
+        // playback + window flash). State derivation upstream of the
+        // projection (the _firedAt dedup write above) stays mode-agnostic so
+        // the next live-mode tick reuses the same suppression contract.
+        if (_worldClock?.Mode == WorldMode.Replaying) return;
+
         var soundPath = ResolveSoundPath(e, _settings);
         Dispatch(() =>
         {
-            var handle = AudioPlayer.Play(soundPath, (float)_settings.AlarmVolume, "gandalf");
+            var handle = _audio.Play(soundPath, (float)_settings.AlarmVolume, "gandalf");
             _playback[key] = handle;
             if (_settings.FlashWindow)
             {

--- a/src/Legolas.Module/Services/ItemCollectionTracker.cs
+++ b/src/Legolas.Module/Services/ItemCollectionTracker.cs
@@ -56,8 +56,9 @@ namespace Legolas.Services;
 /// <see cref="PlayerLogIngestionService"/> (which owns the
 /// area→calibration bridge + absolute <c>ProcessMapFx</c> placement +
 /// Motherlode coordinator wiring) to keep the correlator + collect-credit
-/// concern isolated. Both subscribe through the L1 driver and gate on the
-/// <c>"legolas"</c> module gate.</para>
+/// concern isolated. Both subscribe eagerly through the L1 driver during
+/// <c>StartAsync</c> (#695 Call 1); the legolas module gate no longer
+/// gates state subscription.</para>
 /// </summary>
 public sealed class ItemCollectionTracker : BackgroundService
 {
@@ -66,7 +67,6 @@ public sealed class ItemCollectionTracker : BackgroundService
     private readonly IInventoryView _inventoryView;
     private readonly ILogStreamDriver _driver;
     private readonly PlayerLogParser _parser;
-    private readonly ModuleGates _gates;
     private readonly SessionState _session;
     private readonly IReferenceDataService? _refData;
     private readonly IDiagnosticsSink? _diag;
@@ -81,7 +81,6 @@ public sealed class ItemCollectionTracker : BackgroundService
         IInventoryView inventoryView,
         ILogStreamDriver driver,
         PlayerLogParser parser,
-        ModuleGates gates,
         SessionState session,
         IReferenceDataService? refData = null,
         IDiagnosticsSink? diag = null,
@@ -90,7 +89,6 @@ public sealed class ItemCollectionTracker : BackgroundService
         _inventoryView = inventoryView;
         _driver = driver;
         _parser = parser;
-        _gates = gates;
         _session = session;
         _refData = refData;
         _diag = diag;

--- a/src/Legolas.Module/Services/ItemCollectionTracker.cs
+++ b/src/Legolas.Module/Services/ItemCollectionTracker.cs
@@ -105,24 +105,22 @@ public sealed class ItemCollectionTracker : BackgroundService
     }
 
     /// <summary>
-    /// Attach the <see cref="IInventoryView.Bus"/> subscriptions <b>before</b>
-    /// the host's <see cref="ExecuteAsync"/> pump spins up — and crucially
-    /// before the <c>"legolas"</c> module gate has any chance of holding back
-    /// the pump on a lazy module. <see cref="ViewEventBus.Subscribe"/> has no
-    /// replay-on-subscribe contract; any frame published before <c>Subscribe</c>
-    /// is lost to a subscriber that attaches later. Pre-#688/#606 the bus
-    /// subscriptions sat inside <see cref="ExecuteAsync"/> behind the gate-wait,
-    /// which for a lazy module means every inventory frame published before
-    /// first-tab activation would be lost — the exact race the
-    /// <c>InventoryItemAdded</c> + <c>InventoryStackChanged</c> credit relies on
-    /// not happening. Attaching here closes that window: the host's
-    /// <see cref="BackgroundService.StartAsync"/> contract guarantees we run
-    /// before any consumer can observe the service as "started," so by the time
-    /// any other hosted-service (or the world's merger) publishes a frame, our
-    /// subscriptions are already live. The <see cref="ILogStreamDriver"/>
-    /// subscription stays inside <see cref="ExecuteAsync"/> behind the gate —
-    /// the L1 driver's own <see cref="ReplayMode"/> semantics cover late-attach
-    /// and the FSM-touching collect handler must wait for the module gate.
+    /// Eager subscription attach per Call 1 / principle eager-always (#695):
+    /// both the <see cref="IInventoryView.Bus"/> subscriptions AND the L1
+    /// ProcessScreenText subscription wire up during <c>StartAsync</c>,
+    /// before the trailing world-merger drain starts (#702 / Call 2). The
+    /// legolas module gate no longer gates state subscription — pre-Call-1
+    /// the L1 subscribe sat inside <see cref="ExecuteAsync"/> behind
+    /// <c>gates.For("legolas").WaitAsync</c>, which on a lazy module
+    /// delayed the collect-credit path until first-tab activation. Now the
+    /// L1 subscribe joins the bus subscribes here so a session-start replay
+    /// drain reaches HandleItemCollected from the moment the host's chain
+    /// completes (#702 invariant: trailing-merger starts after every
+    /// other hosted service's <c>StartAsync</c> returns).
+    ///
+    /// <para><see cref="ViewEventBus.Subscribe"/> still has no
+    /// replay-on-subscribe contract; the attach-before-merger contract
+    /// from #702 is what guarantees no frames are missed.</para>
     /// </summary>
     public override Task StartAsync(CancellationToken cancellationToken)
     {
@@ -133,21 +131,16 @@ public sealed class ItemCollectionTracker : BackgroundService
         // consume the resolved view event downstream of that composition.
         _addedSub ??= _inventoryView.Bus.Subscribe<InventoryItemAdded>(OnInventoryAdded);
         _stackChangedSub ??= _inventoryView.Bus.Subscribe<InventoryStackChanged>(OnInventoryStackChanged);
-        return base.StartAsync(cancellationToken);
-    }
-
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        await _gates.For("legolas").WaitAsync(stoppingToken).ConfigureAwait(false);
 
         // Player.log collect channel — parses ProcessScreenText
         // (ImportantInfo, "<Mineral> collected!"). Mirrors the structural
         // shape PlayerLogIngestionService uses (LiveOnly + Marshaled +
         // Legolas.PlayerLog diagnostic category) so the two services share
-        // the same delivery semantics. Stays inside ExecuteAsync (post-gate)
-        // because the collect handler mutates SessionState (UI-bound surveys
-        // + LastLogEvent) — those mutations must wait for the lazy module
-        // to be active; the bus correlator side does not.
+        // the same delivery semantics. The collect handler mutates
+        // SessionState (UI-bound surveys + LastLogEvent); UI VMs hydrate
+        // lazily from the SessionState snapshot when the legolas tab is
+        // first activated, so the eager subscribe here doesn't depend on
+        // any prior UI construction.
         var dispatcher = Application.Current?.Dispatcher;
         _logSub = _driver.Subscribe<LocalPlayerLogLine>(
             envelope =>
@@ -170,6 +163,11 @@ public sealed class ItemCollectionTracker : BackgroundService
                 DiagnosticCategory = "Legolas.ItemCollect",
             });
 
+        return base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
         try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
         catch (OperationCanceledException) { /* expected on host stop */ }
         finally

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -91,7 +91,6 @@ public sealed class PlayerLogIngestionService : BackgroundService
     private readonly SessionState _session;
     private readonly MotherlodeMeasurementCoordinator _motherlode;
     private readonly LegolasSettings _settings;
-    private readonly ModuleGates _gates;
     private readonly IActiveCharacterService? _activeChar;
     private readonly PerCharacterStore<LegolasIngestionState>? _ingestionStore;
     private readonly IDiagnosticsSink? _diag;
@@ -120,7 +119,6 @@ public sealed class PlayerLogIngestionService : BackgroundService
         SessionState session,
         MotherlodeMeasurementCoordinator motherlode,
         LegolasSettings settings,
-        ModuleGates gates,
         IActiveCharacterService? activeChar = null,
         PerCharacterStore<LegolasIngestionState>? ingestionStore = null,
         IDiagnosticsSink? diag = null)
@@ -133,7 +131,6 @@ public sealed class PlayerLogIngestionService : BackgroundService
         _session = session;
         _motherlode = motherlode;
         _settings = settings;
-        _gates = gates;
         _activeChar = activeChar;
         _ingestionStore = ingestionStore;
         _diag = diag;
@@ -142,17 +139,26 @@ public sealed class PlayerLogIngestionService : BackgroundService
         _highWaterFlush.Elapsed += (_, _) => FlushHighWater();
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Eager subscription attach per Call 1 / principle eager-always (#695):
+    /// the area-bridge + map-fx + motherlode handlers wire up during
+    /// <c>StartAsync</c>, before the trailing world-merger drain starts
+    /// (#702 / Call 2). Legolas's three UI-hydration gates
+    /// (<c>AutoOverlayCoordinator</c>, <c>ForegroundFocusGate</c>,
+    /// <c>OverlayController</c>) remain gated by the legolas
+    /// <c>ModuleGate</c> — they install overlay windows + Win32
+    /// dispatcher hooks that genuinely depend on the module's view being
+    /// constructed.
+    /// </summary>
+    public override Task StartAsync(CancellationToken cancellationToken)
     {
-        await _gates.For("legolas").WaitAsync(stoppingToken).ConfigureAwait(false);
-
         // Resolve the persisted high-water for the active character (if any)
         // BEFORE we hand the value to the L1 driver — once Subscribe latches
         // SkipProcessedHighWater into its options bag a later character
         // switch can't change the threshold. The character-changed event
         // updates the in-memory write-side so persistence still tracks the
         // active character, but the driver's filter stays whatever was
-        // active at gate-open. See "Character-switch caveat" below.
+        // active at attach time. See "Character-switch caveat" below.
         var initialHighWater = ResolveInitialHighWater();
 
         // Area is seeded by the shared PlayerAreaTracker itself (one-shot,
@@ -256,6 +262,11 @@ public sealed class PlayerLogIngestionService : BackgroundService
         _diag?.Info("Legolas.PlayerLog",
             $"Subscribed to L1 driver (LocalPlayer pipe) — LiveOnly, high-water={initialHighWater}");
 
+        return base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
         // Park until the host stops. The L1 subscription runs its own pump
         // on a Task.Run; ExecuteAsync's job is to keep us alive long enough
         // to be disposed.

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -6,7 +6,6 @@ using Mithril.GameState.Areas;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
-using Mithril.Shared.Modules;
 using Microsoft.Extensions.Hosting;
 
 namespace Legolas.Services;
@@ -62,8 +61,11 @@ namespace Legolas.Services;
 /// subscription — <c>LiveOnly</c> serves both purposes once the tracker
 /// self-seeds.</para>
 ///
-/// <para>Gated on the <c>"legolas"</c> module gate — Legolas is a lazy
-/// module, so log work starts on first tab activation.</para>
+/// <para>Subscribes eagerly during <c>StartAsync</c> (#695 Call 1). The
+/// <c>"legolas"</c> module gate no longer gates state subscription; UI
+/// hydration (overlay windows, hotkeys) stays lazy under the three
+/// surviving UI-hydration gates (<c>AutoOverlayCoordinator</c>,
+/// <c>ForegroundFocusGate</c>, <c>OverlayController</c>).</para>
 ///
 /// <para><b>Containment.</b> The L1 driver wraps each handler invocation in
 /// try/catch + rate-limited Warn, retiring the per-service <c>_diag?.Warn</c>

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -174,6 +174,28 @@ public static class Program
             Boot($"modules discovered: {builder.Services.Count(d => d.ServiceType == typeof(IMithrilModule))}");
             host = builder.Build();
             Boot("host built");
+
+            // Construct the WPF Application BEFORE host.StartAsync().
+            //
+            // Under #695 Call 1 (eager-always state subscription) every
+            // ingestion service's StartAsync resolves Application.Current?.Dispatcher
+            // to bind the L1 driver's DeliveryContext.Marshaled — which means
+            // host.StartAsync() now reads Application.Current during the
+            // sequential hosted-service chain. If `new App()` runs AFTER
+            // host.StartAsync, every Marshaled-vs-Inline fallback silently
+            // selects Inline and L1 envelopes dispatch on the pump thread
+            // instead of the WPF dispatcher, violating the cross-thread
+            // ObservableCollection guarantee that #550 capability E was
+            // introduced to provide. The fix is structural: construct App
+            // here so the Dispatcher exists when the chain attaches its
+            // subscriptions. Queued dispatcher operations sit in the
+            // Application's queue until app.Run() starts the message loop
+            // below; the bounded log backlog drains promptly then.
+            Boot("creating App");
+            var app = new App();
+            app.Init(activateEvent, activateCts);
+            app.InitializeComponent();
+
             host.StartAsync().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
             Boot("host started");
@@ -206,21 +228,21 @@ public static class Program
                 if (eager) gates.For(module.Id).Open();
             }
 
-            // Create and run WPF application
-            Boot("creating App");
-            var app = new App();
-            app.Init(activateEvent, activateCts);
+            // App was constructed BEFORE host.StartAsync() above so the L1
+            // dispatcher resolves correctly during the chain. Wire up the
+            // host-dependent App fields now that host services are available.
             app.DeepLinkRouter = host.Services.GetRequiredService<IDeepLinkRouter>();
-            app.InitializeComponent();
 
             _ = new UiFontApplier(app, shellSettings);
 
             // Auto-start a perf-trace session before the shell view-model resolves
             // (which is what fires the first ActivateModule). Anything earlier than
-            // this — Velopack hooks, mutex, settings load, host.Build, eager-module
-            // gate opens — is still only captured by boot.log; the WPF-side hooks
-            // need Application.Current to attach, which only exists from the
-            // `new App()` above onward.
+            // this — Velopack hooks, mutex, settings load, host.Build, host.StartAsync,
+            // eager-module gate opens — is still only captured by boot.log; the
+            // WPF-side hooks need Application.Current to attach, which exists
+            // from the `new App()` above (now constructed before host.StartAsync
+            // so the L1 ingestion services see a non-null Dispatcher during
+            // their StartAsync per #695 Call 1).
             if (shellSettings.EnablePerfTrace && shellSettings.AutoStartPerfTrace)
             {
                 try { host.Services.GetRequiredService<PerfTracerHostedService>().Toggle(); }

--- a/src/Pippin.Module/State/GourmandIngestionService.cs
+++ b/src/Pippin.Module/State/GourmandIngestionService.cs
@@ -63,7 +63,6 @@ public sealed class GourmandIngestionService : BackgroundService
     private readonly GourmandStateService _stateService;
     private readonly PerCharacterView<GourmandState> _view;
     private readonly IDiagnosticsSink? _diag;
-    private readonly ModuleGate _gate;
     private ILogSubscription? _subscription;
 
     public GourmandIngestionService(
@@ -72,7 +71,6 @@ public sealed class GourmandIngestionService : BackgroundService
         GourmandStateMachine state,
         GourmandStateService stateService,
         PerCharacterView<GourmandState> view,
-        ModuleGates gates,
         IDiagnosticsSink? diag = null)
     {
         _driver = driver;
@@ -81,21 +79,24 @@ public sealed class GourmandIngestionService : BackgroundService
         _stateService = stateService;
         _view = view;
         _diag = diag;
-        _gate = gates.For("pippin");
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Eager subscription attach per Call 1 / principle eager-always (#695):
+    /// the active-character wait, persisted-state load, and L1 subscription
+    /// all happen during the IHostedService chain's <c>StartAsync</c>,
+    /// before the trailing world-merger drain starts (#702 / Call 2).
+    /// Pippin's module gate no longer gates state subscription.
+    /// </summary>
+    public override async Task StartAsync(CancellationToken cancellationToken)
     {
-        _diag?.Info("Pippin", "Waiting for module gate…");
-        await _gate.WaitAsync(stoppingToken).ConfigureAwait(false);
-        _diag?.Info("Pippin", "Gate opened — waiting for active character…");
+        _diag?.Info("Pippin", "Waiting for active character…");
+        await WaitForActiveCharacterAsync(cancellationToken).ConfigureAwait(false);
 
-        await WaitForActiveCharacterAsync(stoppingToken).ConfigureAwait(false);
-
-        try { await _stateService.LoadAsync(stoppingToken).ConfigureAwait(false); }
+        try { await _stateService.LoadAsync(cancellationToken).ConfigureAwait(false); }
         catch (Exception ex) { _diag?.Warn("Pippin", $"Failed to load state: {ex.Message}"); }
 
-        _diag?.Info("Pippin", "State hydrated — subscribing to L1 driver (LocalPlayer pipe)");
+        _diag?.Info("Pippin", "State hydrated — subscribing to L1 driver (LocalPlayer pipe) eagerly");
 
         // Seed the high-water from the freshly hydrated per-character state.
         // null = no prior session processed (first run / pre-#550 fresh state).
@@ -103,6 +104,12 @@ public sealed class GourmandIngestionService : BackgroundService
         // before handler invocation — restart-safe idempotence (#549 / #550
         // capability F). Pippin is the canonical demo of the pattern.
         var persistedHighWater = _view.Current?.LastProcessedSequence;
+
+        // Headless / no-Application contexts fall back to Inline delivery.
+        var dispatcher = Application.Current?.Dispatcher;
+        var deliveryContext = dispatcher is null
+            ? DeliveryContext.Inline
+            : DeliveryContext.Marshaled(dispatcher);
 
         // L0.5 (#532) eats the [ts] + LocalPlayer: envelope; the parser now
         // consumes LocalPlayerLogLine.Data directly (anchor dropped per the
@@ -140,11 +147,16 @@ public sealed class GourmandIngestionService : BackgroundService
             new LogSubscriptionOptions
             {
                 ReplayMode = ReplayMode.FromSessionStart,
-                DeliveryContext = DeliveryContext.Marshaled(Application.Current.Dispatcher),
+                DeliveryContext = deliveryContext,
                 SkipProcessedHighWater = persistedHighWater,
                 DiagnosticCategory = "Pippin.Ingestion",
             });
 
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
         // Park until the host stops. The L1 subscription runs its own pump
         // on a Task.Run; ExecuteAsync's job is to dispose it on shutdown.
         try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }

--- a/src/Pippin.Module/State/GourmandIngestionService.cs
+++ b/src/Pippin.Module/State/GourmandIngestionService.cs
@@ -82,24 +82,44 @@ public sealed class GourmandIngestionService : BackgroundService
     }
 
     /// <summary>
-    /// Eager subscription attach per Call 1 / principle eager-always (#695):
-    /// the active-character wait, persisted-state load, and L1 subscription
-    /// all happen during the IHostedService chain's <c>StartAsync</c>,
-    /// before the trailing world-merger drain starts (#702 / Call 2).
-    /// Pippin's module gate no longer gates state subscription.
+    /// Eager subscription attach per Call 1 / principle eager-always (#695).
+    /// The L1 subscription wires up during the IHostedService chain's
+    /// <c>StartAsync</c>, before the trailing world-merger drain starts
+    /// (#702 / Call 2). Pippin's module gate no longer gates state
+    /// subscription.
+    ///
+    /// <para><b>Non-blocking startup.</b> Pre-Call-1 this method awaited
+    /// <c>WaitForActiveCharacterAsync</c> inside <c>ExecuteAsync</c> — fine
+    /// because <c>ExecuteAsync</c> ran on the thread pool. Under Call 1 the
+    /// work moves into <c>StartAsync</c>, which the host awaits sequentially:
+    /// blocking here would hang the whole shell on a truly fresh install with
+    /// no persisted character. So we no longer wait. Persisted-state hydrate
+    /// runs only when <see cref="PerCharacterView{T}.Current"/> is already
+    /// populated (the common case — <c>ActiveCharacterService</c> initialises
+    /// from persistence in its ctor). On a fresh install the subscription
+    /// still attaches; the handler is null-safe to <c>_view.Current</c>, and
+    /// <see cref="GourmandStateMachine.Apply"/> is snapshot-replace (the
+    /// latest <c>FoodsConsumedReport</c> wins), so missing pre-character-pick
+    /// envelopes is benign.</para>
     /// </summary>
     public override async Task StartAsync(CancellationToken cancellationToken)
     {
-        _diag?.Info("Pippin", "Waiting for active character…");
-        await WaitForActiveCharacterAsync(cancellationToken).ConfigureAwait(false);
-
-        try { await _stateService.LoadAsync(cancellationToken).ConfigureAwait(false); }
-        catch (Exception ex) { _diag?.Warn("Pippin", $"Failed to load state: {ex.Message}"); }
-
-        _diag?.Info("Pippin", "State hydrated — subscribing to L1 driver (LocalPlayer pipe) eagerly");
+        if (_view.Current is not null)
+        {
+            try { await _stateService.LoadAsync(cancellationToken).ConfigureAwait(false); }
+            catch (Exception ex) { _diag?.Warn("Pippin", $"Failed to load state: {ex.Message}"); }
+            _diag?.Info("Pippin",
+                "State hydrated for active character — subscribing to L1 driver (LocalPlayer pipe) eagerly");
+        }
+        else
+        {
+            _diag?.Info("Pippin",
+                "No persisted active character — subscribing to L1 driver eagerly; hydrate deferred to next session");
+        }
 
         // Seed the high-water from the freshly hydrated per-character state.
-        // null = no prior session processed (first run / pre-#550 fresh state).
+        // null = no prior session processed (first run / pre-#550 fresh state)
+        // OR no persisted active character (fresh install pre-character-pick).
         // The driver drops every envelope whose Sequence is <= this value
         // before handler invocation — restart-safe idempotence (#549 / #550
         // capability F). Pippin is the canonical demo of the pattern.
@@ -181,26 +201,4 @@ public sealed class GourmandIngestionService : BackgroundService
         base.Dispose();
     }
 
-    private async Task WaitForActiveCharacterAsync(CancellationToken ct)
-    {
-        if (_view.Current is not null) return;
-        var tcs = new TaskCompletionSource();
-        void Handler(object? _, EventArgs __)
-        {
-            if (_view.Current is not null) tcs.TrySetResult();
-        }
-        _view.CurrentChanged += Handler;
-        try
-        {
-            if (_view.Current is not null) return;
-            using (ct.Register(() => tcs.TrySetCanceled(ct)))
-            {
-                await tcs.Task.ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            _view.CurrentChanged -= Handler;
-        }
-    }
 }

--- a/src/Samwise.Module/Alarms/AlarmService.cs
+++ b/src/Samwise.Module/Alarms/AlarmService.cs
@@ -176,6 +176,13 @@ public sealed class AlarmService : IDisposable
 
     private void Fire(ActiveAlarm alarm, PlotStage stage, StageAlarmRule rule)
     {
+        // Call 3 / principle 12 — mode-gate the user-facing projection (audio
+        // playback, window flash, AlarmTriggered event consumed by toast/inbox
+        // UIs). State derivation upstream of this method (the _firedAt /
+        // _snoozedUntil writes in OnPlotChanged) stays mode-agnostic so the
+        // first Live tick after a Replaying drain sees a coherent dedup state.
+        if (_worldClock?.Mode == WorldMode.Replaying) return;
+
         Dispatch(() =>
         {
             TryRouteToChannel(stage, rule, alarm.Key, out _);

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -79,7 +79,9 @@ public sealed class GardenIngestionService : BackgroundService
     private readonly GardenStateMachine _state;
     private readonly GardenStateService _stateService;
     private readonly IDiagnosticsSink? _diag;
-    private readonly ModuleGate _gate;
+    private ILogSubscription? _logSub;
+    private IDisposable? _invSub;
+    private IDisposable? _skillSub;
 
     // These are pulled into the ctor so DI actually constructs them.
     // They attach to events inside their own ctors, so holding references here
@@ -94,7 +96,6 @@ public sealed class GardenIngestionService : BackgroundService
         AlarmService alarms,
         GrowthCalibrationService calibration,
         SettingsAutoSaver<SamwiseSettings> autoSaver,
-        ModuleGates gates,
         IDiagnosticsSink? diag = null)
     {
         _driver = driver;
@@ -107,7 +108,6 @@ public sealed class GardenIngestionService : BackgroundService
         _ = alarms;       // subscribes to state.PlotChanged in ctor
         _ = calibration;  // subscribes to state.PlotChanged in ctor
         _ = autoSaver;    // subscribes to SamwiseSettings.PropertyChanged in ctor
-        _gate = gates.For("samwise");
 
         if (diag is not null)
         {
@@ -116,11 +116,20 @@ public sealed class GardenIngestionService : BackgroundService
         }
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Eager subscription attach per Call 1 / principle eager-always (#695).
+    /// The persisted-state hydrate + the three subscriptions (inventory,
+    /// skill, L1 driver) all complete during the IHostedService chain's
+    /// <c>StartAsync</c>, before the trailing world-merger drain starts
+    /// (#702 / Call 2 ordering invariant). Samwise was already Eager so
+    /// the gate-open at module-init opened immediately in production —
+    /// the retirement here is a structural cleanup that makes the
+    /// no-frames-missed contract uniform across Samwise + the lazy
+    /// modules.
+    /// </summary>
+    public override async Task StartAsync(CancellationToken cancellationToken)
     {
-        _diag?.Info("Samwise", "Waiting for module gate…");
-        await _gate.WaitAsync(stoppingToken).ConfigureAwait(false);
-        _diag?.Info("Samwise", "Gate opened — loading persisted state and subscribing to L1 driver");
+        _diag?.Info("Samwise", "Loading persisted state and subscribing to L1 driver (eager attach)");
 
         // Restore previous session before we start applying new events.
         // HydrateCharacter must run on the UI thread: it raises PlotChanged for each
@@ -129,7 +138,7 @@ public sealed class GardenIngestionService : BackgroundService
         long persistedHighWater = 0L;
         try
         {
-            var (loaded, highWater) = await _stateService.LoadAllAsync(stoppingToken).ConfigureAwait(false);
+            var (loaded, highWater) = await _stateService.LoadAllAsync(cancellationToken).ConfigureAwait(false);
             persistedHighWater = highWater;
             DispatchHydrate(() =>
             {
@@ -142,11 +151,8 @@ public sealed class GardenIngestionService : BackgroundService
         catch (Exception ex) { _diag?.Warn("Samwise", $"Failed to load state: {ex.Message}"); }
 
         // Inventory add/delete events are sourced from the shared IInventoryService
-        // so Samwise picks up the same canonical map as Arwen, regardless of how
-        // late this gate opens. Subscribe replays the current map contents
-        // synchronously on this thread before going live, closing the race
-        // where session-replay AddItem events fired before this gate opened
-        // (and a plain += handler would have permanently missed them).
+        // so Samwise picks up the same canonical map as Arwen. Subscribe replays
+        // the current map contents synchronously on this thread before going live.
         //
         // This is a SERVICE-event consumer (in-process), NOT an L1 log
         // stream — the L1 high-water filter does not apply here. The inventory
@@ -155,7 +161,7 @@ public sealed class GardenIngestionService : BackgroundService
         // bridge does for the Player.log path, so PlotChanged → bound
         // ObservableCollection stays single-threaded.
 #pragma warning disable CS0618 // back-compat shim use during the #602 → #659 migration window
-        var subscription = _inventory.Subscribe(OnInventoryEvent);
+        _invSub = _inventory.Subscribe(OnInventoryEvent);
 #pragma warning restore CS0618
 
         // Gardening XP arrival is the harvest-confirmation discriminator
@@ -175,7 +181,7 @@ public sealed class GardenIngestionService : BackgroundService
         // Self-marshal via DispatchInventory for the same reason: the
         // GardenStateMachine.Apply path raises PlotChanged → bound
         // ObservableCollection which has UI-thread affinity.
-        var skillSubscription = _skillState.SubscribeChanges(OnSkillChange);
+        _skillSub = _skillState.SubscribeChanges(OnSkillChange);
 
         // L1 driver subscription for the Player.log payloads Samwise still owns
         // (everything except AddItem/DeleteItem, which come via IInventoryService).
@@ -192,7 +198,7 @@ public sealed class GardenIngestionService : BackgroundService
         var deliveryContext = dispatcher is null
             ? DeliveryContext.Inline               // headless / tests — no dispatcher available
             : DeliveryContext.Marshaled(dispatcher);
-        var logSubscription = _driver.Subscribe<LocalPlayerLogLine>(
+        _logSub = _driver.Subscribe<LocalPlayerLogLine>(
             envelope =>
             {
                 var line = envelope.Payload;
@@ -218,6 +224,11 @@ public sealed class GardenIngestionService : BackgroundService
                 DiagnosticCategory = "Samwise.Ingestion",
             });
 
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
         try
         {
             await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
@@ -225,9 +236,9 @@ public sealed class GardenIngestionService : BackgroundService
         catch (OperationCanceledException) { /* expected on host stop */ }
         finally
         {
-            logSubscription.Dispose();
-            subscription.Dispose();
-            skillSubscription.Dispose();
+            _logSub?.Dispose();
+            _invSub?.Dispose();
+            _skillSub?.Dispose();
         }
     }
 

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -285,9 +285,10 @@ public sealed class GardenIngestionService : BackgroundService
     /// <see href="https://github.com/moumantai-gg/mithril/issues/597">#597</see>):</b>
     /// <see cref="IPlayerSkillState.SubscribeChanges"/> is no-replay — a late
     /// subscriber sees only changes from the moment it attaches. The handler
-    /// here attaches after <c>_gate.WaitAsync</c> + <c>LoadAllAsync</c>, while
-    /// <c>PlayerSkillStateService</c> has no gate and can drain L1 envelopes
-    /// ahead of Samwise. Any Gardening <see cref="SkillChangeKind.Delta"/>
+    /// here attaches after the persisted-state hydrate (<c>LoadAllAsync</c>)
+    /// inside <see cref="StartAsync"/>, while <c>PlayerSkillStateService</c>
+    /// attaches earlier in the same chain and can drain L1 envelopes ahead
+    /// of Samwise. Any Gardening <see cref="SkillChangeKind.Delta"/>
     /// fired in that pre-attach window is lost. Bound: harvests completed in
     /// that window stay <c>Ripe</c> with stale <c>_pendingHarvestPlotId</c>
     /// until the next live interaction, where <c>MarkOldestRipeOfType</c>

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -3,7 +3,6 @@ using Mithril.Shared.Diagnostics;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Skills;
 using Mithril.Shared.Logging;
-using Mithril.Shared.Modules;
 using Mithril.Shared.Settings;
 using Microsoft.Extensions.Hosting;
 using Samwise.Alarms;
@@ -296,7 +295,7 @@ public sealed class GardenIngestionService : BackgroundService
     /// on <c>SubscribeChanges</c> (sister to <see href="https://github.com/moumantai-gg/mithril/issues/585">#585</see>).</para>
     /// </summary>
     // internal for tests (Samwise.Tests has InternalsVisibleTo); production
-    // callers go through SubscribeChanges in ExecuteAsync above.
+    // callers go through SubscribeChanges in StartAsync above.
     internal void OnSkillChange(SkillChange change)
     {
         var ge = TryProjectGardeningXp(change);

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -72,9 +72,9 @@ public sealed class VendorIngestionService : BackgroundService
     private readonly IActiveCharacterService _activeCharacter;
     private readonly IPlayerSkillState _skillState;
     private readonly IDiagnosticsSink? _diag;
-    private readonly ModuleGate _gate;
     private ILogSubscription? _subscription;
     private IDisposable? _skillSubscription;
+    private CancellationTokenRegistration _stopRegistration;
 
     public VendorIngestionService(
         ILogStreamDriver driver,
@@ -83,7 +83,6 @@ public sealed class VendorIngestionService : BackgroundService
         VendorSellContext context,
         IActiveCharacterService activeCharacter,
         IPlayerSkillState skillState,
-        ModuleGates gates,
         IDiagnosticsSink? diag = null)
     {
         _driver = driver;
@@ -93,37 +92,35 @@ public sealed class VendorIngestionService : BackgroundService
         _activeCharacter = activeCharacter;
         _skillState = skillState;
         _diag = diag;
-        _gate = gates.For("smaug");
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Eager subscription attach per Call 1 / principle eager-always (#695):
+    /// the L1 LocalPlayer subscription and the shared skill-state subscribe
+    /// both happen during the IHostedService chain's <c>StartAsync</c>,
+    /// before the trailing world-merger drain starts (#702 / Call 2). The
+    /// Smaug module gate no longer gates state subscription — gate-driven
+    /// UI hydration remains Smaug's own concern (today: lazy
+    /// CalibrationViewModel hydration on tab activation, which reads the
+    /// PriceCalibrationService snapshot independently of this service).
+    /// </summary>
+    public override Task StartAsync(CancellationToken cancellationToken)
     {
-        _diag?.Info("Smaug", "Waiting for module gate…");
-        await _gate.WaitAsync(stoppingToken).ConfigureAwait(false);
-        _diag?.Info("Smaug", "Gate opened — subscribing to L1 driver (LocalPlayer pipe) for vendor events");
+        _diag?.Info("Smaug",
+            "Subscribing to L1 driver (LocalPlayer pipe) + shared skill state for vendor events (eager attach)");
 
         PrimeCivicPrideFromActiveCharacter();
         _activeCharacter.ActiveCharacterChanged += OnActiveCharacterChanged;
         _activeCharacter.CharacterExportsChanged += OnActiveCharacterChanged;
-        stoppingToken.Register(() =>
-        {
-            _activeCharacter.ActiveCharacterChanged -= OnActiveCharacterChanged;
-            _activeCharacter.CharacterExportsChanged -= OnActiveCharacterChanged;
-        });
 
         // Subscribe to shared skill state (#580). Subscribe is atomic
         // replay + live under the tracker's lock, so the current snapshot
-        // — including any CivicPride observed pre-gate — is delivered
+        // — including any CivicPride observed pre-attach — is delivered
         // synchronously before this call returns, and before any vendor
         // envelope reaches the L1 handler below.
         _skillSubscription = _skillState.Subscribe(OnSkillSnapshot);
 
-        // Latent-bug fix per #549 + #550 capability E. The Smaug gate only
-        // opens after the user has clicked the Smaug tab, so Application.Current
-        // is guaranteed non-null and its Dispatcher already pumping by here. We
-        // fall back to Inline if for any reason no Application is hosting (e.g.
-        // headless integration tests that share this service) — better silent
-        // best-effort than an NRE.
+        // Latent-bug fix per #549 + #550 capability E.
         var uiDispatcher = Application.Current?.Dispatcher;
         var deliveryContext = uiDispatcher is not null
             ? DeliveryContext.Marshaled(uiDispatcher)
@@ -177,6 +174,20 @@ public sealed class VendorIngestionService : BackgroundService
                 DiagnosticCategory = "Smaug.Ingestion",
             });
 
+        return base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Detach active-character handlers on host stop. Pre-Call-1 this hooked
+        // via `stoppingToken.Register` AFTER the gate opened; under eager
+        // attach the registration lives across the host lifetime.
+        _stopRegistration = stoppingToken.Register(() =>
+        {
+            _activeCharacter.ActiveCharacterChanged -= OnActiveCharacterChanged;
+            _activeCharacter.CharacterExportsChanged -= OnActiveCharacterChanged;
+        });
+
         try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
         catch (OperationCanceledException) { /* expected on host stop */ }
         finally
@@ -185,6 +196,7 @@ public sealed class VendorIngestionService : BackgroundService
             _subscription = null;
             _skillSubscription?.Dispose();
             _skillSubscription = null;
+            _stopRegistration.Dispose();
         }
     }
 

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -257,7 +257,7 @@ public sealed class VendorIngestionService : BackgroundService
     /// When the active character changes, overwrites unconditionally; on first prime, only fills in
     /// a zero level so a live log-parsed value is not clobbered by a stale export.
     ///
-    /// <para><b>Ordering — live wins over export.</b> <see cref="ExecuteAsync"/>
+    /// <para><b>Ordering — live wins over export.</b> <see cref="StartAsync"/>
     /// calls this <em>before</em> subscribing to <see cref="IPlayerSkillState"/>,
     /// so the export-derived value is in place first and the subsequent
     /// synchronous replay of <see cref="OnSkillSnapshot"/> overwrites it with

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -3,7 +3,6 @@ using Mithril.GameState.Skills;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
-using Mithril.Shared.Modules;
 using Microsoft.Extensions.Hosting;
 using Smaug.Domain;
 using Smaug.Parsing;
@@ -12,8 +11,10 @@ namespace Smaug.State;
 
 /// <summary>
 /// Subscribes (via the L1 <see cref="ILogStreamDriver"/>) to the LocalPlayer
-/// pipe once the Smaug module gate opens, parses vendor-related lines, and
-/// feeds recorded sells into <see cref="PriceCalibrationService"/>.
+/// pipe eagerly during <c>StartAsync</c> (#695 Call 1), parses vendor-related
+/// lines, and feeds recorded sells into <see cref="PriceCalibrationService"/>.
+/// The Smaug module gate no longer gates state subscription; UI hydration
+/// (the calibration tab) stays lazy.
 ///
 /// <para><b>L1 migration shape (#550 PR 3, archetype-B).</b> Subscribes to
 /// <see cref="LocalPlayerLogLine"/> with
@@ -74,7 +75,6 @@ public sealed class VendorIngestionService : BackgroundService
     private readonly IDiagnosticsSink? _diag;
     private ILogSubscription? _subscription;
     private IDisposable? _skillSubscription;
-    private CancellationTokenRegistration _stopRegistration;
 
     public VendorIngestionService(
         ILogStreamDriver driver,
@@ -179,15 +179,6 @@ public sealed class VendorIngestionService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Detach active-character handlers on host stop. Pre-Call-1 this hooked
-        // via `stoppingToken.Register` AFTER the gate opened; under eager
-        // attach the registration lives across the host lifetime.
-        _stopRegistration = stoppingToken.Register(() =>
-        {
-            _activeCharacter.ActiveCharacterChanged -= OnActiveCharacterChanged;
-            _activeCharacter.CharacterExportsChanged -= OnActiveCharacterChanged;
-        });
-
         try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
         catch (OperationCanceledException) { /* expected on host stop */ }
         finally
@@ -196,12 +187,23 @@ public sealed class VendorIngestionService : BackgroundService
             _subscription = null;
             _skillSubscription?.Dispose();
             _skillSubscription = null;
-            _stopRegistration.Dispose();
         }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Symmetric with the StartAsync subscribe so a bootstrap failure
+        // that disposes the service without ExecuteAsync ever running
+        // doesn't leak the active-character handlers.
+        _activeCharacter.ActiveCharacterChanged -= OnActiveCharacterChanged;
+        _activeCharacter.CharacterExportsChanged -= OnActiveCharacterChanged;
+        return base.StopAsync(cancellationToken);
     }
 
     public override void Dispose()
     {
+        _activeCharacter.ActiveCharacterChanged -= OnActiveCharacterChanged;
+        _activeCharacter.CharacterExportsChanged -= OnActiveCharacterChanged;
         _subscription?.Dispose();
         _subscription = null;
         _skillSubscription?.Dispose();

--- a/tests/Arwen.Tests/FavorIngestionServiceTests.cs
+++ b/tests/Arwen.Tests/FavorIngestionServiceTests.cs
@@ -371,11 +371,14 @@ public sealed class FavorIngestionServiceTests : IDisposable
 
         public async Task StartAsync()
         {
+            // Post-Call-1 (#695): the L1 subscription attaches inside
+            // FavorIngestionService.StartAsync — Subscribe completes before
+            // this await returns, so the WaitForSubscriptionAsync poll
+            // below is a defence-in-depth sync rather than a wait-for-gate.
+            // The Gates field stays on the fixture only so the
+            // "Subscription_attaches_in_StartAsync_without_opening_module_gate"
+            // test can assert IsOpen.Should().BeFalse() against it.
             await Service.StartAsync(CancellationToken.None);
-            Gates.For("arwen").Open();
-            // Allow ExecuteAsync to pass the WaitAsync and call Subscribe.
-            // The driver's Subscribe is synchronous from the consumer side,
-            // so a brief poll on the pump task being ready suffices.
             await Driver.WaitForSubscriptionAsync();
         }
 

--- a/tests/Arwen.Tests/FavorIngestionServiceTests.cs
+++ b/tests/Arwen.Tests/FavorIngestionServiceTests.cs
@@ -166,6 +166,47 @@ public sealed class FavorIngestionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Subscription_attaches_in_StartAsync_without_opening_module_gate()
+    {
+        // Call 1 / principle eager-always: the L1 LocalPlayer subscription and
+        // the IGiftSignalService React subscription must both be in place by
+        // the time `await service.StartAsync(ct)` returns — regardless of
+        // whether the Arwen tab is ever activated. Pre-Call-1 the L1
+        // subscribe sat inside ExecuteAsync behind `await gate.WaitAsync`;
+        // post-Call-1 it lifts into StartAsync so a session-start replay
+        // drain reaches the FavorState rebuild even on a never-opened tab.
+        //
+        // The original sink-list source is the Call 1 ratification in
+        // docs/world-simulator.md §Decisions ratified post-#642 (resolves #695).
+
+        var giftedAt = new DateTimeOffset(2026, 5, 19, 10, 30, 00, TimeSpan.Zero);
+
+        using var fixture = NewFixture("EagerStartAsync");
+
+        // Pre-load the L1 driver with a session-start replay snapshot.
+        fixture.Driver.PushReplay(MakeLine(
+            $"ProcessStartInteraction(42, 0, 100.0, True, \"NPC_Sanja\")", giftedAt));
+
+        // Start the host WITHOUT opening the arwen module gate. The Call 1
+        // contract requires the subscription to be live regardless.
+        await fixture.Service.StartAsync(CancellationToken.None);
+        await fixture.Driver.WaitForSubscriptionAsync();
+
+        fixture.Gates.For("arwen").IsOpen.Should().BeFalse(
+            "the gate-retirement audit — this test must not touch ModuleGate.Open to validate the eager attach (Call 1)");
+
+        // The replay snapshot drains through the live subscription.
+        await fixture.Driver.DrainLocalPlayerAsync();
+        await fixture.Service.StopAsync(CancellationToken.None);
+
+        // FavorState was rebuilt from the replayed verb — no tab activation needed.
+        var favor = fixture.FavorState.GetExactFavor("NPC_Sanja");
+        favor.Should().NotBeNull(
+            "the L1 subscription's session-start replay processed the FavorUpdate while the gate stayed closed");
+        favor!.ExactFavor.Should().Be(100.0);
+    }
+
+    [Fact]
     public async Task Late_subscribe_to_IGiftSignalService_still_observes_replayed_gifts()
     {
         // ── The #608 race contract (iteration 2 of the PR).
@@ -302,7 +343,6 @@ public sealed class FavorIngestionServiceTests : IDisposable
                 _view,
                 active,
                 _saver,
-                Gates,
                 GiftSignal);
         }
 

--- a/tests/Gandalf.Tests/TimerAlarmServiceTests.cs
+++ b/tests/Gandalf.Tests/TimerAlarmServiceTests.cs
@@ -1,0 +1,249 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Audio;
+using Mithril.Shared.Character;
+using Mithril.Shared.Settings;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Call 3 / principle 12 acceptance tests for <see cref="TimerAlarmService"/>.
+///
+/// <para>Under <see cref="WorldMode.Replaying"/>, <c>OnTimerReady</c> must NOT
+/// fire user-facing side effects (audio playback, window flash). Upstream state
+/// derivation (the <c>_firedAt</c> dedup ledger) stays mode-agnostic so a
+/// transition to <see cref="WorldMode.Live"/> mid-session doesn't re-blast
+/// alarms the user already lived through.</para>
+///
+/// <para>The original sink-list source is the Call 3 ratification in
+/// <c>docs/world-simulator.md</c> §Decisions ratified post-#642 (resolves #676).</para>
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class TimerAlarmServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _defsPath;
+    private readonly string _charactersDir;
+    private readonly List<IDisposable> _disposables = new();
+
+    public TimerAlarmServiceTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_timer_alarm_mode_gating");
+        _defsPath = Path.Combine(_dir, "definitions.json");
+        _charactersDir = Path.Combine(_dir, "characters");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        for (int i = _disposables.Count - 1; i >= 0; i--)
+        {
+            try { _disposables[i].Dispose(); } catch { /* best-effort */ }
+        }
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void OnTimerReady_Replaying_DoesNotPlayAudio()
+    {
+        var sink = new RecordingAudioSink();
+        var world = new FakePlayerWorld(WorldMode.Replaying);
+        var (service, _, _, _) = BuildService(sink, world);
+
+        service.OnTimerReady(this, MakeReadyArgs("key1"));
+
+        sink.Plays.Should().BeEmpty(
+            "principle 12 — under WorldMode.Replaying the projection (audio + window flash) is suppressed; "
+            + "the user already lived through these events in real time");
+    }
+
+    [Fact]
+    public void OnTimerReady_Live_PlaysAudio()
+    {
+        var sink = new RecordingAudioSink();
+        var world = new FakePlayerWorld(WorldMode.Live);
+        var (service, _, _, _) = BuildService(sink, world);
+
+        service.OnTimerReady(this, MakeReadyArgs("key1"));
+
+        sink.Plays.Should().HaveCount(1,
+            "Live mode is the projection-honest window: side effects fire normally");
+        sink.Plays[0].CallerId.Should().Be("gandalf");
+    }
+
+    [Fact]
+    public void OnTimerReady_NullPlayerWorld_PlaysAudio()
+    {
+        // Defensive default: when no IPlayerWorld is injected (e.g., a
+        // partial-composition test or pre-#601 code path), the
+        // _worldClock?.Mode null-conditional treats the world as Live so
+        // existing call sites aren't broken by the guard.
+        var sink = new RecordingAudioSink();
+        var (service, _, _, _) = BuildService(sink, playerWorld: null);
+
+        service.OnTimerReady(this, MakeReadyArgs("key1"));
+
+        sink.Plays.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void OnTimerReady_ReplayingThenLive_FiresOnceUnderLive()
+    {
+        // Boundary transition shape: the same key fires once during replay
+        // drain (suppressed by the guard) and once during Live (normal
+        // fire). The _firedAt write happens before the guard so the
+        // refire-suppression window is honoured across the boundary;
+        // here the Live emission lands well past the 30s window so it
+        // fires cleanly.
+        var sink = new RecordingAudioSink();
+        var world = new FakePlayerWorld(WorldMode.Replaying);
+        // Seed the world clock to a stable instant so the SUT's `Now`
+        // reads (which prefer _worldClock?.Now over the time provider)
+        // see a non-MinValue value across both calls.
+        world.WorldClock.Now = new DateTimeOffset(2026, 5, 23, 10, 0, 0, TimeSpan.Zero);
+        var (service, _, _, _) = BuildService(sink, world);
+
+        // Replaying — suppressed.
+        service.OnTimerReady(this, MakeReadyArgs("key1"));
+        sink.Plays.Should().BeEmpty();
+
+        // Flip to Live and advance the world clock past the 30s
+        // refire-suppression window (the SUT reads _worldClock?.Now over
+        // the TimeProvider fallback).
+        world.WorldClock.Mode = WorldMode.Live;
+        world.WorldClock.Now += TimeSpan.FromSeconds(45);
+        service.OnTimerReady(this, MakeReadyArgs("key1"));
+
+        sink.Plays.Should().HaveCount(1, "Live-mode emission past the suppression window must fire");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private (TimerAlarmService Service, UserTimerSource Source, TimerDefinitionsService Defs, TimerProgressService Progress)
+        BuildService(
+            IAudioPlaybackSink sink,
+            FakePlayerWorld? playerWorld,
+            TimeProvider? time = null)
+    {
+        var defStore = new JsonSettingsStore<GandalfDefinitions>(_defsPath,
+            GandalfDefinitionsJsonContext.Default.GandalfDefinitions);
+        var defs = defStore.Load();
+        var defsSvc = new TimerDefinitionsService(defStore, defs);
+        _disposables.Add(defsSvc);
+
+        var active = new FakeActiveCharacterService();
+        var store = new PerCharacterStore<GandalfProgress>(_charactersDir, "gandalf.json",
+            GandalfProgressJsonContext.Default.GandalfProgress);
+        var view = new PerCharacterView<GandalfProgress>(active, store);
+        var progressSvc = new TimerProgressService(view, defsSvc,
+            new PerCharacterStoreOptions { CharactersRootDir = _charactersDir });
+        _disposables.Add(progressSvc);
+
+        var source = new UserTimerSource(defsSvc, progressSvc);
+        _disposables.Add(source);
+
+        var settings = new GandalfSettings
+        {
+            AlarmEnabled = true,
+            FlashWindow = false,    // no Application.MainWindow available — keep the assertion focused on audio.
+            SoundFilePath = null,   // AudioPlayer falls back to beep on null; the fake sink records the call regardless.
+            AlarmVolume = 0.5,
+        };
+
+        var service = new TimerAlarmService(source, settings, sink, time, playerWorld);
+        _disposables.Add(service);
+        return (service, source, defsSvc, progressSvc);
+    }
+
+    private static TimerReadyEventArgs MakeReadyArgs(string key) =>
+        new()
+        {
+            SourceId = UserTimerSource.Id,
+            Key = key,
+            DisplayName = key,
+            ReadyAt = DateTimeOffset.UtcNow,
+            SourceMetadata = null,
+        };
+
+    /// <summary>
+    /// Recording <see cref="IAudioPlaybackSink"/> for Mode-gating verification.
+    /// Local to this fixture because Gandalf.Tests doesn't share Samwise's
+    /// <c>FakeAudioPlaybackSink</c>.
+    /// </summary>
+    private sealed class RecordingAudioSink : IAudioPlaybackSink
+    {
+        public sealed record PlayCall(string? Path, float Volume, string? CallerId, bool Loop);
+
+        public List<PlayCall> Plays { get; } = new();
+        public int GlobalStopCount { get; private set; }
+        public List<string> CallerStops { get; } = new();
+
+        public IPlaybackHandle Play(string? path, float volume = 1.0f, string? callerId = null, bool loop = false)
+        {
+            Plays.Add(new PlayCall(path, volume, callerId, loop));
+            return EmptyHandle.Instance;
+        }
+
+        public void Stop() => GlobalStopCount++;
+        public void Stop(string callerId) => CallerStops.Add(callerId);
+
+        private sealed class EmptyHandle : IPlaybackHandle
+        {
+            public static readonly EmptyHandle Instance = new();
+            public bool IsPlaying => false;
+            public void Stop() { }
+            public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// Minimal mutable <see cref="TimeProvider"/> for boundary-transition
+    /// tests. The production refire-suppression check uses the world clock
+    /// when one is injected and this fallback when not; here both reads
+    /// happen against the world clock since we inject one, but the SUT
+    /// still asks the provider for absolute Now in places, so we hand it
+    /// a controllable provider.
+    /// </summary>
+    private sealed class RewindableTimeProvider : TimeProvider
+    {
+        public DateTimeOffset Now { get; private set; }
+        public RewindableTimeProvider(DateTime utc) => Now = new DateTimeOffset(utc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => Now;
+        public void Advance(TimeSpan ts) => Now += ts;
+    }
+
+    /// <summary>
+    /// Local <see cref="IPlayerWorld"/> stub — Gandalf.Tests doesn't share
+    /// Samwise's <c>FakePlayerWorld</c>. Only <see cref="IWorldClock.Mode"/>
+    /// is read by the SUT; the bus/folder surfaces throw to flag accidental
+    /// use.
+    /// </summary>
+    private sealed class FakePlayerWorld : IPlayerWorld
+    {
+        public FakePlayerWorld(WorldMode mode) => WorldClock = new() { Mode = mode };
+        public FakeWorldClock WorldClock { get; }
+        public IWorldClock Clock => WorldClock;
+        public IWorldEventBus Bus => throw new NotSupportedException(
+            "FakePlayerWorld exposes only Clock; bus/folder/composer surfaces aren't needed for Mode-gating tests.");
+        public void RegisterProducer<T>(IFrameProducer<T> producer) =>
+            throw new NotSupportedException("FakePlayerWorld is read-only.");
+        public void RegisterFolder<T>(IFolder<T> folder) =>
+            throw new NotSupportedException("FakePlayerWorld is read-only.");
+        public void RegisterComposer(IComposer composer) =>
+            throw new NotSupportedException("FakePlayerWorld is read-only.");
+        public Task StartMerger(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class FakeWorldClock : IWorldClock
+    {
+        public DateTimeOffset Now { get; set; } = DateTimeOffset.MinValue;
+        public long Frame { get; set; }
+        public WorldMode Mode { get; set; } = WorldMode.Live;
+    }
+}

--- a/tests/Legolas.Tests/Services/ItemCollectionTrackerTests.cs
+++ b/tests/Legolas.Tests/Services/ItemCollectionTrackerTests.cs
@@ -34,23 +34,26 @@ public sealed class ItemCollectionTrackerTests
         TestLogStreamDriver Driver,
         SessionState Session,
         CapturingSink Sink,
-        ManualTimeProvider Clock);
+        ManualTimeProvider Clock,
+        ModuleGates Gates);
 
-    private static Harness Build()
+    private static Harness Build() => Build(openGate: true);
+
+    private static Harness Build(bool openGate)
     {
         var view = new FakeInventoryView();
         var driver = new TestLogStreamDriver();
         var parser = new PlayerLogParser();
         var session = new SessionState();
         var gates = new ModuleGates();
-        gates.For("legolas").Open();
+        if (openGate) gates.For("legolas").Open();
         var sink = new CapturingSink();
         var clock = new ManualTimeProvider(new DateTime(2026, 5, 22, 14, 0, 0, DateTimeKind.Utc));
         var refData = new FakeRefData();
         var svc = new ItemCollectionTracker(
             view, driver, parser, gates, session,
             refData: refData, diag: sink, time: clock);
-        return new Harness(svc, view, driver, session, sink, clock);
+        return new Harness(svc, view, driver, session, sink, clock, gates);
     }
 
     private static SurveyItemViewModel SeedSurvey(SessionState session, string displayName)
@@ -111,6 +114,42 @@ public sealed class ItemCollectionTrackerTests
     }
 
     // ── tests ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Call 1 / principle eager-always: both the IInventoryView.Bus
+    /// subscriptions (pre-Call-1 already in StartAsync) AND the L1
+    /// LocalPlayer subscription (pre-Call-1 sat behind <c>_gates.For("legolas").WaitAsync</c>
+    /// inside ExecuteAsync) must be live after `await service.StartAsync(ct)`
+    /// — regardless of whether the Legolas tab is ever activated.
+    ///
+    /// The original sink-list source is the Call 1 ratification in
+    /// docs/world-simulator.md §Decisions ratified post-#642 (resolves #695).
+    /// </summary>
+    [Fact]
+    public async Task Subscription_attaches_in_StartAsync_without_opening_module_gate()
+    {
+        var h = Build(openGate: false);
+        SeedSurvey(h.Session, "Iron Ore");
+        await Run(h, async () =>
+        {
+            // IInventoryView.Bus has no replay-on-subscribe contract; the
+            // #702 trailing-merger invariant is what guarantees the view-bus
+            // subscribe completes before any frame flows in production. The
+            // Run helper above already returned from `await
+            // h.Service.StartAsync` so both the view-bus subs and the L1
+            // driver sub are live by here under Call 1's eager-attach.
+            h.View.PushAdded("IronOre", stackSize: 5, sizeConfirmed: true);
+            h.Driver.PushLive(CollectLine("Iron Ore"));
+            await h.Driver.DrainLocalPlayerAsync();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await WaitUntil(() => h.Session.CollectedItems.ContainsKey("Iron Ore"), cts.Token);
+
+            h.Gates.For("legolas").IsOpen.Should().BeFalse(
+                "the gate-retirement audit — this test must not touch ModuleGate.Open to validate the eager attach (Call 1)");
+            h.Session.CollectedItems["Iron Ore"].Should().Be(5,
+                "the L1 ProcessScreenText subscription is attached by StartAsync regardless of tab activation");
+        });
+    }
 
     /// <summary>
     /// Added (SizeConfirmed=true) then ProcessScreenText collected! within TTL

--- a/tests/Legolas.Tests/Services/ItemCollectionTrackerTests.cs
+++ b/tests/Legolas.Tests/Services/ItemCollectionTrackerTests.cs
@@ -51,7 +51,7 @@ public sealed class ItemCollectionTrackerTests
         var clock = new ManualTimeProvider(new DateTime(2026, 5, 22, 14, 0, 0, DateTimeKind.Utc));
         var refData = new FakeRefData();
         var svc = new ItemCollectionTracker(
-            view, driver, parser, gates, session,
+            view, driver, parser, session,
             refData: refData, diag: sink, time: clock);
         return new Harness(svc, view, driver, session, sink, clock, gates);
     }
@@ -434,7 +434,7 @@ public sealed class ItemCollectionTrackerTests
         var clock = new ManualTimeProvider(new DateTime(2026, 5, 22, 14, 0, 0, DateTimeKind.Utc));
         var refData = new FakeRefData();
         var svc = new ItemCollectionTracker(
-            view, driver, parser, gates, session,
+            view, driver, parser, session,
             refData: refData, diag: sink, time: clock);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -51,10 +51,12 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         SpyAreaCalibration Spy,
         SessionState Session,
         SurveyFlowController Flow,
-        PlayerAreaTracker Tracker);
+        PlayerAreaTracker Tracker,
+        ModuleGates Gates);
 
     private static Fixture Build(
-        AreaCalibration? calibration = null, GameConfig? config = null)
+        AreaCalibration? calibration = null, GameConfig? config = null,
+        bool openGate = true)
     {
         var driver = new TestLogStreamDriver();
         // #514: the shared tracker owns its one-shot seed. Route the test's
@@ -67,15 +69,15 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         var settings = new LegolasSettings();
         var flow = new SurveyFlowController(session, settings);
         var gates = new ModuleGates();
-        gates.For("legolas").Open();
+        if (openGate) gates.For("legolas").Open();
         var motherlode = new MotherlodeMeasurementCoordinator(
             new MultilaterationSolver(), new MotherlodeFlowController(session),
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
             driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
-            settings, gates,
+            settings,
             activeChar: null, ingestionStore: null);
-        return new Fixture(svc, driver, spy, session, flow, tracker);
+        return new Fixture(svc, driver, spy, session, flow, tracker, gates);
     }
 
     /// <summary>
@@ -112,6 +114,44 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             idx += actor.Length;
         }
         return idx == 0 ? line : line.Substring(idx);
+    }
+
+    // ---- Call 1 / principle eager-always (resolves #695) ----------------
+
+    /// <summary>
+    /// Call 1: PlayerLogIngestionService's L1 driver subscription must attach
+    /// during <c>StartAsync</c>, not behind <c>gate.WaitAsync</c> in
+    /// ExecuteAsync. A live envelope pushed after StartAsync — but before the
+    /// legolas tab is activated — must reach the area-bridge / map-fx
+    /// handlers.
+    ///
+    /// The original sink-list source is the Call 1 ratification in
+    /// docs/world-simulator.md §Decisions ratified post-#642.
+    /// </summary>
+    [Fact]
+    public async Task Subscription_attaches_in_StartAsync_without_opening_module_gate()
+    {
+        var f = Build(calibration: Identity(), openGate: false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = f.Service.StartAsync(cts.Token);
+        try
+        {
+            // The MapFx live envelope reaches the handler only if the L1
+            // driver subscription is attached. Pre-Call-1 the subscribe sat
+            // behind gate.WaitAsync, so this drain would hang waiting on the
+            // gate; post-Call-1 the subscribe happens in StartAsync.
+            f.Driver.PushLive(LiveLine(MapFx));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(
+                () => f.Session.LastLogEvent?.Contains("placed (absolute)") == true,
+                cts.Token);
+
+            f.Gates.For("legolas").IsOpen.Should().BeFalse(
+                "the gate-retirement audit — this test must not touch ModuleGate.Open to validate the eager attach (Call 1)");
+            f.Session.Surveys.Should().HaveCount(1,
+                "the L1 subscription processed the MapFx envelope while the gate stayed closed");
+        }
+        finally { await Stop(f, run, cts); }
     }
 
     // ---- area→calibration bridge (Phase 2) -------------------------------
@@ -498,7 +538,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
             driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
-            settings, gates,
+            settings,
             activeChar: activeChar, ingestionStore: store);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -564,7 +604,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
             driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
-            settings, gates,
+            settings,
             activeChar: activeChar, ingestionStore: store);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/Samwise.Tests/Alarms/AlarmServiceTests.cs
+++ b/tests/Samwise.Tests/Alarms/AlarmServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Mithril.Shared.Audio;
+using Mithril.WorldSim;
 using Samwise.Alarms;
 using Samwise.Parsing;
 using Samwise.State;
@@ -18,14 +19,17 @@ public class AlarmServiceTests
         GardenStateMachine StateMachine,
         FakeTime Time,
         FakeActiveCharacterService ActiveChar,
-        SamwiseSettings Settings);
+        SamwiseSettings Settings,
+        FakePlayerWorld? PlayerWorld);
 
-    private static Sut BuildSut(AlarmCollisionBehavior collision = AlarmCollisionBehavior.Replace)
+    private static Sut BuildSut(
+        AlarmCollisionBehavior collision = AlarmCollisionBehavior.Replace,
+        FakePlayerWorld? playerWorld = null)
     {
         var cfg = new InMemoryCropConfig();
         var time = new FakeTime(Base);
         var ac = new FakeActiveCharacterService();
-        var sm = new GardenStateMachine(cfg, time, activeChar: ac);
+        var sm = new GardenStateMachine(cfg, time, activeChar: ac, playerWorld: playerWorld);
         ac.SetActiveCharacter("Hits", "");
 
         var settings = new SamwiseSettings();
@@ -35,8 +39,8 @@ public class AlarmServiceTests
         settings.Alarms.Rules[PlotStage.Thirsty].Enabled = true;
 
         var sink = new FakeAudioPlaybackSink();
-        var service = new AlarmService(sm, settings, sink);
-        return new Sut(service, sink, sm, time, ac, settings);
+        var service = new AlarmService(sm, settings, sink, playerWorld);
+        return new Sut(service, sink, sm, time, ac, settings, playerWorld);
     }
 
     /// <summary>
@@ -458,5 +462,83 @@ public class AlarmServiceTests
 
         liveHandle.IsPlaying.Should().BeFalse();
         s.Sink.Plays.Should().HaveCount(2);
+    }
+
+    // ── Call 3 / principle 12 — Mode-gated projection ────────────────────────
+    //
+    // Under WorldMode.Replaying, AlarmService.Fire must not emit user-facing
+    // side effects (audio playback, AlarmTriggered event). Upstream state
+    // derivation (the _firedAt dedup write in OnPlotChanged) stays
+    // mode-agnostic so a Replaying → Live transition mid-session doesn't
+    // re-fire alarms the user already lived through.
+    //
+    // The original sink-list source is the Call 3 ratification in
+    // docs/world-simulator.md §Decisions ratified post-#642 (resolves #676).
+
+    [Fact]
+    public void OnPlotChanged_Replaying_DoesNotPlayAudio_AndDoesNotRaiseAlarmTriggered()
+    {
+        var world = new FakePlayerWorld();
+        world.WorldClock.Mode = WorldMode.Replaying;
+        var s = BuildSut(playerWorld: world);
+        var triggered = new List<ActiveAlarm>();
+        s.Service.AlarmTriggered += (_, a) => triggered.Add(a);
+
+        RipenPlot(s, "1", "Carrot");
+
+        s.Sink.Plays.Should().BeEmpty(
+            "principle 12 — audio playback is a user-facing projection that must not fire while the world is still draining replayed frames");
+        triggered.Should().BeEmpty(
+            "the AlarmTriggered event is also a user-facing side effect (consumed by toast/inbox UIs) and is suppressed under Replaying");
+    }
+
+    [Fact]
+    public void OnPlotChanged_Live_FiresAudioAndAlarmTriggered()
+    {
+        var world = new FakePlayerWorld();
+        world.WorldClock.Mode = WorldMode.Live;
+        var s = BuildSut(playerWorld: world);
+        var triggered = new List<ActiveAlarm>();
+        s.Service.AlarmTriggered += (_, a) => triggered.Add(a);
+
+        RipenPlot(s, "1", "Carrot");
+
+        s.Sink.Plays.Should().HaveCount(1,
+            "Live mode is the projection-honest window: side effects fire normally");
+        triggered.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void OnPlotChanged_Replaying_StillUpdatesFiredAtDedup()
+    {
+        // State derivation is mode-agnostic — _firedAt is updated even under
+        // Replaying so a subsequent same-key transition (e.g., a duplicate
+        // log line during replay) does not blast the user when the mode
+        // transitions to Live.
+        var world = new FakePlayerWorld();
+        world.WorldClock.Mode = WorldMode.Replaying;
+        var s = BuildSut(playerWorld: world);
+
+        RipenPlot(s, "1", "Carrot");
+
+        s.Service.ActiveKeys.Should().HaveCount(1,
+            "OnPlotChanged stamps _firedAt before invoking Fire; that dedup write happens regardless of mode");
+    }
+
+    [Fact]
+    public void OnPlotChanged_NullPlayerWorld_FiresNormally()
+    {
+        // Defensive default: when no IPlayerWorld is injected (e.g., partial
+        // composition tests or pre-#601 code paths), the _worldClock?.Mode
+        // null-conditional treats the world as Live so existing tests aren't
+        // broken by the guard.
+        var s = BuildSut(playerWorld: null);
+        var triggered = new List<ActiveAlarm>();
+        s.Service.AlarmTriggered += (_, a) => triggered.Add(a);
+
+        RipenPlot(s, "1", "Carrot");
+
+        s.Sink.Plays.Should().HaveCount(1);
+        triggered.Should().HaveCount(1);
     }
 }

--- a/tests/Smaug.Tests/VendorIngestionServiceSkillStateTests.cs
+++ b/tests/Smaug.Tests/VendorIngestionServiceSkillStateTests.cs
@@ -52,6 +52,30 @@ public sealed class VendorIngestionServiceSkillStateTests
         "[22:27:48] LocalPlayer: ProcessVendorAddItem(130, BottleOfWater(78177652), False)";
 
     // ============================================================
+    // Call 1 / principle eager-always (#695) — Smaug is a Lazy module and
+    // pre-Call-1 its L1 subscription sat behind `gates.For("smaug").WaitAsync`
+    // inside ExecuteAsync. After Call 1 the subscription attaches in
+    // StartAsync; the smaug ModuleGate no longer participates in state
+    // subscription. The TestHarness.StartAsync helper no longer touches a
+    // ModuleGates instance — every test in this file structurally exercises
+    // the eager-attach contract by construction. This explicit assertion
+    // makes the contract visible.
+    [Fact]
+    public async Task L1_subscription_attaches_in_StartAsync_without_gate()
+    {
+        // The harness's StartAsync invokes service.StartAsync but never
+        // creates a ModuleGates / Open() — Call 1's eager-attach contract.
+        await using var harness = await TestHarness.StartAsync();
+
+        // Push a skill snapshot so the OnSkillSnapshot handler has observable
+        // effect — proves the subscription is live without any tab activation.
+        harness.SkillState.Push(SnapshotWithCivicPride(level: 7, bonus: 0));
+
+        harness.Context.CivicPrideLevel.Should().Be(7,
+            "the IPlayerSkillState subscription was attached during StartAsync, before any module gate could be opened");
+    }
+
+    // ============================================================
     // Test 1 — snapshot with CivicPride → context updated to raw+bonus.
     // ============================================================
 
@@ -243,19 +267,18 @@ public sealed class VendorIngestionServiceSkillStateTests
             var parser = new VendorLogParser();
             var context = new VendorSellContext();
             var activeChar = new TestActiveCharacterService();
-            var gates = new ModuleGates();
             var driver = new TestDriver();
             var skillState = new FakeSkillState(initialSkillSnapshot ?? PlayerSkillSnapshot.Empty);
 
+            // Post-Call-1 (#695): VendorIngestionService no longer takes a
+            // ModuleGates parameter — its L1 subscription attaches eagerly
+            // in StartAsync, not behind the smaug gate.
             var service = new VendorIngestionService(
-                driver, parser, calibration, context, activeChar, skillState, gates);
-
-            // Open the gate so ExecuteAsync drops into subscribing immediately.
-            gates.For("smaug").Open();
+                driver, parser, calibration, context, activeChar, skillState);
 
             // Kick the service via the hosted-service contract. StartAsync
-            // returns once the executor has begun (does not wait for the
-            // infinite-delay loop to complete).
+            // attaches the L1 subscription and the skill subscription
+            // before returning, then schedules ExecuteAsync's park loop.
             await service.StartAsync(CancellationToken.None);
 
             // Give the service a moment to land on its Subscribe calls.


### PR DESCRIPTION
## Summary

Couples §Call 1 ([#695](https://github.com/moumantai-gg/mithril/issues/695)) and §Call 3 ([#676](https://github.com/moumantai-gg/mithril/issues/676)) from [docs/world-simulator.md](docs/world-simulator.md) §Decisions ratified post-#642. These must land together: Call 1 attaches every module's state subscription during the IHostedService chain at startup; Call 3 gates the user-facing projection (audio + window flash + alarm event) on `WorldMode.Live` so the first replay drain after a Mithril restart doesn't blast alarms the user already lived through.

- **Call 1** — retire six state-subscription gates. Each ingestion service moves its L1/world-bus subscriptions out of `ExecuteAsync` (behind `gate.WaitAsync`) into `StartAsync` (eager, no gate). The trailing `WorldMergerStartHostedService` from [#702](https://github.com/moumantai-gg/mithril/pull/702) guarantees subscribers attach before the merger drain, so a session-start replay reaches every consumer regardless of UI activation. The `ModuleGates` ctor parameter is removed from each service; Legolas's three UI-hydration gates (`AutoOverlayCoordinator`, `ForegroundFocusGate`, `OverlayController`) still wait on the legolas gate per the narrowed `DefaultActivation` scope. `ModuleGate` retirement is deferred to Phase 5 ([#700](https://github.com/moumantai-gg/mithril/issues/700)).
- **Call 3** — mode-gate sinks. Each user-facing projection guards its emission with `if (_worldClock?.Mode == WorldMode.Replaying) return;`. State derivation upstream (dedup ledgers) stays mode-agnostic so Replaying → Live transitions preserve a coherent suppression contract. `Gandalf.ShiftAlarmService` and the `LootSource`/`QuestSource` emit-side are explicitly **not** gated here — `ShiftAlarmService` sits outside the projection-outwards contract until [#613](https://github.com/moumantai-gg/mithril/issues/613); the loot/quest sources route through `TimerAlarmService`'s outer sink which already catches the projection. `TimerAlarmService` now consumes `IAudioPlaybackSink` (matching `AlarmService`'s DI seam) instead of calling `AudioPlayer.Play` statically — necessary scaffolding so the Mode-gating is observable in tests.

Closes #695. Closes #676.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (warnings-as-errors enforced)
- [x] `dotnet test Mithril.slnx --filter "Category!=Integration"` clean (4,055 tests across 23 projects, 0 failures, 0 skipped)
- [x] Composition smoke from [#702](https://github.com/moumantai-gg/mithril/pull/702) (`WorldMergerStartCompositionTests`) + the `ShellSelfCheckGuardTests` Integration suite remain authoritative — both green
- [x] Call 3: 4 new Samwise `AlarmService` Mode-gating tests + 4 new Gandalf `TimerAlarmServiceTests` (new file) including a Replaying → Live boundary that exercises the suppression window across the mode flip
- [x] Call 1: per-site assertions for **Arwen** (`FavorIngestionService` — L1 subscription attaches in `StartAsync` without `ModuleGate.Open`), **Legolas `ItemCollectionTracker`** (bus + L1 both eager), **Legolas `PlayerLogIngestionService`** (`MapFx` envelope reaches handler with gate closed), **Smaug** (`VendorIngestionService` skill-state subscription attaches without gate)
- [x] Samwise's per-site Call 1 retirement is structural cleanup (the module was already Eager, gate opened at startup in production); existing 125 Samwise tests cover the unchanged behavior
- [x] Pippin's `GourmandIngestionService` is covered by the composition smoke + the identical refactor pattern shared with the other five sites (no full-service fixture exists today; building one is deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
