### PR TITLE
feat(gamestate): expose IInventoryView.Items bindable surface (#729)

### DIFF
--- a/src/Mithril.GameState/Inventory/IInventoryView.cs
+++ b/src/Mithril.GameState/Inventory/IInventoryView.cs
@@ -1,3 +1,4 @@
+using Mithril.Shared.Collections;
 using Mithril.WorldSim;
 
 namespace Mithril.GameState.Inventory;
@@ -34,6 +35,38 @@ public interface IInventoryView
     /// canonical post-migration surface.
     /// </summary>
     IWorldEventBus Bus { get; }
+
+    /// <summary>
+    /// Bindable live view of the currently-tracked inventory state — the
+    /// third read surface alongside the typed event <see cref="Bus"/> (React)
+    /// and <see cref="TryResolve"/> / <see cref="TryGetStackSize"/>
+    /// (Query). Per-item state changes (<c>StackSize</c>, <c>SizeConfirmed</c>,
+    /// <c>IsDeleted</c>) propagate as <c>INotifyPropertyChanged</c> on each
+    /// row; add of a new instance id propagates as
+    /// <c>NotifyCollectionChangedAction.Add</c>. Removals follow the
+    /// <b>soft-delete</b> contract — rows stay in the collection with
+    /// <see cref="InventoryItem.IsDeleted"/> = <c>true</c>, matching the
+    /// view's existing <c>_map</c> retention (Arwen's gift-attribution path
+    /// needs pre-delete state). The "Bind" channel of the three-channel
+    /// state-service contract from <c>docs/module-charters.md</c>.
+    ///
+    /// <para><b>Threading.</b> Mutations fire under the view's internal
+    /// <see cref="ItemsSyncRoot"/> on whatever thread originated the
+    /// underlying world bus frame (Player.log L1 dispatch or chat dispatch).
+    /// WPF consumers binding from a non-dispatcher thread MUST call
+    /// <c>BindingOperations.EnableCollectionSynchronization(view.Items,
+    /// view.ItemsSyncRoot)</c> once at bind time so XAML notifications
+    /// marshal correctly across threads.</para>
+    /// </summary>
+    IReadOnlyObservableCollection<InventoryItem> Items { get; }
+
+    /// <summary>
+    /// Lock the view holds while mutating <see cref="Items"/> + firing
+    /// per-row notifications. Passed to
+    /// <c>BindingOperations.EnableCollectionSynchronization</c> by WPF
+    /// consumers binding from a non-dispatcher thread.
+    /// </summary>
+    object ItemsSyncRoot { get; }
 
     /// <summary>
     /// Resolve an instance id to its <c>InternalName</c> via the PlayerWorld

--- a/src/Mithril.GameState/Inventory/InventoryItem.cs
+++ b/src/Mithril.GameState/Inventory/InventoryItem.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Mithril.GameState.Inventory;
+
+/// <summary>
+/// Bindable row in <see cref="IInventoryView.Items"/> — one entry per
+/// inventory instance the view currently tracks (#729). Mirrors the
+/// canonical <c>(InstanceId → InternalName + StackSize + SizeConfirmed)</c>
+/// state with WPF-friendly <see cref="INotifyPropertyChanged"/> plumbing so
+/// UI consumers bind to per-row state changes directly instead of
+/// re-mirroring the view's event stream into a local collection.
+///
+/// <para><b>Mutation policy.</b> Properties are settable only through the
+/// view's internal correlator paths — the type exposes <c>internal</c>
+/// setters so external code cannot reach in and re-write state. The view
+/// holds <c>_stateLock</c> when calling the setters; <see cref="PropertyChanged"/>
+/// fires synchronously on whatever thread owns the lock at the time. WPF
+/// consumers binding from a non-dispatcher thread call
+/// <c>BindingOperations.EnableCollectionSynchronization</c> with the view's
+/// <see cref="IInventoryView.ItemsSyncRoot"/> to marshal cross-thread.</para>
+///
+/// <para><b>Soft-delete semantic.</b> When the player.log <c>ProcessDeleteItem</c>
+/// fires for an instance id, <see cref="IsDeleted"/> flips to <c>true</c> but
+/// the row stays in <see cref="IInventoryView.Items"/>. This matches the
+/// view's existing <c>_map</c> retention contract (Arwen's gift-attribution
+/// path needs the pre-delete name + size via <c>TryResolve</c> /
+/// <c>TryGetStackSize</c>) and Palantir's pre-#729 row-greying behaviour
+/// (the live-inventory grid hides deleted rows by default but keeps them in
+/// the underlying index so "show deleted" can reveal them). See PR #729 body
+/// for the rationale.</para>
+/// </summary>
+public sealed class InventoryItem : INotifyPropertyChanged
+{
+    internal InventoryItem(long instanceId, string internalName, int stackSize, bool sizeConfirmed)
+    {
+        InstanceId = instanceId;
+        InternalName = internalName;
+        _stackSize = stackSize;
+        _sizeConfirmed = sizeConfirmed;
+    }
+
+    /// <summary>PG's per-instance unique id (from <c>ProcessAddItem</c>). Immutable.</summary>
+    public long InstanceId { get; }
+
+    /// <summary>Reference-data <c>InternalName</c> key. Immutable — the
+    /// view never re-labels an instance id under a different name.</summary>
+    public string InternalName { get; }
+
+    private int _stackSize;
+
+    /// <summary>Current stack size. Updates on chat correlation, player
+    /// <c>ProcessUpdateItemCode</c>/<c>ProcessRemoveFromStorageVault</c>,
+    /// non-stackable confirmation, and export reconcile.</summary>
+    public int StackSize
+    {
+        get => _stackSize;
+        internal set => Set(ref _stackSize, value);
+    }
+
+    private bool _sizeConfirmed;
+
+    /// <summary><c>true</c> once an authoritative source (chat correlation,
+    /// non-stackable reference data, export seed/reconcile, player stack
+    /// update) has spoken for this entry. Flips false → true when chat
+    /// correlation arrives after the Add — see
+    /// <see cref="IInventoryView.TryGetStackSize"/>.</summary>
+    public bool SizeConfirmed
+    {
+        get => _sizeConfirmed;
+        internal set => Set(ref _sizeConfirmed, value);
+    }
+
+    private bool _isDeleted;
+
+    /// <summary>Soft-delete marker — set by <see cref="IInventoryView"/>
+    /// when the underlying instance id is removed from inventory. The row
+    /// stays in <see cref="IInventoryView.Items"/> with this flag flipped
+    /// so consumers can grey out / filter deleted entries while preserving
+    /// late lookup of pre-delete state (Arwen's gift-attribution path).</summary>
+    public bool IsDeleted
+    {
+        get => _isDeleted;
+        internal set => Set(ref _isDeleted, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Mithril.GameState/Inventory/InventoryView.cs
+++ b/src/Mithril.GameState/Inventory/InventoryView.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Mithril.GameReports;
 using Mithril.GameState.Sessions;
+using Mithril.Shared.Collections;
 using Mithril.Shared.Correlation;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
@@ -120,13 +121,22 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     private readonly Dictionary<string, int> _seededStackSizes = new(StringComparer.Ordinal);
 
     // _stateLock guards _map, _shimHandlers, _eventLog, _eventLogOverflowWarned,
-    // _seededStackSizes. The correlators have their own internal locks; we still
-    // take _stateLock around correlator calls so the drain-then-mutate-_map
+    // _seededStackSizes, _items. The correlators have their own internal locks;
+    // we still take _stateLock around correlator calls so the drain-then-mutate-_map
     // sequence inside each handler is atomic. Two independent world-bus
     // subscriptions dispatch on different threads, so _stateLock is also
     // load-bearing for cross-source serialization.
+    //
+    // _items is the WPF "Bind" surface (#729). Per-row InventoryItem state
+    // (StackSize / SizeConfirmed / IsDeleted) mutates via the same code paths
+    // that update _map; collection add/remove fires via _items's INotifyCollectionChanged.
+    // Soft-delete: Removed entries stay in _items with IsDeleted = true (matching
+    // _map's retention for Arwen's gift-attribution path). WPF consumers binding
+    // from a non-dispatcher thread call BindingOperations.EnableCollectionSynchronization
+    // on (_items, _stateLock).
     private readonly object _stateLock = new();
     private readonly Dictionary<long, MapEntry> _map = new();
+    private readonly ObservableInventoryItems _items = new();
 
     // Legacy union-shaped subscriber list — same atomic-replay shape the
     // pre-#602 service offered (#585 contract). The six pre-#602 consumers
@@ -142,7 +152,13 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     // One-shot SinceSubscribe coercion diag — same as the pre-split service.
     private static int s_sinceSubscribeDiagFired;
 
-    private readonly record struct MapEntry(string InternalName, DateTime Timestamp, bool Deleted, int StackSize, bool SizeConfirmed);
+    // Item is the per-instance row exposed via the bindable _items surface.
+    // The view drives its mutable bits (StackSize / SizeConfirmed / IsDeleted)
+    // in lockstep with MapEntry's scalar fields so the two surfaces never
+    // drift; the duplicate state is the price of giving WPF a row identity
+    // that survives PropertyChanged notifications. MapEntry stays a struct so
+    // dictionary mutations don't allocate.
+    private readonly record struct MapEntry(string InternalName, DateTime Timestamp, bool Deleted, int StackSize, bool SizeConfirmed, InventoryItem Item);
 
     /// <summary>
     /// Correlator scope key: <c>(Server, Character, InternalName)</c>. The
@@ -180,6 +196,10 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     }
 
     public IWorldEventBus Bus => _bus;
+
+    public IReadOnlyObservableCollection<InventoryItem> Items => _items;
+
+    public object ItemsSyncRoot => _stateLock;
 
     /// <summary>
     /// The view's derived clock — <c>Now</c> = <c>max(lastPlayerFrameTs,
@@ -315,8 +335,26 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
                 _pendingAdd.Add(key, evt.InstanceId);
             }
 
+            // Re-add of a previously-deleted instance id is rare (PG would
+            // normally allocate a fresh id) but the legacy LiveInventoryViewModel
+            // already handles it as an in-place reset. Reuse the existing row so
+            // the bindable surface tracks the same identity instead of leaving
+            // an orphan row + adding a duplicate.
+            InventoryItem newItem;
+            if (_map.TryGetValue(evt.InstanceId, out var reAddExisting))
+            {
+                newItem = reAddExisting.Item;
+                newItem.StackSize = size;
+                newItem.SizeConfirmed = confirmed;
+                newItem.IsDeleted = false;
+            }
+            else
+            {
+                newItem = new InventoryItem(evt.InstanceId, evt.InternalName, size, confirmed);
+                _items.AddItem(newItem);
+            }
             _map[evt.InstanceId] = new MapEntry(
-                evt.InternalName, evt.Timestamp, Deleted: false, StackSize: size, SizeConfirmed: confirmed);
+                evt.InternalName, evt.Timestamp, Deleted: false, StackSize: size, SizeConfirmed: confirmed, Item: newItem);
             var sourceTag = nonStackable ? " (non-stackable)"
                 : seeded ? " (export-seeded)"
                 : confirmed ? " (chat)"
@@ -342,6 +380,7 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
             }
             if (entry.Deleted) return;
             _map[evt.InstanceId] = entry with { Deleted = true, Timestamp = evt.Timestamp };
