### PR TITLE
docs(world-sim): sweep stale IInventoryService refs (#754)

### DIFF
--- a/docs/gamestate-services-gap-audit.md
+++ b/docs/gamestate-services-gap-audit.md
@@ -61,7 +61,7 @@ completeness but deferred to the existing architectural commitment.
 | # | Module / file:line | State holder | What it models | Class | Recommended disposition |
 |---|---|---|---|---|---|
 | 1 | [Saruman/Settings/SarumanState.cs:17](../src/Saruman.Module/Settings/SarumanState.cs) | `Codebook: Dictionary<string, KnownWord>` (per-character) | Player's set of discovered Words of Power + their lifecycle state (Known / Spent, count, timestamps) | **A** | Propose `IPlayerWordOfPowerState` in `Mithril.GameState/WordsOfPower/`. Parallels `IPlayerRecipeState`/`IPlayerSkillState` — same shape (per-character unlocked-set parsed from `Player.log`). Single-consumer today, so this is anticipatory; not load-bearing yet. |
-| 2 | [Pippin/Domain/GourmandState.cs:47](../src/Pippin.Module/Domain/GourmandState.cs) | `EatenFoodsByInternalName: Dictionary<string, int>` (per-character) | Player's set of foods eaten (the Gourmand-skill input domain) | **A** | Same shape as #1. Live signature = `ProcessDeleteItem(<food>(...))` via `IInventoryService` (exists) **+** `ProcessAddEffects([foodEffect],...)` on the same timestamp — the effects half requires a new GameState effects tracker (no `Effects/` submodule under `Mithril.GameState/` today). Snapshot report continues to feed the historical baseline (eats before Mithril was recording). Multi-PR lift; single-consumer today — anticipatory like #1. |
+| 2 | [Pippin/Domain/GourmandState.cs:47](../src/Pippin.Module/Domain/GourmandState.cs) | `EatenFoodsByInternalName: Dictionary<string, int>` (per-character) | Player's set of foods eaten (the Gourmand-skill input domain) | **A** | Same shape as #1. Live signature = `ProcessDeleteItem(<food>(...))` via `IInventoryView` (exists; pre-#602 this was `IInventoryService`) **+** `ProcessAddEffects([foodEffect],...)` on the same timestamp — the effects half requires a new GameState effects tracker (no `Effects/` submodule under `Mithril.GameState/` today). Snapshot report continues to feed the historical baseline (eats before Mithril was recording). Multi-PR lift; single-consumer today — anticipatory like #1. |
 | 3 | [Smaug/State/VendorSellContext.cs:23](../src/Smaug.Module/State/VendorSellContext.cs) | `EntityToNpc: Dictionary<int, string>` (4000-entry capped) | entityId → NpcKey mapping for resolving vendor screens | **A** | Lift into `INpcStateTracker` ([#552](https://github.com/moumantai-gg/mithril/issues/552), in flight). The #552 spec explicitly names "entityId↔NpcKey binding" as in-scope — this is the second uncovered Smaug state holder under that umbrella (the first, `CivicPrideLevel`, is already filed as [#580](https://github.com/moumantai-gg/mithril/issues/580)). |
 | 4 | [Smaug/State/VendorSellContext.cs:11](../src/Smaug.Module/State/VendorSellContext.cs) | `ActiveVendorEntityId / ActiveFavorTier / ActiveNpcKey` | Transient "which vendor screen am I in" context for sell attribution | **B** | Tier-2 signature candidate. Mirrors the Arwen/Gandalf prior-audit deferrals — defer to the #552 Tier-2 work. |
 | 5 | [Smaug/State/VendorCatalogService.cs:38](../src/Smaug.Module/State/VendorCatalogService.cs) | `_entries: IReadOnlyList<VendorCatalogEntry>` | Joined projection of CDN data × `IFavorLookupService` × Civic Pride | **C** | Pure projection; consumes services correctly. Module-specific catalog view. |
@@ -70,9 +70,9 @@ completeness but deferred to the existing architectural commitment.
 | 8 | [Arwen/Domain/ArwenFavorState.cs:19](../src/Arwen.Module/Domain/ArwenFavorState.cs) | `Favor: Dictionary<string, NpcFavorSnapshot>` (per-character) | Per-NPC exact favor from `Player.log` (consumed via `IFavorLookupService` by **Smaug too**) | A (prior-classified, deferred) | Already in flight: [#582](https://github.com/moumantai-gg/mithril/issues/582) covers Arwen's correlation SM; #552's `INpcStateTracker` is the natural home. Cross-module consumption (Smaug reads it via `IFavorLookupService`) is exactly the "shared service" signal the principle predicts. No new ask — confirms prior classification. |
 | 9 | [Arwen/State/FavorStateService.cs:47](../src/Arwen.Module/State/FavorStateService.cs) | `_tierByNpcKey: Dictionary<string, FavorTier>` | Joined view of CDN NPC × character export × persisted exact favor | **D** | Already consumes `IReferenceDataService.FileUpdated`, `IActiveCharacterService.CharacterExportsChanged`, `PerCharacterView`. (Will become a thin adapter once #552 absorbs the favor map.) |
 | 10 | [Arwen/Domain/GiftIndex.cs:29](../src/Arwen.Module/Domain/GiftIndex.cs) | `_npcGifts`, `_items`, `_allMatchesByNpcItem` | Pre-computed CDN-derived index: NPC preferences → matching items | **C** | Pure reference-data projection. Module-specific (rebuilds on `FileUpdated`). |
-| 11 | [Arwen/Domain/CalibrationService.cs:52](../src/Arwen.Module/Domain/CalibrationService.cs) | `_pending: TtlObservableCollection<PendingGiftObservation>` | TTL-aged pending gift confirmations awaiting user quantity input | **C** | Module-specific UX state. Consumes `IInventoryService.TryResolve`/`TryGetStackSize` correctly (Class D in its log consumption). |
+| 11 | [Arwen/Domain/CalibrationService.cs:52](../src/Arwen.Module/Domain/CalibrationService.cs) | `_pending: TtlObservableCollection<PendingGiftObservation>` | TTL-aged pending gift confirmations awaiting user quantity input | **C** | Module-specific UX state. Consumes `IInventoryView.TryResolve`/`TryGetStackSize` correctly (Class D in its log consumption; pre-#753 this was `IInventoryService` on both surfaces). |
 | 12 | [Arwen/Domain/CalibrationService.cs:74](../src/Arwen.Module/Domain/CalibrationService.cs) | `_activeNpcKey`, `_pendingDeletedItem`, `_pendingDelta` | Correlation SM for `DeleteItem + DeltaFavor` gift attribution | B (prior-classified) | Prior audit: deferred to Tier-2 signature work atop #552. No change. |
-| 13 | [Legolas/Services/MotherlodeMeasurementCoordinator.cs:133](../src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs) | `_session: MotherlodeSession`, `_dugMaps`, `_open`, `_undo`, `_latestFix`, `_sessionArea` | In-flight surveying activity state (positions, fixes, slot solves) | **D** | Already consumes `IPlayerPositionTracker.Subscribe`, `IPlayerPinTracker.Subscribe`, `IInventoryService.Subscribe`, `PlayerAreaTracker`. Canonical Tier-2 reference per [docs/cross-source-correlation.md](cross-source-correlation.md). |
+| 13 | [Legolas/Services/MotherlodeMeasurementCoordinator.cs:133](../src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs) | `_session: MotherlodeSession`, `_dugMaps`, `_open`, `_undo`, `_latestFix`, `_sessionArea` | In-flight surveying activity state (positions, fixes, slot solves) | **D** | Already consumes `IPlayerPositionTracker.Subscribe`, `IPlayerPinTracker.Subscribe`, `IInventoryView.Bus.Subscribe<…>` (post-#606/#659; pre-shim-retirement this was `IInventoryService.Subscribe`), `PlayerAreaTracker`. Canonical Tier-2 reference per [docs/cross-source-correlation.md](cross-source-correlation.md). |
 | 14 | [Legolas/Services/PinCalibrationCoordinator.cs:110](../src/Legolas.Module/Services/PinCalibrationCoordinator.cs) | `_pairs: List<(MapPin, PixelPoint)>`, `_skipped`, `ExistingPins` | Calibration session (clicks paired to map pins) | **D** | Consumes `IPlayerPinTracker.Subscribe` correctly. Module-specific calibration state — Class C in nature, Class D in dependency. |
 | 15 | [Legolas/Domain/LegolasIngestionState.cs:46](../src/Legolas.Module/Domain/LegolasIngestionState.cs) | `PlayerLogHighWaterSequence` (per-character) | Per-character L1 driver dedup high-water | **C** | Module-side ingestion bookkeeping; legitimate per-#550 capability F shape. |
 | 16 | [Legolas/Services/ItemCollectionTracker.cs](../src/Legolas.Module/Services/ItemCollectionTracker.cs) | `_pendingAdds: PendingCorrelator<string, int>` | Module-specific `InventoryItemAdded` ↔ `ProcessScreenText "<X> collected!"` pairing for survey-collect attribution (post-#606) | **C** | Intra-module Tier-1 correlator (per [docs/cross-source-correlation.md](cross-source-correlation.md)); the chat side migrated to `IInventoryView.Bus` in #602, the collect side migrated to Player.log `ProcessScreenText` in #606. |
@@ -101,8 +101,10 @@ and mutated to `Spent` by chat-line events
 **Why Class A:** the shape is identical to `IPlayerRecipeState`
 ([#475](https://github.com/moumantai-gg/mithril/pull/475)), `IPlayerSkillState`
 ([#465](https://github.com/moumantai-gg/mithril/pull/465)), and
-`IInventoryService` — a per-character monotonically-built set of game-mechanic
-identifiers the player has unlocked, derived from `Player.log`. The charter's
+`IInventoryService` (legacy; split into `IPlayerInventoryState` +
+`IChatInventoryState` + `IInventoryView` per #602) — a per-character
+monotonically-built set of game-mechanic identifiers the player has unlocked,
+derived from `Player.log`. The charter's
 principle says *"GameState owns the emulated game world; modules project
 subsets for UX."* Whether the player has discovered a particular Word of
 Power is part of the emulated game world, parallel to whether they know
@@ -128,7 +130,7 @@ the player has eaten
 Today populated **exclusively** from the in-game *Foods Consumed* snapshot
 report (`HandleReport` snapshot-replaces the dict,
 [GourmandStateMachine.cs:113](../src/Pippin.Module/State/GourmandStateMachine.cs));
-Pippin subscribes to neither `IInventoryService` nor any effects channel.
+Pippin subscribes to neither `IInventoryView` (nor its predecessor `IInventoryService` pre-#602) nor any effects channel.
 Charter is explicit: Pippin owns "the per-character set of foods already
 eaten."
 
@@ -141,8 +143,8 @@ event itself is fully observable on event-stream channels. The live
 signature is:
 
 - **`ProcessDeleteItem(<foodInternal>(<instanceId>))`** — the consumable went
-  away. Exposed today via `IInventoryService`. Classify as food via
-  `items.json`.
+  away. Exposed today via `IInventoryView` (pre-#602 this was `IInventoryService`).
+  Classify as food via `items.json`.
 - **`ProcessAddEffects(<charId>, …, [foodEffect, …], True)`** on the same /
   adjacent timestamp — a food-effect appeared on the player. Classify as
   food-effect via `effects.json`. **Requires a new GameState effects
@@ -169,9 +171,11 @@ of an adjacent dependency:
    needed for the `ProcessAddEffects` half of the live signature, and
    broadly useful (Vampirism sun-damage detection, Saruman's WoP effect
    side, future buff trackers).
-2. `IPlayerGourmandState` fusing `IInventoryService.ItemDeleted` (filtered
-   to foods via `items.json`) with the new effects tracker (filtered to
-   food-effects via `effects.json`) via a Tier-1 timestamp correlator per
+2. `IPlayerGourmandState` fusing `IInventoryView.Bus.Subscribe<InventoryItemRemoved>`
+   (post-#602/#659; pre-shim-retirement this would have been
+   `IInventoryService.ItemDeleted`; filtered to foods via `items.json`) with
+   the new effects tracker (filtered to food-effects via `effects.json`) via a
+   Tier-1 timestamp correlator per
    [docs/cross-source-correlation.md](cross-source-correlation.md).
 3. Pippin becomes a thin projection over the GameState service; the
    snapshot report continues to feed the historical baseline through the
@@ -247,11 +251,13 @@ GameState services do so correctly**. Specifically:
 
 - **Arwen's `FavorStateService`** consumes
   `IReferenceDataService`/`IActiveCharacterService`/`PerCharacterView`.
-- **Arwen's `CalibrationService`** consumes `IInventoryService.TryResolve` +
-  `TryGetStackSize` + `IGameSessionService`.
+- **Arwen's `CalibrationService`** consumes `IInventoryView.TryResolve` +
+  `TryGetStackSize` + `IGameSessionService` (post-#753 — pre-#753 this was
+  `IInventoryService` on both query surfaces).
 - **Legolas's `MotherlodeMeasurementCoordinator`** is the canonical Tier-2
   reference — consumes `IPlayerPositionTracker`, `IPlayerPinTracker`,
-  `IInventoryService` all via `Subscribe`.
+  `IInventoryView.Bus` all via `Subscribe` (post-#606/#659 — pre-shim-retirement
+  the inventory path was `IInventoryService.Subscribe`).
 - **Legolas's `PinCalibrationCoordinator`** consumes
   `IPlayerPinTracker.Subscribe`.
 - **Bilbo's `StorageViewModel`** consumes `IActiveCharacterService`.
@@ -259,7 +265,8 @@ GameState services do so correctly**. Specifically:
   `IActiveCharacterService`.
 - **Palantir's `WorldStateViewModel`** consumes `IPlayerPositionTracker`,
   `IPlayerPinTracker`, `IPlayerCelestialState`, `IPlayerWeatherTracker` (and
-  `LiveInventoryViewModel` similarly consumes `IInventoryService`).
+  `LiveInventoryViewModel` similarly consumes `IInventoryView` post-#745 —
+  pre-migration this was `IInventoryService`).
 
 The Palantir/Legolas-VM "manually-building-observable-state" pattern is real
 but is explicitly already named in the charter's three-channel section as the

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -51,7 +51,10 @@ services that have emerged organically through the project's arc —
 ([#462](https://github.com/moumantai-gg/mithril/issues/462)/[#465](https://github.com/moumantai-gg/mithril/pull/465)),
 [`IPlayerPinTracker`](../src/Mithril.GameState/Pins/IPlayerPinTracker.cs)
 ([#468](https://github.com/moumantai-gg/mithril/issues/468)),
-[`IInventoryService`](../src/Mithril.GameState/Inventory/IInventoryService.cs),
+[`IInventoryView`](../src/Mithril.GameState/Inventory/IInventoryView.cs)
+([#602](https://github.com/moumantai-gg/mithril/issues/602) — composes
+[`IPlayerInventoryState`](../src/Mithril.GameState/Inventory/IPlayerInventoryState.cs) +
+[`IChatInventoryState`](../src/Mithril.GameState/Inventory/IChatInventoryState.cs)),
 [`IPlayerWeatherTracker`](../src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs),
 [`IPlayerCelestialState`](../src/Mithril.GameState/Celestial/IPlayerCelestialState.cs)
 ([#490](https://github.com/moumantai-gg/mithril/pull/490)),
@@ -102,7 +105,7 @@ channel rule, and this strategic principle):
   |---|---|---|
   | Reference (CDN) data | `IReferenceDataService` (Mithril.Shared) | **Silmarillion** |
   | Static storage *export* | `IActiveCharacterService` / `StorageReport` (Mithril.Shared) | **Bilbo** (+ immediate craftability) |
-  | Live inventory simulation | `IInventoryService` (**Mithril.GameState**) — tails `IPlayerLogStream` `ProcessAddItem/…` + chat `[Status]` for stack sizes | **Palantir** (debug surface — `LiveInventoryView`) |
+  | Live inventory simulation | `IInventoryView` (**Mithril.GameState**, #602) — composes `IPlayerInventoryState` (tails `IPlayerLogStream` `ProcessAddItem/…`) with `IChatInventoryState` (tails chat `[Status]` for stack sizes) | **Palantir** (debug surface — `LiveInventoryView`) |
   | Eaten-food state | in-game report (dumped to `Player.log`) | **Pippin** (Gourmand) |
   | Progression state | character export | **Elrond** (as leveling constraints) |
   | NPC store state | **Smaug** mines it itself (no shared service) | **Smaug** — the one domain where a single module owns *both* layers |
@@ -117,7 +120,7 @@ channel rule, and this strategic principle):
 
 - **Modules `Subscribe` to the GameState service surface; they do not subscribe to
   raw logs for cross-cutting state. ✅ owner-confirmed 2026-05-21.** Each GameState
-  service ([`IInventoryService`](../src/Mithril.GameState/Inventory/IInventoryService.cs),
+  service ([`IInventoryView`](../src/Mithril.GameState/Inventory/IInventoryView.cs),
   [`IPlayerPinTracker`](../src/Mithril.GameState/Pins/IPlayerPinTracker.cs),
   [`IPlayerWeatherTracker`](../src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs),
   [`IPlayerPositionTracker`](../src/Mithril.GameState/Movement/IPlayerPositionTracker.cs),
@@ -157,7 +160,9 @@ channel rule, and this strategic principle):
   lifting the gift-detection FSM into the Tier-2 `IGiftSignalService`; see
   [`world-sim-migration-audit.md`](world-sim-migration-audit.md) §Arwen)
   plus one Class C design discussion (Samwise `ProcessUpdateItemCode` needs
-  a new `InventoryEvent.CodeChanged` event kind on `IInventoryService`).
+  a new `InventoryEvent.CodeChanged` event kind on `IInventoryService`
+  — described pre-#602; the post-split equivalent would land on
+  `IPlayerInventoryState` or `IInventoryView`).
   Each filed as its own retiring-PR issue.
 
 - **GameState services translate log events into a developer-facing domain
@@ -174,7 +179,7 @@ channel rule, and this strategic principle):
   **The three channels:**
 
   - **Query** — synchronous state lookup at moment of call.
-    `IInventoryService.TryResolve(instanceId, out internalName)`,
+    `IInventoryView.TryResolve(instanceId, out internalName)`,
     `IPlayerWeatherTracker.Current`, `IPlayerPinTracker.CurrentAreaPins`,
     etc. Returns the current value; no side effects.
   - **React** — event stream, default `ReplayMode.FromSessionStart`.
@@ -197,29 +202,30 @@ channel rule, and this strategic principle):
   **Why three channels.** Each maps to a structurally different question:
   *Query* = "what's the current state?" (point-in-time); *React* =
   "what's happening?" (ordered event log); *Bind* = "how does this view
-  stay in sync?" (declarative, UI-safe). Conflating them costs
-  concretely. Today `IInventoryService.Subscribe` (retired by
-  [#659](https://github.com/moumantai-gg/mithril/issues/659)) tries to
-  serve both *current-state-replay* (synthesizes `Added` events for live
-  items) and *event-log-replay* (live events forward) through one API —
-  and silently loses pre-attach `Deleted` and `StackChanged` events.
-  Three current REACT consumers silently degrade as a result:
+  stay in sync?" (declarative, UI-safe). Conflating them cost concretely.
+  Pre-#602/#659, `IInventoryService.Subscribe` tried to serve both
+  *current-state-replay* (synthesizing `Added` events for live items) and
+  *event-log-replay* (live events forward) through one API — and silently
+  lost pre-attach `Deleted` and `StackChanged` events. Three REACT consumers
+  silently degraded as a result:
 
   - [`Samwise.GardenIngestionService.OnInventoryEvent`](../src/Samwise.Module/State/GardenIngestionService.cs)
-    loses `_itemIdToCrop` map entries for items added-then-deleted before
+    lost `_itemIdToCrop` map entries for items added-then-deleted before
     Mithril attached.
   - [Arwen's gift calibration](../src/Arwen.Module/Domain/CalibrationService.cs)
-    would lose every gift made before Mithril attached in the current PG
+    would have lost every gift made before Mithril attached in the current PG
     session — surfaced in [#582](https://github.com/moumantai-gg/mithril/issues/582)'s
     replay-contract analysis.
   - [`Legolas.MotherlodeMeasurementCoordinator`](../src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs)
-    silently misses dig-completion signals for digs completing before
-    Mithril attached — the inline comment cites it consumes "the
-    IInventoryService Deleted event" as the authoritative completion
-    signal.
+    silently missed dig-completion signals for digs completing before
+    Mithril attached — the inline comment cited it consumes "the
+    IInventoryService Deleted event" (legacy, pre-#602) as the
+    authoritative completion signal.
 
-  Three sharp channels with distinct semantics retires the bug class
-  structurally.
+  Three sharp channels with distinct semantics retired the bug class
+  structurally (delivered via the #602 split + #659 shim retirement —
+  the post-split surfaces today are `IPlayerInventoryState`,
+  `IChatInventoryState`, and the composing `IInventoryView`).
 
   **Anti-pattern (flag immediately).** A consumer manually building
   observable state from a GameState service's event stream
@@ -385,10 +391,12 @@ channel rule, and this strategic principle):
   `IActiveCharacterService` / `StorageReport` (Mithril.Shared, single source of truth);
   Bilbo consumes it.
 - **Does NOT own:**
-  - **✅ confirmed (verified 2026-05-16)** — *Live inventory simulation.* The live
-    `instanceId→item` + stack-size model is `IInventoryService` in **Mithril.GameState**
-    (tails `ProcessAddItem/…` + chat `[Status]`); its user-facing surface is
-    **Palantir** (`LiveInventoryView`), not Bilbo. Bilbo is export-*snapshot*, not live.
+  - **✅ confirmed (verified 2026-05-16; refreshed 2026-05-23 post-#602/#753)** —
+    *Live inventory simulation.* The live `instanceId→item` + stack-size model
+    is `IInventoryView` in **Mithril.GameState** — composes `IPlayerInventoryState`
+    (tails `ProcessAddItem/…`) with `IChatInventoryState` (tails chat `[Status]`);
+    its user-facing surface is **Palantir** (`LiveInventoryView`), not Bilbo.
+    Bilbo is export-*snapshot*, not live.
   - **✅ confirmed** — *Craft planning* (shopping lists, what-to-acquire, quantity
     math) → Celebrimbor. "What can I make from what I hold *now*" is Bilbo (a state
     property); "what do I need to make N of X" is Celebrimbor (a plan). See the
@@ -485,13 +493,13 @@ channel rule, and this strategic principle):
 
 - **Owns: ✅ confirmed (owner, 2026-05-16)** — a **debug module** (not player-facing):
   the browser/inspector over **Mithril.GameState** state (incl. the live-inventory
-  view, `LiveInventoryView` over `IInventoryService`), plus dev tools — currently a
+  view, `LiveInventoryView` over `IInventoryView`), plus dev tools — currently a
   **badge tester**. A development/diagnostic surface.
 - **Does NOT own:**
   - **✅ confirmed (owner, 2026-05-16)** — *Any player-facing feature.* Debug-only by
     charter: exposes engine/GameState internals for development, never a user workflow.
     (Hard boundary, by the module's nature.)
-- **Data:** reads Mithril.GameState services (`IInventoryService`, …) as a debug
+- **Data:** reads Mithril.GameState services (`IInventoryView`, …) as a debug
   surface — owns no player data domain of its own.
 
 ## Smaug — NPC stores & sale economics
@@ -634,7 +642,8 @@ libraries; the charter follows the code:
   shipped the layered log pipeline (L0/L0.5/L1/L2): #511's mission is rebuilding the
   emulated game from logs, and the GameState services that emerged through the project's
   arc (`IPlayerPositionTracker` #454, `IPlayerSkillState` #462/#465, `IPlayerPinTracker`
-  #468, `IInventoryService`, `IPlayerWeatherTracker`, `IPlayerCelestialState` #490,
+  #468, `IInventoryService` (legacy; split into `IPlayerInventoryState` + `IChatInventoryState` + `IInventoryView` per #602),
+  `IPlayerWeatherTracker`, `IPlayerCelestialState` #490,
   `IPlayerRecipeState` #475, `IGameSessionService`, `IPlayerQuestJournalState` #607, `PlayerAreaTracker`,
   and `INpcStateTracker` #552 in flight) are the canonical model of that emulated game.
   Articulating the principle explicitly clarifies that modules are *projections* of
@@ -657,9 +666,10 @@ libraries; the charter follows the code:
   service surface (consumption-side); services translate log events into a domain model
   with three channels — Query for "what's the current state?", React for "what's
   happening?", Bind for "how does this view stay in sync?". Grounded in the inventory
-  channel-conflation bug class: `IInventoryService.Subscribe` today tries to serve both
-  current-state-replay and event-log-replay through one API, with the result that three
-  current REACT consumers silently miss pre-attach `Deleted` / `StackChanged` events —
+  channel-conflation bug class: `IInventoryService.Subscribe` (legacy, pre-#602/#659)
+  tried to serve both current-state-replay and event-log-replay through one API, with
+  the result that three REACT consumers silently missed pre-attach
+  `Deleted` / `StackChanged` events —
   Samwise's plant-resolution map, Arwen's gift calibration (surfaced in
   [#582](https://github.com/moumantai-gg/mithril/issues/582)), and Legolas's
   Motherlode dig-completion signal. Three sharp channels with distinct semantics retire
@@ -679,11 +689,13 @@ libraries; the charter follows the code:
   Grounded in real, hard-to-reproduce bugs from earlier in the project's history
   where multiple modules each rebuilt overlapping state from raw logs and produced
   symptoms that didn't replay deterministically. Lists the five HEAD-existent
-  GameState services (`IInventoryService`, `IPlayerPinTracker`,
-  `IPlayerWeatherTracker`, `IPlayerPositionTracker`, `IPlayerSkillState`) plus
-  recipes/celestial/area trackers; names a verb list that signals the anti-pattern;
-  records `LootBracketTracker.AddItemRx` as a known instance to retire by switching
-  the tracker to `IInventoryService.Subscribe`. Surfaced during the mithril#574
+  GameState services (`IInventoryService` (legacy; now `IInventoryView` post-#602),
+  `IPlayerPinTracker`, `IPlayerWeatherTracker`, `IPlayerPositionTracker`,
+  `IPlayerSkillState`) plus recipes/celestial/area trackers; names a verb list that
+  signals the anti-pattern; records `LootBracketTracker.AddItemRx` as a known
+  instance to retire by switching the tracker to `IInventoryService.Subscribe`
+  (the as-of-date migration target; the actual landing later went via the post-#602
+  PlayerWorld-direct route). Surfaced during the mithril#574
   L2 spec review chain. A full repo audit for additional anti-pattern instances is
   pending and will be filed as its own issue.
 - **2026-05-19** — **Radagast charter sketch added (⚠️ Claude draft).** A proposed
@@ -785,7 +797,8 @@ libraries; the charter follows the code:
   version.
 - **2026-05-16** — Layering corrected after code verification: split the single-owner
   rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
-  is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from
+  (legacy; split into `IPlayerInventoryState` + `IChatInventoryState` + `IInventoryView`
+  per #602) is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from
   `ProcessAddItem/…` + chat `[Status]`; its surface is **Palantir**, not Bilbo. Bilbo
   scoped to the static-*export* surface (data = Mithril.Shared `IActiveCharacterService`/
   `StorageReport`). Dropped the stale "candidate for shared extraction" note (the

--- a/docs/module-signal-map.md
+++ b/docs/module-signal-map.md
@@ -30,7 +30,7 @@ A component classified as "no state machines" still appears if it consumes or ex
 ## Conventions
 
 - Log pipe names (`LocalPlayer`, `CombatActor`, `SystemSignal`, unified classified `IClassifiedPlayerLogStream`, `IChatLogStream`) refer to the post-#556 L1 driver surfaces. Modules subscribe via `ILogStreamDriver`; the canonical pipe definitions live in [`src/Mithril.Shared/Logging/PlayerLogPipeSplitter.cs`](../src/Mithril.Shared/Logging/PlayerLogPipeSplitter.cs).
-- GameState services are named by interface (`IInventoryService` etc.). Modules subscribe to **these**, not raw log pipes — the architectural commitment per #587. (Post-#606 there are zero in-module direct `IChatLogStream` consumers — Legolas's `LogIngestionService` was the last and retired alongside Phase 3 of the world-sim migration.)
+- GameState services are named by interface (`IInventoryView` etc.). Modules subscribe to **these**, not raw log pipes — the architectural commitment per #587. (Post-#606 there are zero in-module direct `IChatLogStream` consumers — Legolas's `LogIngestionService` was the last and retired alongside Phase 3 of the world-sim migration.)
 - "Wall-clock TTL" means a transition guarded by `_time.GetUtcNow()` deltas. Distinguished from event-time deltas (`envelope.Payload.Timestamp` arithmetic) which are part of the log stream and replay-deterministic.
 
 ### Scope vocabulary
@@ -59,7 +59,7 @@ Two streams (Player.log and chat) each **self-scope** via their own intra-source
 | `IPlayerAreaTracker` | world (area-existence ledger) + character (current area) |
 | `IPlayerPositionTracker` | character |
 | `IPlayerPinTracker` | character (user pins) |
-| `IInventoryService` | character |
+| `IInventoryView` | character |
 | `IPlayerQuestJournalState` | character |
 
 The `Player*` naming on the world-scope services (`IPlayerWeatherTracker`, `IPlayerCelestialStateService`, parts of `IPlayerAreaTracker`) is misleading under this partition — they're actually world-scope readings of "what the active character can observe of the world." Rename target if/when the world-sim refactor lands; not worth churning ahead of that.
@@ -236,24 +236,31 @@ Design notes: [`player-pin-service.md`](player-pin-service.md). Pin grammar: no 
 
 ---
 
-### `IInventoryService`
+### `IInventoryView`
+
+> **Note:** the description below mirrors the pre-#602 monolithic
+> `IInventoryService` topology at the *composed* level — the full per-half
+> decomposition (`IPlayerInventoryState` (PlayerWorld) + `IChatInventoryState`
+> (ChatWorld) + `IInventoryView` (composing layer) per #602; `Subscribe` shim
+> retired per #659; `Items` Bind channel added per #729) is tracked under
+> the broader signal-map reshape in
+> [#665](https://github.com/moumantai-gg/mithril/issues/665).
 
 **Inputs**
-- Log: `LocalPlayer` pipe (`ProcessAddItem` / `ProcessRemoveItem`)
-- Log: `IChatLogStream` **raw lines** (`[Status] X xN added to inventory.`) — second log subscription
-- Filesystem: character export JSON via `FileSystemWatcher` (debounced 500 ms)
+- Log: `LocalPlayer` pipe (`ProcessAddItem` / `ProcessRemoveItem`) — folded by `IPlayerInventoryState` post-#602
+- Chat: `IChatInventoryState` consumes `[Status] X xN added to inventory.` frames via ChatWorld (no direct `IChatLogStream` tail post-#602)
 
 **State machines**
-- Instance-id ledger — `InstanceId → InternalName / stack size` per character
-- **Player.log + chat correlator** (canonical Tier 1) — `PendingCorrelator<string, *>` keyed by InternalName, 5s **wall-clock** TTL; either side may arrive first
-- Export-reconcile reactor — reads exported file on filesystem change, synthesizes `StackChanged` events for drift
+- Instance-id ledger — `InstanceId → InternalName` per character (PlayerWorld half) + name-keyed stack-size observations (ChatWorld half)
+- **Player.log + chat correlator** (canonical Tier 1) — `PendingCorrelator<string, *>` keyed by InternalName, 5s **wall-clock** TTL; lives inside `IInventoryView` composition (cross-source join above both worlds per principle 4)
 
 **Outputs**
-- `TryResolve(instanceId)`, `TryGetStackSize(instanceId)` (snapshot reads — consumed by Arwen, Samwise, Legolas)
-- `Subscribe(Action<InventoryEvent>)`
+- **Query** — `TryResolve(instanceId)` / `TryGetStackSize(instanceId)` (snapshot reads — consumed by Arwen, plus the post-#659 PlayerWorld-direct consumers retain blueprint access)
+- **React** — `Bus.Subscribe<InventoryItemAdded>` / `InventoryItemRemoved` / `InventoryStackChanged` (typed-frame surface; replaces the pre-#659 union-shaped `Subscribe(Action<InventoryEvent>)` shim)
+- **Bind** — `Items: IReadOnlyObservableCollection<InventoryItem>` per #729 — consumed by Palantir's `LiveInventoryViewModel` per #745
 - Character-scoped state
 
-⚠️ Two parallel L1 subscriptions plus a `FileSystemWatcher` = three source classes. The correlator TTL is the only wall-clock-gated **transition** in `Mithril.GameState`; everything else there is event-time-gated. Pattern reference: [`cross-source-correlation.md`](cross-source-correlation.md) §Tier 1.
+⚠️ The correlator TTL is the only wall-clock-gated **transition** in `Mithril.GameState`; everything else there is event-time-gated. Pattern reference: [`cross-source-correlation.md`](cross-source-correlation.md) §Tier 1.
 
 ---
 
@@ -287,7 +294,7 @@ Design notes: [`player-pin-service.md`](player-pin-service.md). Pin grammar: no 
 
 **Inputs**
 - Log: `LocalPlayer` pipe via `GardenIngestionService` — garden parser events (`SetPetOwner`, `UpdateDescription`, `StartInteraction`, `AddItem`, `DeleteItem`, `UpdateItemCode`, `GardeningXp`, `PlantingCapReached`, `ScreenTextError`)
-- GameState: `IInventoryService` (`Added` / `Deleted` re-shaped into `AddItem` / `DeleteItem` inside the ingestion service)
+- GameState: `IInventoryView` composing layer (post-#602; pre-#659 the input was the `IInventoryService.Subscribe` shim re-shaping `Added` / `Deleted` into `AddItem` / `DeleteItem` inside the ingestion service — Samwise's post-#659 PlayerWorld-direct rewiring is tracked under [#665](https://github.com/moumantai-gg/mithril/issues/665))
 - Reference: `IReferenceDataService` items.json (`FileUpdated`)
 - Identity: `IActiveCharacterService`
 - Settings: `SamwiseSettings`
@@ -296,7 +303,7 @@ Design notes: [`player-pin-service.md`](player-pin-service.md). Pin grammar: no 
 **State machines**
 - `GardenStateMachine` — per-character plot ledger; pairs gardening signals into plot transitions (empty → planted → growing → ripe → withered)
 - `AlarmService` — reactor over `PlotChanged`; fires audio + window flash when a plot reaches Ripe; supports per-plot snooze
-- `GardenIngestionService` — fan-in (Player.log pipe + `IInventoryService.Subscribe`); not a real FSM, just a forwarder with dispatcher marshaling
+- `GardenIngestionService` — fan-in (Player.log pipe + `IInventoryService.Subscribe` — the latter retired #659; post-shim wiring tracked under [#665](https://github.com/moumantai-gg/mithril/issues/665)); not a real FSM, just a forwarder with dispatcher marshaling
 
 **Outputs**
 - `GardenStateMachine.PlotChanged` event
@@ -334,7 +341,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 - Log: `LocalPlayer` pipe via `FavorIngestionService` — one event type parsed by `FavorLogParser`:
   - `FavorUpdate` — `ProcessStartInteraction` marker; absolute favor snapshot for the active NPC
 - GameState: `IGiftSignalService` (Tier-2 signal service in `Mithril.GameState.Gifting`) — React-channel `Subscribe` for `GiftAccepted`. The signal service owns a single L1 subscription with its own `ProcessAddItem`-fed `instanceId → InternalName` map, correlates the `ProcessStartInteraction` / `ProcessDeleteItem` / `ProcessDeltaFavor` verb triple on its own pump, and emits a fully-resolved `GiftAccepted` with `InternalName` baked in. The React channel atomically replays the in-session event log to late subscribers (#585 contract).
-- GameState: `IInventoryService.TryGetStackSize` — same-source read against the view's composed map (sim-coherent under Player.log dispatch order, encapsulated inside the view layer per principle 4).
+- GameState: `IInventoryView.TryGetStackSize` (post-#753 — pre-#753 this was `IInventoryService.TryGetStackSize`, retired with the legacy interface) — same-source read against the view's composed map (sim-coherent under Player.log dispatch order, encapsulated inside the view layer per principle 4).
 - GameState: `IGameSessionService` (SessionId for record stamps + dedup key)
 - Reference: `IReferenceDataService` items.json, NPC data, gift preferences
 - Settings: `ArwenSettings`, `CalibrationSettings`
@@ -353,7 +360,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 - Community export: sanitized rate aggregates only (no per-observation timestamps / NPC favor snapshots)
 - UI: favor dashboard, gift scanner, observations editor, calibration tab
 
-**Cross-source posture.** Resolved post-#608 — the historical `IInventoryService.TryResolve` cross-FSM peek (the canonical Rule-1 violation cited in earlier revisions of the world-simulator design notes) was eliminated by lifting the gift-detection FSM into the Tier-2 `IGiftSignalService`. The signal service does all three verbs on a single L1 pump and emits resolved events; Arwen consumes only same-source signals (its own L1 favor pipe + the React channel). No cross-pump race on subscribe-late. See [`world-sim-migration-audit.md`](world-sim-migration-audit.md) §Arwen for the full narrative.
+**Cross-source posture.** Resolved post-#608 — the historical `IInventoryService.TryResolve` cross-FSM peek (legacy, pre-#602; the canonical Rule-1 violation cited in earlier revisions of the world-simulator design notes) was eliminated by lifting the gift-detection FSM into the Tier-2 `IGiftSignalService`. The signal service does all three verbs on a single L1 pump and emits resolved events; Arwen consumes only same-source signals (its own L1 favor pipe + the React channel). No cross-pump race on subscribe-late. See [`world-sim-migration-audit.md`](world-sim-migration-audit.md) §Arwen for the full narrative.
 
 ---
 
@@ -376,7 +383,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 - Persisted: per-character JSON
 - UI: codebook view (known / spent words, discovery counts)
 
-⚠️ **Saruman is the second cross-source consumer in the codebase** (alongside `IInventoryService`). Its cross-source pattern is structurally different from the existing Tier 1 / 2 references: the two sides aren't *paired in time* — discovery on Player.log and the matching `Spent` on chat may be hours or days apart. Both sides write to the same record keyed by **word code**; no TTL, no correlator. This is closer to "Tier 1-without-pairing" than to any cataloged tier. Under the per-character sim scope, this stays well-defined as long as both ingestion sides see frames in matching `(Server, Character)` scope — same caveat as the Inventory correlator.
+⚠️ **Saruman is the second cross-source consumer in the codebase** (alongside `IInventoryService` (legacy, pre-#602; now `IInventoryView` composing the post-split halves)). Its cross-source pattern is structurally different from the existing Tier 1 / 2 references: the two sides aren't *paired in time* — discovery on Player.log and the matching `Spent` on chat may be hours or days apart. Both sides write to the same record keyed by **word code**; no TTL, no correlator. This is closer to "Tier 1-without-pairing" than to any cataloged tier. Under the per-character sim scope, this stays well-defined as long as both ingestion sides see frames in matching `(Server, Character)` scope — same caveat as the Inventory correlator.
 
 ⚠️ Saruman is not in CLAUDE.md's module table — update CLAUDE.md when this entry lands so future audits don't miss it.
 
@@ -536,14 +543,14 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 
 A handful of patterns are worth seeing all at once after the per-component scan. These reflect the **current state** of the codebase — the [world-simulator design](world-simulator.md) migration plan addresses each one.
 
-- **Cross-FSM peeks live in three places.** `Arwen.CalibrationService.OnItemDeleted` → `IInventoryService.TryResolve`. `Legolas.PlayerLogIngestionService` → `PlayerAreaTracker.CurrentArea` + `AreaCalibrationService.CurrentCalibration` + `SurveyFlowController.CurrentState`. `Samwise.AlarmService` → `GardenStateMachine.IsLikelyGarbageCollected`. None inside `Mithril.GameState` itself — the foundation layer is peek-free post-#556 / #587. Under the clocked-sim model these peeks become legal (declared dispatch order makes them coherent); the cross-source one (Arwen → Inventory) moves through the view layer instead.
-- **Cross-source services span both Player.log and chat in two places today.** `IInventoryService` (foundation; fuses Player.log `ProcessAddItem` with chat `[Status] added` via Tier-1 `PendingCorrelator`) and `SarumanCodebookService` (module-level; mutated from both `SarumanDiscoveryIngestionService` and `SarumanChatIngestionService`). Both **must split** per the [world-simulator rule](world-simulator.md) — Player.log half stays in PlayerWorld, chat half stays in ChatWorld, an `IInventoryView` / `IWordOfPowerView` composes at the view layer.
+- **Cross-FSM peeks live in three places.** `Arwen.CalibrationService.OnItemDeleted` → `IInventoryView.TryResolve` (post-#753 — pre-#753 this was `IInventoryService.TryResolve`). `Legolas.PlayerLogIngestionService` → `PlayerAreaTracker.CurrentArea` + `AreaCalibrationService.CurrentCalibration` + `SurveyFlowController.CurrentState`. `Samwise.AlarmService` → `GardenStateMachine.IsLikelyGarbageCollected`. None inside `Mithril.GameState` itself — the foundation layer is peek-free post-#556 / #587. Under the clocked-sim model these peeks become legal (declared dispatch order makes them coherent); the cross-source one (Arwen → Inventory) moves through the view layer instead.
+- **Cross-source services spanned both Player.log and chat in two places pre-migration.** `IInventoryService` (foundation; fused Player.log `ProcessAddItem` with chat `[Status] added` via Tier-1 `PendingCorrelator`) and `SarumanCodebookService` (module-level; mutated from both `SarumanDiscoveryIngestionService` and `SarumanChatIngestionService`). Both **were split** per the [world-simulator rule](world-simulator.md) — Player.log half stays in PlayerWorld, chat half stays in ChatWorld, an `IInventoryView` / `IWordOfPowerView` composes at the view layer. The inventory split shipped in #602; the Saruman split is tracked in #603. (Pre-migration framing retained for the historical context — the broader signal-map reshape lives in [#665](https://github.com/moumantai-gg/mithril/issues/665).)
 - **Chat-input surface post-migration.** After #602 (inventory split), #603 (Saruman split), #604 / #605 / #606 (Legolas retirements), there are **zero direct module-level `IChatLogStream` consumers**. The chat stream is consumed only inside `ChatWorld` (the `IChatInventoryState` folder + the `IChatWordOfPowerState` folder, both fed by the chat-channel classifier). Modules consume the composed view surfaces (`IInventoryView`, `IWordOfPowerView`) instead. Legolas — the last holdout — retired its chat tail in #606; every chat verb it consumed has a same-source Player.log equivalent (mapped in the wiki Player-Log-Signals page).
 - **Both streams self-scope independently.** Player.log identifies its `(Server, Character)` from its own intra-source signals (`Servers:` catalog + `EVENT(Ok): connected, url=…` + `LoginBanner` — the latter two planned). Chat identifies its `(Server, Character)` from its own `**** Logged In As X. Server Y. Timezone Offset Z.` banner. No cross-source coupling for scope determination. Cross-source agreement (both banners' character names match) is verification, not derivation.
 - **View-layer correlators must scope-check.** Once the splits land and cross-source correlation lives in the view layer, every cross-world join must assert both sides are in the same `(Server, Character)` before firing — otherwise it's pairing across a session boundary. In single-server play this is implicitly safe; under multi-server use it's a latent correctness gap that needs the scope check to land alongside the connect-event / catalog parsers.
-- **Wall-clock-gated transitions live in five places.** `IInventoryService` correlator TTL (5s, the only foundation-layer wall-clock gate); `Samwise.GardenStateMachine.PruneWithered` + `AlarmService.IsLikelyGarbageCollected`; `Gandalf.TimerProgressService.CheckExpirations` + `TimerExpirationScheduler` + `ShiftAlarmService`; `Legolas.MotherlodeMeasurementCoordinator` (event-time but compared against a fresh foreign-FSM timestamp, which is wall-clock-shaped). Everything else uses event-time arithmetic on payload timestamps. **Under the worlds**, all of these migrate from `_time.GetUtcNow()` to `IWorldClock.Now` and become replay-deterministic — a mechanical search-replace.
-- **Second event sources (non-log inputs that mutate state).** `IInventoryService` `FileSystemWatcher` for export-reconcile; `Gandalf` three wakeup schedulers; user-input commands across every UI-bearing module. (The legacy `IQuestService` `PerCharacterView.CurrentChanged` character-switch reload was a second event source until #607 — see the `IPlayerQuestJournalState` entry — and is now retired under per-character world scope.) Under the worlds these become **timestamped producer-emitted frames** for a world's merger (filesystem reconcile, wake-at-T) or move out of world scope entirely (user input mutates adjacent state directly).
-- **Module → GameState dependency graph is shallow.** No module depends on more than four GameState services. The deepest consumer (`Legolas.MotherlodeMeasurementCoordinator` — 4 services) is *today* the only Tier-2 SM in the repo; post-migration (item 3 in the world-simulator design plan) it becomes single-source and the Tier-2 reference vanishes. Arwen depends on 2 (`IInventoryService`, `IGameSessionService`). Samwise on 1 (`IInventoryService`). Saruman on 0 GameState services (consumes reference + per-character view only, despite being a cross-source consumer). Pippin / Bilbo / Silmarillion / Celebrimbor / Elrond on 0.
+- **Wall-clock-gated transitions live in five places.** `IInventoryView` correlator TTL (5s, the only foundation-layer wall-clock gate; pre-#602 this lived in the monolithic `IInventoryService`); `Samwise.GardenStateMachine.PruneWithered` + `AlarmService.IsLikelyGarbageCollected`; `Gandalf.TimerProgressService.CheckExpirations` + `TimerExpirationScheduler` + `ShiftAlarmService`; `Legolas.MotherlodeMeasurementCoordinator` (event-time but compared against a fresh foreign-FSM timestamp, which is wall-clock-shaped). Everything else uses event-time arithmetic on payload timestamps. **Under the worlds**, all of these migrate from `_time.GetUtcNow()` to `IWorldClock.Now` and become replay-deterministic — a mechanical search-replace.
+- **Second event sources (non-log inputs that mutate state).** Pre-#602 `IInventoryService` carried a `FileSystemWatcher` for export-reconcile (retired with the split); `Gandalf` three wakeup schedulers; user-input commands across every UI-bearing module. (The legacy `IQuestService` `PerCharacterView.CurrentChanged` character-switch reload was a second event source until #607 — see the `IPlayerQuestJournalState` entry — and is now retired under per-character world scope.) Under the worlds these become **timestamped producer-emitted frames** for a world's merger (wake-at-T) or move out of world scope entirely (user input mutates adjacent state directly).
+- **Module → GameState dependency graph is shallow.** No module depends on more than four GameState services. The deepest consumer (`Legolas.MotherlodeMeasurementCoordinator` — 4 services) is *today* the only Tier-2 SM in the repo; post-migration (item 3 in the world-simulator design plan) it becomes single-source and the Tier-2 reference vanishes. Arwen depends on 2 (`IInventoryView`, `IGameSessionService`). Samwise on 1 (`IInventoryView`). Saruman on 0 GameState services (consumes reference + per-character view only, despite being a cross-source consumer). Pippin / Bilbo / Silmarillion / Celebrimbor / Elrond on 0.
 - **Five of ten modules are pure projectors** (Pippin, Elrond, Bilbo, Silmarillion, Celebrimbor) — no log subscriptions, no GameState subscriptions for state mutation. They consume reference data + persisted JSON + user input only.
 
 ---

--- a/docs/module-signal-map.md
+++ b/docs/module-signal-map.md
@@ -294,7 +294,7 @@ Design notes: [`player-pin-service.md`](player-pin-service.md). Pin grammar: no 
 
 **Inputs**
 - Log: `LocalPlayer` pipe via `GardenIngestionService` — garden parser events (`SetPetOwner`, `UpdateDescription`, `StartInteraction`, `AddItem`, `DeleteItem`, `UpdateItemCode`, `GardeningXp`, `PlantingCapReached`, `ScreenTextError`)
-- GameState: `IInventoryView` composing layer (post-#602; pre-#659 the input was the `IInventoryService.Subscribe` shim re-shaping `Added` / `Deleted` into `AddItem` / `DeleteItem` inside the ingestion service — Samwise's post-#659 PlayerWorld-direct rewiring is tracked under [#665](https://github.com/moumantai-gg/mithril/issues/665))
+- PlayerWorld: `IPlayerWorld.Bus.Subscribe<PlayerInventoryAdded>` / `<PlayerInventoryRemoved>` direct (post-#725 — migrated off the legacy `IInventoryService.Subscribe` shim that re-shaped `Added` / `Deleted` into `AddItem` / `DeleteItem` inside the ingestion service; the shim retired in #659)
 - Reference: `IReferenceDataService` items.json (`FileUpdated`)
 - Identity: `IActiveCharacterService`
 - Settings: `SamwiseSettings`
@@ -303,7 +303,7 @@ Design notes: [`player-pin-service.md`](player-pin-service.md). Pin grammar: no 
 **State machines**
 - `GardenStateMachine` — per-character plot ledger; pairs gardening signals into plot transitions (empty → planted → growing → ripe → withered)
 - `AlarmService` — reactor over `PlotChanged`; fires audio + window flash when a plot reaches Ripe; supports per-plot snooze
-- `GardenIngestionService` — fan-in (Player.log pipe + `IInventoryService.Subscribe` — the latter retired #659; post-shim wiring tracked under [#665](https://github.com/moumantai-gg/mithril/issues/665)); not a real FSM, just a forwarder with dispatcher marshaling
+- `GardenIngestionService` — fan-in (Player.log pipe + `IPlayerWorld.Bus.Subscribe<PlayerInventoryAdded/Removed>` direct, post-#725; pre-#725/#659 the inventory leg was the union-shaped `IInventoryService.Subscribe` shim); not a real FSM, just a forwarder with dispatcher marshaling
 
 **Outputs**
 - `GardenStateMachine.PlotChanged` event


### PR DESCRIPTION
## Summary

Sweep across `module-charters.md`, `module-signal-map.md`, and `gamestate-services-gap-audit.md` to retire stale `IInventoryService` mentions left over after #602 (the split), #659 (shim retirement), and #753 (interface deletion). Applies the `(legacy, pre-#XXX)` annotation convention already established in `glossary.md` by #752.

Markdown-only — no `dotnet build` / `dotnet test` impact.

> **Review fixup (commit `f42d948`):** initial draft of `module-signal-map.md` L290/L299 wrongly framed Samwise's PlayerWorld-direct rewiring as deferred to #665. Samwise's migration actually shipped via PR #731 (closes #725): `GardenIngestionService` subscribes to `IPlayerWorld.Bus.Subscribe<PlayerInventoryAdded>` / `<PlayerInventoryRemoved>` directly today (`src/Samwise.Module/State/GardenIngestionService.cs:199-200`). Both sites rewritten to describe the actual post-#725 wiring. Per-site ledger below updated to match.

## Per-site judgment ledger

Per the issue's request that the implementer documents historical-keep vs current-rewrite for each site:

### `module-charters.md` (15 refs)

| Line | Site | Classification |
|---|---|---|
| 54 | Strategic-principle GameState list — broken file link | **Current-rewrite** — repointed to `IInventoryView.cs` with split annotation |
| 105 | Data-owner table row | **Current-rewrite** — described post-#602 split (IInventoryView composing IPlayerInventoryState + IChatInventoryState) |
| 120 | Consumption-side rule GameState list — broken file link | **Current-rewrite** — repointed to `IInventoryView.cs` |
| 160 | Class C audit bullet (Samwise CodeChanged) | **Historical-keep** — annotated; post-split equivalent would land on IPlayerInventoryState or IInventoryView |
| 177 | Query channel example | **Current-rewrite** — renamed to `IInventoryView.TryResolve` |
| 201–219 | "Why three channels" bug narrative | **Current-rewrite** — converted present-tense bug description to past tense; the bug class was retired structurally by #602/#659 |
| 389 | Bilbo "Does NOT own" live inventory | **Current-rewrite** — `IInventoryView` with composing-layer description |
| 488 | Palantir Owns (LiveInventoryView over X) | **Current-rewrite** — `IInventoryView` (post-#745 migration shipped) |
| 494 | Palantir Data (Mithril.GameState services list) | **Current-rewrite** — `IInventoryView` |
| 636 | History 2026-05-21 strategic-principle entry | **Historical-keep** — annotated `(legacy; split per #602)` for future readers |
| 660 | History 2026-05-21 three-channel-rule entry | **Historical-keep** — annotated `(legacy, pre-#602/#659)`; past-tensed the present-tense claims |
| 682 | History 2026-05-21 consumption-side rule entry | **Historical-keep** — annotated `(legacy; now IInventoryView post-#602)` |
| 686 | History 2026-05-21 LootBracketTracker migration target | **Historical-keep** — noted the as-of-date migration target plus the actual landing path |
| 787 | History 2026-05-16 layering-correction entry | **Historical-keep** — annotated split |

### `module-signal-map.md` (13 refs after #752 added one)

| Line | Site | Classification |
|---|---|---|
| 33 | Convention note | **Current-rewrite** — `IInventoryView` |
| 62 | State-holder scope-at-a-glance table | **Current-rewrite** — `IInventoryView` (same character scope) |
| 239 | `### IInventoryService` section header | **Current-rewrite** — renamed to `### IInventoryView`; added top-of-section pointer to #665 for the broader topology reshape; Outputs section refreshed to drop the retired union-shaped `Subscribe(Action<InventoryEvent>)` shim in favour of the typed-frame Bus + Items Bind channel per #729 |
| 290 | Samwise input row | **Current-rewrite (corrected per review)** — described Samwise's actual post-#725 wiring (`IPlayerWorld.Bus.Subscribe<PlayerInventoryAdded>` / `<PlayerInventoryRemoved>` direct); pre-#659 union-shaped shim path retained as historical annotation. (Initial draft wrongly deferred this to #665.) |
| 299 | GardenIngestionService state-machine row | **Current-rewrite (corrected per review)** — same pattern; describes post-#725 PlayerWorld-direct subscription |
| 337 | Arwen GameState input `IInventoryService.TryGetStackSize` | **Current-rewrite** — `IInventoryView.TryGetStackSize` (post-#753) |
| 356 | Arwen cross-source posture (historical `IInventoryService.TryResolve` peek) | **Historical-keep** — already framed historical; added `(legacy, pre-#602)` marker |
| 379 | Saruman "second cross-source consumer" ⚠️ | **Historical-keep** — annotated `(legacy, pre-#602; now IInventoryView composing post-split halves)` |
| 539 | Cross-FSM peek bullet (Arwen) | **Current-rewrite** — `IInventoryView.TryResolve` with `pre-#753` note |
| 540 | "Cross-source services span both sources today" | **Historical-keep** — past-tensed (`spanned`/`fused`/`were split`) since the split shipped in #602; framing retained for context with #665 pointer |
| 544 | Wall-clock-gated transitions list | **Current-rewrite** — `IInventoryView` correlator TTL with pre-#602 note |
| 545 | Second event sources (FileSystemWatcher) | **Historical-keep** — past-tensed (the reconcile retired with the split) |
| 546 | Dependency graph (Arwen depends on 2, Samwise on 1) | **Current-rewrite** — `IInventoryView` |

### `gamestate-services-gap-audit.md` (11 refs)

This audit is explicitly anchored at HEAD `6f47e88` (the strategic-principle PR snapshot), so most references describe the as-of-date codebase state. Mechanical API renames where the audit's recommended disposition describes consumer behaviour that's now post-#602/#753.

| Line | Site | Classification |
|---|---|---|
| Row 2 | Pippin Class A live-signature description | **Historical-keep with rename** — `IInventoryView` with `pre-#602 this was IInventoryService` annotation |
| Row 11 | Arwen `CalibrationService` Class C disposition | **Current-rewrite** — `IInventoryView.TryResolve/TryGetStackSize` (post-#753) with pre-migration note |
| Row 13 | Legolas Motherlode Class D disposition | **Current-rewrite** — `IInventoryView.Bus.Subscribe<…>` (post-#606/#659) with pre-shim-retirement note |
| L104 | Class A "Why" — list of canonical per-character set services | **Historical-keep** — `(legacy; split into IPlayerInventoryState + IChatInventoryState + IInventoryView per #602)` |
| L131 | Pippin Class A narrative | **Current-rewrite with historical note** — "Pippin subscribes to neither `IInventoryView` (nor its predecessor `IInventoryService` pre-#602)" |
| L144 | Pippin eat-detection signature | **Current-rewrite** — `IInventoryView` with pre-#602 note |
| L172 | Pippin recommended disposition step 2 | **Current-rewrite** — `IInventoryView.Bus.Subscribe<InventoryItemRemoved>` with pre-shim-retirement context |
| L250–254 | Class D narrative (Arwen + Legolas) | **Current-rewrite** — `IInventoryView.TryResolve/TryGetStackSize` and `IInventoryView.Bus` with pre-migration annotations |
| L262 | Class D narrative (Palantir LiveInventoryViewModel) | **Current-rewrite** — `IInventoryView` post-#745, with pre-migration note |

## Acceptance verification

- [x] `grep -rn "IInventoryService" docs/` returns only annotated historical references for the three in-scope files (every surviving mention carries a `legacy`, `pre-#602`, `pre-#659`, `pre-#725`, `pre-#753`, or `pre-shim-retirement` marker).
- [x] Broken file links at `module-charters.md:54,120` (`../src/Mithril.GameState/Inventory/IInventoryService.cs`) repointed to `IInventoryView.cs`.
- [x] `### IInventoryService` section header at `module-signal-map.md:239` rewritten as `### IInventoryView` with a top-of-section pointer to the broader #665 reshape.
- [x] `gamestate-services-gap-audit.md` Class A narrative (rows 104–262) reflects post-#602/#753 reality — Arwen's "consumes `IInventoryService`" rows now read as `IInventoryView` (post-#753).
- [x] Markdown-only; no build or test impact.
- [x] This PR body documents per-site judgments above.

## Out of scope

Per the issue: `world-simulator.md`, `world-simulator-orchestration-plan.md`, and `world-sim-migration-audit.md` retain `IInventoryService` mentions — they're the canonical migration narrative/ledger where the pre-migration name is load-bearing context. `glossary.md` was already swept by #752. The broader `module-signal-map.md` reshape covering the full post-#602 split treatment stays scoped to #665; this PR is the narrower "stale reference sweep" subset only.

## References

- Issue: #754
- Origin: world-sim-reviewer findings on #753 (review of `d8ba98fa`)
- Prior cleanup: #752 (glossary + module-charters refresh)
- Shim retirement: #751 (closes #659)
- Samwise PlayerWorld-direct migration (post-shim): #731 (closes #725)
- Palantir IInventoryView.Items migration: #745 (closes #726)
- Pattern reference: `docs/glossary.md` preamble + `Previous names:` annotations
- Broader signal-map rewrite (out of scope): #665

## Test plan

- [x] Markdown-only diff confirmed via `git diff --stat`
- [x] Final `grep IInventoryService docs/` against the three in-scope files returns only annotated references
- [x] No file path references to deleted `IInventoryService.cs` remain in scope files
- [x] Verified #725 / #731 shipped Samwise's PlayerWorld-direct migration before describing it (review fixup `f42d948`)
- [x] Verified #745 is the correct Palantir PR (`gh pr view 745` confirms — title `refactor(palantir): LiveInventoryViewModel → IInventoryView.Items (#726)`)
- [ ] Reviewer reads the per-site judgment ledger above to spot-check any classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
