### PR TITLE
docs(world-sim): refresh references after #659 shim retirement

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -124,8 +124,6 @@ Canonical source: [`docs/world-simulator.md` §Contracts §Producer interface](w
 
 Canonical inventory surface for modules — composes Player.log's instance-id ledger ([IPlayerInventoryState](#iplayerinventorystate)) with chat's name-keyed stack-size observations ([IChatInventoryState](#ichatinventorystate)) via a stateful [PendingCorrelator](#pendingcorrelatortkeytreq) (5s simulated-time TTL). Per #602, the view's canonical surface is the **typed-frame-bus**: subscribers receive `Frame<InventoryItemAdded>` / `Frame<InventoryItemRemoved>` / `Frame<InventoryStackChanged>` on the view's bus, with synchronous resolution helpers `TryResolve(instanceId)` and `TryGetStackSize(instanceId)` preserved for point lookups.
 
-The view also exposes a temporary shim `Subscribe(Action<InventoryEvent>)` annotated `[Obsolete]` during the migration so existing consumers (Bilbo, Arwen, Samwise) can be ported one at a time. Shim removal is tracked in #659.
-
 The view's event types match the [naming conventions in #657](#change-event-type-convention): past-tense participles, no `Event` suffix, no world prefix (view events are above the world layer). See [InventoryItemAdded](#inventoryitemadded), [InventoryItemRemoved](#inventoryitemremoved), [InventoryStackChanged](#inventorystackchanged).
 
 See also: [View](#view), [IPlayerInventoryState](#iplayerinventorystate), [IChatInventoryState](#ichatinventorystate), [IWordOfPowerView](#iwordofpowerview), [Tier 1 (correlation)](#tier-14-correlation), [#661 passthrough refinement](#661-passthrough-refinement).

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -198,11 +198,12 @@ channel rule, and this strategic principle):
   *Query* = "what's the current state?" (point-in-time); *React* =
   "what's happening?" (ordered event log); *Bind* = "how does this view
   stay in sync?" (declarative, UI-safe). Conflating them costs
-  concretely. Today `IInventoryService.Subscribe` tries to serve both
-  *current-state-replay* (synthesizes `Added` events for live items) and
-  *event-log-replay* (live events forward) through one API — and
-  silently loses pre-attach `Deleted` and `StackChanged` events. Three
-  current REACT consumers silently degrade as a result:
+  concretely. Today `IInventoryService.Subscribe` (retired by
+  [#659](https://github.com/moumantai-gg/mithril/issues/659)) tries to
+  serve both *current-state-replay* (synthesizes `Added` events for live
+  items) and *event-log-replay* (live events forward) through one API —
+  and silently loses pre-attach `Deleted` and `StackChanged` events.
+  Three current REACT consumers silently degrade as a result:
 
   - [`Samwise.GardenIngestionService.OnInventoryEvent`](../src/Samwise.Module/State/GardenIngestionService.cs)
     loses `_itemIdToCrop` map entries for items added-then-deleted before


### PR DESCRIPTION
## Summary

Two forward-looking references to the deleted `IInventoryView.Subscribe(Action<InventoryEvent>)` shim survived [#751](https://github.com/moumantai-gg/mithril/pull/751) (which retired the shim, the `InventoryEvent` record, and the `InventoryEventKind` enum):

- [`docs/glossary.md`](docs/glossary.md) §IInventoryView claimed the view _\"also exposes a temporary shim `Subscribe(Action<InventoryEvent>)` annotated `[Obsolete]`\"_. It no longer does. Paragraph deleted; the surrounding **Canonical source** line already references #659 for readers tracing the history.
- [`docs/module-charters.md`](docs/module-charters.md) §Why three channels still introduced its bug-class rationale with _\"Today `IInventoryService.Subscribe` tries to serve both ...\"_. Adds a _\"(retired by #659)\"_ parenthetical so the present-tense framing reads as historical context. Per the audit brief: design-rationale paragraphs stay; just signal the surface no longer exists.

The rest of the audit (six other grep hits) was either historical-by-construction (dated journal entries, audit-finding bullets, already-past-tense naming-convention text) or a false positive (`InventoryItemAdded` is the *current* event name, not the deleted union type).

## Out-of-scope drift surfaced during this sweep

Will file as follow-ups under [#665](https://github.com/moumantai-gg/mithril/issues/665):

- [`docs/module-charters.md:169`](docs/module-charters.md#L169) — naming-example list \`(InventoryEvent, PinSetChanged, SkillChange)\` is now post-[#657](https://github.com/moumantai-gg/mithril/issues/657) stale on multiple tokens (`SkillChange` and `RecipeChange` are also dropped per world-sim naming conventions, not just `InventoryEvent`). Needs a broader naming-convention pass.
- [`docs/module-signal-map.md`](docs/module-signal-map.md) §IInventoryService (lines 239-256) — entire section is pre-[#602](https://github.com/moumantai-gg/mithril/issues/602) framing; should be rewritten to reflect the IInventoryView / IPlayerInventoryState / IChatInventoryState split.
- [`docs/module-signal-map.md:299`](docs/module-signal-map.md#L299) — `GardenIngestionService` line references `IInventoryService.Subscribe`; [#725](https://github.com/moumantai-gg/mithril/issues/725) made Samwise PlayerWorld-direct, so its Inputs/State-machines bullets need updating too.

## Test plan

Docs-only — no build/test gate. Verified via grep that no `IInventoryView.Subscribe` / `IInventoryService.Subscribe` / `InventoryEvent` references survive in [`docs/glossary.md`](docs/glossary.md) after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)