### PR TITLE
feat(gandalf): RingOnCurrentShiftAtStartup setting; default OFF (#712)

### DIFF
--- a/src/Gandalf.Module/Domain/GandalfShiftSettings.cs
+++ b/src/Gandalf.Module/Domain/GandalfShiftSettings.cs
@@ -36,8 +36,26 @@ public sealed class ShiftAlarmConfig : SettingsNode
 /// </summary>
 public sealed class GandalfShiftSettings : SettingsNode, IPostLoadInit
 {
+    private bool _ringOnCurrentShiftAtStartup;
+
     public Dictionary<string, ShiftAlarmConfig> ByShiftSlug { get; set; } =
         new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// When <c>true</c>, the first <c>TimeOfDayShift</c> emission observed
+    /// after Mithril starts — which carries <c>From == null</c> because the
+    /// composer has no prior shift on cold-start — fires the per-shift
+    /// alarm if the shift's <see cref="ShiftAlarmConfig.Enabled"/> is set.
+    /// Defaults to <c>false</c>: pre-#709 <c>Reschedule</c>-based scheduling
+    /// armed only the next transition, so cold-start was always silent.
+    /// Default-off matches that prior behaviour for users who relied on it;
+    /// users who want "ring me when I launch in an enabled shift" opt in.
+    /// </summary>
+    public bool RingOnCurrentShiftAtStartup
+    {
+        get => _ringOnCurrentShiftAtStartup;
+        set => Set(ref _ringOnCurrentShiftAtStartup, value);
+    }
 
     /// <summary>
     /// Lookup-or-create. Used by the settings view and by

--- a/src/Gandalf.Module/Services/ShiftAlarmService.cs
+++ b/src/Gandalf.Module/Services/ShiftAlarmService.cs
@@ -167,6 +167,16 @@ public sealed class ShiftAlarmService : BackgroundService
         // Gandalf.TimerAlarmService.OnTimerReady (both PR #705).
         if (_world.Clock.Mode == WorldMode.Replaying) return;
 
+        // #712 — cold-start suppression. The composer reports From == null
+        // exactly once per session: the first TimeOfDayShift emission after
+        // Mithril starts, carrying the in-progress shift the user already
+        // sees on-screen. Pre-#709 Reschedule-based scheduling armed only
+        // the NEXT transition, so cold-start was always silent; default-off
+        // matches that prior behaviour. Same shape as the Mode gate above —
+        // ledger has already advanced, only the audio + flash side-effect
+        // is suppressed.
+        if (shift.From is null && !_shiftSettings.RingOnCurrentShiftAtStartup) return;
+
         var path = ResolveSoundPath(config, _globalSettings);
         Dispatch(() =>
         {

--- a/tests/Gandalf.Tests/ShiftAlarmServiceTests.cs
+++ b/tests/Gandalf.Tests/ShiftAlarmServiceTests.cs
@@ -100,6 +100,9 @@ public class ShiftAlarmServiceTests
     [Fact]
     public void Live_TimeOfDayShift_for_enabled_shift_plays_audio()
     {
+        // Genuine cross-shift transition (From != null) — exercises the
+        // "alarm fires on every enabled shift change" smoke path. Cold-
+        // start suppression (#712) is covered separately below.
         var sink = new RecordingAudioSink();
         var settings = new GandalfSettings { AlarmEnabled = true };
         var shifts = new GandalfShiftSettings();
@@ -107,7 +110,7 @@ public class ShiftAlarmServiceTests
         var world = new TestPlayerWorld { Clock = { Mode = WorldMode.Live, Now = new DateTimeOffset(2026, 5, 23, 5, 0, 0, TimeSpan.Zero) } };
         using var svc = new ShiftAlarmService(Catalog, settings, shifts, sink, world);
 
-        svc.OnShiftTransitionForTests(new TimeOfDayShift(From: null, To: "dawn",
+        svc.OnShiftTransitionForTests(new TimeOfDayShift(From: "night", To: "dawn",
             At: world.Clock.Now, Mode: WorldMode.Live));
 
         sink.Plays.Should().HaveCount(1, "Live-mode shift transition for an enabled shift fires audio");
@@ -210,6 +213,78 @@ public class ShiftAlarmServiceTests
 
         sink.Plays.Should().BeEmpty("disabled shift never fires audio");
         svc.LastObservedShift.Should().Be("dawn", "ledger advances regardless");
+    }
+
+    // ── #712: cold-start (From == null) suppression ────────────────────
+
+    [Fact]
+    public void ColdStart_TimeOfDayShift_does_not_play_audio_when_setting_is_OFF()
+    {
+        // #712 default — RingOnCurrentShiftAtStartup = false. The composer's
+        // first emission after Mithril starts carries From == null (the
+        // in-progress shift the user already sees on-screen). Pre-#709
+        // Reschedule-based scheduling armed only the next transition, so
+        // cold-start was always silent; default-off matches that behaviour.
+        var sink = new RecordingAudioSink();
+        var settings = new GandalfSettings { AlarmEnabled = true };
+        var shifts = new GandalfShiftSettings();
+        shifts.GetOrCreate("dawn").Enabled = true;
+        shifts.RingOnCurrentShiftAtStartup.Should().BeFalse("default — pre-#709 parity");
+        var world = new TestPlayerWorld { Clock = { Mode = WorldMode.Live, Now = new DateTimeOffset(2026, 5, 23, 5, 0, 0, TimeSpan.Zero) } };
+        using var svc = new ShiftAlarmService(Catalog, settings, shifts, sink, world);
+
+        svc.OnShiftTransitionForTests(new TimeOfDayShift(From: null, To: "dawn",
+            At: world.Clock.Now, Mode: WorldMode.Live));
+
+        sink.Plays.Should().BeEmpty(
+            "default-off — cold-start (From == null) is silent without opt-in");
+        svc.LastObservedShift.Should().Be("dawn",
+            "ledger advances regardless so the next genuine transition isn't masked");
+    }
+
+    [Fact]
+    public void ColdStart_TimeOfDayShift_plays_audio_when_setting_is_ON()
+    {
+        // #712 opt-in. With RingOnCurrentShiftAtStartup = true, the cold-
+        // start emission rings (subject to the existing AlarmEnabled +
+        // per-shift Enabled gates).
+        var sink = new RecordingAudioSink();
+        var settings = new GandalfSettings { AlarmEnabled = true };
+        var shifts = new GandalfShiftSettings { RingOnCurrentShiftAtStartup = true };
+        shifts.GetOrCreate("dawn").Enabled = true;
+        var world = new TestPlayerWorld { Clock = { Mode = WorldMode.Live, Now = new DateTimeOffset(2026, 5, 23, 5, 0, 0, TimeSpan.Zero) } };
+        using var svc = new ShiftAlarmService(Catalog, settings, shifts, sink, world);
+
+        svc.OnShiftTransitionForTests(new TimeOfDayShift(From: null, To: "dawn",
+            At: world.Clock.Now, Mode: WorldMode.Live));
+
+        sink.Plays.Should().HaveCount(1,
+            "opt-in — cold-start (From == null) fires the audio when the user has opted in");
+        sink.Plays[0].CallerId.Should().Be("gandalf");
+        svc.LastObservedShift.Should().Be("dawn");
+    }
+
+    [Fact]
+    public void Genuine_cross_shift_transition_fires_regardless_of_cold_start_setting()
+    {
+        // #712 scope — the cold-start gate ONLY suppresses From == null
+        // emissions. A genuine cross-shift transition (From != null) fires
+        // even when RingOnCurrentShiftAtStartup == false; the setting is not
+        // a master kill-switch for shift alarms.
+        var sink = new RecordingAudioSink();
+        var settings = new GandalfSettings { AlarmEnabled = true };
+        var shifts = new GandalfShiftSettings();
+        shifts.RingOnCurrentShiftAtStartup.Should().BeFalse();
+        shifts.GetOrCreate("dawn").Enabled = true;
+        var world = new TestPlayerWorld { Clock = { Mode = WorldMode.Live, Now = new DateTimeOffset(2026, 5, 23, 5, 0, 0, TimeSpan.Zero) } };
+        using var svc = new ShiftAlarmService(Catalog, settings, shifts, sink, world);
+
+        svc.OnShiftTransitionForTests(new TimeOfDayShift(From: "night", To: "dawn",
+            At: world.Clock.Now, Mode: WorldMode.Live));
+
+        sink.Plays.Should().HaveCount(1,
+            "transition with a known prior shift fires regardless of the cold-start setting");
+        svc.LastObservedShift.Should().Be("dawn");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds the configurable cold-start suppression discussed in the pinned #712 design comment.

- New `GandalfShiftSettings.RingOnCurrentShiftAtStartup` (bool, **default `false`**).
- Sink-side gate in `ShiftAlarmService.OnShiftTransition`: when the incoming `TimeOfDayShift` has `From == null` AND the setting is off, audio + window-flash is suppressed (the per-shift dedup ledger advances regardless so the next genuine transition isn't masked).

The composer emits `From == null` exactly once per session — the first observation after Mithril starts, carrying the in-progress shift the user already sees on-screen. Pre-#709 `Reschedule`-based scheduling armed only the *next* transition, so cold-start was always silent; default-off matches that behaviour for users who relied on it. Users who want "ring me when I launch in an enabled shift" opt in via the new setting.

Same shape as the existing principle-12 Mode gate (PR #705 / #708) — state derivation upstream stays mode-agnostic; only the user-facing side-effect is suppressed.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors).
- [x] `dotnet test Mithril.slnx` — clean (23 test projects, all passing).
- [x] New `ColdStart_TimeOfDayShift_does_not_play_audio_when_setting_is_OFF` — default-off suppresses the cold-start fire; ledger still advances.
- [x] New `ColdStart_TimeOfDayShift_plays_audio_when_setting_is_ON` — opt-in fires audio.
- [x] New `Genuine_cross_shift_transition_fires_regardless_of_cold_start_setting` — pins the gate's scope; cross-shift transitions are unaffected by the setting.
- [x] Updated `Live_TimeOfDayShift_for_enabled_shift_plays_audio` to pass `From: "night"` (genuine cross-shift transition) so it tests its actual intent ("any Live transition for an enabled shift fires") without colliding with the new cold-start gate.

Closes #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
