### PR TITLE
refactor(gandalf): brush resource keys + two-row shift layout in settings view (#761)

### DIFF
--- a/src/Gandalf.Module/Views/GandalfSettingsView.xaml
+++ b/src/Gandalf.Module/Views/GandalfSettingsView.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="Gandalf.Views.GandalfSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             Background="#FF1A1A1A">
+             Background="{DynamicResource BgPrimaryBrush}">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="24,16" MaxWidth="720" HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
@@ -9,18 +9,18 @@
                        Width="28" Height="28" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBlock Text="Gandalf · Timers Settings"
                            FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeHero}" FontWeight="SemiBold"
-                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                           Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
             </StackPanel>
 
             <!-- Alarm settings -->
-            <TextBlock Text="Alarms" Foreground="#88FFFFFF" Margin="0,0,0,6" FontWeight="SemiBold"/>
-            <CheckBox Content="Enabled" IsChecked="{Binding Settings.AlarmEnabled}" Foreground="#FFE8E8E8" Margin="0,0,0,4"/>
+            <TextBlock Text="Alarms" Foreground="{DynamicResource TextTertiaryBrush}" Margin="0,0,0,6" FontWeight="SemiBold"/>
+            <CheckBox Content="Enabled" IsChecked="{Binding Settings.AlarmEnabled}" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,4"/>
             <CheckBox Content="Flash the Mithril window when a timer completes" IsChecked="{Binding Settings.FlashWindow}"
-                      Foreground="#FFE8E8E8" Margin="0,0,0,4"/>
+                      Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,4"/>
 
             <DockPanel Margin="0,8,0,0" LastChildFill="True">
-                <TextBlock Text="Volume" VerticalAlignment="Center" Foreground="#FFE8E8E8" Width="110"/>
-                <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" Foreground="#88FFFFFF" Width="50"
+                <TextBlock Text="Volume" VerticalAlignment="Center" Foreground="{DynamicResource TextPrimaryBrush}" Width="110"/>
+                <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" Foreground="{DynamicResource TextTertiaryBrush}" Width="50"
                            Text="{Binding Settings.AlarmVolume, StringFormat={}{0:P0}}"/>
                 <Slider Minimum="0" Maximum="2" SmallChange="0.05" LargeChange="0.1" TickFrequency="0.1"
                         IsSnapToTickEnabled="False" VerticalAlignment="Center" Margin="8,0"
@@ -28,14 +28,14 @@
             </DockPanel>
 
             <DockPanel Margin="0,8,0,0" LastChildFill="False">
-                <TextBlock Text="Snooze duration" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
+                <TextBlock Text="Snooze duration" VerticalAlignment="Center" Foreground="{DynamicResource TextPrimaryBrush}"/>
                 <TextBox Width="70" Margin="8,0" Padding="6,4"
                          Text="{Binding Settings.SnoozeMinutes, UpdateSourceTrigger=LostFocus, StringFormat=F1}"/>
-                <TextBlock Text="minutes" VerticalAlignment="Center" Foreground="#88FFFFFF"/>
+                <TextBlock Text="minutes" VerticalAlignment="Center" Foreground="{DynamicResource TextTertiaryBrush}"/>
             </DockPanel>
 
             <!-- Sound file -->
-            <TextBlock Text="Alarm sound" Foreground="#88FFFFFF" Margin="0,16,0,6" FontWeight="SemiBold"/>
+            <TextBlock Text="Alarm sound" Foreground="{DynamicResource TextTertiaryBrush}" Margin="0,16,0,6" FontWeight="SemiBold"/>
             <DockPanel Margin="0,0,0,4" LastChildFill="True">
                 <Button DockPanel.Dock="Right" Content="Browse..." Padding="10,4" Margin="6,0,0,0"
                         Click="BrowseSound_Click"/>
@@ -47,54 +47,55 @@
             </DockPanel>
 
             <!-- Time-of-day shift alarms -->
-            <TextBlock Text="Time-of-day alarms" Foreground="#88FFFFFF" Margin="0,24,0,4" FontWeight="SemiBold"/>
-            <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8">
+            <TextBlock Text="Time-of-day alarms" Foreground="{DynamicResource TextTertiaryBrush}" Margin="0,24,0,4" FontWeight="SemiBold"/>
+            <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8">
                 Project Gorgon's in-game day has six named periods. Enable a shift to ring an alarm when
                 it begins (every ~2 real hours per shift). Picking a sound here overrides the global
                 default for that shift only; leave it blank to inherit the global default above.
             </TextBlock>
             <CheckBox Content="Ring on current shift at startup"
                       IsChecked="{Binding ShiftSettings.RingOnCurrentShiftAtStartup}"
-                      Foreground="#FFE8E8E8" Margin="0,0,0,8"
+                      Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"
                       ToolTip="When Mithril starts and you're already in an enabled shift, ring the alarm immediately. Off by default — matches pre-#709 behaviour of only ringing on the next shift change."/>
             <ItemsControl ItemsSource="{Binding ShiftRows}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <DockPanel Margin="0,0,0,4" LastChildFill="True">
-                            <CheckBox DockPanel.Dock="Left" Width="180"
-                                      IsChecked="{Binding Config.Enabled}"
+                        <StackPanel Margin="0,0,0,8">
+                            <CheckBox IsChecked="{Binding Config.Enabled}"
                                       Content="{Binding Display}"
