### PR TITLE
feat(saruman): one-time UX hint for pre-#603 spent flags lost in schema 1→2 upgrade (#686)

### DIFF
--- a/src/Saruman.Module/Services/SarumanLegacyMigration.cs
+++ b/src/Saruman.Module/Services/SarumanLegacyMigration.cs
@@ -35,6 +35,12 @@ public sealed class SarumanLegacyMigration : ILegacyMigration<SarumanState>
             using var stream = File.OpenRead(_legacyPath);
             var loaded = JsonSerializer.Deserialize(stream, _typeInfo);
             if (loaded is null) return false;
+            // The legacy flat file is by definition pre-#603 and carried the old
+            // Codebook field that STJ silently drops during deserialization here
+            // (the field no longer exists on the type). Surface the same one-time
+            // hint as the schema 1→2 in-place migration so the user knows their
+            // previously-marked-spent codes are gone and how to recover them.
+            loaded.ShowPreSplitMigrationHint = true;
             migrated = loaded;
             return true;
         }

--- a/src/Saruman.Module/Services/SarumanOverrideService.cs
+++ b/src/Saruman.Module/Services/SarumanOverrideService.cs
@@ -84,6 +84,46 @@ public sealed class SarumanOverrideService
         return removed;
     }
 
+    /// <summary>
+    /// Whether the one-time post-#603 migration banner should be shown for the
+    /// active character. <c>false</c> when no character is active or when the
+    /// hint has already been dismissed (or never set).
+    /// </summary>
+    public bool ShowMigrationHint
+    {
+        get
+        {
+            var state = _view.Current;
+            if (state is null) return false;
+            lock (_lock) return state.ShowPreSplitMigrationHint;
+        }
+    }
+
+    /// <summary>
+    /// Clear the post-#603 migration hint flag. Returns <c>true</c> when the
+    /// dismiss had an effect (the flag was set), <c>false</c> when it was
+    /// already cleared or no character is active. Piggybacks on
+    /// <see cref="OverridesChanged"/> so the VM rebinds <see cref="ShowMigrationHint"/>
+    /// on the next refresh without a dedicated event.
+    /// </summary>
+    public bool DismissMigrationHint()
+    {
+        var state = _view.Current;
+        if (state is null) return false;
+        bool wasShowing;
+        lock (_lock)
+        {
+            wasShowing = state.ShowPreSplitMigrationHint;
+            if (wasShowing)
+            {
+                state.ShowPreSplitMigrationHint = false;
+                Persist();
+            }
+        }
+        if (wasShowing) OverridesChanged?.Invoke(this, EventArgs.Empty);
+        return wasShowing;
+    }
+
     private void Persist()
     {
         try { _view.Save(); }

--- a/src/Saruman.Module/Settings/SarumanState.cs
+++ b/src/Saruman.Module/Settings/SarumanState.cs
@@ -27,11 +27,21 @@ public sealed class SarumanState : IVersionedState<SarumanState>
     /// not re-imported here — discovery state rebuilds from log replay; chat
     /// spent state rebuilds from chat replay on first observation per
     /// (server, character). The override ledger starts empty.
+    ///
+    /// <para>Sets <see cref="ShowPreSplitMigrationHint"/> so the next time
+    /// the user opens the Saruman tab they get a one-time banner explaining
+    /// why their previously-marked-spent codes are missing and how to recover
+    /// older offline burns via the right-click <c>Mark as spent</c> path.
+    /// Users who already migrated under a Mithril build that lacked this flag
+    /// won't see the hint — accepted trade-off, the only alternative was a
+    /// retroactive heuristic (e.g. "discovered entries with no overrides")
+    /// that overlaps with the legitimate fresh-install steady state.</para>
     /// </summary>
     public static SarumanState Migrate(SarumanState loaded)
     {
         loaded.SchemaVersion = Version;
         loaded.SpentOverrides ??= new HashSet<string>(StringComparer.Ordinal);
+        loaded.ShowPreSplitMigrationHint = true;
         return loaded;
     }
 
@@ -43,6 +53,16 @@ public sealed class SarumanState : IVersionedState<SarumanState>
     /// at the VM layer: <c>isSpent = view.IsSpent(code) || overrides.Contains(code)</c>.
     /// </summary>
     public HashSet<string> SpentOverrides { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// When <c>true</c>, the Saruman view surfaces a one-time banner explaining
+    /// the pre-#603 spent-flag loss and the manual recovery path. Set by
+    /// <see cref="Migrate"/> (schema 1→2 upgrade) and by
+    /// <c>SarumanLegacyMigration</c> (pre-per-character flat-file migration);
+    /// cleared when the user dismisses the banner. Defaults to <c>false</c> so
+    /// fresh installs never see the notice.
+    /// </summary>
+    public bool ShowPreSplitMigrationHint { get; set; }
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Saruman.Module/ViewModels/SarumanViewModel.cs
+++ b/src/Saruman.Module/ViewModels/SarumanViewModel.cs
@@ -57,7 +57,29 @@ public sealed partial class SarumanViewModel : ObservableObject
 
     [ObservableProperty] private bool _hideSpent = true;
 
+    /// <summary>
+    /// One-time post-#603 migration banner (#686). Mirrors the active
+    /// character's <c>SarumanState.ShowPreSplitMigrationHint</c> flag; updated
+    /// on every <see cref="Refresh"/> so a character switch (which fires
+    /// <see cref="SarumanOverrideService.OverridesChanged"/> via the
+    /// <c>PerCharacterView.CurrentChanged</c> chain) re-evaluates against the
+    /// newly-active character's state.
+    /// </summary>
+    [ObservableProperty] private bool _showMigrationHint;
+
     partial void OnHideSpentChanged(bool value) => WordsView.Refresh();
+
+    [RelayCommand]
+    private void DismissMigrationHint()
+    {
+        if (_overrides.DismissMigrationHint())
+        {
+            // OverridesChanged already fires inside DismissMigrationHint, but
+            // that's a dispatched refresh hop — set the local flag synchronously
+            // so the banner collapses on the same UI tick as the click.
+            ShowMigrationHint = false;
+        }
+    }
 
     private bool FilterPredicate(object o)
     {
@@ -99,6 +121,7 @@ public sealed partial class SarumanViewModel : ObservableObject
         }
         TrackedCount = known;
         SpentCount = spent;
+        ShowMigrationHint = _overrides.ShowMigrationHint;
 
         WordsView.Refresh();
     }

--- a/src/Saruman.Module/Views/SarumanView.xaml
+++ b/src/Saruman.Module/Views/SarumanView.xaml
@@ -30,6 +30,27 @@
     </UserControl.Resources>
 
     <DockPanel Margin="16">
+        <!-- Post-#603 migration banner (#686): one-time notice that the
+             schema 1→2 upgrade dropped pre-existing spent-flag state. Dismiss
+             persists per-character via SarumanState.ShowPreSplitMigrationHint;
+             fresh installs and already-dismissed characters never see it. -->
+        <Border DockPanel.Dock="Top"
+                Visibility="{Binding ShowMigrationHint, Converter={StaticResource BoolToVis}}"
+                Margin="0,0,0,12" Padding="12,8"
+                Background="#221E3A5F" BorderBrush="{StaticResource SetRefBorderBrush}" BorderThickness="1"
+                CornerRadius="3">
+            <DockPanel LastChildFill="True">
+                <Button DockPanel.Dock="Right" Content="Got it" Padding="10,4" Margin="12,0,0,0"
+                        VerticalAlignment="Top"
+                        Command="{Binding DismissMigrationHintCommand}"
+                        ToolTip="Dismiss this notice for the active character. It won't appear again."/>
+                <TextBlock TextWrapping="Wrap" VerticalAlignment="Center"
+                           Foreground="{StaticResource TextPrimaryBrush}"
+                           FontSize="{DynamicResource AppFontSize}"
+                           Text="Your previously-marked-spent Words of Power were reset by the Words of Power split. Chat replay covers codes spoken since the latest in-game chat banner — for older offline burns, right-click a code and pick 'Mark as spent (offline burn)'."/>
+            </DockPanel>
+        </Border>
+
         <!-- Header -->
         <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Margin="0,0,0,12">

--- a/tests/Saruman.Tests/Services/SarumanOverrideServiceTests.cs
+++ b/tests/Saruman.Tests/Services/SarumanOverrideServiceTests.cs
@@ -100,4 +100,35 @@ public sealed class SarumanOverrideServiceTests : IDisposable
         svc.IsSpent("FEAVEG").Should().BeFalse();
         view.Dispose();
     }
