### PR TITLE
refactor(world-sim): retire event-driven wall-clock stamps (#715)

### DIFF
--- a/src/Arwen.Module/State/FavorIngestionService.cs
+++ b/src/Arwen.Module/State/FavorIngestionService.cs
@@ -163,7 +163,7 @@ public sealed class FavorIngestionService : BackgroundService
                     var favor = _favorView.Current;
                     if (favor is not null)
                     {
-                        favor.SetExactFavor(update.NpcKey, update.AbsoluteFavor, DateTimeOffset.UtcNow);
+                        favor.SetExactFavor(update.NpcKey, update.AbsoluteFavor, ts);
                         _favorView.Save();
                         _state.OnFavorUpdated(update.NpcKey);
                     }

--- a/src/Mithril.GameState/Pins/IPlayerPinTracker.cs
+++ b/src/Mithril.GameState/Pins/IPlayerPinTracker.cs
@@ -28,8 +28,11 @@ public enum PinSetChange
 /// <see cref="Pin"/> is the single affected pin for
 /// <see cref="PinSetChange.Added"/>/<see cref="PinSetChange.Removed"/> and
 /// <c>null</c> otherwise. <see cref="ObservedAt"/> is the source log line's
-/// UTC instant as a <see cref="DateTimeOffset"/> (Snapshot replays use the
-/// subscribe instant).
+/// UTC instant as a <see cref="DateTimeOffset"/>; for
+/// <see cref="PinSetChange.Snapshot"/> replays it is the most-recent envelope
+/// timestamp the tracker has applied (<see cref="DateTimeOffset.MinValue"/> if
+/// no envelope has been applied yet — in which case the snapshot payload is
+/// also empty).
 /// </summary>
 /// <param name="Kind">Why this notification arose.</param>
 /// <param name="Area">The area key the set belongs to (may be <c>null</c> if
@@ -40,8 +43,11 @@ public enum PinSetChange
 /// <see cref="PinSetChange.AreaChanged"/>.</param>
 /// <param name="Pins">The full current-area set <em>after</em> the change —
 /// an immutable snapshot, safe to retain.</param>
-/// <param name="ObservedAt">UTC instant of the source log line (or the
-/// subscribe instant for a <see cref="PinSetChange.Snapshot"/> replay).</param>
+/// <param name="ObservedAt">UTC instant of the source log line. For a
+/// <see cref="PinSetChange.Snapshot"/> replay this is the most-recent envelope
+/// timestamp the tracker has applied (<see cref="DateTimeOffset.MinValue"/> if
+/// no envelope has been applied yet — in which case the snapshot payload is
+/// also empty).</param>
 public sealed record PinSetChanged(
     PinSetChange Kind,
     string? Area,

--- a/src/Mithril.GameState/Pins/PlayerPinTracker.cs
+++ b/src/Mithril.GameState/Pins/PlayerPinTracker.cs
@@ -63,6 +63,16 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
     private bool _areaInitialised;
     private ILogSubscription? _subscription;
 
+    // Most-recent envelope timestamp the tracker has applied (area
+    // transition or pin add/remove). Subscribe-replay stamps its synthetic
+    // Snapshot notification with this so late subscribers observe the same
+    // envelope-time view already-attached handlers were given (principle 13:
+    // never leak wall clock into world-event-driven state). Default
+    // (DateTimeOffset.MinValue) when no envelope has been applied yet —
+    // the snapshot payload is also empty in that case, so the stamp is
+    // never meaningful in isolation.
+    private DateTimeOffset _lastObservedAt;
+
     private const string DiagCategory = "GameState.Pins";
 
     /// <param name="driver">L1 driver — subscribed to via the
@@ -107,10 +117,12 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
         {
             // Replay the current set before going live so a late subscriber
             // observes the same view already-attached handlers see. Mirrors
-            // PlayerPositionTracker.Subscribe.
+            // PlayerPositionTracker.Subscribe. The stamp comes from the
+            // most-recent envelope the tracker has applied (NOT wall-clock
+            // — principle 13); see _lastObservedAt's field doc.
             Invoke(handler, new PinSetChanged(
                 PinSetChange.Snapshot, _trackedArea, null, Snapshot(),
-                DateTimeOffset.UtcNow));
+                _lastObservedAt));
             _handlers.Add(handler);
             return new Subscription(this, handler);
         }
@@ -142,7 +154,7 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
                         if (_areaParser.TryParse(s.Data, s.Timestamp.UtcDateTime)
                             is Areas.Parsing.AreaTransitionEvent areaEvt)
                         {
-                            ReconcileArea(areaEvt.AreaKey);
+                            ReconcileArea(areaEvt.AreaKey, s.Timestamp);
                         }
                         break;
 
