### PR TITLE
refactor(world-sim): revert #709 IGameClock DI rewire (#711)

### DIFF
--- a/src/Mithril.WorldSim.Player/DependencyInjection/PlayerWorldServiceCollectionExtensions.cs
+++ b/src/Mithril.WorldSim.Player/DependencyInjection/PlayerWorldServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Mithril.Shared.Game;
 using Mithril.Shared.Logging;
 using Mithril.WorldSim.Player.Composers;
@@ -58,24 +57,18 @@ public static class PlayerWorldServiceCollectionExtensions
             // explicitly to IPlayerWorld / IChatWorld.
             .AddSingleton<IWorld>(sp => sp.GetRequiredService<PlayerWorld>());
 
-        // Replace the default IGameClock registration (TimeProvider.System-
-        // backed, set up by AddMithrilGameServices for headless / pre-world
-        // configurations) with one that reads from PlayerWorld's IWorldClock —
-        // scheduler-collapse migration item #12, #613. The in-game clock is
-        // now replay-deterministic: a Replaying-mode tick at world-clock T
-        // yields the same in-game time as a Live-mode tick at the same T.
-        // The shell's countdown chip + Gandalf's GameTimeOfDay-kind alarms
-        // both route through this; both stop leaking real wall-clock into
-        // the state-decision path (docs/world-simulator.md §Eliminations #8).
-        //
-        // Replace (Add + Remove) rather than the safer
-        // Add-Last-Wins-in-Resolution: the latter only works for IEnumerable<T>
-        // resolves, and IGameClock is a single-instance resolve.
-        services.Replace(ServiceDescriptor.Singleton<IGameClock>(sp =>
-        {
-            var world = sp.GetRequiredService<IPlayerWorld>();
-            return new GameClock(() => world.Clock.Now);
-        }));
+        // Intentionally does NOT replace the default IGameClock registration
+        // from AddMithrilGameServices. IGameClock is the wall-clock-anchored
+        // projection of PG in-game time-of-day — its DI-injected consumers
+        // (ShellViewModel chip + countdown; TimerProgressService.ComputeFiringAt
+        // for GameTimeOfDay timers) all want wall-clock semantics. Replay-
+        // deterministic shift event emission flows through
+        // TimeOfDayShiftComposer + the pure static GameClock.Project, with
+        // the world-clock-derived CalendarTimeAdvanced.Now as input —
+        // replay-deterministic by construction without involving the DI
+        // IGameClock. A previous attempt (#709) to rewire IGameClock to read
+        // from world.Clock.Now broke both consumer paths during the Replaying
+        // drain and was reverted in #711.
 
         return services;
     }

