### PR TITLE
refactor(gamestate): expose IList on ObservableInventoryItems for CollectionViewSource

### DIFF
--- a/src/Mithril.GameState/Inventory/ObservableInventoryItems.cs
+++ b/src/Mithril.GameState/Inventory/ObservableInventoryItems.cs
@@ -18,8 +18,18 @@ namespace Mithril.GameState.Inventory;
 /// every mutation, and WPF consumers binding from a non-dispatcher thread
 /// call <c>BindingOperations.EnableCollectionSynchronization</c> with the
 /// same lock (exposed via <see cref="IInventoryView.ItemsSyncRoot"/>).</para>
+///
+/// <para><b>Non-generic <see cref="IList"/> surface (#741).</b> Implemented
+/// via explicit-interface methods so the public API typed as
+/// <see cref="IReadOnlyObservableCollection{T}"/> is unchanged — mutators are
+/// only reachable through an explicit cast to <see cref="IList"/> and throw
+/// <see cref="NotSupportedException"/>. WPF's <c>CollectionViewSource</c>
+/// reflects on the runtime type; the presence of <see cref="IList"/> is what
+/// lets <c>GetDefaultView</c> return a <c>ListCollectionView</c> (supporting
+/// sort, filter, group) rather than falling back to
+/// <c>EnumerableCollectionView</c>.</para>
 /// </summary>
-internal sealed class ObservableInventoryItems : IReadOnlyObservableCollection<InventoryItem>
+internal sealed class ObservableInventoryItems : IReadOnlyObservableCollection<InventoryItem>, IList
 {
     private readonly ObservableCollection<InventoryItem> _inner = new();
 
@@ -46,4 +56,46 @@ internal sealed class ObservableInventoryItems : IReadOnlyObservableCollection<I
     internal void AddItem(InventoryItem item) => _inner.Add(item);
 
     internal bool RemoveItem(InventoryItem item) => _inner.Remove(item);
+
+    // ── IList / ICollection (non-generic) ──────────────────────────────
+    //
+    // Read-only members delegate to the inner ObservableCollection<T>
+    // (which already implements IList via its Collection<T> base). Mutators
+    // throw — the privileged entry points are AddItem/RemoveItem above.
+    // Explicit-interface implementations so the public surface typed as
+    // IReadOnlyObservableCollection<InventoryItem> is unaffected; see #741.
+
+    private const string ReadOnlyMessage =
+        "ObservableInventoryItems is a read-only view; mutations occur via the internal correlator paths in InventoryView.";
+
+    object? IList.this[int index]
+    {
+        get => _inner[index];
+        set => throw new NotSupportedException(ReadOnlyMessage);
+    }
+
+    bool IList.IsReadOnly => true;
+
+    // Size changes via the privileged AddItem/RemoveItem paths — not fixed.
+    bool IList.IsFixedSize => false;
+
+    bool ICollection.IsSynchronized => ((ICollection)_inner).IsSynchronized;
+
+    object ICollection.SyncRoot => ((ICollection)_inner).SyncRoot;
+
+    int IList.Add(object? value) => throw new NotSupportedException(ReadOnlyMessage);
+
+    void IList.Clear() => throw new NotSupportedException(ReadOnlyMessage);
+
+    bool IList.Contains(object? value) => ((IList)_inner).Contains(value);
+
+    int IList.IndexOf(object? value) => ((IList)_inner).IndexOf(value);
+
+    void IList.Insert(int index, object? value) => throw new NotSupportedException(ReadOnlyMessage);
+
+    void IList.Remove(object? value) => throw new NotSupportedException(ReadOnlyMessage);
+
+    void IList.RemoveAt(int index) => throw new NotSupportedException(ReadOnlyMessage);
+
+    void ICollection.CopyTo(Array array, int index) => ((ICollection)_inner).CopyTo(array, index);
 }

--- a/src/Mithril.Shared/Collections/IReadOnlyObservableCollection.cs
+++ b/src/Mithril.Shared/Collections/IReadOnlyObservableCollection.cs
@@ -31,6 +31,19 @@ namespace Mithril.Shared.Collections;
 /// <c>BindingOperations.EnableCollectionSynchronization</c> with the same
 /// lock the implementer mutates under.</para>
 /// </summary>