+            entry.Item.IsDeleted = true;
             _diag?.Trace("GameState.Inventory.View",
                 $"Remove id={evt.InstanceId} name={entry.InternalName} (retained)");
             FireRemoved(evt.InstanceId, entry.InternalName, evt.Timestamp, entry.StackSize, entry.SizeConfirmed);
@@ -364,6 +403,8 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
                 Timestamp = evt.Timestamp,
                 SizeConfirmed = true,
             };
+            entry.Item.StackSize = evt.StackSize;
+            entry.Item.SizeConfirmed = true;
             _diag?.Trace("GameState.Inventory.View",
                 $"StackUpdate id={evt.InstanceId} name={entry.InternalName} size={evt.StackSize}");
             FireStackChanged(evt.InstanceId, entry.InternalName, evt.Timestamp, evt.StackSize, sizeConfirmed: true);
@@ -421,6 +462,8 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
                         Timestamp = evt.Timestamp,
                         SizeConfirmed = true,
                     };
+                    entry.Item.StackSize = evt.Count;
+                    entry.Item.SizeConfirmed = true;
                     _diag?.Trace("GameState.Inventory.View",
                         $"Chat → Add id={instanceId} name={internalName} size={evt.Count}");
                     FireStackChanged(instanceId, internalName, evt.Timestamp, evt.Count, sizeConfirmed: true);