--- a/tests/Gandalf.Tests/TimerProgressServiceGameTimeOfDayClockTests.cs
+++ b/tests/Gandalf.Tests/TimerProgressServiceGameTimeOfDayClockTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// #711 — pins the wall-clock-anchoring contract on
+/// <see cref="TimerProgressService.ComputeFiringAt"/> for
+/// <see cref="GandalfTriggerKind.GameTimeOfDay"/> timers. The user-driven
+/// "fire at next 6 AM in-game" semantics demand wall-clock anchoring: a user
+/// clicking Start during the Replaying drain expects the alarm to fire at the
+/// real-world moment PG's in-game clock reads 6 AM, not at a moment offset
+/// by however far the world clock currently lags wall-clock.
+/// </summary>
+public class TimerProgressServiceGameTimeOfDayClockTests
+{
+    [Fact]
+    public void ComputeFiringAt_for_GameTimeOfDay_returns_a_wall_clock_instant_projecting_onto_the_target_in_game_time()
+    {
+        // Post-#711 DI hands TimerProgressService a wall-clock-anchored
+        // IGameClock (TimeProvider.System-backed). Independently of the
+        // injected clock's _nowSource, NextOccurrence is pure math on (target,
+        // startedAt) — when startedAt is wall-clock (the user-action carve-out
+        // in TimerProgressService.Start sets startedAt = _time.GetUtcNow()),
+        // the resulting FiringAt projects onto the target in-game time and is
+        // strictly after startedAt by at most one in-game day (7200 real
+        // seconds = 2 real hours).
+        var clock = new GameClock(TimeProvider.System);
+        var def = new GandalfTimerDef
+        {
+            Name = "Fire at next 6 AM",
+            Kind = GandalfTriggerKind.GameTimeOfDay,
+            GameHour = 6,
+            GameMinute = 0,
+        };
+
+        var startedAt = DateTimeOffset.UtcNow;
+        var firingAt = TimerProgressService.ComputeFiringAt(def, startedAt, clock);
+
+        firingAt.Should().BeAfter(startedAt,
+            "the EpsilonTicks guard in NextOccurrence bumps a target == floor result " +
+            "one full in-game day forward — Start at 6:00 should fire at the NEXT 6:00, " +
+            "not immediately");
+        (firingAt - startedAt).Should().BeLessThanOrEqualTo(
+            TimeSpan.FromSeconds(7200) + TimeSpan.FromSeconds(1),
+            "one in-game day == 7200 real seconds; FiringAt is strictly within one cycle of startedAt");
+
+        // The wall-clock instant `firingAt` projects onto the target's
+        // (GameHour, GameMinute). This is the property the user perceives —
+        // when wall-clock reaches firingAt, the in-game clock reads 6:00.
+        GameClock.Project(firingAt).Should().Be(new GameTimeOfDay(6, 0));
+    }
+
+    [Fact]
+    public void ComputeFiringAt_for_GameTimeOfDay_is_pure_math_on_startedAt_independent_of_clock_nowSource()
+    {
+        // The injected clock's _nowSource is only read by GetCurrent; NextOccurrence
+        // is pure math on (target, floor=startedAt). This test pins that contract:
+        // two clocks with wildly-different _nowSources but the same startedAt yield
+        // the same FiringAt. So during the Replaying drain — where PlayerWorld.Clock.Now
+        // lags real wall-clock by minutes — a GameTimeOfDay timer started with
+        // startedAt = wall-clock still anchors its FiringAt in wall-clock,
+        // *independent* of what the world clock currently reads.
+        var startedAt = DateTimeOffset.UtcNow;
+        var wallAnchoredClock = new GameClock(() => startedAt);
+        var laggedAnchoredClock = new GameClock(() => DateTimeOffset.MinValue);
+
+        var def = new GandalfTimerDef
+        {
+            Name = "Fire at next 8 PM",
+            Kind = GandalfTriggerKind.GameTimeOfDay,
+            GameHour = 20,
+            GameMinute = 0,
+        };
+
+        var firingViaWall = TimerProgressService.ComputeFiringAt(def, startedAt, wallAnchoredClock);
+        var firingViaLagged = TimerProgressService.ComputeFiringAt(def, startedAt, laggedAnchoredClock);
+
+        firingViaWall.Should().Be(firingViaLagged,
+            "NextOccurrence ignores _nowSource — FiringAt anchors in startedAt alone");
+        GameClock.Project(firingViaWall).Should().Be(new GameTimeOfDay(20, 0));
+    }
+}