@@ -190,7 +202,13 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
     /// the key — repopulates it. Called from the unified-pipe handler when a
     /// new <see cref="SystemSignalKind.AreaLoading"/> envelope arrives.
     /// </summary>
-    private void ReconcileArea(string? area)
+    /// <param name="area">New area key (null for the empty / ChooseCharacter
+    /// form).</param>
+    /// <param name="observedAt">Envelope timestamp of the triggering
+    /// <c>LOADING LEVEL</c> system-signal — stamped on the resulting
+    /// <see cref="PinSetChange.AreaChanged"/> notification so consumers see
+    /// log-instant time, never wall clock (principle 13).</param>
+    private void ReconcileArea(string? area, DateTimeOffset observedAt)
     {
         PinSetChanged? note = null;
         lock (_lock)
@@ -199,9 +217,10 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
             _areaInitialised = true;
             _trackedArea = area;
             _pins.Clear();
+            _lastObservedAt = observedAt;
             note = new PinSetChanged(
                 PinSetChange.AreaChanged, area, null, Snapshot(),
-                DateTimeOffset.UtcNow);
+                observedAt);
         }
         if (note is not null) Publish(note);
     }
@@ -209,15 +228,19 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
     private void Apply(MapPinLogEvent evt)
     {
         var key = PinKey.From(evt.X, evt.Z);
+        var observedAt = ToOffset(evt.Timestamp);
         PinSetChanged? note = null;
         lock (_lock)
         {
             if (evt.Change == MapPinChange.Removed)
             {
                 if (_pins.Remove(key, out var removed))
+                {
+                    _lastObservedAt = observedAt;
                     note = new PinSetChanged(
                         PinSetChange.Removed, _trackedArea, removed, Snapshot(),
-                        ToOffset(evt.Timestamp));
+                        observedAt);
+                }
             }
             else
             {
@@ -229,9 +252,10 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
                 if (!_pins.TryGetValue(key, out var existing) || existing != pin)
                 {
                     _pins[key] = pin;
+                    _lastObservedAt = observedAt;
                     note = new PinSetChanged(
                         PinSetChange.Added, _trackedArea, pin, Snapshot(),
-                        ToOffset(evt.Timestamp));
+                        observedAt);
                 }
             }
         }

--- a/src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs
+++ b/src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs
@@ -58,9 +58,13 @@ public enum WeatherChangeKind
 /// unknown).</param>
 /// <param name="State">The current map's weather after the change, or
 /// <c>null</c> if not yet known for this map.</param>
-/// <param name="ObservedAt">UTC instant of the source log line (or the
-/// subscribe instant for a <see cref="WeatherChangeKind.Snapshot"/> replay /
-/// the area-transition instant for <see cref="WeatherChangeKind.AreaChanged"/>).</param>
+/// <param name="ObservedAt">UTC instant of the source log line. For a
+/// <see cref="WeatherChangeKind.Snapshot"/> replay this is the most-recent
+/// envelope timestamp the tracker has applied
+/// (<see cref="DateTimeOffset.MinValue"/> if no envelope has been applied yet
+/// — in which case <c>State</c> is also <c>null</c>); for a
+/// <see cref="WeatherChangeKind.AreaChanged"/> notification this is the
+/// area-transition envelope instant.</param>
 public sealed record WeatherChanged(
     WeatherChangeKind Kind,
     string? Area,

--- a/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
+++ b/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
@@ -65,6 +65,16 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
     private bool _areaInitialised;
     private ILogSubscription? _subscription;
 
+    // Most-recent envelope timestamp the tracker has applied (area
+    // transition or weather change). Subscribe-replay stamps its synthetic
+    // Snapshot notification with this so late subscribers observe the same
+    // envelope-time view already-attached handlers were given (principle 13:
+    // never leak wall clock into world-event-driven state). Mirrors
+    // PlayerPinTracker._lastObservedAt. Default (DateTimeOffset.MinValue)
+    // when no envelope has been applied yet — the snapshot payload is also
+    // empty in that case, so the stamp is never meaningful in isolation.
+    private DateTimeOffset _lastObservedAt;
+
     private const string DiagCategory = "GameState.Weather";
 
     /// <param name="driver">L1 driver — subscribed to via the
@@ -110,10 +120,12 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
         {
             // Replay the current state before going live so a late subscriber
             // observes the same view already-attached handlers see. Mirrors
-            // PlayerPinTracker.Subscribe.
+            // PlayerPinTracker.Subscribe. The stamp comes from the
+            // most-recent envelope the tracker has applied (NOT wall-clock
+            // — principle 13); see _lastObservedAt's field doc.
             Invoke(handler, new WeatherChanged(
                 WeatherChangeKind.Snapshot, _trackedArea, _current,
-                DateTimeOffset.UtcNow));
+                _lastObservedAt));
             _handlers.Add(handler);
             return new Subscription(this, handler);
         }