@@ -537,6 +580,8 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
                 if (itemEntry.MaxStackSize != 1) continue;
 
                 _map[id] = entry with { StackSize = 1, Timestamp = nowNs, SizeConfirmed = true };
+                entry.Item.StackSize = 1;
+                entry.Item.SizeConfirmed = true;
                 FireStackChanged(id, entry.InternalName, nowNs, 1, sizeConfirmed: true);
                 nonStackConfirmed++;
             }
@@ -572,6 +617,8 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
 
                 var entry = _map[live.Id];
                 _map[live.Id] = entry with { StackSize = exportSize, Timestamp = nowNs, SizeConfirmed = true };
+                entry.Item.StackSize = exportSize;
+                entry.Item.SizeConfirmed = true;
                 FireStackChanged(live.Id, name, nowNs, exportSize, sizeConfirmed: true);
                 reconciled++;
             }

--- a/src/Mithril.GameState/Inventory/ObservableInventoryItems.cs
+++ b/src/Mithril.GameState/Inventory/ObservableInventoryItems.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Mithril.Shared.Collections;
+
+namespace Mithril.GameState.Inventory;
+
+/// <summary>
+/// Wraps an <see cref="ObservableCollection{T}"/> as the
+/// <see cref="IReadOnlyObservableCollection{T}"/> surface backing
+/// <see cref="IInventoryView.Items"/>. Mutations are restricted to internal
+/// callers (<see cref="InventoryView"/>'s correlator paths) — external code
+/// gets the read-only interface only.
+///
+/// <para>The underlying <see cref="ObservableCollection{T}"/> is not
+/// thread-safe; <see cref="InventoryView"/> holds <c>_stateLock</c> during
+/// every mutation, and WPF consumers binding from a non-dispatcher thread
+/// call <c>BindingOperations.EnableCollectionSynchronization</c> with the
+/// same lock (exposed via <see cref="IInventoryView.ItemsSyncRoot"/>).</para>
+/// </summary>
+internal sealed class ObservableInventoryItems : IReadOnlyObservableCollection<InventoryItem>
+{
+    private readonly ObservableCollection<InventoryItem> _inner = new();
+
+    public InventoryItem this[int index] => _inner[index];
+
+    public int Count => _inner.Count;
+
+    public IEnumerator<InventoryItem> GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_inner).GetEnumerator();
+
+    public event NotifyCollectionChangedEventHandler? CollectionChanged
+    {
+        add => _inner.CollectionChanged += value;
+        remove => _inner.CollectionChanged -= value;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged
+    {
+        add => ((INotifyPropertyChanged)_inner).PropertyChanged += value;
+        remove => ((INotifyPropertyChanged)_inner).PropertyChanged -= value;
+    }
+
+    internal void AddItem(InventoryItem item) => _inner.Add(item);
+
+    internal bool RemoveItem(InventoryItem item) => _inner.Remove(item);
+}