--- a/tests/Mithril.Shell.Tests/ShellChipCountdownTimeBaseTests.cs
+++ b/tests/Mithril.Shell.Tests/ShellChipCountdownTimeBaseTests.cs
@@ -1,0 +1,115 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Player;
+using Mithril.WorldSim.Player.DependencyInjection;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #711 — exercises the Shell chrome's "what's now / what's next?" path
+/// against the post-revert DI graph. <c>ShellViewModel.RefreshGameTime</c>
+/// reads <see cref="IGameClock.GetCurrent"/> for the chip text and reads
+/// <see cref="DateTimeOffset.UtcNow"/> as the floor for
+/// <see cref="IShiftCatalog.NextTransition"/>. Both must anchor in wall-clock
+/// so the chip's in-game time and the countdown's floor reference the same
+/// instant. The #709 <c>services.Replace(IGameClock)</c> made the chip read
+/// from <c>PlayerWorld.Clock.Now</c> (which lags during the Replaying drain)
+/// while the floor stayed wall-clock — causing the symptom this issue was
+/// opened against. The revert in #711 restores wall-clock semantics for both.
+/// </summary>
+public sealed class ShellChipCountdownTimeBaseTests
+{
+    [Fact]
+    public async Task Chip_and_countdown_share_wall_clock_when_PlayerWorld_clock_has_not_advanced()
+    {
+        // A freshly-built PlayerWorld has not yet drained its merger — its
+        // clock reads DateTimeOffset.MinValue, the canonical "Replaying drain
+        // hasn't started" state. If the #709 rewire returned, the chip would
+        // be projecting from MinValue (i.e., a definite but wildly-wrong
+        // in-game time) while the countdown floor would still be DateTimeOffset.UtcNow.
+        var services = new ServiceCollection();
+        services.AddSingleton<IGameClock, GameClock>();
+        services.AddSingleton<IShiftCatalog>(_ => new JsonShiftCatalog());
+        services.AddSingleton<IClassifiedPlayerLogStream>(new EmptyClassifiedStream());
+        services.AddPlayerWorld();
+
+        await using var sp = services.BuildServiceProvider();
+        var clock = sp.GetRequiredService<IGameClock>();
+        var catalog = sp.GetRequiredService<IShiftCatalog>();
+        var world = sp.GetRequiredService<IPlayerWorld>();
+
+        world.Clock.Now.Should().Be(DateTimeOffset.MinValue,
+            "fresh world simulates the moment the Replaying drain begins — " +
+            "rewired clock would project from this");
+
+        // Mirror ShellViewModel.RefreshGameTime + BuildNextShiftCountdown.
+        var floor = DateTimeOffset.UtcNow;
+        var chip = clock.GetCurrent();
+        var (at, shift) = catalog.NextTransition(clock, floor);
+
+        // 1) Same time base — chip text and countdown floor both anchor in
+        //    wall-clock. Tolerated jitter is one in-game minute because
+        //    clock.GetCurrent() and the floor read are microseconds apart
+        //    and the in-game minute grain is 5 real seconds.
+        var floorProjection = GameClock.Project(floor);
+        InGameMinuteDistance(chip, floorProjection).Should().BeLessThanOrEqualTo(1,
+            "chip and countdown floor share wall-clock — the #709 rewire would " +
+            "have made the chip project from PlayerWorld.Clock.Now (DateTimeOffset.MinValue " +
+            "here), diverging by hundreds of in-game minutes");
+
+        // 2) Countdown's target instant projects onto the named shift's StartHour —
+        //    NextTransition's math is wall-clock-correct given a wall-clock floor
+        //    + a wall-clock-anchored clock.
+        GameClock.Project(at).Should().Be(new GameTimeOfDay(shift.StartHour, 0),
+            "NextTransition's `at` is the wall-clock instant the in-game clock " +
+            "next reaches the chosen shift's StartHour");
+
+        // 3) Countdown duration is positive and bounded by one PG shift cycle.
+        //    The published table's largest gap is 5 in-game hours = 25 real
+        //    minutes; a 30-minute upper bound absorbs any jitter without
+        //    masking real divergence.
+        (at - floor).Should().BeGreaterThan(TimeSpan.Zero);
+        (at - floor).Should().BeLessThanOrEqualTo(TimeSpan.FromMinutes(30));
+    }
+
+    /// <summary>
+    /// Cyclic distance between two in-game times-of-day in minutes (0..720).
+    /// 12:00 and 12:59 are 59 apart; 23:59 and 00:00 are 1 apart.
+    /// </summary>
+    private static int InGameMinuteDistance(GameTimeOfDay a, GameTimeOfDay b)
+    {
+        var aMin = a.Hour * 60 + a.Minute;
+        var bMin = b.Hour * 60 + b.Minute;
+        var raw = Math.Abs(aMin - bMin);
+        return Math.Min(raw, 1440 - raw);
+    }
+
+    /// <summary>
+    /// Empty <see cref="IClassifiedPlayerLogStream"/> so the
+    /// <c>WorldClockTickProducer</c> dependency resolves. The merger is
+    /// never started — only <c>IGameClock</c>, <c>IShiftCatalog</c>, and
+    /// <c>IPlayerWorld</c> are pulled from the container.
+    /// </summary>
+    private sealed class EmptyClassifiedStream : IClassifiedPlayerLogStream
+    {
+        private readonly Channel<LogEnvelope<IClassifiedPlayerLogLine>> _channel
+            = Channel.CreateUnbounded<LogEnvelope<IClassifiedPlayerLogLine>>(
+                new UnboundedChannelOptions { SingleReader = true });
+
+        public EmptyClassifiedStream() => _channel.Writer.TryComplete();
+
+        public async IAsyncEnumerable<LogEnvelope<IClassifiedPlayerLogLine>>
+            SubscribeWithReplayMarkerAsync([EnumeratorCancellation] CancellationToken ct)
+        {
+            await foreach (var e in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return e;
+            }
+        }
+    }
+}

