### PR TITLE
docs(world-sim): worker context pack forbids self-merging the PR (#737)

### DIFF
--- a/docs/world-sim-driver-playbook.md
+++ b/docs/world-sim-driver-playbook.md
@@ -535,7 +535,7 @@ Shape:
 - Do NOT merge the PR. Stop after `gh pr create` and report `outcome:
   success` to team-lead. The driver runs reviews and calls `gh pr merge`;
   if you merge yourself, the driver's review-iteration gate is silently
-  bypassed (see PR #730 anomaly).
+  bypassed.
 
 ### Structured outcome reporting (CRITICAL — read carefully)
 

--- a/docs/world-sim-driver-playbook.md
+++ b/docs/world-sim-driver-playbook.md
@@ -532,6 +532,10 @@ Shape:
   prefix matching the issue's scope (feat/, fix/, refactor/, etc.).
 - PR body MUST include "Closes #<issue>" and the "🤖 Generated with Claude
   Code" trailer.
+- Do NOT merge the PR. Stop after `gh pr create` and report `outcome:
+  success` to team-lead. The driver runs reviews and calls `gh pr merge`;
+  if you merge yourself, the driver's review-iteration gate is silently
+  bypassed (see PR #730 anomaly).
 
 ### Structured outcome reporting (CRITICAL — read carefully)
 


### PR DESCRIPTION
## Summary

- Adds one bullet to §Workflow rules in the worker context pack: workers must stop after `gh pr create` and report `outcome: success`; the driver owns review iteration + `gh pr merge`.
- Closes #737. Anomaly was PR #730 (worker self-merged mid-tick, bypassing the review-iteration gate).

## Test plan

- [x] Diff is docs-only — one bullet added under §Workflow rules. No code or test changes.
- [ ] On the next driver tick that dispatches a worker, confirm the new bullet renders inline in the worker's prompt (verify by reading the prompt the driver builds, or by spot-checking the worker's first message back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