--- a/src/Mithril.Shared/Collections/IReadOnlyObservableCollection.cs
+++ b/src/Mithril.Shared/Collections/IReadOnlyObservableCollection.cs
@@ -1,0 +1,37 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace Mithril.Shared.Collections;
+
+/// <summary>
+/// Read-only collection surface for WPF data-binding: combines indexed access
+/// (<see cref="IReadOnlyList{T}"/>) with the two notification interfaces a XAML
+/// <c>ItemsControl</c> consumes — <see cref="INotifyCollectionChanged"/> for
+/// add/remove/reset, <see cref="INotifyPropertyChanged"/> for the standard
+/// <c>Count</c> / <c>Item[]</c> notifications that
+/// <see cref="System.Collections.ObjectModel.ObservableCollection{T}"/> emits.
+///
+/// <para>This is the "Bind" channel of the three-channel state-service
+/// contract described in <c>docs/module-charters.md</c>: collection-shaped
+/// services expose <c>IReadOnlyObservableCollection&lt;T&gt;</c> so UI code
+/// binds to canonical state instead of re-mirroring an event stream into a
+/// local <c>ObservableCollection</c>.</para>
+///
+/// <para>The intentional alias of the BCL-shaped contract — there is no
+/// <c>IReadOnlyObservableCollection&lt;T&gt;</c> in the framework, but the
+/// observable / read-only / list axes compose naturally for any read-only
+/// view over an <c>ObservableCollection</c>. Implementers are free to back
+/// the surface with a wrapped <c>ObservableCollection&lt;T&gt;</c>, a custom
+/// keyed observable collection, or any other source that fires the two
+/// notification interfaces consistently.</para>
+///
+/// <para><b>Threading.</b> Implementers document where mutations are raised
+/// (background ingestion thread vs marshalled to the UI dispatcher). WPF
+/// consumers binding from a non-dispatcher thread must call
+/// <c>BindingOperations.EnableCollectionSynchronization</c> with the same
+/// lock the implementer mutates under.</para>
+/// </summary>
+public interface IReadOnlyObservableCollection<out T>
+    : IReadOnlyList<T>, INotifyCollectionChanged, INotifyPropertyChanged
+{
+}

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using FluentAssertions;
 using Mithril.GameReports;
 using Mithril.GameState.Inventory;
