### PR TITLE
chore(shared): delete dead IChatLogParser interface (#749)

### DIFF
--- a/src/Mithril.Shared/Logging/IChatLogParser.cs
+++ b/src/Mithril.Shared/Logging/IChatLogParser.cs
@@ -1,6 +1,0 @@
-namespace Mithril.Shared.Logging;
-
-public interface IChatLogParser
-{
-    LogEvent? TryParse(string line, DateTime timestamp);
-}

--- a/src/Mithril.Shared/Logging/LogEvent.cs
+++ b/src/Mithril.Shared/Logging/LogEvent.cs
@@ -2,8 +2,8 @@ namespace Mithril.Shared.Logging;
 
 /// <summary>
 /// Abstract base for typed parser events (L2 territory). Every parser
-/// (<see cref="ILogParser"/> / <see cref="IChatLogParser"/>) returns a
-/// concrete subclass — <c>WeatherChangedEvent</c>, <c>QuestAcceptedEvent</c>,
+/// (<see cref="ILogParser"/>) returns a concrete subclass —
+/// <c>WeatherChangedEvent</c>, <c>QuestAcceptedEvent</c>,
 /// <c>MapPinLogEvent</c>, etc. <c>Timestamp</c> is the <b>UTC</b> instant
 /// the event occurred — carried as <see cref="DateTime"/> (Kind=Utc)
 /// because parsers accept <c>(string line, DateTime timestamp)</c> per the


### PR DESCRIPTION
## Summary

- Delete the orphaned `IChatLogParser` interface at `src/Mithril.Shared/Logging/IChatLogParser.cs`. PR #606 retired the chat-log ingestion path (`Legolas.LogIngestionService`, `ChatLogParser`) but left this interface file on disk. `docs/world-sim-migration-audit.md:333` and `:445`, plus `docs/world-simulator.md:665`, already claim the interface is gone — this PR makes the file match the narrative.
- Drop the corresponding `<see cref="IChatLogParser"/>` doc-comment reference in `src/Mithril.Shared/Logging/LogEvent.cs:5` so the build stays clean under warnings-as-errors.

## Verification

Confirmed the interface is truly dead before deleting:

| Check | Result |
|---|---|
| `: IChatLogParser` / `, IChatLogParser` (implementers) | 0 hits |
| `Add{Singleton,Transient,Scoped,HostedService}<IChatLogParser` (DI registrations) | 0 hits |
| `typeof(IChatLogParser)` / `nameof(IChatLogParser)` (reflection) | 0 hits |
| `AddMithrilModules` reflection scan | scans `IMithrilModule` only — does not touch `IChatLogParser`. The pre-#694 README claim about "modules register their own chat-line handlers" was never backed by live discovery code. |
| Git log on the file | last touched `4d8a7d4` (Gandalf flatten, pre-#606) — PR #606 orphaned the file without deleting it |

The two surviving textual references in `docs/world-sim-migration-audit.md` and `docs/world-simulator.md` both frame the interface deletion as part of #606's retirement work; they become retroactively accurate once this PR lands, so no rewording is needed. (README.md's stale "lifted into Mithril.Shared" sentence was already cleaned up by PR #747.)

## Test plan

- [x] `dotnet build Mithril.slnx -nologo -clp:NoSummary -v:m` — clean (0 warnings, 0 errors across all 47 projects). XML doc cref removal is complete; warnings-as-errors would have caught a CS1574 if the `LogEvent.cs` cleanup missed a reference.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)