+/// <remarks>
+/// Implementers SHOULD also implement non-generic
+/// <see cref="System.Collections.IList"/> (with mutators throwing
+/// <see cref="NotSupportedException"/> via explicit-interface
+/// implementations) if they expect downstream consumers to wrap the surface
+/// in WPF's <c>CollectionViewSource</c> for sort, filter, or group support.
+/// WPF reflects on the runtime type when resolving the default view; without
+/// <c>IList</c>, <c>CollectionViewSource.GetDefaultView</c> falls back to
+/// <c>EnumerableCollectionView</c>, which does not support sort, filter, or
+/// group. See <c>System.Collections.ObjectModel.ReadOnlyObservableCollection&lt;T&gt;</c>
+/// for the canonical BCL pattern (read-only <see cref="System.Collections.IList"/>
+/// over an <see cref="System.Collections.ObjectModel.ObservableCollection{T}"/>).
+/// </remarks>
 public interface IReadOnlyObservableCollection<out T>
     : IReadOnlyList<T>, INotifyCollectionChanged, INotifyPropertyChanged
 {

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
@@ -1,4 +1,7 @@
+using System.Collections;
 using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows.Data;
 using FluentAssertions;
 using Mithril.GameReports;
 using Mithril.GameState.Inventory;
@@ -876,4 +879,128 @@ public sealed class InventoryViewTests
         view.ItemsSyncRoot.Should().NotBeNull();
         view.ItemsSyncRoot.Should().BeSameAs(view.ItemsSyncRoot);
     }
+
+    // ── CollectionViewSource compatibility (issue #741) ─────────────────
+    //
+    // Items must implement non-generic IList so WPF's CollectionViewSource
+    // resolves a ListCollectionView (supporting sort, filter, group) instead
+    // of falling back to EnumerableCollectionView. The CollectionViewSource
+    // APIs require an STA thread; tests run on a dedicated STA worker to
+    // satisfy that without spinning up a full Application.
+
+    private static void RunOnSta(Action action)
+    {
+        Exception? captured = null;
+        var thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { captured = ex; }
+            finally { System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown(); }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.IsBackground = true;
+        thread.Start();
+        thread.Join();
+        if (captured is not null) throw captured;
+    }
+
+    [Fact]
+    public void Items_implements_non_generic_IList_for_CollectionViewSource()
+    {
+        // Direct runtime-type pin: CollectionViewSource reflects on IList to
+        // pick a ListCollectionView. The reflection itself happens later; this
+        // test catches a regression that drops the interface without needing STA.
+        var (view, _, _, _) = Build();
+        view.Items.Should().BeAssignableTo<IList>();
+    }
+
+    [Fact]
+    public void CollectionViewSource_GetDefaultView_returns_ListCollectionView_supporting_sort_filter_group()
+    {
+        RunOnSta(() =>
+        {
+            var (view, pw, _, _) = Build();
+            PlayerAdd(pw, 42, "Moonstone", Ts(1));
+            PlayerAdd(pw, 99, "RingOfPower", Ts(2));
+            PlayerAdd(pw, 7, "Moonstone", Ts(3));
+
+            var defaultView = CollectionViewSource.GetDefaultView(view.Items);
+
+            // The flagship #741 acceptance: without IList on ObservableInventoryItems
+            // this returns an EnumerableCollectionView that does not support
+            // sort/filter/group operations.
+            defaultView.Should().BeOfType<ListCollectionView>(
+                "ObservableInventoryItems implements IList, so GetDefaultView must " +
+                "pick ListCollectionView rather than EnumerableCollectionView");
+            defaultView.CanSort.Should().BeTrue();
+            defaultView.CanFilter.Should().BeTrue();
+            defaultView.CanGroup.Should().BeTrue();
+
+            // Sort by InternalName ascending.
+            defaultView.SortDescriptions.Add(new SortDescription(nameof(InventoryItem.InternalName), ListSortDirection.Ascending));
+            defaultView.Refresh();
+            defaultView.Cast<InventoryItem>().Select(i => i.InternalName)
+                .Should().Equal("Moonstone", "Moonstone", "RingOfPower");
+
+            // Filter to RingOfPower only.
+            defaultView.Filter = o => o is InventoryItem i && i.InternalName == "RingOfPower";
+            defaultView.Refresh();
+            defaultView.Cast<InventoryItem>().Select(i => i.InstanceId).Should().Equal(99L);
+
+            // Clear filter, group by InternalName.
+            defaultView.Filter = null;
+            defaultView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(InventoryItem.InternalName)));
+            defaultView.Refresh();
+            defaultView.Groups!.Should().HaveCount(2);
+            defaultView.Groups!
+                .Cast<System.Windows.Data.CollectionViewGroup>()
+                .Select(g => (string)g.Name)
+                .Should().BeEquivalentTo(new[] { "Moonstone", "RingOfPower" });
+        });
+    }
+
+    [Fact]
+    public void Items_IList_read_members_delegate_to_inner_collection()
+    {
+        var (view, pw, _, _) = Build();
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+        PlayerAdd(pw, 99, "RingOfPower", Ts(2));
+
+        var list = (IList)view.Items;
+
+        list.Count.Should().Be(2);
+        list.IsReadOnly.Should().BeTrue();
+        list.IsFixedSize.Should().BeFalse("size changes via the privileged internal correlator paths");
+
+        var row0 = list[0];
+        row0.Should().BeAssignableTo<InventoryItem>();
+        ((InventoryItem)row0!).InstanceId.Should().Be(42L);
+
+        list.Contains(row0).Should().BeTrue();
+        list.IndexOf(row0).Should().Be(0);
+
+        var buffer = new InventoryItem[2];
+        list.CopyTo(buffer, 0);
+        buffer.Select(i => i.InstanceId).Should().Equal(42L, 99L);
+    }
+
+    [Fact]
+    public void Items_IList_mutators_throw_NotSupportedException()
+    {
+        // Add one row so list[0] / RemoveAt(0) reach into real entries — the
+        // mutator pin is that ObservableInventoryItems refuses the call before
+        // ever delegating to the inner collection, regardless of index validity.
+        var (view, pw, _, _) = Build();
+        PlayerAdd(pw, 42, "Moonstone", Ts(1));
+        var list = (IList)view.Items;
+        var existing = list[0];
+
+        ((Action)(() => list.Add(existing))).Should().Throw<NotSupportedException>();
+        ((Action)(() => list.Insert(0, existing))).Should().Throw<NotSupportedException>();
+        ((Action)(() => list.Remove(existing))).Should().Throw<NotSupportedException>();
+        ((Action)(() => list.RemoveAt(0))).Should().Throw<NotSupportedException>();
+        ((Action)(() => list.Clear())).Should().Throw<NotSupportedException>();
+        ((Action)(() => list[0] = existing)).Should().Throw<NotSupportedException>();
+    }
 }