@@ -701,5 +702,178 @@ public sealed class InventoryViewTests
         added[0].Payload.StackSize.Should().Be(42,
             because: "the storage-changed event re-ran LoadExportSeeds and populated the seed map");
         added[0].Payload.SizeConfirmed.Should().BeTrue();
+    }
+
+    // ── Bindable Items surface (issue #729) ─────────────────────────────
+    //
+    // The third read shape of the view layer alongside the typed Bus (React)
+    // and TryResolve/TryGetStackSize (Query): a WPF-friendly bindable list
+    // whose rows expose per-property INotifyPropertyChanged and whose
+    // adds/removes propagate via INotifyCollectionChanged. Used by Palantir's
+    // LiveInventoryViewModel post-#726 instead of re-mirroring the event
+    // stream into a local ObservableCollection.
+
+    [Fact]
+    public void Items_Player_Added_propagates_as_collection_changed_Add()
+    {
+        var (view, pw, _, _) = Build();
+        var changes = new List<NotifyCollectionChangedEventArgs>();
+        view.Items.CollectionChanged += (_, e) => changes.Add(e);
+
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+
+        view.Items.Should().ContainSingle();
+        view.Items[0].InstanceId.Should().Be(42L);
+        view.Items[0].InternalName.Should().Be("Moonstone");
+        view.Items[0].StackSize.Should().Be(1);
+        view.Items[0].SizeConfirmed.Should().BeFalse("no chat correlation yet — unconfirmed default-1");
+        view.Items[0].IsDeleted.Should().BeFalse();
+
+        changes.Should().ContainSingle();
+        changes[0].Action.Should().Be(NotifyCollectionChangedAction.Add);
+        changes[0].NewItems!.Cast<InventoryItem>().Single().InstanceId.Should().Be(42L);
+    }
+
+    [Fact]
+    public void Items_Player_StackUpdated_fires_per_row_PropertyChanged_no_collection_change()
+    {
+        var (view, pw, _, _) = Build();
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+        var row = view.Items.Single();
+
+        var propertyChanges = new List<string>();
+        row.PropertyChanged += (_, e) => propertyChanges.Add(e.PropertyName ?? "");
+        var collectionChanges = new List<NotifyCollectionChangedEventArgs>();
+        view.Items.CollectionChanged += (_, e) => collectionChanges.Add(e);
+
+        PlayerStackUpdate(pw, 42, "Moonstone", 13, Ts(2));
+
+        row.StackSize.Should().Be(13);
+        row.SizeConfirmed.Should().BeTrue("StackUpdate is authoritative");
+        propertyChanges.Should().Contain(nameof(InventoryItem.StackSize));
+        propertyChanges.Should().Contain(nameof(InventoryItem.SizeConfirmed));
+        collectionChanges.Should().BeEmpty("stack-size update doesn't add/remove rows");
+    }
+
+    [Fact]
+    public void Items_chat_correlation_flips_SizeConfirmed_via_PropertyChanged_on_existing_row()
+    {
+        // The flagship "third surface" case: Player.log Add lands first with
+        // SizeConfirmed=false (unconfirmed default-1); a later chat status
+        // arrives within TTL and back-fills the size. The bindable row must
+        // see both StackSize and SizeConfirmed flip — no collection change,
+        // same row identity throughout.
+        var (view, pw, cw, _) = Build();
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+        var row = view.Items.Single();
+        row.SizeConfirmed.Should().BeFalse("baseline: chat hasn't paired yet");
+
+        var propertyChanges = new List<string>();
+        row.PropertyChanged += (_, e) => propertyChanges.Add(e.PropertyName ?? "");
+        var collectionChanges = new List<NotifyCollectionChangedEventArgs>();
+        view.Items.CollectionChanged += (_, e) => collectionChanges.Add(e);
+
+        ChatObserved(cw, "Moonstone", 7, Ts(2));
+
+        row.StackSize.Should().Be(7);
+        row.SizeConfirmed.Should().BeTrue();
+        propertyChanges.Should().Contain(nameof(InventoryItem.SizeConfirmed));
+        propertyChanges.Should().Contain(nameof(InventoryItem.StackSize));
+        collectionChanges.Should().BeEmpty("flip happens in-place on the existing row");
+        view.Items.Should().ContainSingle("row identity preserved across correlation");
+    }
+
+    [Fact]
+    public void Items_Player_Removed_soft_deletes_row_via_PropertyChanged_collection_membership_preserved()
+    {
+        // Soft-delete semantic (documented in InventoryItem.IsDeleted): the
+        // row stays in Items with IsDeleted = true. Matches the view's _map
+        // retention (Arwen's gift-attribution path needs the pre-delete name
+        // + size via TryResolve / TryGetStackSize) and Palantir's pre-#729
+        // row-greying UI behaviour.
+        var (view, pw, _, _) = Build();
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+        var row = view.Items.Single();
+        row.IsDeleted.Should().BeFalse();
+
+        var propertyChanges = new List<string>();
+        row.PropertyChanged += (_, e) => propertyChanges.Add(e.PropertyName ?? "");
+        var collectionChanges = new List<NotifyCollectionChangedEventArgs>();
+        view.Items.CollectionChanged += (_, e) => collectionChanges.Add(e);
+
+        PlayerRemove(pw, 42, "Moonstone", Ts(2));
+
+        row.IsDeleted.Should().BeTrue("soft-delete — row remains in Items");
+        propertyChanges.Should().Contain(nameof(InventoryItem.IsDeleted));
+        collectionChanges.Should().BeEmpty(
+            "soft-delete must NOT remove the row from Items; per-row IsDeleted flip is the signal");
+        view.Items.Should().ContainSingle("soft-delete preserves membership");
+        view.Items[0].Should().BeSameAs(row);
+    }
+
+    [Fact]
+    public void Items_chat_then_Player_added_uses_confirmed_stack_size_on_row()
+    {
+        // Inverse arrival order: chat arrives first (slot stored in _pendingChat),
+        // Player.log Add consumes it at construction → row is born already
+        // confirmed. No StackChanged fires (the size was correct on Add); the
+        // bindable row reflects the confirmed value directly.
+        var (view, pw, cw, _) = Build();
+        ChatObserved(cw, "Moonstone", 5, Ts(1));
+        PlayerAdd(pw, 42, "Moonstone", Ts(2));
+
+        view.Items.Should().ContainSingle();
+        view.Items[0].StackSize.Should().Be(5);
+        view.Items[0].SizeConfirmed.Should().BeTrue("chat slot consumed at Add time");
+    }
+
+    [Fact]
+    public void Items_non_stackable_item_is_confirmed_at_add()
+    {
+        var (view, pw, _, _) = Build();
+        PlayerAdd(pw, 99, "RingOfPower", Ts(1));
+
+        view.Items.Should().ContainSingle();
+        view.Items[0].StackSize.Should().Be(1);
+        view.Items[0].SizeConfirmed.Should().BeTrue("MaxStackSize == 1");
+        view.Items[0].IsDeleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Items_re_add_of_previously_deleted_id_reuses_row_identity()
+    {
+        // Rare path — PG normally allocates a fresh id rather than recycling.
+        // But the legacy LiveInventoryViewModel.Upsert handles it as an
+        // in-place reset, and the view's _map keeps the entry under the same
+        // key. The bindable surface must do the same: same row, IsDeleted
+        // flipped back to false, no duplicate add.
+        var (view, pw, _, _) = Build();
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+        PlayerRemove(pw, 42, "Moonstone", Ts(2));
+        var row = view.Items.Single();
+        row.IsDeleted.Should().BeTrue();
+
+        var collectionChanges = new List<NotifyCollectionChangedEventArgs>();
+        view.Items.CollectionChanged += (_, e) => collectionChanges.Add(e);
+
+        PlayerAdd(pw, 42, "Moonstone", Ts(3));
+
+        view.Items.Should().ContainSingle("re-add reuses the soft-deleted row identity");
+        view.Items[0].Should().BeSameAs(row);
+        row.IsDeleted.Should().BeFalse("re-add clears the soft-delete marker");
+        collectionChanges.Should().BeEmpty("no new row added; existing row reset in place");
+    }
+
+    [Fact]
+    public void Items_ItemsSyncRoot_is_the_view_mutation_lock()
+    {
+        // The view exposes its internal _stateLock as ItemsSyncRoot so WPF
+        // consumers can pass it to BindingOperations.EnableCollectionSynchronization.
+        // We can't easily test the BindingOperations side from a unit test, but
+        // we can pin that the property returns a stable non-null reference
+        // (calling it twice yields the same object identity).
+        var (view, _, _, _) = Build();
+        view.ItemsSyncRoot.Should().NotBeNull();
+        view.ItemsSyncRoot.Should().BeSameAs(view.ItemsSyncRoot);
     }
 }