-                                      Foreground="#FFE8E8E8" VerticalAlignment="Center"/>
-                            <Button DockPanel.Dock="Right" Content="Browse..." Padding="10,4" Margin="6,0,0,0"
-                                    Click="BrowseShift_Click"/>
-                            <Button DockPanel.Dock="Right" Content="Test" Padding="10,4" Margin="6,0,0,0"
-                                    Click="TestShift_Click"/>
-                            <Button DockPanel.Dock="Right" Content="Clear" Padding="8,4" Margin="6,0,0,0"
-                                    Click="ClearShift_Click" ToolTip="Reset to global default sound"/>
-                            <TextBox Text="{Binding Config.SoundFilePath, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"
-                                     Padding="6,4"
-                                     IsEnabled="{Binding Config.Enabled}"/>
-                        </DockPanel>
+                                      Foreground="{DynamicResource TextPrimaryBrush}"/>
+                            <DockPanel Margin="24,4,0,0" LastChildFill="True">
+                                <Button DockPanel.Dock="Right" Content="Browse..." Padding="10,4" Margin="6,0,0,0"
+                                        Click="BrowseShift_Click"/>
+                                <Button DockPanel.Dock="Right" Content="Test" Padding="10,4" Margin="6,0,0,0"
+                                        Click="TestShift_Click"/>
+                                <Button DockPanel.Dock="Right" Content="Clear" Padding="8,4" Margin="6,0,0,0"
+                                        Click="ClearShift_Click" ToolTip="Reset to global default sound"/>
+                                <TextBox Text="{Binding Config.SoundFilePath, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"
+                                         Padding="6,4"
+                                         IsEnabled="{Binding Config.Enabled}"/>
+                            </DockPanel>
+                        </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
             <!-- Danger zone -->
-            <Border Margin="0,24,0,0" Padding="0,12,0,0" BorderBrush="#33FFFFFF" BorderThickness="0,1,0,0">
+            <Border Margin="0,24,0,0" Padding="0,12,0,0" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,1,0,0">
                 <StackPanel>
                     <TextBlock Text="Danger zone" Foreground="#FFCC6666" Margin="0,0,0,6" FontWeight="SemiBold"/>
-                    <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8">
+                    <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8">
                         Deletes every timer definition (shared across all characters) and clears every
                         character's progress. There's no undo.
                     </TextBlock>
                     <Button HorizontalAlignment="Left" Padding="12,5" Command="{Binding DeleteAllCommand}"
-                            Background="#FF3B1F1F" Foreground="#FFE8E8E8" BorderBrush="#FF8B3A3A">
+                            Background="#FF3B1F1F" Foreground="{DynamicResource TextPrimaryBrush}" BorderBrush="#FF8B3A3A">
                         <TextBlock Text="Delete All Timers"/>
                     </Button>
                 </StackPanel>
             </Border>
 
-            <TextBlock Margin="0,24,0,0" TextWrapping="Wrap" Foreground="#66FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+            <TextBlock Margin="0,24,0,0" TextWrapping="Wrap" Foreground="{DynamicResource TextQuaternaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
                 Settings are saved automatically to %LOCALAPPDATA%\Mithril\Gandalf\settings.json.
                 Timer definitions persist to %LOCALAPPDATA%\Mithril\Gandalf\definitions.json; per-character
                 progress lives under %LOCALAPPDATA%\Mithril\characters\{character}_{server}\gandalf.json.


### PR DESCRIPTION
## Summary

Closes #761. The issue asked for a one-line fix (a single Foreground swap), but on audit the file's actual problem was the opposite: every Foreground in GandalfSettingsView.xaml was hardcoded hex, and changing only the new checkbox would have made *it* the odd one out. So this PR converts the whole file to the central palette.

While doing that, a layout issue surfaced (visible in the screenshot on the issue thread): shift labels like "Midnight (12:00 AM in-game start)" were truncating at "12:00 AM in-g…" because the checkbox column was fixed at 180px. Bundled the fix in.

### Brush keys (cosmetic refactor — bit-identical colors)

- `#FF1A1A1A` → `BgPrimaryBrush`
- `#FFE8E8E8` → `TextPrimaryBrush` (7 occurrences, including the new RingOnCurrentShiftAtStartup checkbox added in #759)
- `#88FFFFFF` → `TextTertiaryBrush` (7 occurrences)
- `#FFD4A847` → `AccentBrush` (header gold)
- `#33FFFFFF` → `BorderSubtleBrush` (danger-zone divider)
- `#66FFFFFF` → `TextQuaternaryBrush` (footer hint)

Left hardcoded: `#FFCC6666` (danger-label red), `#FF3B1F1F`/`#FF8B3A3A` (delete-button bg/border) — no semantic resource keys exist for these yet, and they're hardcoded the same way across Smaug/Arwen/Samwise.

### Shift-row layout

Previously each shift was a single DockPanel: `[checkbox+label width=180][textbox fills][Clear][Test][Browse]`. The 180px column truncated longer labels. Restructured to two rows per shift:

```
[☑] Midnight  (12:00 AM in-game start)
    C:\Users\…\Summon Darkness.flac        [Clear][Test][Browse]
```

The second row is indented 24px to visually group it with its parent checkbox.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `XamlResourceLint` — OK (121 keys validated, all DynamicResource references resolve)
- [x] Shell reaches `Application started` (headless harness launch)
- [ ] Visual check of Gandalf settings tab in the new layout — owed to the reviewer (PR author already eyeballed the pre-layout state and asked for the second-row change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