+
+    [Fact]
+    public void DismissMigrationHint_clears_flag_persists_and_fires_event()
+    {
+        // Seed a v1 saruman.json on disk so the store's Load runs Migrate()
+        // and stamps ShowPreSplitMigrationHint, the production path the UX
+        // banner sees.
+        var charDir = Path.Combine(_root, "Arthur_Kwatoxi");
+        Directory.CreateDirectory(charDir);
+        File.WriteAllText(Path.Combine(charDir, "saruman.json"),
+            """{"schemaVersion":1,"spentOverrides":[]}""");
+
+        var (svc, view) = Build();
+        var fires = 0;
+        svc.OverridesChanged += (_, _) => fires++;
+
+        svc.ShowMigrationHint.Should().BeTrue("Migrate() set the flag on load");
+        svc.DismissMigrationHint().Should().BeTrue();
+        svc.ShowMigrationHint.Should().BeFalse();
+        fires.Should().Be(1, "dismiss piggybacks on OverridesChanged for VM refresh");
+
+        // Idempotent: a second dismiss is a no-op.
+        svc.DismissMigrationHint().Should().BeFalse();
+        view.Dispose();
+
+        // Round-trip: the dismissal persisted to disk; reloading does not
+        // re-trigger the hint (Migrate doesn't run for current-version files).
+        var (svc2, view2) = Build();
+        svc2.ShowMigrationHint.Should().BeFalse();
+        view2.Dispose();
+    }
 }