### PR DESCRIPTION
## Summary

Closes #729.

Adds the third read shape to `IInventoryView` alongside the typed event `Bus` (React) and `TryResolve` / `TryGetStackSize` (Query): an `IReadOnlyObservableCollection<InventoryItem> Items` surface for WPF consumers binding the canonical correlated inventory directly. Required prerequisite for #726 (Palantir `LiveInventoryViewModel` migration off the `[Obsolete]` `Subscribe(Action<InventoryEvent>)` shim).

`InventoryItem` rows expose `INotifyPropertyChanged` for `StackSize` / `SizeConfirmed` / `IsDeleted`; collection adds propagate via `INotifyCollectionChanged`. The view's existing correlator paths (`OnPlayerAdded` / `OnPlayerRemoved` / `OnPlayerStackUpdated` / `OnChatObserved` plus the `LoadExportSeeds` reconcile passes) mutate the per-row state in lockstep with `_map` under `_stateLock`.

The doc paragraph in `docs/world-simulator.md` is unaffected — its dual-surface contract was scoped to snapshot+bus axes per #707's conversation. The Items surface is an orthogonal third access mode, and this PR's implementation is the self-documenting precedent.

## Judgment calls

**Backing storage (Dictionary + parallel `ObservableCollection<InventoryItem>`)** — chose the simpler Dictionary + parallel observable shape over a custom `KeyedObservableCollection<long, InventoryItem>`. The view already holds `_map` under `_stateLock`; extending each `MapEntry` to carry the live `InventoryItem` keeps mutations atomic without introducing a new utility type. A `ObservableInventoryItems` wrapper exposes the read-only surface and restricts mutation to internal callers.