@@ -140,7 +152,7 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
                         if (_areaParser.TryParse(s.Data, s.Timestamp.UtcDateTime)
                             is AreaTransitionEvent areaEvt)
                         {
-                            ReconcileArea(areaEvt.AreaKey);
+                            ReconcileArea(areaEvt.AreaKey, s.Timestamp);
                         }
                         break;
 
@@ -187,7 +199,13 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
     /// <c>ProcessSetWeather</c> — which follows the <c>LOADING LEVEL</c>
     /// envelope on the same unified pipe — repopulates it.
     /// </summary>
-    private void ReconcileArea(string? area)
+    /// <param name="area">New area key (null for the empty / ChooseCharacter
+    /// form).</param>
+    /// <param name="observedAt">Envelope timestamp of the triggering
+    /// <c>LOADING LEVEL</c> system-signal — stamped on the resulting
+    /// <see cref="WeatherChangeKind.AreaChanged"/> notification so
+    /// consumers see log-instant time, never wall clock (principle 13).</param>
+    private void ReconcileArea(string? area, DateTimeOffset observedAt)
     {
         WeatherChanged? note = null;
         lock (_lock)
@@ -196,15 +214,17 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
             _areaInitialised = true;
             _trackedArea = area;
             _current = null;
+            _lastObservedAt = observedAt;
             note = new WeatherChanged(
                 WeatherChangeKind.AreaChanged, area, null,
-                DateTimeOffset.UtcNow);
+                observedAt);
         }
         if (note is not null) Publish(note);
     }
 
     private void Apply(WeatherChangedEvent evt)
     {
+        var observedAt = ToOffset(evt.Timestamp);
         WeatherChanged? note = null;
         lock (_lock)
         {
@@ -217,10 +237,11 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
                 return;
             }
 
-            _current = new WeatherState(evt.Condition, evt.Flag, ToOffset(evt.Timestamp));
+            _current = new WeatherState(evt.Condition, evt.Flag, observedAt);
+            _lastObservedAt = observedAt;
             note = new WeatherChanged(
                 WeatherChangeKind.Changed, _trackedArea, _current,
-                ToOffset(evt.Timestamp));
+                observedAt);
         }
         if (note is not null) Publish(note);
     }

--- a/src/Pippin.Module/State/GourmandStateMachine.cs
+++ b/src/Pippin.Module/State/GourmandStateMachine.cs
@@ -105,7 +105,13 @@ public sealed class GourmandStateMachine
                 _unknownByName[name] = count;
         }
 
-        _lastReportTime ??= DateTimeOffset.UtcNow;
+        // No envelope timestamp in the legacy migration path — the v1
+        // persisted state didn't carry a per-report instant. Leave
+        // _lastReportTime as Hydrate set it (null when the v1 state had no
+        // value); the next real FoodsConsumedReport will stamp it from the
+        // log envelope. Pre-#715 this fell back to DateTimeOffset.UtcNow,
+        // leaking real wall-clock into a path consumers compare across
+        // replays.
         StateChanged?.Invoke(this, EventArgs.Empty);
         return true;
     }
@@ -123,7 +129,11 @@ public sealed class GourmandStateMachine
                 _unknownByName[food.Name] = food.Count;
         }
 
