### PR TITLE
feat(gandalf): RingOnCurrentShiftAtStartup settings checkbox (#758)

### DIFF
--- a/src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs
@@ -72,12 +72,19 @@ public sealed partial class GandalfSettingsViewModel : ObservableObject
         Settings = settings;
         _defs = defs;
         _progress = progress;
+        ShiftSettings = shiftSettings;
         ShiftRows = shiftCatalog.Shifts
             .Select(s => new ShiftAlarmRow(s, shiftSettings.GetOrCreate(s.Slug), preferences))
             .ToArray();
     }
 
     public GandalfSettings Settings { get; }
+
+    /// <summary>
+    /// Cross-shift settings (currently just <see cref="GandalfShiftSettings.RingOnCurrentShiftAtStartup"/>).
+    /// Exposed so the settings view can two-way-bind the cold-start opt-in checkbox.
+    /// </summary>
+    public GandalfShiftSettings ShiftSettings { get; }
 
     /// <summary>One row per published in-game-time-of-day shift, in time order.</summary>
     public IReadOnlyList<ShiftAlarmRow> ShiftRows { get; }

--- a/src/Gandalf.Module/Views/GandalfSettingsView.xaml
+++ b/src/Gandalf.Module/Views/GandalfSettingsView.xaml
@@ -53,6 +53,10 @@
                 it begins (every ~2 real hours per shift). Picking a sound here overrides the global
                 default for that shift only; leave it blank to inherit the global default above.
             </TextBlock>
+            <CheckBox Content="Ring on current shift at startup"
+                      IsChecked="{Binding ShiftSettings.RingOnCurrentShiftAtStartup}"
+                      Foreground="#FFE8E8E8" Margin="0,0,0,8"
+                      ToolTip="When Mithril starts and you're already in an enabled shift, ring the alarm immediately. Off by default — matches pre-#709 behaviour of only ringing on the next shift change."/>
             <ItemsControl ItemsSource="{Binding ShiftRows}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>

--- a/tests/Gandalf.Tests/GandalfShiftSettingsBubbleTests.cs
+++ b/tests/Gandalf.Tests/GandalfShiftSettingsBubbleTests.cs
@@ -96,4 +96,29 @@ public class GandalfShiftSettingsBubbleTests
 
         fired.Should().Be(1, "the second GetOrCreate must not have re-subscribed");
     }
+
+    [Fact]
+    public void RingOnCurrentShiftAtStartup_round_trips_through_JsonSettingsStore()
+    {
+        // Pins the UI checkbox contract (#758): the setting persists through
+        // %LocalAppData%/Mithril/Gandalf/shifts.json so a user opt-in survives
+        // restart. Default is false (matches pre-#709 silent cold-start).
+        var tempPath = Path.Combine(Path.GetTempPath(), $"mithril-shifts-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            new GandalfShiftSettings().RingOnCurrentShiftAtStartup.Should().BeFalse();
+
+            var seed = new GandalfShiftSettings { RingOnCurrentShiftAtStartup = true };
+            var store = new JsonSettingsStore<GandalfShiftSettings>(
+                tempPath, GandalfShiftSettingsJsonContext.Default.GandalfShiftSettings);
+            store.Save(seed);
+
+            var loaded = store.Load();
+            loaded.RingOnCurrentShiftAtStartup.Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

PR #757 added `GandalfShiftSettings.RingOnCurrentShiftAtStartup` (default OFF) as the opt-in for ringing on the cold-start `From == null` shift emission, but with **no UI surface** — users had to JSON-edit `%LocalAppData%/Mithril/Gandalf/shifts.json` to opt in. This adds the discoverability surface that #712 / #758 flagged as low-priority but real.

- New checkbox in `GandalfSettingsView.xaml` immediately above the `ShiftRows` list, labelled "Ring on current shift at startup".
- `GandalfSettingsViewModel` now exposes `ShiftSettings` (the `GandalfShiftSettings` already injected in its ctor but previously only used to seed `ShiftRows`) so the checkbox has a binding root, sitting alongside the existing `Settings` (per-app) and `ShiftRows` (per-shift) properties.
- Tooltip captures the cold-start semantics + the pre-#709 parity rationale, lifted from the #757 commit body: *"When Mithril starts and you're already in an enabled shift, ring the alarm immediately. Off by default — matches pre-#709 behaviour of only ringing on the next shift change."*

## Test plan

- [x] `dotnet build src/Gandalf.Module/Gandalf.Module.csproj` — clean (0 warnings, 0 errors).
- [x] `dotnet test tests/Gandalf.Tests/Gandalf.Tests.csproj` — clean (325 passed, 0 failed).
- [x] New `RingOnCurrentShiftAtStartup_round_trips_through_JsonSettingsStore` pins the persistence contract: default is `false` on a fresh `GandalfShiftSettings`; setting `true` survives Save→Load via the production `JsonSettingsStore<GandalfShiftSettings>` path that backs `shifts.json`.

XAML binding mode is default OneWay for `CheckBox.IsChecked` (which is itself two-way friendly), so the tick mark writes back through the existing `SettingsNode.Set` plumbing to fire `PropertyChanged` and wake the autosaver — same path used by every other checkbox in this settings view.

Closes #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)