**`IsDeleted` semantic: soft-delete (row stays in Items with flag flipped)**, NOT hard-remove. Rationale:
- The view's existing `_map` already does soft-delete on the underlying scalar (`Deleted = true`) — `TryResolve` / `TryGetStackSize` must still resolve pre-delete state for Arwen's gift-attribution path (PR #659 chain).
- Palantir's current `LiveInventoryViewModel.Apply` already implements soft-delete UX (greys out deleted rows; "show deleted" toggle reveals them). Hard-removing rows from the bindable surface would force #726 to invert the UI behaviour, which is out of scope.
- Symmetry: the two surfaces (`_map`'s `Deleted` flag and `InventoryItem.IsDeleted`) flip together. No divergence between the canonical scalar state and the bindable shape.

Re-add of a previously-deleted instance id reuses the same row identity (`InventoryItem` reference preserved across delete → re-add), matching `LiveInventoryViewModel.Upsert`'s existing reset-in-place handling.

**Thread-safety pattern: view exposes `ItemsSyncRoot`; WPF consumers call `EnableCollectionSynchronization`.** The view lives in `Mithril.GameState` (foundation, non-WPF) and must not take a `Dispatcher` dependency. Surfacing the lock follows the lighter-touch pattern; #726 will wire `BindingOperations.EnableCollectionSynchronization(view.Items, view.ItemsSyncRoot)` at Palantir's first bind. Tested that the property returns a stable reference.

**New shared type: `Mithril.Shared.Collections.IReadOnlyObservableCollection<T>`.** The `docs/module-charters.md` "Bind" channel already references this type, and `IPlayerEffectsStateService.cs` quotes it in a deferred-work comment, but it hadn't been defined yet. Combines `IReadOnlyList<T>` + `INotifyCollectionChanged` + `INotifyPropertyChanged` on the same axis as `ObservableCollection<T>`. Adds it as the natural home for the bind-surface lift initiative (#584 follow-ups, future effects/skills/recipes bindable surfaces).

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` clean (all suites pass)
- [x] New tests in `InventoryViewTests.cs`:
  - `Items_Player_Added_propagates_as_collection_changed_Add` — `Add` event + row appears with correct state
  - `Items_Player_StackUpdated_fires_per_row_PropertyChanged_no_collection_change` — `StackSize` + `SizeConfirmed` PropertyChanged, no collection event
  - `Items_chat_correlation_flips_SizeConfirmed_via_PropertyChanged_on_existing_row` — the flagship case: late chat back-fills the row in-place
  - `Items_Player_Removed_soft_deletes_row_via_PropertyChanged_collection_membership_preserved` — `IsDeleted` flips, row stays
  - `Items_chat_then_Player_added_uses_confirmed_stack_size_on_row` — inverse arrival order, row born confirmed
  - `Items_non_stackable_item_is_confirmed_at_add` — ref-data `MaxStackSize == 1` path
  - `Items_re_add_of_previously_deleted_id_reuses_row_identity` — re-add semantic
  - `Items_ItemsSyncRoot_is_the_view_mutation_lock` — stable lock identity
- [x] Existing `InventoryView` tests (15 pre-existing) all pass — no regression in Query / React surfaces or shim translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