-        _lastReportTime = DateTimeOffset.UtcNow;
+        // Stamp from the report's envelope timestamp so replay produces
+        // byte-identical LastReportTime regardless of real-elapsed time
+        // (principle 13). report.Timestamp is the log-line instant in UTC.
+        _lastReportTime = new DateTimeOffset(
+            DateTime.SpecifyKind(report.Timestamp, DateTimeKind.Utc));
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/tests/Arwen.Tests/FavorIngestionServiceTests.cs
+++ b/tests/Arwen.Tests/FavorIngestionServiceTests.cs
@@ -166,6 +166,54 @@ public sealed class FavorIngestionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Favor_snapshot_timestamp_uses_log_line_instant_not_wall_clock()
+    {
+        // Principle 13 — world-event-driven paths must not leak the host's
+        // real wall clock into derived state. Pre-#715 this handler stamped
+        // ArwenFavorState.SetExactFavor with DateTimeOffset.UtcNow, so the
+        // persisted NpcFavorSnapshot.Timestamp drifted across replay runs
+        // even when the underlying log line carried the same envelope
+        // timestamp. Post-#715 the timestamp comes from the envelope (the
+        // same `ts` already in scope for the gift-detection plumbing two
+        // lines above) — replay produces byte-identical snapshots.
+        //
+        // The test runs the same log line twice with a real-elapsed pause
+        // between the two passes and asserts the persisted timestamp is the
+        // envelope's value (well in the past), not "now-ish".
+
+        var giftedAt = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
+        using var passOne = NewFixture("PassOne");
+        await passOne.StartAsync();
+        passOne.Driver.PushLive(MakeLine(
+            "ProcessStartInteraction(42, 0, 73.5, True, \"NPC_Sanja\")", giftedAt));
+        await passOne.Driver.DrainLocalPlayerAsync();
+        await passOne.StopAsync();
+
+        // Inject a real-elapsed gap between the two passes. Under the old
+        // wall-clock stamp the two snapshot timestamps would diverge by at
+        // least this much; under the envelope-stamp fix they're identical.
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+        using var passTwo = NewFixture("PassTwo");
+        await passTwo.StartAsync();
+        passTwo.Driver.PushLive(MakeLine(
+            "ProcessStartInteraction(42, 0, 73.5, True, \"NPC_Sanja\")", giftedAt));
+        await passTwo.Driver.DrainLocalPlayerAsync();
+        await passTwo.StopAsync();
+
+        var snapOne = passOne.FavorState.GetExactFavor("NPC_Sanja");
+        var snapTwo = passTwo.FavorState.GetExactFavor("NPC_Sanja");
+
+        snapOne.Should().NotBeNull();
+        snapTwo.Should().NotBeNull();
+        snapOne!.Timestamp.Should().Be(giftedAt,
+            "the persisted timestamp must come from the log envelope, not the host's real wall clock");
+        snapTwo!.Timestamp.Should().Be(snapOne.Timestamp,
+            "replaying the same log line yields a byte-identical snapshot regardless of real-elapsed time");
+    }
+
+    [Fact]
     public async Task Subscription_attaches_in_StartAsync_without_opening_module_gate()
     {
         // Call 1 / principle eager-always: the L1 LocalPlayer subscription and

--- a/tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs
@@ -233,6 +233,116 @@ public sealed class PlayerPinTrackerTests
         finally { await StopAsync(svc); }
     }
 
