### PR TITLE
chore(world-sim): retire IInventoryView legacy shim + refresh audit rows (#659 + #687 + #746)

### DIFF
--- a/docs/world-sim-migration-audit.md
+++ b/docs/world-sim-migration-audit.md
@@ -25,6 +25,12 @@ Audited against: [`docs/world-simulator.md`](world-simulator.md) and
 > spot-check #1 were rewritten after the #602 split shipped in
 > [#679](https://github.com/moumantai-gg/mithril/pull/679). The rest of the
 > doc remains the 2026-05-21 snapshot — read other rows in pre-Phase-2 tense.
+>
+> **Updates 2026-05-23 post-shim-retirement.** The Inventory + Samwise +
+> Palantir rows and spot-check #1 were re-tightened after the #659 shim
+> retirement landed (Palantir's Bind-channel migration was the last
+> precondition, via #726 / #745). The Saruman row was rewritten for the
+> post-#603 split architecture (#687).
 
 ## Executive summary
 
@@ -39,12 +45,12 @@ Audited against: [`docs/world-simulator.md`](world-simulator.md) and
      (Player.log, chat, FileSystemWatcher, reference data, `_seededStackSizes`
      reconcile); every other migration sat downstream of it.
      **Delivered ([#602](https://github.com/moumantai-gg/mithril/issues/602) via
-     [#679](https://github.com/moumantai-gg/mithril/pull/679)).** Remaining work
-     is the per-consumer migration off the `[Obsolete]` shim, tracked in
-     [#659](https://github.com/moumantai-gg/mithril/issues/659).
+     [#679](https://github.com/moumantai-gg/mithril/pull/679)); the shim
+     retired in [#659](https://github.com/moumantai-gg/mithril/issues/659)
+     once all six pre-#602 consumers reached their post-shim destinations.**
   2. **`SarumanCodebookService` split + view** — different shape than Inventory
      (no temporal pairing, key-join only) so the view-layer abstraction needs
-     to admit two distinct view patterns.
+     to admit two distinct view patterns. **Delivered ([#603](https://github.com/moumantai-gg/mithril/issues/603)).**
   3. **`Legolas.LogIngestionService` full retirement (per #531)** —
      **Delivered ([#606](https://github.com/moumantai-gg/mithril/issues/606)).**
      Last direct `IChatLogStream` module consumer retired; all five chat verbs
@@ -165,20 +171,25 @@ resolves to the view (for the six pre-existing consumers; cleanup tracked in
   `InventoryView.LoadExportSeeds` / `OnGameReportsStorageChanged`. Export
   read goes through `IGameReportsService.GetStorageContents` — `InventoryView`
   no longer touches the filesystem directly.
-- **Legacy shim**: `IInventoryService.Subscribe(Action<InventoryEvent>)` and
-  the union-shaped `InventoryEvent` type survive only as `[Obsolete]` surfaces
-  on `InventoryView` so the six pre-#602 consumers (Arwen, Samwise, Palantir,
-  Legolas, Saruman, `MotherlodeMeasurementCoordinator`) keep working unchanged.
-  Per-consumer migration to the typed bus is the cleanup obligation tracked
-  in [#659](https://github.com/moumantai-gg/mithril/issues/659); follow-on
-  consumer PRs are filed against that issue as each consumer's
-  `[Obsolete]` warnings get addressed.
-- **Status**: **split delivered**. The keystone Phase 2 work landed in
-  [#679](https://github.com/moumantai-gg/mithril/pull/679). Remaining
-  obligations: (1) the six consumer migrations under
-  [#659](https://github.com/moumantai-gg/mithril/issues/659); (2) eventual
-  deletion of `IInventoryService` / `InventoryEvent` / the `[Obsolete]`
-  annotations once those six consumers are off the shim.
+- **Legacy shim (retired)**: the union-shaped
+  `Subscribe(Action<InventoryEvent>)` plus the `InventoryEvent` /
+  `InventoryEventKind` types retired in
+  [#659](https://github.com/moumantai-gg/mithril/issues/659) once all six
+  pre-#602 consumers reached their post-shim destinations. The remaining
+  `IInventoryService` interface stays alive for the Query-channel consumer
+  (Arwen's `CalibrationService` reads `TryResolve` /
+  `TryGetStackSize` through it); the concrete `InventoryView` still
+  implements both `IInventoryView` and `IInventoryService`.
+- **Status**: **split delivered + shim retired**. The keystone Phase 2 work
+  landed in [#679](https://github.com/moumantai-gg/mithril/pull/679); the
+  shim and its dependent types deleted alongside the audit row updates
+  ([#659](https://github.com/moumantai-gg/mithril/issues/659) +
+  [#687](https://github.com/moumantai-gg/mithril/issues/687) +
+  [#746](https://github.com/moumantai-gg/mithril/issues/746)). The
+  `IInventoryService` interface itself survives as a Query-only surface
+  for Arwen — a possible future cleanup (migrate Arwen to inject
+  `IInventoryView` and delete `IInventoryService`) is mechanical but
+  outside the #659 scope.
 
 ### `IQuestService` ⚠️ **SYNTHESIS + WALL-CLOCK STAMP**
 
@@ -213,13 +224,17 @@ resolves to the view (for the six pre-existing consumers; cleanup tracked in
 `src/Samwise.Module/State/GardenStateMachine.cs`,
 `src/Samwise.Module/Alarms/AlarmService.cs`.
 
-- **Source spanning**: single (LocalPlayer via `GardenIngestionService`) + reads
-  the `IInventoryService.Subscribe` `[Obsolete]` shim on `InventoryView` for
-  `Added`/`Deleted` reshape. Post-#679 the underlying surface is split
-  (`IPlayerInventoryState` / `IChatInventoryState` / `IInventoryView`); Samwise
-  still consumes the shim until its per-consumer migration to
-  `IInventoryView.Bus.Subscribe<InventoryItemAdded>(…)` lands. Tracked in
-  [#659](https://github.com/moumantai-gg/mithril/issues/659).
+- **Source spanning**: single (LocalPlayer via `GardenIngestionService`). The
+  inventory dependency is now PlayerWorld-direct: `GardenIngestionService`
+  subscribes to `IPlayerWorld.Bus.Subscribe<PlayerInventoryAdded>(…)` and
+  `<PlayerInventoryRemoved>(…)` in its `StartAsync`, replacing the pre-#725
+  union-shaped `IInventoryService.Subscribe` shim. Migration tracked in
+  [#725](https://github.com/moumantai-gg/mithril/issues/725); the
+  destination follows the principle-4 single-world-direct exit Legolas
+  landed on first (per #699 → #721). Reads only `InstanceId` + `InternalName`
+  — Samwise never composes Player.log adds with chat `[Status]`
+  observations, so the cross-source view layer offers nothing the
+  PlayerWorld bus doesn't already give.
 - **Wall-clock transition gates**:
   - `GardenStateMachine.PruneWithered` at `:541-557`: `_time.GetUtcNow() - p.UpdatedAt > ttl`.
   - `GardenStateMachine.IsLikelyGarbageCollected` at `:596-600`.
@@ -229,7 +244,8 @@ resolves to the view (for the six pre-existing consumers; cleanup tracked in
 - **Migration**: every `_time.GetUtcNow()` / `DateTimeOffset.UtcNow` in the
   transition paths becomes `_worldClock.Now`. Mechanical. Mutation surface is
   small: `GardenStateMachine` already takes `TimeProvider` ctor arg.
-- **Status**: **migration owed** — mechanical.
+- **Status**: inventory subscription migrated to PlayerWorld-direct
+  (#725); wall-clock swap **still owed** — mechanical.
 
 ### Pippin (food)
 
@@ -277,29 +293,46 @@ resolves to the view (for the six pre-existing consumers; cleanup tracked in
   consumption of the Tier-2 signal service that owns the verb-triple
   correlation on a single L1 pump.
 
-### Saruman (Words of Power) ⚠️ **CROSS-SOURCE**
+### Saruman (Words of Power) — **SPLIT DELIVERED ([#603](https://github.com/moumantai-gg/mithril/issues/603))**
 
-`src/Saruman.Module/Services/SarumanCodebookService.cs:14-175`,
-`SarumanChatIngestionService.cs:42-101`, `SarumanDiscoveryIngestionService.cs:53-`.
+Pre-#603: `SarumanCodebookService` consumed Player.log (discovery via
+`SarumanDiscoveryIngestionService` → `RecordDiscovery`) AND chat (spent
+via `SarumanChatIngestionService` → `MarkSpent`) in a single module-resident
+service — same principle 3 violation as the pre-#602 `InventoryService`.
+Post-#603 the cross-source service split into two folders + a view:
 
-- **Source spanning**: **YES.** `SarumanCodebookService` is mutated by two
-  ingestion services with separate L1 subscriptions:
-  - Discovery (Player.log): `Subscribe<LocalPlayerLogLine>` →
-    `RecordDiscovery(...)`.
-  - Spent (chat): `Subscribe<RawLogLine>` → `MarkSpent(code, …)`.
-- **Structural difference from Inventory**: no temporal pairing — join is by
-  word code only, no TTL, no correlator. Discovery and Spent can be hours/days
-  apart on the same record.
+- **Player.log half** → `IPlayerWordOfPowerDiscoveryState`
+  (`src/Mithril.GameState/WordsOfPower/PlayerWordOfPowerDiscoveryStateService.cs`),
+  fed by `Producers/PlayerWordOfPowerDiscoveryFrameProducer.cs`. Persists per
+  character to `wop-discovery.json`; emits `PlayerWordOfPowerDiscovered`
+  on the `IPlayerWorld.Bus`.
+- **Chat half** → `IPlayerChatLineLog`
+  (`src/Mithril.GameState/Chat/PlayerChatLineLogService.cs`), fed by
+  `Producers/PlayerChatLineProducer.cs` and `ChatChannelClassifier`. A
+  passthrough folder: it doesn't own a Word-of-Power-aware filter, it routes
+  every chat line into per-channel `PlayerChatLineFrame`s on the
+  `IChatWorld.Bus`; the view applies the uppercase-token regex on top.
+- **View** → `IWordOfPowerView` backed by `WordOfPowerView`
+  (`src/Mithril.GameState/WordsOfPower/WordOfPowerView.cs`). Subscribes to
+  both world buses; composes "code is known + code is spent" as a plain
+  per-character dictionary merge — **no temporal pairing, no TTL, no
+  correlator**. Discovery and Spent can be hours/days apart on the same
+  record, so the join is on code identity alone. This is structurally
+  different from `IInventoryView`'s Tier-1 cross-source pairing and is the
+  worked second-pattern that validates the view-layer abstraction's ability
+  to host both compositions.
+- **Module surface** → `SarumanOverrideService` (module-internal). Stores
+  user-driven sticky-spent overrides on top of `IWordOfPowerView.IsSpent(code)`;
+  no log subscription of its own.
 - **Wall-clock**: `DateTime.UtcNow` in `SarumanViewModel.cs:119` — for the
   user-driven "mark spent" UI action, not log ingestion. Outside sim scope
   (user input).
-- **Migration**: matches design notebook's worked example 2. Split:
-  - Player.log half → `IPlayerWordOfPowerDiscoveryState` (`Code → discovery
-    record`).
-  - Chat half → `IChatWordOfPowerStateMachine` (`Code → spent timestamp`).
-  - View → `IWordOfPowerView` plain dictionary merge.
-- **Status**: **migration owed**. Second-priority after Inventory; structurally
-  different so the view-layer abstraction needs to admit both patterns.
+- **Status**: **split delivered**. Remaining follow-on:
+  [#686](https://github.com/moumantai-gg/mithril/issues/686) (the
+  Saruman state-store schema-1→2 upgrade hint UX). No #659-equivalent shim
+  obligation — the cross-source migration here was a full rewrite at the
+  consumer side, with no union-shaped event surface preserved for
+  intermediate consumers.
 - **Charter note**: per module-signal-map.md `:377`, Saruman is NOT in
   CLAUDE.md's module table. Pre-existing oversight.
 
@@ -383,20 +416,31 @@ QuestSource.cs}`.
 - **Wall-clock**: none in mutation path.
 - **Status**: green. Mechanical handler migration.
 
-### Palantir (dev/debug shell)
+### Palantir (dev/debug shell) — **MIGRATED ([#726](https://github.com/moumantai-gg/mithril/issues/726) via [#745](https://github.com/moumantai-gg/mithril/pull/745))**
 
-Read-only consumer of `IInventoryService` (`LiveInventoryViewModel.cs:19-42`).
-No FSM, no log subscription. Reactor only — subscribes via
-`_inventory.Subscribe(OnEvent)` at `:55`, which post-#679 lands on the
-`[Obsolete]` shim that `InventoryView` implements. Typed-bus migration to
-`view.Bus.Subscribe<InventoryItemAdded>(…)` is one of the six follow-ons
-tracked in [#659](https://github.com/moumantai-gg/mithril/issues/659).
+Read-only consumer of `IInventoryView.Items` (`LiveInventoryViewModel.cs:43-150`).
+No FSM, no log subscription. Binds directly to the Bind channel — the
+post-#729 `IReadOnlyObservableCollection<InventoryItem>` exposed by
+`IInventoryView` — and observes per-row state via the rows' own
+`INotifyPropertyChanged`. No event subscription. Soft-deleted rows stay in
+the collection with `IsDeleted = true`; the VM's default `CollectionView`
+hides them unless `ShowDeleted` is set.
+
+Palantir is the only one of the six pre-#602 consumers whose post-shim
+destination was the Bind channel rather than a typed-event subscription —
+the others (Samwise, Legolas, Motherlode) went PlayerWorld-direct via
+`IPlayerWorld.Bus.Subscribe<PlayerInventoryAdded/Removed>(…)`, Arwen
+landed on the Tier-2 `IGiftSignalService` lift, and Saruman was
+blueprint-only (it never actually consumed the shim). The Bind-channel
+destination is documented in the dual-surface view contract
+(`docs/world-simulator.md` §Worked example 1 and §Decisions ratified
+post-#642).
 
 ---
 
 ## Migration-plan spot-checks
 
-### 1. `IInventoryService` split — **DELIVERED (#602 via [#679](https://github.com/moumantai-gg/mithril/pull/679))**
+### 1. `IInventoryService` split — **DELIVERED + SHIM RETIRED (#602 via [#679](https://github.com/moumantai-gg/mithril/pull/679); shim removed in #659)**
 
 Pre-#602 the cross-source span was confirmed at `InventoryService.cs:250`
 (Player.log L1) + `:261` (chat L1) — a five-input service (Player.log, chat,
@@ -405,18 +449,28 @@ retired the pre-split file entirely and shipped the worked-example-1 shape:
 `IPlayerInventoryState` folder (`PlayerInventoryStateService.cs` + producer),
 `IChatInventoryState` folder (`ChatInventoryStateService.cs` + producer), and
 `IInventoryView` (`InventoryView.cs`) as the cross-source composer. See the
-rewritten Inventory row above for the post-#679 file/line cites. Remaining
-work is the per-consumer migration off the `[Obsolete]`
-`Subscribe(Action<InventoryEvent>)` shim, tracked in
-[#659](https://github.com/moumantai-gg/mithril/issues/659).
+rewritten Inventory row above for the post-#679 file/line cites. The
+union-shaped `Subscribe(Action<InventoryEvent>)` shim retired in
+[#659](https://github.com/moumantai-gg/mithril/issues/659) once all six
+pre-#602 consumers reached their post-shim destinations (PlayerWorld-direct
+for Samwise/Legolas/Motherlode, the Bind channel for Palantir, the Tier-2
+`IGiftSignalService` for Arwen, blueprint-only for Saruman). The
+`IInventoryService` interface itself stays alive in a Query-only shape for
+Arwen's `CalibrationService.TryResolve` / `TryGetStackSize` reads.
 
-### 2. `SarumanCodebookService` split — **CONFIRMED**
+### 2. `SarumanCodebookService` split — **DELIVERED ([#603](https://github.com/moumantai-gg/mithril/issues/603))**
 
-Cross-source via two ingestion services:
-`SarumanDiscoveryIngestionService.cs:62-74` + `SarumanChatIngestionService.cs:42-101`.
-Both mutate `SarumanCodebookService` (`:64 RecordDiscovery`, `:120 MarkSpent`).
-Different shape than Inventory: key-only join, no TTL. View needs different
-abstraction.
+Pre-#603 the cross-source span lived in `SarumanCodebookService` via two
+ingestion services (`SarumanDiscoveryIngestionService.cs:62-74` Player.log +
+`SarumanChatIngestionService.cs:42-101` chat). Post-#603 the split runs:
+`IPlayerWordOfPowerDiscoveryState` (PlayerWorld folder) +
+`IPlayerChatLineLog` (ChatWorld passthrough folder) + `IWordOfPowerView`
+(cross-world composer). Different shape than Inventory — key-only join, no
+TTL, no correlator — so the view abstraction now has two worked patterns
+(Tier-1 temporal pairing for Inventory, plain dictionary merge for
+Words-of-Power). See the rewritten Saruman row above for the post-#603
+file/line cites; remaining follow-on is the schema-upgrade hint UX in
+[#686](https://github.com/moumantai-gg/mithril/issues/686).
 
 ### 3. `MotherlodeMeasurementCoordinator` migration — **DONE (#604)**
 

--- a/docs/world-simulator.md
+++ b/docs/world-simulator.md
@@ -419,8 +419,6 @@ public interface IInventoryView
     /// stackable; null if stackable + no chat observation paired.
     /// </summary>
     bool TryGetStackSize(long instanceId, out int stackSize);
-
-    IDisposable Subscribe(Action<InventoryEvent> handler);
 }
 
 /// <summary>
@@ -755,7 +753,7 @@ The typed bus is intentionally fire-and-forget — no `SinceSubscribe` / replay-
 
 **Corollary for lazy WPF VMs.** A VM that re-applies bus frames to a locally cached copy of the view's state — reproducing the view's `_map` inside the VM and mutating it on every change event — is an antipattern, not a deferred sharp edge. The view's `_map` is the canonical state; a local mirror invites divergence with no recoverable upside, because any inconsistency becomes a bug whose root cause is split across two places. VMs that need point-in-time reads call `view.TryGet*` / `view.Current` per render or on demand; VMs that need a live-bound collection bind directly to the view's `IReadOnlyObservableCollection<T>` Bind surface; React bus events are change-notification only, never ledger inputs.
 
-**`_eventLog` is shim-era infrastructure.** `InventoryView._eventLog` (and its `EventLogSoftCap` / `EventLogTrimChunk` / `AppendToEventLog` / `s_sinceSubscribeDiagFired` machinery) exists solely to preserve the pre-#602 union-shaped `Subscribe(Action<InventoryEvent>, ReplayMode)` surface for the six legacy consumers tracked under #659. It is not a typed-bus feature and is not a template for future views. When the last shim consumer migrates and #659 lands, the event log retires with it; no future view ships its own event log and no future bus ships a `SinceSubscribe` overload.
+**`_eventLog` was shim-era infrastructure (retired in #751 / closed [#659](https://github.com/moumantai-gg/mithril/issues/659)).** `InventoryView._eventLog` and its `EventLogSoftCap` / `EventLogTrimChunk` / `AppendToEventLog` / `s_sinceSubscribeDiagFired` machinery existed solely to preserve the pre-#602 union-shaped `Subscribe(Action<InventoryEvent>, ReplayMode)` surface for the six legacy consumers tracked under [#659](https://github.com/moumantai-gg/mithril/issues/659). It was never a typed-bus feature and never a template for future views. With every consumer migrated to its post-shim destination and #659 closed, the event log retired with the shim; no future view ships its own event log and no future bus ships a `SinceSubscribe` overload.
 
 See: [issue #707](https://github.com/moumantai-gg/mithril/issues/707) (closed wontfix — this section is the design-rationale residual of [#695](https://github.com/moumantai-gg/mithril/issues/695) point 3); [issue #740](https://github.com/moumantai-gg/mithril/issues/740) (Bind-surface harmonization with `module-charters.md`'s three-channel pattern).
 

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -81,18 +81,20 @@ public static class GameStateServiceCollectionExtensions
         //     replay source and emits chat-observation frames.
         //   - InventoryView is the cross-world composer: subscribes to typed
         //     change events on both world buses, runs the relocated
-        //     PendingCorrelator with (Server,Character)-scoped keys, holds the
-        //     composed instance-id ledger + the event-log shim back-compat for
-        //     the six pre-#602 consumers via IInventoryService.
+        //     PendingCorrelator with (Server,Character)-scoped keys, and holds
+        //     the composed instance-id ledger + the bindable Items collection
+        //     (#729) + the typed change-event bus.
         //
         // The legacy InventoryService class retired entirely in #602 — its
         // L1-direct subscriptions violated world-sim principle 3. The
-        // IInventoryService DI binding still resolves (so the six pre-#602
-        // consumers continue to inject and subscribe unchanged) — it now
-        // points at the view, which holds all the prior behaviour. Each
-        // consumer migrates to the typed view bus in its own follow-on under
-        // #659; at the last migration, IInventoryService + InventoryEvent
-        // can be deleted.
+        // IInventoryService DI binding still resolves (Arwen's CalibrationService
+        // consumes TryResolve / TryGetStackSize through it) and points at the
+        // view, which implements both surfaces. The union-shaped
+        // Subscribe(Action<InventoryEvent>) shim retired in #659 once all six
+        // pre-#602 consumers reached their post-shim destinations
+        // (PlayerWorld-direct for Samwise/Legolas/Motherlode, the Bind channel
+        // for Palantir, the Tier-2 IGiftSignalService for Arwen, blueprint-only
+        // for Saruman).
         //
         // Folder + producer registration happens in PlayerInventoryWorldRegistration
         // / ChatInventoryWorldRegistration hosted services (ordering preserved by

--- a/src/Mithril.GameState/Effects/IPlayerEffectsStateService.cs
+++ b/src/Mithril.GameState/Effects/IPlayerEffectsStateService.cs
@@ -17,8 +17,7 @@ namespace Mithril.GameState.Effects;
 ///   <see cref="EffectEvent"/> stream. Default
 ///   <see cref="ReplayMode.FromSessionStart"/> atomically replays every
 ///   Added / Removed / DisplayNameChanged event in log order before live
-///   dispatch begins (the post-#585 <c>IInventoryService.Subscribe</c>
-///   contract; this service ships with it from day one).
+///   dispatch begins (the post-#585 late-attach atomic-replay contract).
 ///   <see cref="ReplayMode.LiveOnly"/> skips the replay.</item>
 ///   <item><b>Bind</b> — deferred. A full
 ///   <c>IReadOnlyObservableCollection&lt;EffectState&gt;</c> with
@@ -26,8 +25,8 @@ namespace Mithril.GameState.Effects;
 ///   service-side Bind-surface lift initiative (#584 follow-up). Consumers
 ///   needing observable mutation today seed off <see cref="ActiveEffects"/>
 ///   + subscribe via <see cref="Subscribe"/> and rebuild their own
-///   observable surface — same shape Palantir's
-///   <c>LiveInventoryViewModel</c> uses over <c>IInventoryService</c>.</item>
+///   observable surface — the same wrap-a-Subscribe pattern Palantir used
+///   over the inventory service pre-#726.</item>
 /// </list>
 /// </para>
 ///

--- a/src/Mithril.GameState/Inventory/IInventoryService.cs
+++ b/src/Mithril.GameState/Inventory/IInventoryService.cs
@@ -1,83 +1,24 @@
-using Mithril.Shared.Logging;
-
 namespace Mithril.GameState.Inventory;
 
 /// <summary>
-/// A live inventory transition. <paramref name="InstanceId"/> is the per-item
-/// unique id emitted by <c>ProcessAddItem</c> / <c>ProcessDeleteItem</c>.
-/// <paramref name="InternalName"/> maps to
-/// <see cref="Mithril.Reference.Models.Items.Item.InternalName"/>.
-/// <paramref name="Timestamp"/> is the source log line's timestamp (UTC), not
-/// wall-clock — consumers with time-window logic (e.g. Samwise's plant-resolve
-/// window) need the in-game timeline.
-/// <paramref name="StackSize"/> is the stack size at the moment of the event:
-/// for <see cref="InventoryEventKind.Added"/> it's the size known when the
-/// item entered the map (1 if no chat correlation has landed yet);
-/// for <see cref="InventoryEventKind.Deleted"/> it's the last-known size
-/// before removal; for <see cref="InventoryEventKind.StackChanged"/> it's
-/// the new size.
-/// <paramref name="SizeConfirmed"/> is the same bit
-/// <see cref="IInventoryService.TryGetStackSize"/> consults — false when the
-/// <paramref name="StackSize"/> is the unconfirmed default-1 (a session-replayed
-/// AddItem with no chat correlation), true when an authoritative source
-/// (chat, UpdateItemCode, vault, export seed/reconcile) has spoken.
-/// <see cref="InventoryEventKind.StackChanged"/> events always carry
-/// <c>SizeConfirmed = true</c>.
-/// </summary>
-public readonly record struct InventoryEvent(
-    InventoryEventKind Kind,
-    long InstanceId,
-    string InternalName,
-    DateTime Timestamp,
-    int StackSize,
-    bool SizeConfirmed = false);
-
-public enum InventoryEventKind
-{
-    Added,
-    Deleted,
-    /// <summary>
-    /// Fired when the stack size of an existing entry changes in place
-    /// (split, merge, plant-consume, vault transfer, chat back-fill of a
-    /// previously-defaulted size). Not fired on Add or Delete — those carry
-    /// their own size on the event.
-    /// </summary>
-    StackChanged,
-}
-
-/// <summary>
-/// Canonical <c>instanceId → InternalName</c> lookup maintained by tailing
-/// <c>ProcessAddItem</c> / <c>ProcessDeleteItem</c> / <c>ProcessUpdateItemCode</c>
-/// / <c>ProcessRemoveFromStorageVault</c> on <c>IPlayerLogStream</c>, plus the
-/// chat <c>[Status]</c> channel via <c>IChatLogStream</c> for stack-size
-/// correlation on fresh additions.
+/// Query-channel surface for the live <c>instanceId → InternalName</c> +
+/// stack-size ledger composed by <see cref="InventoryView"/> (#602 split).
+/// Retained post-#659 for Arwen's gift-attribution path; the same concrete
+/// <see cref="InventoryView"/> implements both this interface and the broader
+/// <see cref="IInventoryView"/>. New code that wants change events or the
+/// bindable items collection takes <see cref="IInventoryView"/>; consumers
+/// that only need point-in-time lookups can stay on this interface.
 ///
-/// <para><b>Three channels (per <a href="https://github.com/moumantai-gg/mithril/pull/584">#584</a>'s
-/// service-design rule).</b></para>
-/// <list type="bullet">
-///   <item><b>Query</b> — <see cref="TryResolve"/> and
-///   <see cref="TryGetStackSize"/> answer "what's in inventory right now?"
-///   (including last-known state for deleted entries — Arwen's
-///   gift-attribution path needs the pre-delete name/size).</item>
-///   <item><b>React</b> — <see cref="Subscribe(Action{InventoryEvent}, ReplayMode)"/>
-///   delivers the full session <see cref="InventoryEvent"/> log. The default
-///   <see cref="ReplayMode.FromSessionStart"/> replays every Added / Deleted /
-///   StackChanged event the service has emitted in this session (in order)
-///   before going live; <see cref="ReplayMode.LiveOnly"/> skips the replay
-///   for consumers that genuinely don't care about history. The contract
-///   matches <see cref="Mithril.Shared.Logging.ILogStreamDriver"/>'s
-///   default replay-then-live shape.</item>
-///   <item><b>Bind</b> — not exposed today. Consumers that want an
-///   observable <c>Items</c> collection wrap <see cref="Subscribe"/> at the
-///   call site (see <c>Palantir.LiveInventoryViewModel</c>).</item>
-/// </list>
-///
-/// <para>Owning this centrally (rather than having each module rebuild its
-/// own map from the stream) avoids the late-subscribe race: modules either
-/// query the live map at use-time via <see cref="TryResolve"/> or
-/// <see cref="TryGetStackSize"/>, or subscribe via <see cref="Subscribe"/>
-/// which atomically replays the full event log to the new handler before
-/// delivering live events.</para>
+/// <para>The pre-#659 React-channel <c>Subscribe(Action&lt;InventoryEvent&gt;)</c>
+/// shim retired with the issue once all six pre-#602 consumers migrated to
+/// their post-shim destinations (PlayerWorld-direct for Samwise / Legolas /
+/// Motherlode, the Bind channel for Palantir, the Tier-2
+/// <c>IGiftSignalService</c> for Arwen, blueprint-only for Saruman).
+/// The accompanying <c>InventoryEvent</c> union and <c>InventoryEventKind</c>
+/// enum were deleted at the same time — change-event consumers subscribe to
+/// the typed <see cref="InventoryItemAdded"/> / <see cref="InventoryItemRemoved"/>
+/// / <see cref="InventoryStackChanged"/> frames on
+/// <see cref="IInventoryView.Bus"/>.</para>
 /// </summary>
 public interface IInventoryService
 {
@@ -97,8 +38,8 @@ public interface IInventoryService
     ///   <item>The instance has never been observed (carryover from a prior
     ///   game session whose AddItem isn't in this log's replay buffer).</item>
     ///   <item>The instance is in the map but its size is still the
-    ///   unconfirmed default of 1 (a session-replayed AddItem with no
-    ///   chat status in the correlation window). A real stack of 1 is
+    ///   unconfirmed default of 1 (a session-replayed AddItem with no chat
+    ///   status in the correlation window). A real stack of 1 is
     ///   distinguishable: the chat status confirms it, the corresponding
     ///   AddItem path flips confirmation on, and TryGetStackSize reports
     ///   <c>true, 1</c>.</item>
@@ -108,58 +49,4 @@ public interface IInventoryService
     /// gift-attribution path needs the pre-delete size.
     /// </summary>
     bool TryGetStackSize(long instanceId, out int stackSize);
-
-    /// <summary>
-    /// React-channel subscription. Attach a handler that receives every
-    /// <see cref="InventoryEvent"/> the service emits.
-    ///
-    /// <para><b>Default replay shape (<see cref="ReplayMode.FromSessionStart"/>).</b>
-    /// On attach, the service replays the full in-session event log to the
-    /// handler (every Added / Deleted / StackChanged event it has emitted
-    /// since startup, in original order) before delivering live events.
-    /// This is the same contract <see cref="Mithril.Shared.Logging.ILogStreamDriver"/>
-    /// offers for L1 subscriptions and resolves the late-subscribe class of
-    /// bug surfaced by audits <a href="https://github.com/moumantai-gg/mithril/issues/579">#579</a>
-    /// / <a href="https://github.com/moumantai-gg/mithril/issues/588">#588</a>:
-    /// a consumer attaching after some items have been added-and-deleted
-    /// during this session now receives the Deleted (and any interim
-    /// StackChanged) events for those items, not just the survivors.</para>
-    ///
-    /// <para><b>Live-only subscriptions.</b> Callers that genuinely don't
-    /// care about session history (e.g. a UI that only renders events from
-    /// "now" forward) pass <see cref="ReplayMode.LiveOnly"/>. Replay is
-    /// skipped; the handler only sees events fired after the subscription
-    /// is established.</para>
-    ///
-    /// <para><b>Atomicity.</b> Replay and live-attach are atomic — under an
-    /// internal lock — so no event is lost, duplicated, or reordered
-    /// relative to the canonical map. A live event firing during another
-    /// handler's replay either runs after replay completes (and is
-    /// delivered live) or runs before (and is in the replay), never both
-    /// and never neither.</para>
-    ///
-    /// <para><b>Threading.</b> The handler is invoked synchronously under
-    /// the internal lock both during replay (on the subscribing thread) and
-    /// during live dispatch (on the ingestion-loop thread). Subscribers
-    /// that do non-trivial work should dispatch off-thread immediately to
-    /// avoid blocking ingestion.</para>
-    ///
-    /// <para><b>Query vs. React.</b> For "what's in inventory right now?"
-    /// use the Query channel — <see cref="TryResolve"/> /
-    /// <see cref="TryGetStackSize"/>. Subscribe is the React channel: a
-    /// log of what happened, in order, including the Deleted events the
-    /// pre-#585 contract silently dropped for fresh subscribers.</para>
-    ///
-    /// <para>Dispose the returned subscription to stop receiving further
-    /// events.</para>
-    /// </summary>
-    /// <param name="handler">Event handler. Must not be null.</param>
-    /// <param name="replay">Backlog policy. Default
-    /// <see cref="ReplayMode.FromSessionStart"/> replays the full session
-    /// event log atomically before going live;
-    /// <see cref="ReplayMode.LiveOnly"/> skips the replay.</param>
-    [Obsolete("Subscribe to Frame<InventoryItemAdded> et al. on IInventoryView.Bus. Cleanup tracked in #659.")]
-    IDisposable Subscribe(
-        Action<InventoryEvent> handler,
-        ReplayMode replay = ReplayMode.FromSessionStart);
 }

--- a/src/Mithril.GameState/Inventory/IInventoryView.cs
+++ b/src/Mithril.GameState/Inventory/IInventoryView.cs
@@ -10,15 +10,21 @@ namespace Mithril.GameState.Inventory;
 /// <see cref="IChatInventoryState"/>), pairing them with a TTL-windowed
 /// correlator keyed on <c>(InternalName, Server, Character)</c>.
 ///
-/// <para><b>Canonical surface = typed-frame bus.</b> Subscribe via
-/// <see cref="Bus"/> for any of the three view-emitted typed events
-/// — <see cref="InventoryItemAdded"/>, <see cref="InventoryItemRemoved"/>,
-/// <see cref="InventoryStackChanged"/>. Consumers post-migration use the bus.
-/// The legacy <see cref="Subscribe(Action{InventoryEvent}, Mithril.Shared.Logging.ReplayMode)"/>
-/// shim translates these typed frames back into the union-shaped
-/// <c>InventoryEvent</c> for the six pre-existing consumers (Arwen, Samwise,
-/// Palantir, Legolas, Saruman, Motherlode) — migrations of each are tracked
-/// in <a href="https://github.com/moumantai-gg/mithril/issues/659">#659</a>.</para>
+/// <para><b>Three consumer surfaces.</b> Per the React / Query / Bind
+/// taxonomy in <c>docs/module-charters.md</c>:
+/// <list type="bullet">
+///   <item><b>React</b> — <see cref="Bus"/> publishes typed
+///   <see cref="InventoryItemAdded"/> / <see cref="InventoryItemRemoved"/> /
+///   <see cref="InventoryStackChanged"/> frames.</item>
+///   <item><b>Query</b> — <see cref="TryResolve"/> /
+///   <see cref="TryGetStackSize"/> answer "what's in inventory now?".</item>
+///   <item><b>Bind</b> — <see cref="Items"/> is a live observable collection
+///   of <see cref="InventoryItem"/> rows for WPF binding (#729).</item>
+/// </list>
+/// The pre-#659 union-shaped <c>Subscribe(Action&lt;InventoryEvent&gt;)</c>
+/// shim retired in #659; consumers landed at PlayerWorld-direct
+/// (Samwise/Legolas/Motherlode), the Bind channel (Palantir), the Tier-2
+/// <c>IGiftSignalService</c> (Arwen), or stayed blueprint-only (Saruman).</para>
 ///
 /// <para><b>Why a view, not a service.</b> Pre-#602 <c>IInventoryService</c>
 /// consumed both Player.log AND chat directly. That violates the world-sim
@@ -83,20 +89,4 @@ public interface IInventoryView
     /// verbatim for the pre-#602 consumers.
     /// </summary>
     bool TryGetStackSize(long instanceId, out int stackSize);
-
-    /// <summary>
-    /// Legacy union-shaped event subscription. The view translates its typed
-    /// frames into <see cref="InventoryEvent"/> for backward compatibility
-    /// with the six pre-#602 consumers; new code subscribes via <see cref="Bus"/>
-    /// directly.
-    /// </summary>
-    /// <remarks>
-    /// The default <see cref="Mithril.Shared.Logging.ReplayMode.FromSessionStart"/>
-    /// replays the full in-session event log atomically before going live,
-    /// closing the late-subscribe race the pre-split service surfaced in #585.
-    /// </remarks>
-    [Obsolete("Subscribe to Frame<InventoryItemAdded> et al. on IInventoryView.Bus")]
-    IDisposable Subscribe(
-        Action<InventoryEvent> handler,
-        Mithril.Shared.Logging.ReplayMode replay = Mithril.Shared.Logging.ReplayMode.FromSessionStart);
 }

--- a/src/Mithril.GameState/Inventory/InventoryView.cs
+++ b/src/Mithril.GameState/Inventory/InventoryView.cs
@@ -4,7 +4,6 @@ using Mithril.GameState.Sessions;
 using Mithril.Shared.Collections;
 using Mithril.Shared.Correlation;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Mithril.WorldSim;
 using Mithril.WorldSim.Chat;
@@ -43,19 +42,27 @@ namespace Mithril.GameState.Inventory;
 /// service used <c>TimeProvider.System</c> for the same gate, breaking
 /// determinism under replay.)</para>
 ///
-/// <para><b>Two consumer surfaces.</b>
+/// <para><b>Three consumer surfaces (per the React / Query / Bind taxonomy
+/// in <c>docs/module-charters.md</c>).</b>
 /// <list type="bullet">
-///   <item><b>Typed bus</b> — the canonical post-migration surface. New code
-///   subscribes via <c>view.Bus.Subscribe&lt;InventoryItemAdded&gt;(...)</c>
-///   etc.</item>
-///   <item><b>Legacy union-shaped <c>Subscribe(Action&lt;InventoryEvent&gt;)</c></b>
-///   — preserved for the six pre-#602 consumers (Arwen, Samwise, Palantir,
-///   Legolas, Saruman, Motherlode). The view owns its own event log + handler
-///   list (replacing what <c>InventoryService</c> previously owned), so the
-///   late-subscribe atomic-replay contract (#585) survives unchanged. Migration
-///   of each consumer to the typed bus is tracked in #659.</item>
+///   <item><b>React</b> — typed-frame bus. Subscribers attach via
+///   <c>view.Bus.Subscribe&lt;InventoryItemAdded&gt;(…)</c> /
+///   <c>InventoryItemRemoved</c> / <c>InventoryStackChanged</c>.</item>
+///   <item><b>Query</b> — <see cref="TryResolve"/> /
+///   <see cref="TryGetStackSize"/> on both <see cref="IInventoryView"/> and
+///   <see cref="IInventoryService"/>.</item>
+///   <item><b>Bind</b> — <see cref="IInventoryView.Items"/>: a live
+///   <see cref="IReadOnlyObservableCollection{InventoryItem}"/> for WPF
+///   binding. Per-row mutations propagate via
+///   <see cref="System.ComponentModel.INotifyPropertyChanged"/>; soft-delete
+///   contract — removed rows stay in the collection with
+///   <see cref="InventoryItem.IsDeleted"/> = <c>true</c>.</item>
 /// </list>
-/// </para>
+/// The pre-#659 union-shaped <c>Subscribe(Action&lt;InventoryEvent&gt;)</c>
+/// shim retired with that issue once all six pre-#602 consumers migrated to
+/// their post-shim destinations (PlayerWorld-direct for Samwise/Legolas/Motherlode,
+/// the Bind channel for Palantir, the Tier-2 <c>IGiftSignalService</c> for
+/// Arwen, blueprint-only for Saruman).</para>
 ///
 /// <para><b>Stack-size sources of truth.</b> The composed stack size is the
 /// merge of:
@@ -73,12 +80,13 @@ namespace Mithril.GameState.Inventory;
 /// unconfirmed default-1 — distinguishable from a real stack of 1 confirmed
 /// via chat).</para>
 ///
-/// <para><b>What this PR retires.</b> The legacy <c>InventoryService</c>
+/// <para><b>What #602 retired.</b> The pre-split <c>InventoryService</c>
 /// L1-direct subscriptions to <c>LocalPlayerLogLine</c> and <c>RawLogLine</c>
-/// retire entirely. The class survives only as a thin wrapper that resolves
+/// retired entirely. The class survives only as a thin wrapper that resolves
 /// to this view (so the existing <see cref="IInventoryService"/> DI binding
-/// stays valid for the six pre-#602 consumers). FSW reconcile retired per
-/// #612 — <see cref="IGameReportsService.StorageReportsChanged"/> is the sole
+/// stays valid for the remaining Query-channel consumer, Arwen's
+/// <c>CalibrationService</c>). FSW reconcile retired per #612 —
+/// <see cref="IGameReportsService.StorageReportsChanged"/> is the sole
 /// seed-refresh signal.</para>
 /// </summary>
 public sealed class InventoryView : IInventoryView, IInventoryService, IDisposable
@@ -120,12 +128,12 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     // MaxStackSize > 1.
     private readonly Dictionary<string, int> _seededStackSizes = new(StringComparer.Ordinal);
 
-    // _stateLock guards _map, _shimHandlers, _eventLog, _eventLogOverflowWarned,
-    // _seededStackSizes, _items. The correlators have their own internal locks;
-    // we still take _stateLock around correlator calls so the drain-then-mutate-_map
-    // sequence inside each handler is atomic. Two independent world-bus
-    // subscriptions dispatch on different threads, so _stateLock is also
-    // load-bearing for cross-source serialization.
+    // _stateLock guards _map, _seededStackSizes, _items. The correlators have
+    // their own internal locks; we still take _stateLock around correlator
+    // calls so the drain-then-mutate-_map sequence inside each handler is
+    // atomic. Two independent world-bus subscriptions dispatch on different
+    // threads, so _stateLock is also load-bearing for cross-source
+    // serialization.
     //
     // _items is the WPF "Bind" surface (#729). Per-row InventoryItem state
     // (StackSize / SizeConfirmed / IsDeleted) mutates via the same code paths
@@ -137,20 +145,6 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     private readonly object _stateLock = new();
     private readonly Dictionary<long, MapEntry> _map = new();
     private readonly ObservableInventoryItems _items = new();
-
-    // Legacy union-shaped subscriber list — same atomic-replay shape the
-    // pre-#602 service offered (#585 contract). The six pre-#602 consumers
-    // subscribe here through the IInventoryService shim; #659 follow-on PRs
-    // migrate each to the typed bus.
-    private readonly List<Action<InventoryEvent>> _shimHandlers = new();
-
-    private const int EventLogSoftCap = 50_000;
-    private const int EventLogTrimChunk = 4_096;
-    private readonly List<InventoryEvent> _eventLog = new();
-    private bool _eventLogOverflowWarned;
-
-    // One-shot SinceSubscribe coercion diag — same as the pre-split service.
-    private static int s_sinceSubscribeDiagFired;
 
     // Item is the per-instance row exposed via the bindable _items surface.
     // The view drives its mutable bits (StackSize / SizeConfirmed / IsDeleted)
@@ -260,29 +254,6 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
         }
         stackSize = 0;
         return false;
-    }
-
-    public IDisposable Subscribe(
-        Action<InventoryEvent> handler,
-        ReplayMode replay = ReplayMode.FromSessionStart)
-    {
-        ArgumentNullException.ThrowIfNull(handler);
-        if (replay == ReplayMode.SinceSubscribe
-            && Interlocked.CompareExchange(ref s_sinceSubscribeDiagFired, 1, 0) == 0)
-        {
-            _diag?.Trace("GameState.Inventory.View",
-                "ReplayMode.SinceSubscribe is not yet implemented; treating as LiveOnly. " +
-                "This diagnostic fires once per process.");
-        }
-        lock (_stateLock)
-        {
-            if (replay == ReplayMode.FromSessionStart)
-            {
-                foreach (var evt in _eventLog) InvokeShim(handler, evt);
-            }
-            _shimHandlers.Add(handler);
-            return new ShimSubscription(this, handler);
-        }
     }
 
     // ── PlayerWorld bus handlers ─────────────────────────────────────────
@@ -640,50 +611,18 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
     {
         var typed = new InventoryItemAdded(instanceId, internalName, size, confirmed, timestamp);
         _bus.Publish(new Frame<InventoryItemAdded>(new DateTimeOffset(timestamp, TimeSpan.Zero), typed));
-        FireShim(new InventoryEvent(InventoryEventKind.Added, instanceId, internalName, timestamp, size, confirmed));
     }
 
     private void FireRemoved(long instanceId, string internalName, DateTime timestamp, int size, bool confirmed)
     {
         var typed = new InventoryItemRemoved(instanceId, internalName, size, confirmed, timestamp);
         _bus.Publish(new Frame<InventoryItemRemoved>(new DateTimeOffset(timestamp, TimeSpan.Zero), typed));
-        FireShim(new InventoryEvent(InventoryEventKind.Deleted, instanceId, internalName, timestamp, size, confirmed));
     }
 
     private void FireStackChanged(long instanceId, string internalName, DateTime timestamp, int size, bool sizeConfirmed)
     {
         var typed = new InventoryStackChanged(instanceId, internalName, size, sizeConfirmed, timestamp);
         _bus.Publish(new Frame<InventoryStackChanged>(new DateTimeOffset(timestamp, TimeSpan.Zero), typed));
-        FireShim(new InventoryEvent(InventoryEventKind.StackChanged, instanceId, internalName, timestamp, size, sizeConfirmed));
-    }
-
-    /// <summary>MUST hold <see cref="_stateLock"/>.</summary>
-    private void FireShim(InventoryEvent evt)
-    {
-        AppendToEventLog(evt);
-        foreach (var h in _shimHandlers) InvokeShim(h, evt);
-    }
-
-    private void AppendToEventLog(InventoryEvent evt)
-    {
-        if (_eventLog.Count >= EventLogSoftCap)
-        {
-            var trim = Math.Min(EventLogTrimChunk, _eventLog.Count);
-            _eventLog.RemoveRange(0, trim);
-            if (!_eventLogOverflowWarned)
-            {
-                _eventLogOverflowWarned = true;
-                _diag?.Warn("GameState.Inventory.View",
-                    $"React-channel event log exceeded soft cap ({EventLogSoftCap}); dropping oldest entries.");
-            }
-        }
-        _eventLog.Add(evt);
-    }
-
-    private void InvokeShim(Action<InventoryEvent> handler, InventoryEvent evt)
-    {
-        try { handler(evt); }
-        catch (Exception ex) { _diag?.Warn("GameState.Inventory.View", $"Subscriber threw: {ex.Message}"); }
     }
 
     /// <summary>
@@ -704,24 +643,5 @@ public sealed class InventoryView : IInventoryView, IInventoryService, IDisposab
         _playerStackUpdatedSub?.Dispose();
         _chatObservedSub?.Dispose();
         _gameReports.StorageReportsChanged -= OnGameReportsStorageChanged;
-    }
-
-    private sealed class ShimSubscription : IDisposable
-    {
-        private InventoryView? _owner;
-        private readonly Action<InventoryEvent> _handler;
-
-        public ShimSubscription(InventoryView owner, Action<InventoryEvent> handler)
-        {
-            _owner = owner;
-            _handler = handler;
-        }
-
-        public void Dispose()
-        {
-            var owner = Interlocked.Exchange(ref _owner, null);
-            if (owner is null) return;
-            lock (owner._stateLock) { owner._shimHandlers.Remove(_handler); }
-        }
     }
 }

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -50,7 +50,7 @@ namespace Samwise.State;
 /// <see cref="GardenStateMachine"/> never reads <c>StackSize</c> or
 /// <c>SizeConfirmed</c>, never composes Player.log adds with chat
 /// <c>[Status] X xN added</c> observations, and the pre-migration handler
-/// explicitly dropped <see cref="InventoryEventKind.StackChanged"/> events.
+/// explicitly dropped the union shim's StackChanged events.
 /// Per the principle 4 single-world-direct exit
 /// (<c>docs/world-simulator.md</c> §"Views can compose across all three
 /// categories"), we subscribe directly to
@@ -60,17 +60,17 @@ namespace Samwise.State;
 /// after its own principle-4 audit.</para>
 ///
 /// <para><b>Replay-on-subscribe is unnecessary under Call 1 + Call 2.</b> The
-/// shim's late-attach atomic-replay contract (#585, inherited by
-/// <see cref="IInventoryView"/> post-#602) guarded against frames published
-/// before the subscriber attached. Under the eager-always Call 1 contract
-/// (#695 / PR #705) Samwise's subscriptions attach inside <see cref="StartAsync"/>
-/// before the trailing <c>WorldMergerStartHostedService</c> from Call 2
-/// (#696 / PR #702) begins draining frames, so no frames can have been
-/// dispatched by the time the bus subscription is live. The three-surface
-/// view contract (<c>docs/world-simulator.md</c> §"Three-surface contract for
-/// views") explicitly omits a replay-on-subscribe primitive for the same
-/// reason. The legacy <c>SubscribeAfterSeedAdd_StillResolvesPlant</c>
-/// regression's race is by-construction eliminated here.</para>
+/// retired shim's late-attach atomic-replay contract (#585; the shim itself
+/// retired in #659) guarded against frames published before the subscriber
+/// attached. Under the eager-always Call 1 contract (#695 / PR #705) Samwise's
+/// subscriptions attach inside <see cref="StartAsync"/> before the trailing
+/// <c>WorldMergerStartHostedService</c> from Call 2 (#696 / PR #702) begins
+/// draining frames, so no frames can have been dispatched by the time the bus
+/// subscription is live. The three-surface view contract
+/// (<c>docs/world-simulator.md</c> §"Three-surface contract for views")
+/// explicitly omits a replay-on-subscribe primitive for the same reason. The
+/// legacy <c>SubscribeAfterSeedAdd_StillResolvesPlant</c> regression's race
+/// is by-construction eliminated here.</para>
 ///
 /// <para><b>Containment retired.</b> The pre-L1 <c>ThrottledWarn</c> field,
 /// ctor init, and per-message catch around the parse-and-Apply switch are

--- a/tests/Arwen.Tests/FakeInventory.cs
+++ b/tests/Arwen.Tests/FakeInventory.cs
@@ -1,12 +1,14 @@
 using Mithril.GameState.Inventory;
-using Mithril.Shared.Logging;
 
 namespace Arwen.Tests;
 
 /// <summary>
 /// Tests seed the map via <see cref="Add"/> to mirror what the real
-/// <c>InventoryService</c> would learn from <c>ProcessAddItem</c> and the
-/// chat-correlation / <c>UpdateItemCode</c> paths.
+/// <see cref="InventoryView"/> would learn from <c>ProcessAddItem</c> and the
+/// chat-correlation / <c>UpdateItemCode</c> paths. Implements the Query-only
+/// <see cref="IInventoryService"/> contract the post-#659
+/// <c>CalibrationService</c> still consumes for
+/// <c>TryResolve</c> / <c>TryGetStackSize</c>.
 /// </summary>
 internal sealed class FakeInventory : IInventoryService
 {
@@ -27,14 +29,5 @@ internal sealed class FakeInventory : IInventoryService
         }
         stackSize = 0;
         return false;
-    }
-    public IDisposable Subscribe(
-        Action<InventoryEvent> handler,
-        ReplayMode replay = ReplayMode.FromSessionStart) => NoopSubscription.Instance;
-
-    private sealed class NoopSubscription : IDisposable
-    {
-        public static readonly NoopSubscription Instance = new();
-        public void Dispose() { }
     }
 }

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs
@@ -22,15 +22,18 @@ namespace Mithril.GameState.Tests.Inventory;
 /// cross-source composer. Drives the two world buses directly (PlayerWorld +
 /// ChatWorld) and asserts the view composes them into the typed three-channel
 /// surface (<see cref="InventoryItemAdded"/> / <see cref="InventoryItemRemoved"/>
-/// / <see cref="InventoryStackChanged"/>) and into the legacy union-shaped
-/// shim. Pins:
+/// / <see cref="InventoryStackChanged"/>). Pins:
 /// <list type="bullet">
 ///   <item>Correlator pairing in both arrival orders.</item>
 ///   <item>Scope check on <c>(Server, Character)</c> mismatch.</item>
 ///   <item>Non-stackable confirmation via reference data.</item>
-///   <item>Shim translation typed-frames → legacy <c>InventoryEvent</c>.</item>
-///   <item>Late-subscribe atomic replay of the shim event log (#585 contract).</item>
+///   <item>Per-row bindable <c>Items</c> surface (Add / StackUpdated /
+///   chat-correlation / soft-delete).</item>
 /// </list>
+/// The pre-#659 union-shaped <c>Subscribe(Action&lt;InventoryEvent&gt;)</c>
+/// shim retired in #659; the previous shim-translation + late-subscribe
+/// replay pins retired with it (no consumer relies on the union shape any
+/// more — see <c>docs/world-sim-migration-audit.md</c>'s Inventory row).
 /// </summary>
 public sealed class InventoryViewTests
 {
@@ -516,54 +519,6 @@ public sealed class InventoryViewTests
         // both runs simultaneously they'd still compare equal but the contract
         // wouldn't be exercised.
         run1.Should().HaveCount(5);
-    }
-
-    // ── Shim translation ────────────────────────────────────────────────
-
-    [Fact]
-    public void Shim_Subscribe_delivers_InventoryEvent_kinds_for_each_typed_emission()
-    {
-        var (view, pw, cw, _) = Build();
-        var shim = new List<InventoryEvent>();
-#pragma warning disable CS0618 // shim surface under the #602 → #659 migration window
-        view.Subscribe(shim.Add);
-#pragma warning restore CS0618
-
-        PlayerAdd(pw, 42, "Moonstone", Ts(1));
-        ChatObserved(cw, "Moonstone", 7, Ts(2));   // → StackChanged on existing add
-        PlayerRemove(pw, 42, "Moonstone", Ts(3));
-
-        shim.Select(e => e.Kind).Should().Equal(new[]
-        {
-            InventoryEventKind.Added,
-            InventoryEventKind.StackChanged,
-            InventoryEventKind.Deleted,
-        });
-    }
-
-    [Fact]
-    public void Late_subscribe_replays_full_session_event_log()
-    {
-        var (view, pw, cw, _) = Build();
-
-        PlayerAdd(pw, 42, "Moonstone", Ts(1));
-        ChatObserved(cw, "Moonstone", 7, Ts(2));
-        PlayerRemove(pw, 42, "Moonstone", Ts(3));
-
-        var replayed = new List<InventoryEvent>();
-#pragma warning disable CS0618
-        view.Subscribe(replayed.Add);
-#pragma warning restore CS0618
-
-        // The shim's event log mirrors the pre-split InventoryService #585
-        // contract: a late subscriber sees the full session, including the
-        // intervening StackChanged + the eventual Deleted.
-        replayed.Select(e => e.Kind).Should().Equal(new[]
-        {
-            InventoryEventKind.Added,
-            InventoryEventKind.StackChanged,
-            InventoryEventKind.Deleted,
-        });
     }
 
     // ── Export seed + reconcile (issue #681) ────────────────────────────

--- a/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
+++ b/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
@@ -7,7 +7,6 @@ using Mithril.GameState.Inventory;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Collections;
-using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Mithril.WorldSim;
 using Palantir.ViewModels;
@@ -16,15 +15,17 @@ using Xunit;
 namespace Palantir.Tests;
 
 /// <summary>
-/// Tests for the #726 migration: Palantir's live-inventory VM now binds to
-/// <see cref="IInventoryView.Items"/> directly instead of mirroring the
-/// legacy <see cref="InventoryEvent"/> shim into a local collection. Each
-/// test seeds / mutates a <see cref="FakeInventoryView"/>'s items and asserts
-/// the VM's <c>View</c>/<c>LiveCount</c>/<c>DeletedCount</c>/<c>ShowDeleted</c>
+/// Tests for the #726 migration: Palantir's live-inventory VM binds to
+/// <see cref="IInventoryView.Items"/> directly instead of mirroring an
+/// event stream into a local collection. Each test seeds / mutates a
+/// <see cref="FakeInventoryView"/>'s items and asserts the VM's
+/// <c>View</c>/<c>LiveCount</c>/<c>DeletedCount</c>/<c>ShowDeleted</c>
 /// surfaces reflect the bound state. The view-internal bus → items mutation
 /// path is covered by <c>InventoryViewTests</c> in
 /// <c>Mithril.GameState.Tests</c> — these tests pin the consumer-side
-/// projection only.
+/// projection only. (The legacy union-shaped event shim Palantir used
+/// pre-#726 retired in #659; this VM's pre-#726 re-mirror path is gone
+/// regardless.)
 /// </summary>
 public sealed class LiveInventoryViewModelTests
 {
@@ -145,11 +146,9 @@ public sealed class LiveInventoryViewModelTests
         => new(id, internalName, stack, confirmed);
 
     /// <summary>
-    /// Minimal <see cref="IInventoryView"/> stub. The legacy
-    /// <c>Subscribe(Action&lt;InventoryEvent&gt;)</c> shim is unused by the
-    /// post-#726 Palantir VM; <c>Bus</c> is unused too (the VM binds to
-    /// <see cref="IInventoryView.Items"/> directly and observes per-row INPC),
-    /// so both throw to surface accidental regressions.
+    /// Minimal <see cref="IInventoryView"/> stub. <c>Bus</c> is unused (the
+    /// VM binds to <see cref="IInventoryView.Items"/> directly and observes
+    /// per-row INPC), so it throws to surface accidental regressions.
     /// </summary>
     private sealed class FakeInventoryView : IInventoryView
     {
@@ -162,11 +161,6 @@ public sealed class LiveInventoryViewModelTests
 
         public bool TryResolve(long instanceId, out string internalName) { internalName = ""; return false; }
         public bool TryGetStackSize(long instanceId, out int stackSize) { stackSize = 0; return false; }
-
-#pragma warning disable CS0618 // shim is obsolete; FakeInventoryView only implements it because IInventoryView requires it
-        public IDisposable Subscribe(Action<InventoryEvent> handler, ReplayMode replay = ReplayMode.FromSessionStart)
-            => throw new NotSupportedException("Palantir VM does not consume the legacy shim post-#726.");
-#pragma warning restore CS0618
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Deletes the union-shaped `IInventoryView.Subscribe(Action<InventoryEvent>)` shim, the `InventoryEvent` record, and the `InventoryEventKind` enum (closes [#659](https://github.com/moumantai-gg/mithril/issues/659)). All six pre-#602 consumers have already reached their post-shim destinations: PlayerWorld-direct for Samwise ([#725](https://github.com/moumantai-gg/mithril/issues/725)) / Legolas ([#699](https://github.com/moumantai-gg/mithril/issues/699)) / Motherlode ([#604](https://github.com/moumantai-gg/mithril/issues/604)), the Bind channel for Palantir ([#726](https://github.com/moumantai-gg/mithril/issues/726)), the Tier-2 `IGiftSignalService` for Arwen ([#608](https://github.com/moumantai-gg/mithril/issues/608)), and blueprint-only for Saruman.
- Keeps the narrower `IInventoryService` interface (`TryResolve` / `TryGetStackSize` only) for Arwen's `CalibrationService`. The concrete `InventoryView` still implements both `IInventoryView` and `IInventoryService`.
- Refreshes [`docs/world-sim-migration-audit.md`](docs/world-sim-migration-audit.md) — rewrites the **Saruman** row for the post-#603 split (closes [#687](https://github.com/moumantai-gg/mithril/issues/687)) and the **Palantir** row for the post-#726 Bind-channel consumer shape (closes [#746](https://github.com/moumantai-gg/mithril/issues/746)). Also tightens the Inventory row, the Samwise row, the exec summary, and spot-checks #1/#2 since the obligations they tracked are now resolved.

### Pre-deletion verification

- Grep + LSP confirm **zero production consumers** of `Subscribe(Action<InventoryEvent>)` survive — the only live references to `IInventoryService` are Arwen's `CalibrationService` via `TryResolve` / `TryGetStackSize` (non-shim methods), plus the DI binding wiring.
- The two GameState inventory tests that exercised the shim translation + late-subscribe replay retired with the shim; the post-#729 Bind-channel surface (`Items`) and the typed bus still have comprehensive coverage in [`InventoryViewTests.cs`](tests/Mithril.GameState.Tests/Inventory/InventoryViewTests.cs).
- `tests/Arwen.Tests/FakeInventory.cs` shrinks to just the Query methods; `tests/Palantir.Tests/LiveInventoryViewModelTests.cs` drops the no-op Subscribe stub.

### Deletion footprint

10 files changed, 234 insertions(+), 440 deletions(-). Roughly half of `InventoryView.cs`'s shim machinery (`_eventLog` + soft cap, `_shimHandlers`, `ShimSubscription`, `FireShim` / `InvokeShim` / `AppendToEventLog`, the `Subscribe` entry-point, the `s_sinceSubscribeDiagFired` one-shot) is now gone; the typed bus + Bind surface stand on their own.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors; warnings-as-errors enforced).
- [x] `dotnet test Mithril.slnx` — 4083 tests, 0 failed across all projects.
- [x] Audit doc updates are scoped to the Saruman + Palantir rows + the Inventory / Samwise rows + exec summary + spot-checks #1/#2 (every other row preserved per the audit's snapshot framing).

Closes #659
Closes #687
Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
