### PR TITLE
feat(world-sim): SessionAgreementComposer — Player.log vs chat banner cross-check (#633)

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ using Mithril.GameState.Weather;
 using Mithril.GameState.WordsOfPower;
 using Mithril.GameState.WordsOfPower.Producers;
 using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Modules;
 using Mithril.WorldSim;
 using Mithril.WorldSim.Chat;
 using Mithril.WorldSim.Player;
@@ -56,6 +57,19 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<GameSessionService>()
             .AddSingleton<IGameSessionService>(sp => sp.GetRequiredService<GameSessionService>())
             .AddHostedService(sp => sp.GetRequiredService<GameSessionService>());
+
+        // View-layer composer (#633): cross-checks the Player.log banner's
+        // server identity against the chat banner's server identity. Verification
+        // only — neither GameSession.Server nor ChatSession.Server is mutated.
+        // Registered as a singleton + IAttentionSource so disagreement surfaces
+        // on IAttentionAggregator alongside other shell-side attention signals.
+        // SessionAgreementWorldRegistration calls Start() at host start so the
+        // subscriptions are in place before the trailing
+        // WorldMergerStartHostedService (#696 Call 2) opens the world drains.
+        services
+            .AddSingleton<SessionAgreementComposer>()
+            .AddSingleton<IAttentionSource>(sp => sp.GetRequiredService<SessionAgreementComposer>())
+            .AddHostedService<SessionAgreementWorldRegistration>();
 
         // World-simulator inventory split (#602 — Phase 2).
         //
@@ -525,6 +539,33 @@ public static class GameStateServiceCollectionExtensions
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _view.Start();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Hosted service that calls <see cref="SessionAgreementComposer.Start"/> at
+    /// host start so the composer's <see cref="IGameSessionService"/> +
+    /// <see cref="IChatSessionService"/> subscriptions are in place before the
+    /// trailing <c>WorldMergerStartHostedService</c> (#696 Call 2) opens the
+    /// world drains (#633). Mirrors <see cref="WordOfPowerViewRegistration"/>'s
+    /// shape — the composer is itself a singleton via its own DI registration;
+    /// this hosted service exists solely to drive <see cref="SessionAgreementComposer.Start"/>.
+    /// </summary>
+    private sealed class SessionAgreementWorldRegistration : IHostedService
+    {
+        private readonly SessionAgreementComposer _composer;
+
+        public SessionAgreementWorldRegistration(SessionAgreementComposer composer)
+        {
+            _composer = composer;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _composer.Start();
             return Task.CompletedTask;
         }
 

--- a/src/Mithril.GameState/Sessions/SessionAgreementComposer.cs
+++ b/src/Mithril.GameState/Sessions/SessionAgreementComposer.cs
@@ -1,0 +1,232 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+using Mithril.WorldSim.Chat;
+
+namespace Mithril.GameState.Sessions;
+
+/// <summary>
+/// View-layer composer (#633) that verifies the server identity carried by the
+/// Player.log login banner agrees with the server identity carried by the chat
+/// login banner. Per <see cref="Mithril.GameState.Sessions.IGameSessionService"/>
+/// (Player.log side) and <see cref="IChatSessionService"/> (chat side), the two
+/// streams self-scope independently (world-sim principle 7); a view-layer
+/// composer is the place where their two banner observations meet and can be
+/// cross-checked (world-sim principle 3 — no service spans both sources).
+///
+/// <para><b>Verification only.</b> Per #633 acceptance, the composer never
+/// mutates either source's <c>GameSession</c> / <see cref="ChatSession"/>. The
+/// Player.log-derived <c>GameSession.Server</c> remains the authoritative
+/// field consumed by downstream <c>(Server, Character)</c>-scoped services;
+/// the chat banner's server identity is purely a cross-check input.</para>
+///
+/// <para><b>Pairing.</b> The composer holds the most-recent <see cref="GameSession"/>
+/// (from <see cref="IGameSessionService"/>) and the most-recent
+/// <see cref="ChatSession"/> (from <see cref="IChatSessionService"/>). Each
+/// time either side updates, it pairs against the other-side's most-recent
+/// observation. A pair is a candidate for the agreement check only when both
+/// observations name the same <c>Character</c> — when characters differ, the
+/// chat side is presumed to be lagging the player side mid-character-swap and
+/// the check is skipped (silent). When characters match and both sides carry
+/// a non-null server identity, the server names are compared verbatim (no
+/// canonicalisation — both sides parse the verbatim banner string, so
+/// equality holds when PG's two banners agree).</para>
+///
+/// <para><b>Missing-side cases are silent.</b> Per #633 acceptance: cold-start
+/// mid-PG-session can leave <see cref="GameSession.Server"/> null (L0 seed
+/// skipped the preamble; the connect-event URL never reached
+/// <c>GameSessionService</c>). The chat side may be unobserved entirely
+/// (Mithril attached after PG's chat banner). Both sides may be null pre-
+/// banner. None of these produce a warning — only a genuine disagreement
+/// (both non-null, different identities, same character) does.</para>
+///
+/// <para><b>Deduplication.</b> Repeated bus emissions for the same logical
+/// pairing (e.g. <see cref="IGameSessionService.SessionStarted"/> for a session
+/// whose chat counterpart has already been compared) re-emit nothing — the
+/// composer keys its last-emitted warning on
+/// <c>(SessionId, ChatBannerTimestamp)</c>. A genuine re-disagreement (a new
+/// chat banner observed against the same player session) fires once per new
+/// chat banner.</para>
+///
+/// <para><b>Attention surface.</b> The composer implements
+/// <see cref="IAttentionSource"/> with <see cref="ModuleId"/> = <c>"session-agreement"</c>
+/// so a disagreement surfaces on <see cref="IAttentionAggregator"/> alongside
+/// other shell-side attention signals (e.g. degraded log subscriptions). The
+/// count is the number of distinct <c>(SessionId, ChatBannerTimestamp)</c>
+/// disagreements observed this process lifetime — non-decreasing, since
+/// disagreements are evidence of a genuine PG / data mismatch that warrants
+/// investigation rather than self-clearing UX.</para>
+///
+/// <para><b>Mode.</b> Both upstream session services are mode-agnostic — they
+/// publish during world replay identically to live. The agreement check is
+/// also mode-agnostic; a disagreement is a structural fault in either source
+/// or in PG's emission, equally significant during replay as live. The Warn
+/// diagnostic is the user-visible surface; no audio / OS notification is
+/// gated.</para>
+/// </summary>
+public sealed class SessionAgreementComposer : IAttentionSource, IDisposable
+{
+    /// <summary>
+    /// Diagnostic category for every emission. Matches the spec — issue #633
+    /// acceptance bullet 2 ("Warn diagnostic (category <c>"SessionAgreement"</c>)").
+    /// </summary>
+    public const string DiagnosticCategory = "SessionAgreement";
+
+    /// <summary>
+    /// <see cref="IAttentionSource.ModuleId"/> bucket id for this composer.
+    /// Not a real module — uses the same convention as
+    /// <see cref="Mithril.Shared.Logging.LogStreamAttentionSource"/>'s shared
+    /// <c>"logging"</c> bucket.
+    /// </summary>
+    public const string AttentionSourceId = "session-agreement";
+
+    private readonly IGameSessionService _playerSessions;
+    private readonly IChatSessionService _chatSessions;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _gate = new();
+    private GameSession? _lastPlayer;
+    private ChatSession? _lastChat;
+
+    // Dedup key: (PlayerSessionId, ChatBannerAt). Each entry is one observed
+    // disagreement; the count is the size of the set. Process-lifetime —
+    // disagreements never self-clear.
+    private readonly HashSet<(string PlayerSessionId, DateTimeOffset ChatBannerAt)> _emittedWarnings = new();
+
+    private IDisposable? _playerSub;
+    private IDisposable? _chatSub;
+    private bool _started;
+    private bool _disposed;
+
+    public SessionAgreementComposer(
+        IGameSessionService playerSessions,
+        IChatSessionService chatSessions,
+        IDiagnosticsSink? diag = null)
+    {
+        _playerSessions = playerSessions ?? throw new ArgumentNullException(nameof(playerSessions));
+        _chatSessions = chatSessions ?? throw new ArgumentNullException(nameof(chatSessions));
+        _diag = diag;
+    }
+
+    public string ModuleId => AttentionSourceId;
+    public string DisplayLabel => "Session agreement — Player.log vs chat banner mismatch";
+
+    public int Count
+    {
+        get { lock (_gate) return _emittedWarnings.Count; }
+    }
+
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Attach to both session services. Idempotent — calling twice is safe.
+    /// The DI extension registers this as a hosted service so attachment
+    /// happens during host start, before the trailing
+    /// <c>WorldMergerStartHostedService</c> (#696 Call 2) opens the
+    /// world-merger drains.
+    /// </summary>
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+
+        // IGameSessionService.Subscribe atomically replays Current before going
+        // live; IChatSessionService.Subscribe does NOT replay Current per its
+        // interface contract. We mirror that asymmetry by reading the chat
+        // side's Current explicitly on attach (under the same lock that holds
+        // the player subscribe so a chat-replay-then-player-subscribe race
+        // doesn't drop a candidate pair).
+        lock (_gate)
+        {
+            _lastChat = _chatSessions.Current;
+            _playerSub = _playerSessions.Subscribe(OnPlayerSession);
+            _chatSub = _chatSessions.Subscribe(OnChatSession);
+
+            // If the chat side already had a banner at attach AND the player
+            // subscribe just delivered the current player session, both
+            // observations are now in place — run the check once.
+            if (_lastChat is not null && _lastPlayer is not null)
+            {
+                CheckAgreementLocked();
+            }
+        }
+    }
+
+    private void OnPlayerSession(GameSession session)
+    {
+        lock (_gate)
+        {
+            _lastPlayer = session;
+            CheckAgreementLocked();
+        }
+    }
+
+    private void OnChatSession(ChatSession session)
+    {
+        lock (_gate)
+        {
+            _lastChat = session;
+            CheckAgreementLocked();
+        }
+    }
+
+    private void CheckAgreementLocked()
+    {
+        var player = _lastPlayer;
+        var chat = _lastChat;
+
+        // Missing-side cases are silent (acceptance bullet 4).
+        if (player is null || chat is null) return;
+
+        // Character mismatch means the chat side hasn't caught up to the most
+        // recent player banner (mid-character-swap). Not a disagreement —
+        // we're comparing the wrong logical pair. Silent.
+        if (!string.Equals(player.CharacterName, chat.Character, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Player-side server identity unknown (cold-start mid-PG-session
+        // skipped the preamble) — silent. See GameSession.Server XML doc for
+        // the documented null-server path.
+        var playerServerName = player.Server?.Name;
+        if (string.IsNullOrEmpty(playerServerName)) return;
+
+        // Chat-side server identity unknown — silent. (The chat banner always
+        // carries Server verbatim, but an empty string indicates the parse
+        // dropped the field; treat as missing rather than disagreeing.)
+        if (string.IsNullOrEmpty(chat.Server)) return;
+
+        if (string.Equals(playerServerName, chat.Server, StringComparison.Ordinal))
+        {
+            // Matching observation — silent (acceptance bullet 4).
+            return;
+        }
+
+        // Genuine disagreement. Dedup by (PlayerSessionId, ChatBannerTimestamp)
+        // so a re-emission of the same player session or the same chat banner
+        // doesn't re-fire. A new chat banner for the same player session DOES
+        // re-fire (different ChatBannerTimestamp).
+        var dedupKey = (player.SessionId, chat.At);
+        if (!_emittedWarnings.Add(dedupKey)) return;
+
+        var message =
+            $"Player.log banner server '{playerServerName}' disagrees with chat banner server '{chat.Server}' " +
+            $"for character '{player.CharacterName}' (session id '{player.SessionId}', chat banner at {chat.At:O}). " +
+            "The Player.log-derived server identity remains authoritative for downstream services; " +
+            "this warning surfaces only as a cross-source consistency check.";
+        _diag?.Warn(DiagnosticCategory, message);
+
+        // IAttentionSource fires Changed under the gate's snapshot — handlers
+        // typically marshal to the UI thread via the aggregator, so a quick
+        // re-entry into Count is safe (Count itself takes the gate).
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _playerSub?.Dispose();
+        _chatSub?.Dispose();
+    }
+}

--- a/tests/Mithril.GameState.Tests/Sessions/SessionAgreementComposerTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/SessionAgreementComposerTests.cs
@@ -1,0 +1,451 @@
+using FluentAssertions;
+using Mithril.GameState.Servers;
+using Mithril.GameState.Sessions;
+using Mithril.Shared.Diagnostics;
+using Mithril.WorldSim.Chat;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Sessions;
+
+public sealed class SessionAgreementComposerTests
+{
+    private static readonly ServerEntry Laeth = new(
+        "s4", "Laeth", "s4.projectgorgon.com", 9002, "Laeth desc");
+    private static readonly ServerEntry Arisetsu = new(
+        "s0", "Arisetsu", "s0.projectgorgon.com", 9002, "Arisetsu desc");
+
+    [Fact]
+    public void Disagreement_emits_warn_with_SessionAgreement_category_carrying_both_identities_and_session_id()
+    {
+        // Player.log says Laeth; chat says Arisetsu for the same character —
+        // the canonical disagreement case from #633 spec.
+        var player = new FakePlayerSessionService(
+            new GameSession(
+                SessionId: "session-1",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 12, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth));
+        var chat = new FakeChatSessionService(
+            new ChatSession(
+                Server: "Arisetsu",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 12, 0, 5, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().ContainSingle(
+                e => e.Level == DiagnosticLevel.Warn
+                  && e.Category == SessionAgreementComposer.DiagnosticCategory);
+            var entry = diag.Entries.Single(e => e.Level == DiagnosticLevel.Warn);
+            entry.Message.Should().Contain("Laeth");
+            entry.Message.Should().Contain("Arisetsu");
+            entry.Message.Should().Contain("session-1");
+            entry.Message.Should().Contain("Emraell");
+            composer.Count.Should().Be(1);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Disagreement_raises_Changed_so_attention_aggregator_surfaces_the_mismatch()
+    {
+        var player = new FakePlayerSessionService(
+            new GameSession(
+                SessionId: "s",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth));
+        var chat = new FakeChatSessionService(
+            new ChatSession(
+                Server: "Arisetsu",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+        var composer = new SessionAgreementComposer(player, chat);
+        var changedCount = 0;
+        composer.Changed += (_, _) => changedCount++;
+
+        try
+        {
+            composer.Start();
+
+            changedCount.Should().Be(1);
+            composer.ModuleId.Should().Be(SessionAgreementComposer.AttentionSourceId);
+            composer.Count.Should().Be(1);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Matching_servers_for_same_character_emit_no_warning_and_no_attention()
+    {
+        var player = new FakePlayerSessionService(
+            new GameSession(
+                SessionId: "s",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth));
+        var chat = new FakeChatSessionService(
+            new ChatSession(
+                Server: "Laeth",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().BeEmpty();
+            composer.Count.Should().Be(0);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Chat_only_observation_is_silent()
+    {
+        // Cold-start mid-PG-session: chat banner observed, Player.log session
+        // never landed (preamble skipped).
+        var player = new FakePlayerSessionService(current: null);
+        var chat = new FakeChatSessionService(
+            new ChatSession(
+                Server: "Laeth",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().BeEmpty();
+            composer.Count.Should().Be(0);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Player_only_observation_is_silent()
+    {
+        var player = new FakePlayerSessionService(
+            new GameSession(
+                SessionId: "s",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth));
+        var chat = new FakeChatSessionService(current: null);
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().BeEmpty();
+            composer.Count.Should().Be(0);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Both_null_is_silent()
+    {
+        var player = new FakePlayerSessionService(current: null);
+        var chat = new FakeChatSessionService(current: null);
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().BeEmpty();
+            composer.Count.Should().Be(0);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Null_player_server_is_silent_even_when_chat_carries_one()
+    {
+        // Cold-start mid-PG-session: banner landed in replay but the connect
+        // preamble didn't, so GameSession.Server is null.
+        var player = new FakePlayerSessionService(
+            new GameSession(
+                SessionId: "s",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: null));
+        var chat = new FakeChatSessionService(
+            new ChatSession(
+                Server: "Laeth",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().BeEmpty();
+            composer.Count.Should().Be(0);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Character_mismatch_does_not_trigger_warn_even_with_disagreeing_servers()
+    {
+        // Mid-character-swap: player session ahead of chat banner. The two
+        // observations belong to different logical pairings; warning here
+        // would be spurious.
+        var player = new FakePlayerSessionService(
+            new GameSession(
+                SessionId: "s",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth));
+        var chat = new FakeChatSessionService(
+            new ChatSession(
+                Server: "Arisetsu",
+                Character: "Frodo",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            diag.Entries.Should().BeEmpty();
+            composer.Count.Should().Be(0);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Same_logical_pairing_emits_only_once_when_player_session_re_published()
+    {
+        var player = new MutablePlayerSessionService();
+        var chat = new MutableChatSessionService();
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+
+            var initial = new GameSession(
+                SessionId: "session-1",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth);
+            player.Publish(initial);
+            chat.Publish(new ChatSession(
+                Server: "Arisetsu",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+
+            diag.WarnCount(SessionAgreementComposer.DiagnosticCategory).Should().Be(1);
+
+            // Re-publishing the same player session re-runs the check but the
+            // (SessionId, ChatBannerAt) dedup keeps the warning to one.
+            player.Publish(initial);
+            diag.WarnCount(SessionAgreementComposer.DiagnosticCategory).Should().Be(1);
+            composer.Count.Should().Be(1);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void New_chat_banner_against_same_disagreeing_player_session_re_fires()
+    {
+        // PG re-logs into chat (or chat banner re-emits) while the Player.log
+        // session is unchanged — the chat-banner-At differs, so dedup admits
+        // a fresh warning.
+        var player = new MutablePlayerSessionService();
+        var chat = new MutableChatSessionService();
+        var diag = new RecordingDiagnosticsSink();
+
+        var composer = new SessionAgreementComposer(player, chat, diag);
+        try
+        {
+            composer.Start();
+            player.Publish(new GameSession(
+                SessionId: "session-1",
+                CharacterName: "Emraell",
+                LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+                TimezoneOffset: TimeSpan.Zero,
+                Server: Laeth));
+            chat.Publish(new ChatSession(
+                Server: "Arisetsu",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+            chat.Publish(new ChatSession(
+                Server: "Arisetsu",
+                Character: "Emraell",
+                At: new DateTimeOffset(2026, 5, 22, 0, 1, 0, TimeSpan.Zero),
+                Offset: TimeSpan.Zero));
+
+            diag.WarnCount(SessionAgreementComposer.DiagnosticCategory).Should().Be(2);
+            composer.Count.Should().Be(2);
+        }
+        finally { composer.Dispose(); }
+    }
+
+    [Fact]
+    public void Composer_does_not_mutate_either_source_session_record()
+    {
+        // Acceptance bullet 3 — no mutation; the Player.log-derived
+        // GameSession.Server stays authoritative.
+        var playerSession = new GameSession(
+            SessionId: "s",
+            CharacterName: "Emraell",
+            LoggedInUtc: new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
+            TimezoneOffset: TimeSpan.Zero,
+            Server: Laeth);
+        var chatSession = new ChatSession(
+            Server: "Arisetsu",
+            Character: "Emraell",
+            At: new DateTimeOffset(2026, 5, 22, 0, 0, 0, TimeSpan.Zero),
+            Offset: TimeSpan.Zero);
+        var player = new FakePlayerSessionService(playerSession);
+        var chat = new FakeChatSessionService(chatSession);
+
+        var composer = new SessionAgreementComposer(player, chat);
+        try
+        {
+            composer.Start();
+            player.Current.Should().BeSameAs(playerSession);
+            player.Current!.Server.Should().BeSameAs(Laeth);
+            chat.Current.Should().BeSameAs(chatSession);
+            chat.Current!.Server.Should().Be("Arisetsu");
+        }
+        finally { composer.Dispose(); }
+    }
+
+    // ── Test doubles ────────────────────────────────────────────────────────
+
+    private sealed class FakePlayerSessionService : IGameSessionService
+    {
+        public FakePlayerSessionService(GameSession? current)
+        {
+            Current = current;
+        }
+
+        public GameSession? Current { get; }
+
+        public event EventHandler<GameSession>? SessionStarted { add { } remove { } }
+
+        public IDisposable Subscribe(Action<GameSession> handler)
+        {
+            if (Current is not null) handler(Current);
+            return new NoOp();
+        }
+
+        private sealed class NoOp : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class FakeChatSessionService : IChatSessionService
+    {
+        public FakeChatSessionService(ChatSession? current)
+        {
+            Current = current;
+        }
+
+        public ChatSession? Current { get; }
+
+        public IDisposable Subscribe(Action<ChatSession> handler)
+        {
+            // Matches the IChatSessionService contract — handlers fire on every
+            // new banner observation; Current is NOT replayed on subscribe.
+            return new NoOp();
+        }
+
+        private sealed class NoOp : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class MutablePlayerSessionService : IGameSessionService
+    {
+        private readonly List<Action<GameSession>> _subs = new();
+        public GameSession? Current { get; private set; }
+        public event EventHandler<GameSession>? SessionStarted;
+
+        public IDisposable Subscribe(Action<GameSession> handler)
+        {
+            if (Current is not null) handler(Current);
+            _subs.Add(handler);
+            return new NoOp();
+        }
+
+        public void Publish(GameSession session)
+        {
+            Current = session;
+            SessionStarted?.Invoke(this, session);
+            foreach (var s in _subs.ToArray()) s(session);
+        }
+
+        private sealed class NoOp : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class MutableChatSessionService : IChatSessionService
+    {
+        private readonly List<Action<ChatSession>> _subs = new();
+        public ChatSession? Current { get; private set; }
+
+        public IDisposable Subscribe(Action<ChatSession> handler)
+        {
+            _subs.Add(handler);
+            return new NoOp();
+        }
+
+        public void Publish(ChatSession session)
+        {
+            Current = session;
+            foreach (var s in _subs.ToArray()) s(session);
+        }
+
+        private sealed class NoOp : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class RecordingDiagnosticsSink : IDiagnosticsSink
+    {
+        private readonly List<DiagnosticEntry> _entries = new();
+        public IReadOnlyList<DiagnosticEntry> Entries => _entries;
+        public event EventHandler<DiagnosticEntry>? EntryAdded;
+
+        public void Write(DiagnosticLevel level, string category, string message)
+        {
+            var entry = new DiagnosticEntry(DateTime.UtcNow, level, category, message);
+            _entries.Add(entry);
+            EntryAdded?.Invoke(this, entry);
+        }
+
+        public IReadOnlyList<DiagnosticEntry> Snapshot() => _entries.ToArray();
+
+        public int WarnCount(string category) =>
+            _entries.Count(e => e.Level == DiagnosticLevel.Warn && e.Category == category);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the view-layer composer that cross-checks the Player.log login banner's server identity (`IGameSessionService.Current.Server`) against the chat login banner's server identity (`IChatSessionService.Current.Server`). This was deferred from #611 acceptance bullet 4 and is now unblocked by the closed shells in #616 / #617.

**Verification only.** The composer never mutates `GameSession` or `ChatSession`; the Player.log-derived server identity remains authoritative for downstream `(Server, Character)`-scoped services. Disagreement surfaces as a Warn diagnostic + `IAttentionAggregator` count — not as a state correction.

## What landed

- **`SessionAgreementComposer`** (`src/Mithril.GameState/Sessions/`) — holds the most-recent player + chat session observations; on each update, pairs against the other side and runs the agreement check.
- **Disagreement** (both non-null servers, same character, different server names) emits a Warn diagnostic under category `"SessionAgreement"` carrying both observed server identities + the player session id + the character + the chat banner timestamp.
- **`IAttentionSource`** implementation with `ModuleId = "session-agreement"` — same registration pattern as `LogStreamAttentionSource`; the existing `AttentionAggregator` picks it up via `IEnumerable<IAttentionSource>`.
- **Dedup** keyed on `(PlayerSessionId, ChatBannerTimestamp)` — re-emitting the same player session doesn't re-fire; a fresh chat banner against the same disagreeing player session does.
- **Missing-side cases silent** per acceptance bullet 4: chat-only, Player.log-only, both-null, null `GameSession.Server` (cold-start mid-PG-session preamble skip), character mismatch (mid-character-swap chat lag).
- **DI**: `AddSingleton<SessionAgreementComposer>` + `IAttentionSource` binding + `SessionAgreementWorldRegistration` hosted service to call `Start()` before the trailing `WorldMergerStartHostedService` (#696 Call 2) opens the world drains.

## Design notes

- **Where it lives.** `Mithril.GameState/Sessions/` — alongside `IGameSessionService` and `ChatSession`, sibling to the existing `InventoryView` / `WordOfPowerView` view-layer composers. This composer subscribes only to session-banner observations (not to world buses) since the Player.log banner is still surfaced via `IGameSessionService` rather than `IPlayerWorld.Bus`.
- **Why not subscribe to world buses?** `IPlayerWorld` doesn't currently emit banner frames on its bus — sessions remain on `IGameSessionService`. The session services already are the canonical "banner observation" surfaces. If a future migration moves session frames onto the world buses (per the design notebook), this composer is a 1-paragraph migration: swap the two `Subscribe` calls for `Bus.Subscribe<…BannerObserved>` handlers.
- **Asymmetric subscribe semantics.** `IGameSessionService.Subscribe` atomically replays `Current`; `IChatSessionService.Subscribe` does NOT replay `Current` per its interface contract. The composer reads the chat side's `Current` explicitly on `Start()` to close the gap so a chat-banner-observed-before-Start case still pairs.

## Tests (11 new)

- Disagreement → Warn emitted with category `"SessionAgreement"` carrying both identities + session id + character.
- Disagreement → `Changed` fires so the attention aggregator surfaces the mismatch.
- Matching servers for same character → silent.
- Chat-only observation → silent.
- Player-only observation → silent.
- Both-null → silent.
- Null `GameSession.Server` even when chat carries one → silent (cold-start mid-PG-session).
- Character mismatch with disagreeing servers → silent (mid-character-swap).
- Same logical pairing emits only once when player session re-publishes.
- Fresh chat banner against same disagreeing player session re-fires (new `ChatBannerAt` → new dedup key).
- Composer does not mutate either source record (verification-only contract).

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — all green (incl. 11 new tests in `Mithril.GameState.Tests.Sessions.SessionAgreementComposerTests`)

## References

- Source: #611 acceptance bullet 4 (deferred); PR #632 review note.
- Depends on: #616 (`IPlayerWorld` shell), #617 (`IChatWorld` shell + `IChatSessionService`). Both closed.
- Design notebook: `docs/world-simulator.md` — principle 3 ("no service spans both sources") + principle 4 (view-layer composers).
- Umbrella: #601 (world-simulator migration).

Closes #633.

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