--- a/tests/Mithril.WorldSim.Player.Tests/PlayerWorldClockDIRevertTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/PlayerWorldClockDIRevertTests.cs
@@ -1,0 +1,93 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Player.DependencyInjection;
+using Xunit;
+
+namespace Mithril.WorldSim.Player.Tests;
+
+/// <summary>
+/// #711 — locks in the revert of #709's <c>services.Replace(IGameClock)</c>.
+/// The DI-resolved <see cref="IGameClock"/> after <see cref="PlayerWorldServiceCollectionExtensions.AddPlayerWorld"/>
+/// must project in-game time from real wall-clock, NOT from
+/// <see cref="IPlayerWorld.Clock"/>. Two consumer paths
+/// (<c>ShellViewModel</c>'s chip + countdown; <c>TimerProgressService.ComputeFiringAt</c>
+/// for <c>GameTimeOfDay</c>-kind timers) both want wall-clock semantics —
+/// during the Replaying drain the world clock can lag wall-clock by minutes
+/// without the user perceiving a different "now," so injecting a
+/// world-clock-backed projection broke both.
+///
+/// <para>Replay-deterministic shift event emission flows through a different
+/// path entirely (the <c>TimeOfDayShiftComposer</c> consumes
+/// <see cref="CalendarTimeAdvanced"/> bus events and projects via the pure
+/// static <see cref="GameClock.Project"/>), so the DI rewire was load-bearing
+/// for nothing.</para>
+/// </summary>
+public sealed class PlayerWorldClockDIRevertTests
+{
+    [Fact]
+    public async Task AddPlayerWorld_does_not_rewire_IGameClock_to_world_clock()
+    {
+        // Mirror AddMithrilGameServices' default IGameClock registration
+        // (TimeProvider.System-backed). The post-#711 contract: AddPlayerWorld
+        // must leave this registration intact. If a future change re-adds a
+        // services.Replace(IGameClock, ...) inside AddPlayerWorld, this test
+        // fails because the resolved clock would read from PlayerWorld.Clock.Now
+        // (DateTimeOffset.MinValue on a freshly-built world) instead of from
+        // wall-clock.
+        var services = new ServiceCollection();
+        services.AddSingleton<IGameClock, GameClock>();
+        services.AddSingleton<IShiftCatalog>(_ => new JsonShiftCatalog());
+        services.AddSingleton<IClassifiedPlayerLogStream>(new EmptyClassifiedStream());
+        services.AddPlayerWorld();
+
+        await using var sp = services.BuildServiceProvider();
+        var clock = sp.GetRequiredService<IGameClock>();
+        var world = sp.GetRequiredService<IPlayerWorld>();
+
+        world.Clock.Now.Should().Be(DateTimeOffset.MinValue,
+            "freshly-built PlayerWorld has not advanced its clock — the rewired " +
+            "clock would project from this value");
+
+        var observed = clock.GetCurrent();
+        var wallClockProjection = GameClock.Project(DateTimeOffset.UtcNow);
+        var worldClockProjection = GameClock.Project(world.Clock.Now);
+
+        // Wall-clock projection and world-clock projection are separated by
+        // ~hundreds of in-game hours — DateTimeOffset.MinValue is ~2000 years
+        // before the GameClock anchor — so the comparison is unambiguous.
+        observed.Should().Be(wallClockProjection,
+            "post-#711 IGameClock projects from TimeProvider.System (wall-clock), " +
+            "NOT from PlayerWorld.Clock.Now");
+        observed.Should().NotBe(worldClockProjection,
+            "the #709 rewire would have made GetCurrent() == Project(world.Clock.Now); " +
+            "this test fails if that rewire is re-added");
+    }
+
+    /// <summary>
+    /// Empty <see cref="IClassifiedPlayerLogStream"/> so
+    /// <c>WorldClockTickProducer</c>'s ctor dep is satisfied. The merger is
+    /// never started in these tests — we only resolve <c>IGameClock</c> and
+    /// <c>IPlayerWorld</c> as DI roots.
+    /// </summary>
+    private sealed class EmptyClassifiedStream : IClassifiedPlayerLogStream
+    {
+        private readonly Channel<LogEnvelope<IClassifiedPlayerLogLine>> _channel
+            = Channel.CreateUnbounded<LogEnvelope<IClassifiedPlayerLogLine>>(
+                new UnboundedChannelOptions { SingleReader = true });
+
+        public EmptyClassifiedStream() => _channel.Writer.TryComplete();
+
+        public async IAsyncEnumerable<LogEnvelope<IClassifiedPlayerLogLine>>
+            SubscribeWithReplayMarkerAsync([EnumeratorCancellation] CancellationToken ct)
+        {
+            await foreach (var e in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reverts the `services.Replace(IGameClock)` block in `AddPlayerWorld` (added by #709). The supposed beneficiary — `ShiftAlarmService` — stopped consuming `IGameClock` in the same PR; the two remaining DI consumers (`ShellViewModel` chip + countdown, `TimerProgressService.ComputeFiringAt`) both want wall-clock semantics. The rewire broke them during the Replaying drain and benefited no one.

Replay-deterministic shift event emission still flows through `TimeOfDayShiftComposer` + the pure static `GameClock.Project`, with `CalendarTimeAdvanced.Now` (world-clock-derived) as input — replay-deterministic by construction without involving the DI `IGameClock`.

Architectural commitment captured at the former rewire site:
- `IGameClock` is the **wall-clock-anchored** projection of in-game time. DI-injected consumers get wall-clock semantics.
- Replay-deterministic shift projection is composer-resident via `GameClock.Project` + world-clock-derived input from the bus.
- Any future consumer that needs replay-deterministic in-game-time projection consumes the composer's bus events rather than injecting `IGameClock`.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors).
- [x] `dotnet test Mithril.slnx` — clean (23 test projects, all passing).
- [x] New regression test in `Mithril.WorldSim.Player.Tests` locks in that `AddPlayerWorld` leaves the default `IGameClock` registration intact (DI-resolved clock projects from wall-clock, not from `IPlayerWorld.Clock.Now`).
- [x] New Shell-side test in `Mithril.Shell.Tests` pins the acceptance criterion: chip text and countdown floor share wall-clock under a Replaying-style world.
- [x] New Gandalf-side test in `Gandalf.Tests` pins that `ComputeFiringAt` for `GameTimeOfDay` timers anchors `FiringAt` in wall-clock independent of the clock's `_nowSource`.

Closes #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