+    [Fact]
+    public async Task Subscribe_snapshot_stamp_is_last_envelope_timestamp_not_wall_clock()
+    {
+        // Principle 13 — world-event-driven paths must not leak wall clock
+        // into derived state. Pre-#715 the synthetic Snapshot notification
+        // emitted by Subscribe stamped its ObservedAt with
+        // DateTimeOffset.UtcNow, so two subscribers attaching at different
+        // real-elapsed times observed different timestamps on the same
+        // tracker state. Post-#715 the stamp is the most-recent envelope
+        // timestamp the tracker has applied — identical across late
+        // subscribers regardless of when they attach.
+        var areaTs = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var pinTs = areaTs.AddMinutes(1);
+
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(new SystemSignalLogLine(
+            Timestamp: areaTs,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: "LOADING LEVEL AreaSerbule",
+            Sequence: 1,
+            ReadMonotonicTicks: 0));
+        driver.PushReplay(new LocalPlayerLogLine(
+            Timestamp: pinTs,
+            Data: "ProcessMapPinAdd(1, 0, 0, (10.00, 0.00, 20.00), \"A\")",
+            Sequence: 2,
+            ReadMonotonicTicks: 0));
+
+        var svc = NewTracker(driver);
+        try
+        {
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+
+            // Real-elapsed gap between tracker reaching steady state and
+            // subscription attaching. Under the old wall-clock stamp the
+            // Snapshot's ObservedAt would slip past pinTs by at least this
+            // much; under the envelope-stamp fix it stays anchored to pinTs.
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+            var seenA = new List<PinSetChanged>();
+            using var subA = svc.Subscribe(seenA.Add);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+            var seenB = new List<PinSetChanged>();
+            using var subB = svc.Subscribe(seenB.Add);
+
+            seenA.Should().ContainSingle()
+                .Which.Kind.Should().Be(PinSetChange.Snapshot);
+            seenB.Should().ContainSingle()
+                .Which.Kind.Should().Be(PinSetChange.Snapshot);
+
+            seenA[0].ObservedAt.Should().Be(pinTs,
+                "the Snapshot stamp must come from the most-recent envelope the tracker applied, not wall clock");
+            seenB[0].ObservedAt.Should().Be(seenA[0].ObservedAt,
+                "late subscribers observing the same tracker state must see identical snapshot timestamps");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Area_change_notification_uses_envelope_timestamp_not_wall_clock()
+    {
+        // The other half of the principle-13 fix for ReconcileArea — the
+        // AreaChanged notification's ObservedAt now comes from the
+        // triggering LOADING LEVEL envelope, not DateTimeOffset.UtcNow.
+        // Test pushes two area envelopes at distinct fixed-past timestamps;
+        // each AreaChanged notification carries its envelope's timestamp.
+        var firstAreaTs = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var secondAreaTs = firstAreaTs.AddMinutes(7);
+
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(new SystemSignalLogLine(
+            Timestamp: firstAreaTs,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: "LOADING LEVEL AreaSerbule",
+            Sequence: 1,
+            ReadMonotonicTicks: 0));
+
+        var svc = NewTracker(driver);
+        try
+        {
+            var seen = new List<PinSetChanged>();
+            using var sub = svc.Subscribe(seen.Add);
+
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+
+            // Real-elapsed gap then push a second area envelope at a
+            // separate fixed timestamp.
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+            driver.PushLive(new SystemSignalLogLine(
+                Timestamp: secondAreaTs,
+                Kind: SystemSignalKind.AreaLoading,
+                Data: "LOADING LEVEL AreaEltibule",
+                Sequence: 2,
+                ReadMonotonicTicks: 0));
+            await driver.DrainClassifiedAsync();
+
+            var areaChanges = seen.Where(n => n.Kind == PinSetChange.AreaChanged).ToList();
+            areaChanges.Should().HaveCount(2,
+                "one AreaChanged per envelope (initial replay + the live push)");
+            areaChanges[0].ObservedAt.Should().Be(firstAreaTs,
+                "ReconcileArea must stamp the AreaChanged note with the triggering envelope's timestamp, not wall clock");
+            areaChanges[1].ObservedAt.Should().Be(secondAreaTs);
+        }
+        finally { await StopAsync(svc); }
+    }
+
     private static async Task StartAsync(PlayerPinTracker svc)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs
@@ -246,6 +246,110 @@ public sealed class PlayerWeatherTrackerTests
         finally { await StopAsync(svc); }
     }
 
+    [Fact]
+    public async Task Subscribe_snapshot_stamp_is_last_envelope_timestamp_not_wall_clock()
+    {
+        // Principle 13 — world-event-driven paths must not leak wall clock
+        // into derived state. Pre-#715 the synthetic Snapshot notification
+        // emitted by Subscribe stamped its ObservedAt with
+        // DateTimeOffset.UtcNow, so two subscribers attaching at different
+        // real-elapsed times observed different timestamps on the same
+        // tracker state. Post-#715 the stamp is the most-recent envelope
+        // timestamp the tracker has applied — identical across late
+        // subscribers regardless of when they attach. Mirrors the
+        // PlayerPinTracker test.
+        var areaTs = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var weatherTs = areaTs.AddMinutes(1);
+
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(new SystemSignalLogLine(
+            Timestamp: areaTs,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: "LOADING LEVEL AreaSerbule",
+            Sequence: 1,
+            ReadMonotonicTicks: 0));
+        driver.PushReplay(new LocalPlayerLogLine(
+            Timestamp: weatherTs,
+            Data: "ProcessSetWeather(\"Foggy\", True)",
+            Sequence: 2,
+            ReadMonotonicTicks: 0));
+
+        var svc = NewTracker(driver);
+        try
+        {
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+            var seenA = new List<WeatherChanged>();
+            using var subA = svc.Subscribe(seenA.Add);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+            var seenB = new List<WeatherChanged>();
+            using var subB = svc.Subscribe(seenB.Add);
+
+            seenA.Should().ContainSingle()
+                .Which.Kind.Should().Be(WeatherChangeKind.Snapshot);
+            seenB.Should().ContainSingle()
+                .Which.Kind.Should().Be(WeatherChangeKind.Snapshot);
+
+            seenA[0].ObservedAt.Should().Be(weatherTs,
+                "the Snapshot stamp must come from the most-recent envelope the tracker applied, not wall clock");
+            seenB[0].ObservedAt.Should().Be(seenA[0].ObservedAt,
+                "late subscribers observing the same tracker state must see identical snapshot timestamps");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Area_change_notification_uses_envelope_timestamp_not_wall_clock()
+    {
+        // The other half of the principle-13 fix for ReconcileArea — the
+        // AreaChanged notification's ObservedAt now comes from the
+        // triggering LOADING LEVEL envelope, not DateTimeOffset.UtcNow.
+        // Mirrors the PlayerPinTracker test.
+        var firstAreaTs = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var secondAreaTs = firstAreaTs.AddMinutes(7);
+
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(new SystemSignalLogLine(
+            Timestamp: firstAreaTs,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: "LOADING LEVEL AreaSerbule",
+            Sequence: 1,
+            ReadMonotonicTicks: 0));
+
+        var svc = NewTracker(driver);
+        try
+        {
+            var seen = new List<WeatherChanged>();
+            using var sub = svc.Subscribe(seen.Add);
+
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+            driver.PushLive(new SystemSignalLogLine(
+                Timestamp: secondAreaTs,
+                Kind: SystemSignalKind.AreaLoading,
+                Data: "LOADING LEVEL AreaEltibule",
+                Sequence: 2,
+                ReadMonotonicTicks: 0));
+            await driver.DrainClassifiedAsync();
+
+            var areaChanges = seen.Where(n => n.Kind == WeatherChangeKind.AreaChanged).ToList();
+            areaChanges.Should().HaveCount(2,
+                "one AreaChanged per envelope (initial replay + the live push)");
+            areaChanges[0].ObservedAt.Should().Be(firstAreaTs,
+                "ReconcileArea must stamp the AreaChanged note with the triggering envelope's timestamp, not wall clock");
+            areaChanges[1].ObservedAt.Should().Be(secondAreaTs);
+        }
+        finally { await StopAsync(svc); }
+    }
+
     private static async Task StartAsync(PlayerWeatherTracker svc)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/tests/Pippin.Tests/GourmandStateMachineTests.cs
+++ b/tests/Pippin.Tests/GourmandStateMachineTests.cs
@@ -124,6 +124,85 @@ public class GourmandStateMachineTests
     }
 
     [Fact]
+    public async Task Apply_FoodsConsumedReport_stamps_LastReportTime_from_envelope_not_wall_clock()
+    {
+        // Principle 13 — world-event-driven paths must not leak the host's
+        // real wall clock into derived state. Pre-#715 HandleReport stamped
+        // _lastReportTime with DateTimeOffset.UtcNow, so replaying the same
+        // FoodsConsumedReport at a different real-elapsed time produced a
+        // different persisted timestamp. Post-#715 the stamp comes from
+        // report.Timestamp; replay is byte-identical.
+
+        var sm = new GourmandStateMachine(CreateCatalog((1, "FoodBacon", "Bacon")));
+        var reportInstant = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var report = new FoodsConsumedReport(
+            reportInstant,
+            [new FoodConsumedEntry("Bacon", 2, Array.Empty<string>())]);
+
+        sm.Apply(report);
+        var firstStamp = sm.LastReportTime;
+
+        // Real-elapsed delay between two applies of the same envelope —
+        // under the old wall-clock stamp the second LastReportTime would
+        // diverge by at least this much; under the envelope-stamp fix
+        // both stamps equal the envelope timestamp.
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        sm.Apply(report);
+        var secondStamp = sm.LastReportTime;
+
+        firstStamp.Should().Be(new DateTimeOffset(reportInstant, TimeSpan.Zero),
+            "the report's envelope timestamp is the authoritative stamp source");
+        secondStamp.Should().Be(firstStamp,
+            "re-applying the same report at a different real-elapsed time must not change LastReportTime");
+    }
+
+    [Fact]
+    public void ApplyLegacyByName_does_not_stamp_LastReportTime_from_wall_clock()
+    {
+        // Principle 13 — the legacy-migration path runs once per character
+        // when the catalog becomes ready, with no envelope timestamp in
+        // scope. Pre-#715 this stamped _lastReportTime with
+        // DateTimeOffset.UtcNow as a fallback, leaking real wall clock into
+        // a persisted field consumers compare across replays. Post-#715 the
+        // fallback is removed: the migration leaves LastReportTime as
+        // Hydrate set it (null when the v1 state never carried a stamp).
+        //
+        // The next real FoodsConsumedReport stamps it from the log envelope.
+
+        var sm = new GourmandStateMachine(CreateCatalog(
+            (1, "FoodAppleJuice", "Apple Juice")));
+
+        sm.ApplyLegacyByName(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Apple Juice"] = 8,
+        });
+
+        sm.LastReportTime.Should().BeNull(
+            "no envelope is in scope in the legacy migration path; wall-clock fallback would leak host time into derived state");
+    }
+
+    [Fact]
+    public void ApplyLegacyByName_preserves_existing_LastReportTime_from_Hydrate()
+    {
+        // The other side of the same fix: when the persisted v1 state DID
+        // carry a LastReportTime, Hydrate populates _lastReportTime before
+        // the legacy migration runs. The migration must not clobber it.
+
+        var sm = new GourmandStateMachine(CreateCatalog(
+            (1, "FoodAppleJuice", "Apple Juice")));
+        var hydratedStamp = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+        sm.Hydrate(new GourmandState { LastReportTime = hydratedStamp });
+
+        sm.ApplyLegacyByName(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Apple Juice"] = 8,
+        });
+
+        sm.LastReportTime.Should().Be(hydratedStamp,
+            "legacy migration must not clobber the timestamp Hydrate already loaded from disk");
+    }
+
+    [Fact]
     public void ReconcileUnknowns_promotes_entries_when_catalog_catches_up()
     {
         var stub = new StubReferenceDataService(new Dictionary<long, Item>


### PR DESCRIPTION
## Summary

Retires the four event-driven `DateTimeOffset.UtcNow` reads catalogued during the [#713](https://github.com/moumantai-gg/mithril/issues/713) audit (and ratified-out-of-scope-from-PR-[#716](https://github.com/moumantai-gg/mithril/pull/716)'s user-action carve-out). Each site now stamps from the timestamp that was already in scope at the call site — envelope timestamp, event payload timestamp, or a tracker-maintained "last observed at" field that mirrors envelope-driven state mutations. Closes [#715](https://github.com/moumantai-gg/mithril/issues/715).

Principle 13 (`docs/world-simulator.md` — "no real-wall-clock leaks into world-event-driven state machines or module-side scheduling") is now enforced everywhere it applies. The remaining wall-clock reads in `src/` all fall into the explicitly-allowed categories ratified in PR [#716](https://github.com/moumantai-gg/mithril/pull/716): user-action Tier A stamps, Tier-B paired-clock idiom, share-card / export-artifact filenames, UI render paths anchored on the user's "now", network-fetch timing, and diagnostics/perf infrastructure.

## The four migrations (one commit per site for bisection-friendly history)

1. **`src/Arwen.Module/State/FavorIngestionService.cs:166`** — `favor.SetExactFavor(..., DateTimeOffset.UtcNow)` inside the L1 LocalPlayer-pipe handler. The handler already had `ts = envelope.Payload.Timestamp` in scope (load-bearing for the gift-detection plumbing two lines below) — now used here too. Mechanical one-line edit.
2. **`src/Mithril.GameState/Pins/PlayerPinTracker.cs:113 + :204`** — both `PinSetChanged` events stamped wall-clock. `ReconcileArea` now takes the triggering `AreaLoading` envelope's timestamp as a parameter. `Subscribe`'s synthetic Snapshot notification now stamps from a new private `_lastObservedAt` field maintained on every envelope-driven state mutation.
3. **`src/Mithril.GameState/Weather/PlayerWeatherTracker.cs:116 + :201`** — mirrors PinTracker for consistency. Same `_lastObservedAt` shape, same `ReconcileArea(area, observedAt)` signature, same fix shape for the synthetic Snapshot.
4. **`src/Pippin.Module/State/GourmandStateMachine.cs:126`** — `HandleReport(FoodsConsumedReport)` now stamps `_lastReportTime` from `report.Timestamp`. **`:108`** — `ApplyLegacyByName` (v1→v2 schema-migration drain, NOT a log-event handler despite #715's wording) had no envelope in scope; the wall-clock fallback is removed entirely. Migration leaves `LastReportTime` as `Hydrate` set it (null when the v1 state carried no value); the next real `FoodsConsumedReport` stamps it from the log envelope.

## Replay-determinism tests (one per affected component)

Each test feeds the same envelope sequence at distinct fixed-past timestamps with deliberate real-elapsed pauses between actions, then asserts the persisted/notified timestamps equal the envelope's value — not "now-ish".

- [`tests/Arwen.Tests/FavorIngestionServiceTests.cs`](tests/Arwen.Tests/FavorIngestionServiceTests.cs) — `Favor_snapshot_timestamp_uses_log_line_instant_not_wall_clock`
- [`tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs`](tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs) — `Subscribe_snapshot_stamp_is_last_envelope_timestamp_not_wall_clock`, `Area_change_notification_uses_envelope_timestamp_not_wall_clock`
- [`tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs`](tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs) — `Subscribe_snapshot_stamp_is_last_envelope_timestamp_not_wall_clock`, `Area_change_notification_uses_envelope_timestamp_not_wall_clock`
- [`tests/Pippin.Tests/GourmandStateMachineTests.cs`](tests/Pippin.Tests/GourmandStateMachineTests.cs) — `Apply_FoodsConsumedReport_stamps_LastReportTime_from_envelope_not_wall_clock`, `ApplyLegacyByName_does_not_stamp_LastReportTime_from_wall_clock`, `ApplyLegacyByName_preserves_existing_LastReportTime_from_Hydrate`

## Post-fix grep verification

`grep -rn "DateTimeOffset\.UtcNow\|DateTime\.UtcNow" src/` returns 56 residual hits. Every one maps to an explicitly-allowed category (no event-driven principle-13 violators remain). Walked classification:

**UI display (countdowns / "ago" text anchored on user's perceived now)**
- `Pippin.Module/ViewModels/GourmandViewModel.cs:175, :258`
- `Gandalf.Module/ViewModels/DashboardViewModel.cs:122`
- `Gandalf.Module/Domain/TimerView.cs:29, :39, :51`
- `Legolas.Module/ViewModels/MapOverlayViewModel.cs:668, :673`
- `Arwen.Module/ViewModels/CalibrationViewModel.cs:492, :511`
- `Samwise.Module/ViewModels/PlotViewModel.cs:164`
- `Mithril.Shell/ViewModels/ShellViewModel.cs:146`
- `Mithril.Shell/ViewModels/AboutSettingsViewModel.cs:184`

**Share-card / filename stamps** (explicit excluded list + share-dialog helpers; same carve-out as user-action Tier A — user-perceived "I'm exporting this NOW" semantics)
- `Arwen.Module/Domain/CalibrationService.cs:908, :931, :959` (excluded by spec)
- `Smaug.Module/Domain/PriceCalibrationService.cs:489, :530` (excluded by spec)
- `Samwise.Module/Calibration/GrowthCalibrationService.cs:458, :479` (excluded by spec)
- `Pippin.Module/Sharing/PippinShareDialogViewModel.cs:131, :253`
- `Legolas.Module/Sharing/LegolasShareDialogViewModel.cs:156, :184`
- `Mithril.Shared.Wpf/Dialogs/CommunityShareDialogViewModel.cs:110`

**Tier A user-action stamps** (already correctly wall-clock per PR #716 carve-out)
- `Mithril.Shell/Updates/UpdateStatusService.cs:63, :74, :86`
- `Legolas.Module/ViewModels/MapOverlayViewModel.cs:272` (`RecordManualPosition`)
- `Samwise.Module/Hotkeys/SamwiseHotkeys.cs:47` (`MarkOldestRipeHarvestedCommand`)
- `Samwise.Module/ViewModels/GardenViewModel.cs:47` (`MarkHarvested`)
- `Mithril.Shared/Character/CharacterPresenceService.cs:74` (character-switch / shutdown stamp — same Tier-A semantic: "when did the user last touch this character")

**Tier-B paired-clock idiom** (deliberately world-clock per #609 / #716)
- `Samwise.Module/Alarms/AlarmService.cs:44`

**Network-fetch wall-clock** (genuine "when did we hit the network")
- `Mithril.Shared/Reference/CommunityCalibrationService.cs:118, :130, :142, :154, :252`
- `Mithril.Shared/Reference/ReferenceDataService.cs:613`

**Diagnostics / perf infrastructure** (real-time measurement by definition)
- `Mithril.Shared/Diagnostics/SerilogDiagnosticsSink.cs:135`
- `Mithril.Shared/Diagnostics/DiagnosticsSink.cs:35`
- `Mithril.Shared/Diagnostics/Performance/PerfTracerHostedService.cs:162, :240, :250, :256`
- `Mithril.Shared/Diagnostics/Performance/PerfTracer.cs:53`
- `Mithril.Shared/Diagnostics/Performance/BindingErrorTraceListener.cs:28, :40`

**Cache-load seed fallback** (has explicit "wall-clock-now is fine for seed" comment; the seed only cares about AreaKey, not timestamp)
- `Mithril.GameState/Areas/PlayerAreaTracker.cs:292`

**Comments / docstrings** (not executable code)
- `Pippin.Module/State/GourmandStateMachine.cs:112`, `Gandalf.Module/ViewModels/TimerItemViewModel.cs:159`, `Mithril.GameState/Gifting/GiftSignalService.cs:45`, `Mithril.WorldSim.Core/IFolder.cs:20`, `Arwen.Module/Domain/CalibrationService.cs:73`

**Flagged for follow-up consideration** (out-of-scope per the spec's "pick the safer interpretation" guidance; not migrated speculatively)
- `Gandalf.Module/Services/UserTimerSource.cs:93` — `ReadyAt = e.Progress.CompletedAt ?? DateTimeOffset.UtcNow` inside `OnTimerExpired`. `CompletedAt` should always be non-null at expiry (the world-time stamp set by the timer mechanism); the `??` is a defensive fallback for a never-null contract. If the contract is ever violated, the leak surfaces — but the right fix is in the producer of `CompletedAt`, not here.
- `Legolas.Module/Services/CharacterPinAnchor.cs:152` — `Resolve(_pins, DateTimeOffset.UtcNow)` inside `OnActiveCharacterChanged`. This is a query/projection ("given current state, what's the latest pin") triggered by a non-log-event (active-character change). The result isn't persisted state — it's the current-view snapshot. No envelope timestamp is naturally in scope.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — full suite green. 4 new replay-determinism tests pass (covers all four migrated components).
- [x] Post-fix grep of `src/` walked and classified site-by-site; every residual hit is in an explicitly-allowed category.

## References

- Audit origin: [#713](https://github.com/moumantai-gg/mithril/issues/713) (closed wontfix-by-design)
- User-action carve-out the principle-13 doc text was ratified against: PR [#716](https://github.com/moumantai-gg/mithril/pull/716)
- World-sim umbrella: [#601](https://github.com/moumantai-gg/mithril/issues/601)
- Wall-clock cleanup precedent (transition gates, different shape but same `TimeProvider` migration spirit): [#609](https://github.com/moumantai-gg/mithril/issues/609)

Closes #715

— drafted by Claude (Opus 4.7), posted by @arthur-conde
