### PR TITLE
docs(world-sim): reflect #601 closure across the doc set (#763)

### DIFF
--- a/docs/world-sim-driver-playbook.md
+++ b/docs/world-sim-driver-playbook.md
@@ -2,6 +2,8 @@
 
 # World-sim driver playbook (v4)
 
+> **Status (2026-05-23):** umbrella [#601](https://github.com/moumantai-gg/mithril/issues/601) closed; the migration drained the orchestrator's queue. This playbook remains operational for any future world-sim work tracked under [#700](https://github.com/moumantai-gg/mithril/issues/700) — notably the release-cycle-gated [#732](https://github.com/moumantai-gg/mithril/issues/732) and any opportunistic `IPlayer*` rename work. The cheap-probe short-circuit in the slash command body keeps the cost of idle ticks negligible.
+
 This is the playbook **you (top-level Claude at depth 0)** follow when `/world-sim-orchestrate-tick` finds work and reads you. You are the driver. You read GitHub state, pick the next ready issue (if any), deliver it from initial implementation through merge, file follow-ons, and call `ScheduleWakeup` for the next tick.
 
 **You are NOT a subagent.** v4 collapsed the driver into top-level Claude itself (depth 0, where `Agent` works). Earlier versions wrapped this work in a subagent at depth 1 where `Agent` doesn't work. Design rationale lives in [`world-sim-shepherd.md`](world-sim-shepherd.md) (the design notebook, kept under the historical filename) and `scratch/desktop-harness-probe.md`. This playbook is operational only.

--- a/docs/world-sim-migration-audit.md
+++ b/docs/world-sim-migration-audit.md
@@ -2,6 +2,8 @@
 
 > **Vocabulary:** see [`docs/glossary.md`](glossary.md) for definitions of the world-sim terminology used in this doc.
 
+> **Migration closed 2026-05-23 ([#601](https://github.com/moumantai-gg/mithril/issues/601)).** This audit remains as a historical snapshot of pre-migration component state. The live architecture is documented in [`world-simulator.md`](world-simulator.md); per-row updates over the migration's lifetime kept the Inventory / Samwise / Arwen / Palantir rows current, but other rows remain in pre-Phase-2 tense. Full audit refresh (or supersede-with-fresh-audit) is deferred to [#700](https://github.com/moumantai-gg/mithril/issues/700)'s checklist.
+
 Audit date: 2026-05-21
 Audited against: [`docs/world-simulator.md`](world-simulator.md) and
 [`docs/module-signal-map.md`](module-signal-map.md) at commit `51e39f0` (branch

--- a/docs/world-sim-shepherd.md
+++ b/docs/world-sim-shepherd.md
@@ -2,6 +2,8 @@
 
 > **Vocabulary:** see [`docs/glossary.md`](glossary.md) for definitions of the world-sim terminology used in this doc.
 
+> **Status (2026-05-23):** umbrella [#601](https://github.com/moumantai-gg/mithril/issues/601) closed; the v4 driver delivered the migration to completion. This design notebook remains as the rationale for the v1→v4 evolution and the operational pattern; the driver itself (per the [playbook](world-sim-driver-playbook.md)) remains available for [#700](https://github.com/moumantai-gg/mithril/issues/700) residuals.
+
 A single agent at /loop depth that drives the world-sim migration umbrella (#601) end-to-end. Per tick: pick the next ready issue from the dep graph, dispatch a worker + reviewers as named teammates via Teams + SendMessage, iterate the review-fix loop, merge the PR itself, file follow-ons, and schedule the next tick. Returns a structured verdict via JSON each tick (delivery outcome or `idle` / `no-action` / `circuit-breaker`).
 
 **Pairs with:**

--- a/docs/world-simulator-orchestration-plan.md
+++ b/docs/world-simulator-orchestration-plan.md
@@ -6,7 +6,7 @@ Machine-actionable scheduling plan for the world-simulator migration. Pairs with
 
 **Audience:** an orchestrator (Claude Code subagent harness, or external system) scheduling worker agents to land migration items hands-free.
 
-**Status:** ready for orchestration use. Update this file when a phase completes or a task's metadata changes (estimate revisions, agent reassignment, etc.).
+**Status:** orchestrator queue drained 2026-05-23; umbrella [#601](https://github.com/moumantai-gg/mithril/issues/601) closed. This plan remains a reference for any future tick-style work — notably the Phase 5 residuals tracked under [#700](https://github.com/moumantai-gg/mithril/issues/700) (release-cycle-gated [#732](https://github.com/moumantai-gg/mithril/issues/732), opportunistic `IPlayer*` renames). The dependency graph + verification gates below stay accurate as patterns; the phase-by-phase scheduling is historical.
 
 ---
 

--- a/docs/world-simulator.md
+++ b/docs/world-simulator.md
@@ -4,7 +4,7 @@ Design rationale for the three-layer world-simulator architecture: source stream
 
 > **Vocabulary:** see [`docs/glossary.md`](glossary.md) for definitions of the world-sim terminology used in this doc.
 
-**Status:** design notebook, not implementation spec. Captures the architectural commitments, contracts, and migration plan. Concrete contracts may iterate as implementation surfaces issues; principles are load-bearing.
+**Status:** reference doc; migration delivered 2026-05-23 (umbrella [#601](https://github.com/moumantai-gg/mithril/issues/601) closed). Captures the architectural commitments, contracts, and the migration plan that landed. Principles are load-bearing — every new world-sim consumer adheres to them. The migration-path section below records what shipped, not what's owed; for residual long-tail work see [#700](https://github.com/moumantai-gg/mithril/issues/700) (Phase 5 consolidation umbrella).
 
 **Companion docs:**
 - [`module-signal-map.md`](module-signal-map.md) — the topology this design feeds against (read first).
@@ -647,9 +647,9 @@ Player.log + chat don't see vault contents (the player isn't observing them in-b
 
 ---
 
-## Migration path (concrete to-do)
+## Migration path (delivered)
 
-After this design lands, the following changes are needed:
+All 13 items below shipped as part of the world-sim architecture migration; umbrella [#601](https://github.com/moumantai-gg/mithril/issues/601) closed 2026-05-23. Per-item PR references live in the closure-ceremony comment on #601. This section remains as a record of the migration's scope and decisions; for residual long-tail work see [#700](https://github.com/moumantai-gg/mithril/issues/700).
 
 ### Splits (services that span both sources)
 


### PR DESCRIPTION
## Summary

Five spot updates across the world-sim doc set so future readers don't mistake the migration work for in-progress. With umbrella #601 closed 2026-05-23, the doc-level status framing needed to catch up:

- `world-simulator.md` line 7 status: design-notebook → reference-doc; pointer to #700 for residuals.
- `world-simulator.md` §"Migration path" retitled to "(delivered)" with a closure note.
- `world-sim-migration-audit.md` top: explicit "Migration closed 2026-05-23 (#601)" marker; clarifies historical-snapshot role.
- `world-simulator-orchestration-plan.md` status: "orchestrator queue drained"; remains a reference for future tick-style work.
- `world-sim-driver-playbook.md` + `world-sim-shepherd.md`: small status notes that the umbrella closed but the tooling remains operational for #700 residuals (#732, opportunistic `IPlayer*` renames).

No substantive content changes. The architectural commitments, contracts, and principles in `world-simulator.md` remain canonical; only the framing updates.

## Test plan

- [x] Docs-only diff — no build/test gates relevant.
- [x] Spot-read the modified sections to confirm the rewrites preserve all load-bearing content (principles, contracts, decisions ratified post-#642) and only update status framing.

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)