### PR TITLE
refactor(gamestate): retire InventoryView IGameReportsService fallback (#628)

### DIFF
--- a/src/Mithril.GameState/Inventory/InventoryView.cs
+++ b/src/Mithril.GameState/Inventory/InventoryView.cs
@@ -87,10 +87,10 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     private readonly IPlayerWorld _playerWorld;
     private readonly IChatWorld _chatWorld;
     private readonly IPlayerInventoryState _playerState;
+    private readonly IGameReportsService _gameReports;
     private readonly IReferenceDataService? _refData;
     private readonly IGameSessionService? _playerSession;
     private readonly IChatSessionService? _chatSession;
-    private readonly IGameReportsService? _gameReports;
     private readonly IDiagnosticsSink? _diag;
     private readonly ViewClock _clock;
     private readonly ViewEventBus _bus = new();
@@ -160,19 +160,19 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
         IPlayerWorld playerWorld,
         IChatWorld chatWorld,
         IPlayerInventoryState playerState,
+        IGameReportsService gameReports,
         IReferenceDataService? refData = null,
         IGameSessionService? playerSession = null,
         IChatSessionService? chatSession = null,
-        IGameReportsService? gameReports = null,
         IDiagnosticsSink? diag = null)
     {
         _playerWorld = playerWorld ?? throw new ArgumentNullException(nameof(playerWorld));
         _chatWorld = chatWorld ?? throw new ArgumentNullException(nameof(chatWorld));
         _playerState = playerState ?? throw new ArgumentNullException(nameof(playerState));
+        _gameReports = gameReports ?? throw new ArgumentNullException(nameof(gameReports));
         _refData = refData;
         _playerSession = playerSession;
         _chatSession = chatSession;
-        _gameReports = gameReports;
         _diag = diag;
         _clock = new ViewClock();
         _pendingChat = new PendingCorrelator<ScopedKey, int>(PendingChatTtl, _clock);
@@ -199,10 +199,7 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
         _started = true;
 
         LoadExportSeeds();
-        if (_gameReports is not null)
-        {
-            _gameReports.StorageReportsChanged += OnGameReportsStorageChanged;
-        }
+        _gameReports.StorageReportsChanged += OnGameReportsStorageChanged;
 
         _playerAddedSub = _playerWorld.Bus.Subscribe<PlayerInventoryAdded>(OnPlayerAdded);
         _playerRemovedSub = _playerWorld.Bus.Subscribe<PlayerInventoryRemoved>(OnPlayerRemoved);
@@ -493,7 +490,6 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     private void LoadExportSeeds()
     {
         if (_refData is null) return;
-        if (_gameReports is null) return;
 
         var newest = _gameReports.StorageReports.FirstOrDefault();
         if (newest is null)
@@ -660,10 +656,7 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
         _playerRemovedSub?.Dispose();
         _playerStackUpdatedSub?.Dispose();
         _chatObservedSub?.Dispose();
-        if (_gameReports is not null)
-        {
-            _gameReports.StorageReportsChanged -= OnGameReportsStorageChanged;
-        }
+        _gameReports.StorageReportsChanged -= OnGameReportsStorageChanged;
     }
 
     private sealed class ShimSubscription : IDisposable

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
@@ -291,7 +291,7 @@ public sealed class InventoryViewTests
             refData: refData ?? new TwoItemRefData(),
             playerSession: playerSession,
             chatSession: chatSession,
-            gameReports: gameReports);
+            gameReports: gameReports ?? new FakeGameReportsService());
         view.Start();
         return (view, playerWorld, chatWorld, pstate);
     }


### PR DESCRIPTION
## Summary

Retires the `IGameReportsService` null-tolerance that PR [#626](https://github.com/moumantai-gg/mithril/pull/626) (issue [#612](https://github.com/moumantai-gg/mithril/issues/612)) preserved on `InventoryView` solely to avoid churning test fixtures. In shipped configurations the production composition always wires the foundation service (`src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs:79`), so the null path was unreachable everywhere except tests.

**Closes [#628](https://github.com/moumantai-gg/mithril/issues/628).** Part of the [#601](https://github.com/moumantai-gg/mithril/issues/601) world-simulator migration umbrella; cleanup tail of [#612](https://github.com/moumantai-gg/mithril/issues/612) shipped in PR [#626](https://github.com/moumantai-gg/mithril/pull/626).

## What changed

Two-step retirement (separate commits on this branch — squash-merge will flatten):

1. **Step 1 — fixture migration.** `InventoryViewTests.Build(...)` defaults `gameReports` to a fresh `FakeGameReportsService` (already a nested type in the same file) when callers don't pass one. The empty stub is behaviourally equivalent to null at the existing `LoadExportSeeds` early-return, so no test semantics shift. Tests pass with the fallback still in place — confirms the migration is functionally equivalent before deletion.

2. **Step 2 — fallback deletion.** On `InventoryView`:
   - `_gameReports` field drops the `?` (non-nullable).
   - Ctor parameter moves ahead of the optional ones and drops `= null` (required). C# requires required parameters before optional, so the reorder is mandatory; every test call site already uses the named-arg form so this is non-breaking.
   - ArgumentNullException guard added for parity with `playerWorld`/`chatWorld`/`playerState`.
   - Three null guards retire: the `Start()` event subscribe, the `LoadExportSeeds()` early-return, the `Dispose()` event unsubscribe.

**Note on issue body's stale citations.** Issue [#628](https://github.com/moumantai-gg/mithril/issues/628) references `src/Mithril.GameState/Inventory/InventoryService.cs` lines 735–785 with a `_seedWatcher` field and `FileSystemWatcher` setup branch. Post-PR-[#679](https://github.com/moumantai-gg/mithril/pull/679) (the [#602](https://github.com/moumantai-gg/mithril/issues/602) keystone split) those have already retired — `InventoryService.cs` collapsed into `InventoryView.cs`, and the `_seedWatcher` field disappeared along with it. What remained as "fallback" was just the nullable `IGameReportsService?` ctor parameter + three null guards. This PR retires that residual; the FileSystemWatcher cleanup the issue describes had landed already.

## Verification

- [x] `dotnet build Mithril.slnx` — `0 Warning(s) 0 Error(s)` (warnings-as-errors enforced).
- [x] `dotnet test Mithril.slnx` — all 23 test projects green (3765 tests total, 0 failures).
- [x] `dotnet test tests/Mithril.GameState.Tests` — 421 pass at both the Step 1 and Step 2 commits.
- [x] Post-deletion greps clean:
  - `grep -r "FileSystemWatcher" src/Mithril.GameState/Inventory/` → zero hits
  - `grep -r "_seedWatcher" src/` → zero hits
  - `grep "IGameReportsService?" src/Mithril.GameState/Inventory/InventoryView.cs` → zero hits
- [ ] Manual smoke test (recommended pre-merge): launch the shell and confirm Bilbo storage tab + Samwise gardening + Palantir live inventory still read inventory correctly. The production path was the only path before this PR; no behavioural change is expected.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