+

--- a/tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj
+++ b/tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net10.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Mithril.GameState.Tests</RootNamespace>
+    <!-- ObservableInventoryItems CollectionViewSource tests need System.Windows.Data. -->
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
## Summary

`ObservableInventoryItems` now implements non-generic `IList` (and `ICollection`) via explicit-interface members so that WPF's `CollectionViewSource.GetDefaultView` returns a `ListCollectionView` with sort/filter/group support instead of falling back to `EnumerableCollectionView`. Mirrors the canonical BCL pattern (`System.Collections.ObjectModel.ReadOnlyObservableCollection<T>`).

- **`src/Mithril.GameState/Inventory/ObservableInventoryItems.cs`** — implements `IList`; read members (`Count`, indexer getter, `Contains`, `IndexOf`, `CopyTo`, `IsSynchronized`, `SyncRoot`) delegate to the inner `ObservableCollection<InventoryItem>`. Mutators (`Add`, `Insert`, `Remove`, `RemoveAt`, `Clear`, indexer setter) throw `NotSupportedException` with a message pointing at the privileged `AddItem`/`RemoveItem` entry points. `IsReadOnly = true`, `IsFixedSize = false`. All explicit-interface so the public `IReadOnlyObservableCollection<InventoryItem>` surface is unchanged.
- **`src/Mithril.Shared/Collections/IReadOnlyObservableCollection.cs`** — `<remarks>` block notes implementers SHOULD also implement `IList` if they expect WPF `CollectionViewSource` sort/filter/group consumers, with the one-line rationale about `EnumerableCollectionView` fallback.
- **`tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs`** — new pins:
  - `Items_implements_non_generic_IList_for_CollectionViewSource` — runtime-type check.
  - `CollectionViewSource_GetDefaultView_returns_ListCollectionView_supporting_sort_filter_group` — runs on an STA worker, asserts `ListCollectionView`, then applies `SortDescription` / `Filter` predicate / `PropertyGroupDescription` and verifies each.
  - `Items_IList_read_members_delegate_to_inner_collection` — indexer, `Contains`, `IndexOf`, `CopyTo`, flags.
  - `Items_IList_mutators_throw_NotSupportedException` — every mutator throws.
- **`tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj`** — `<UseWPF>true</UseWPF>` to bring in `System.Windows.Data`.

Closes #741
Blocks #726.

## Test plan

- [x] `dotnet build Mithril.slnx` clean
- [x] `dotnet test Mithril.slnx` clean (full suite green, including 27 inventory view tests after adding 4)
- [x] No regression in typed-bus subscribers or point-lookup consumers of `IInventoryView`
- [x] Public API typed as `IReadOnlyObservableCollection<InventoryItem>` unchanged — `IList` mutators only reachable through explicit cast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