--- a/tests/Saruman.Tests/Settings/SarumanStateMigrationTests.cs
+++ b/tests/Saruman.Tests/Settings/SarumanStateMigrationTests.cs
@@ -1,0 +1,127 @@
+using System.IO;
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.Shared.Character;
+using Saruman.Services;
+using Saruman.Settings;
+using Xunit;
+
+namespace Saruman.Tests.Settings;
+
+/// <summary>
+/// Migration-hint contract for #686: the schema 1→2 upgrade and the legacy
+/// flat-file migration both drop the pre-#603 spent-flag state, so both paths
+/// surface <see cref="SarumanState.ShowPreSplitMigrationHint"/> for the UI to
+/// expose the one-time recovery banner. Fresh installs never flip the flag.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class SarumanStateMigrationTests : IDisposable
+{
+    private readonly string _root;
+
+    public SarumanStateMigrationTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("saruman-migration-hint");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Migrate_from_v1_sets_ShowPreSplitMigrationHint()
+    {
+        var v1 = new SarumanState { SchemaVersion = 1 };
+        var migrated = SarumanState.Migrate(v1);
+        migrated.SchemaVersion.Should().Be(SarumanState.Version);
+        migrated.ShowPreSplitMigrationHint.Should().BeTrue();
+        migrated.SpentOverrides.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Fresh_state_does_not_show_migration_hint()
+    {
+        // Default state (no migration ever runs): the flag stays false.
+        new SarumanState().ShowPreSplitMigrationHint.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PerCharacterStore_v1_file_on_disk_surfaces_hint_then_dismiss_persists()
+    {
+        // Simulates the live-upgrade path: a user's existing saruman.json
+        // was saved at v1, the new Mithril build loads it, Migrate runs, the
+        // hint flag is stamped. After dismiss + save the flag stays false
+        // across restarts (Migrate doesn't re-run for current-version files).
+        var charDir = Path.Combine(_root, "Arthur_Kwatoxi");
+        Directory.CreateDirectory(charDir);
+        var path = Path.Combine(charDir, "saruman.json");
+        File.WriteAllText(path, """{"schemaVersion":1,"spentOverrides":[]}""");
+
+        var store = new PerCharacterStore<SarumanState>(_root, "saruman.json",
+            SarumanJsonContext.Default.SarumanState);
+
+        var loaded = store.Load("Arthur", "Kwatoxi");
+        loaded.SchemaVersion.Should().Be(SarumanState.Version);
+        loaded.ShowPreSplitMigrationHint.Should().BeTrue();
+
+        // User dismisses, we save.
+        loaded.ShowPreSplitMigrationHint = false;
+        store.Save("Arthur", "Kwatoxi", loaded);
+
+        var reloaded = store.Load("Arthur", "Kwatoxi");
+        reloaded.SchemaVersion.Should().Be(SarumanState.Version);
+        reloaded.ShowPreSplitMigrationHint.Should().BeFalse(
+            "Migrate only runs for older-than-current state, so a dismissed-and-saved file stays dismissed");
+    }
+
+    [Fact]
+    public void Legacy_migration_surfaces_hint_when_pre603_flat_file_is_imported()
+    {
+        // Pre-#603 flat-file at %LocalAppData%/Mithril/Saruman/settings.json
+        // carried the old Codebook field; STJ silently drops it during
+        // deserialization (the type no longer has the field). The legacy
+        // migration is the import boundary — it must set the hint flag too,
+        // since the schema 1→2 Migrate() never runs on this path (the
+        // PerCharacterStore forces SchemaVersion = CurrentVersion directly).
+        var legacyDir = Path.Combine(_root, "_legacy_saruman");
+        Directory.CreateDirectory(legacyDir);
+        File.WriteAllText(Path.Combine(legacyDir, "settings.json"),
+            """{"schemaVersion":1,"codebook":{},"spentOverrides":["LEGACY"]}""");
+
+        var legacy = new SarumanLegacyMigration(legacyDir, SarumanJsonContext.Default.SarumanState);
+        legacy.TryMigrate("Arthur", "Kwatoxi", out var migrated, out _).Should().BeTrue();
+        migrated.ShowPreSplitMigrationHint.Should().BeTrue();
+        // SpentOverrides that survived deserialization (post-#603 field) carry over.
+        migrated.SpentOverrides.Should().Contain("LEGACY");
+    }
+
+    [Fact]
+    public void PerCharacterStore_with_legacy_fallback_round_trips_hint_dismissal()
+    {
+        // End-to-end legacy-path round-trip: only the legacy flat file exists,
+        // PerCharacterStore picks it up via the registered ILegacyMigration,
+        // writes the new per-character file with the hint set, and a later
+        // dismiss + save keeps the hint off on subsequent loads.
+        var legacyDir = Path.Combine(_root, "_legacy_saruman");
+        Directory.CreateDirectory(legacyDir);
+        File.WriteAllText(Path.Combine(legacyDir, "settings.json"),
+            """{"schemaVersion":1,"spentOverrides":[]}""");
+
+        var legacy = new SarumanLegacyMigration(legacyDir, SarumanJsonContext.Default.SarumanState);
+        var store = new PerCharacterStore<SarumanState>(_root, "saruman.json",
+            SarumanJsonContext.Default.SarumanState, legacy);
+
+        var loaded = store.Load("Arthur", "Kwatoxi");
+        loaded.ShowPreSplitMigrationHint.Should().BeTrue();
+        // Legacy file is cleaned up by the store on successful import.
+        File.Exists(Path.Combine(legacyDir, "settings.json")).Should().BeFalse();
+
+        loaded.ShowPreSplitMigrationHint = false;
+        store.Save("Arthur", "Kwatoxi", loaded);
+
+        var reloaded = store.Load("Arthur", "Kwatoxi");
+        reloaded.ShowPreSplitMigrationHint.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

PR #685 (Saruman codebook split, #603) intentionally dropped pre-#603 spent-flag state during the schema 1→2 upgrade — both manually-marked overrides and chat-detected burns prior to the latest in-game chat banner. The data loss was documented in `SarumanState.Migrate` and matched the spec, but had **no UX surface**: affected users silently lost their "I've already used this Word" markings with no in-app explanation or recovery hint.

This adds the one-time, dismissable banner the design notebook flagged as the follow-up.

### Detection

Stamps a new `SarumanState.ShowPreSplitMigrationHint` flag (default `false`) in **both** migration paths:

- `SarumanState.Migrate` — the schema 1→2 in-place upgrade.
- `SarumanLegacyMigration.TryMigrate` — the pre-per-character flat-file import. This path bypasses `Migrate` because `PerCharacterStore` forces `SchemaVersion = CurrentVersion` after the import, so the flag has to be set at the legacy-migration layer too.

Fresh installs never run either path, so the flag stays at its default `false` and they never see the hint.

### UX

`SarumanView.xaml` renders a dismissable banner above the existing header when the flag is set, recommending the right-click → **"Mark as spent (offline burn)"** path for older offline burns (the recovery affordance #603 already shipped as the observability-gap escape hatch). Dismiss persists per-character via `SarumanOverrideService.DismissMigrationHint` and piggybacks on the existing `OverridesChanged` event for VM refresh — no new event surface.

### Trade-off

Users who **already migrated** under a Mithril build that predates this change will not see the hint, because their `saruman.json` is already at v2 with the flag absent (deserialized as the new field's default `false`). The only retroactive heuristic — "user has discovered codes but zero `SpentOverrides`" — overlaps with the legitimate fresh-install steady state and would mis-trigger the banner for users who genuinely have nothing to recover. The going-forward catch is the right scope for a one-time UX nudge; the recovery affordance itself (right-click → Mark as spent) was already shipped in #685.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors). XamlResourceLint passes (121 keys; the banner uses only existing `BoolToVis`, `SetRefBorderBrush`, `TextPrimaryBrush`, `AppFontSize`).
- [x] `dotnet test tests/Saruman.Tests/Saruman.Tests.csproj` — clean (11 passed, 0 failed; 5 existing override-service tests + 6 new).
- [x] `dotnet test tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` — clean (1250 passed, regression net for the underlying `IVersionedState<T>` + `PerCharacterStore` machinery the hint hooks into).
- [x] New `SarumanStateMigrationTests`:
  - `Migrate_from_v1_sets_ShowPreSplitMigrationHint`
  - `Fresh_state_does_not_show_migration_hint`
  - `PerCharacterStore_v1_file_on_disk_surfaces_hint_then_dismiss_persists` — end-to-end live-upgrade round-trip (v1 on disk → load runs Migrate → flag set → dismiss + save → reload → flag stays false because `Migrate` doesn't re-run for current-version files).
  - `Legacy_migration_surfaces_hint_when_pre603_flat_file_is_imported`
  - `PerCharacterStore_with_legacy_fallback_round_trips_hint_dismissal`
- [x] New `SarumanOverrideServiceTests.DismissMigrationHint_clears_flag_persists_and_fires_event` — pins the service contract (flag visible after Migrate, dismiss is idempotent, OverridesChanged fires once, persists across service reload).

## WPF gotchas considered

Banner XAML is a `Border` + `DockPanel` + plain `TextBlock` + `Button` — no `<Run>` two-way trap, no `ContentControl.ContentTemplate` null leak, no `NullOrEmptyToVisibilityConverter` mistype (boolean-to-Visibility uses the project's `BoolToVis`). `IsHitTestVisible` isn't constrained (banner sits in the same DockPanel as the header — no layered-window or opacity-0 hit-testing concern).

Closes #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)