### PR TITLE
feat(logging): opt-in toggle for per-line PlayerLog/ChatLog diagnostics mirror (#507)

### DIFF
--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -54,7 +54,23 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddMithrilGameServices(this IServiceCollection services) =>
+    /// <summary>
+    /// Register the core game-services graph (clocks, shift catalog, log
+    /// streams, character snapshots).
+    ///
+    /// <para><paramref name="mirrorRawLogLinesAccessor"/> is a late-bound read
+    /// of an infra diagnostic setting (typically
+    /// <c>ShellSettings.MirrorRawLogLinesToDiagnostics</c>) that gates the
+    /// per-line <c>_diag?.Trace</c> call inside
+    /// <see cref="PlayerLogStream"/> / <see cref="ChatLogStream"/>. When the
+    /// accessor is <c>null</c> or returns <c>false</c> (the default), the
+    /// DiagnosticsSink fanout + Serilog Verbose write per raw line is
+    /// skipped entirely — closing #507's hot-path cost. Flip the setting
+    /// and subsequent emissions reflect the new state (no restart).</para>
+    /// </summary>
+    public static IServiceCollection AddMithrilGameServices(
+        this IServiceCollection services,
+        Func<IServiceProvider, Func<bool>>? mirrorRawLogLinesAccessor = null) =>
         services
             .AddSingleton<IGameClock, GameClock>()
             // Shift catalog is bundled JSON with a hardcoded fallback —
@@ -70,8 +86,18 @@ public static class ServiceCollectionExtensions
             // to the anchor — see SessionAnchor.cs).
             .AddSingleton<SessionAnchor>()
             .AddSingleton<ISessionAnchor>(sp => sp.GetRequiredService<SessionAnchor>())
-            .AddSingleton<IPlayerLogStream, PlayerLogStream>()
-            .AddSingleton<IChatLogStream, ChatLogStream>()
+            .AddSingleton<IPlayerLogStream>(sp => new PlayerLogStream(
+                sp.GetRequiredService<Game.GameConfig>(),
+                sp.GetService<IDiagnosticsSink>(),
+                time: null,
+                sessionAnchor: sp.GetService<ISessionAnchor>(),
+                mirrorAccessor: mirrorRawLogLinesAccessor?.Invoke(sp)))
+            .AddSingleton<IChatLogStream>(sp => new ChatLogStream(
+                sp.GetRequiredService<Game.GameConfig>(),
+                sp.GetService<IDiagnosticsSink>(),
+                time: null,
+                sessionAnchor: sp.GetService<ISessionAnchor>(),
+                mirrorAccessor: mirrorRawLogLinesAccessor?.Invoke(sp)))
             // Foundation service (#612) — owns the FileSystemWatcher on
             // Reports/, parses storage exports + character snapshots,
             // exposes per-(server, character) scope query. ActiveCharacterService

--- a/src/Mithril.Shared/Logging/ChatLogStream.cs
+++ b/src/Mithril.Shared/Logging/ChatLogStream.cs
@@ -19,6 +19,9 @@ public sealed class ChatLogStream : IChatLogStream, IDisposable
     private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
     private readonly ISessionAnchor? _sessionAnchor;
+    // Per-line diagnostics-mirror gate — twin of PlayerLogStream._mirrorAccessor.
+    // See its comment for the #507 rationale.
+    private readonly Func<bool>? _mirrorAccessor;
     private readonly object _gate = new();
     private readonly List<Channel<RawLogLine>> _subs = new();
     private CancellationTokenSource? _runCts;
@@ -28,12 +31,14 @@ public sealed class ChatLogStream : IChatLogStream, IDisposable
         GameConfig config,
         IDiagnosticsSink? diag = null,
         TimeProvider? time = null,
-        ISessionAnchor? sessionAnchor = null)
+        ISessionAnchor? sessionAnchor = null,
+        Func<bool>? mirrorAccessor = null)
     {
         _config = config;
         _diag = diag;
         _time = time ?? TimeProvider.System;
         _sessionAnchor = sessionAnchor;
+        _mirrorAccessor = mirrorAccessor;
         _config.PropertyChanged += OnConfigChanged;
     }
 
@@ -142,9 +147,10 @@ public sealed class ChatLogStream : IChatLogStream, IDisposable
         if (lines.Count == 0) return;
         Channel<RawLogLine>[] snapshot;
         lock (_gate) { snapshot = _subs.ToArray(); }
+        var mirror = _mirrorAccessor?.Invoke() ?? false;
         foreach (var line in lines)
         {
-            _diag?.Trace("ChatLog", line.Line);
+            if (mirror) _diag?.Trace("ChatLog", line.Line);
             foreach (var ch in snapshot) ch.Writer.TryWrite(line);
         }
     }

--- a/src/Mithril.Shared/Logging/PlayerLogStream.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogStream.cs
@@ -21,6 +21,14 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
     private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
     private readonly ISessionAnchor? _sessionAnchor;
+    // Per-line diagnostics-mirror gate. When the accessor is null OR returns
+    // false, the per-line _diag?.Trace call in Publish is skipped entirely
+    // — no DiagnosticsSink fanout, no Serilog Verbose write. Default OFF
+    // closes #507's hot-path cost; the shell wires the accessor to
+    // ShellSettings.MirrorRawLogLinesToDiagnostics so users can flip it on
+    // when actively debugging. Sampled per-line (cheap delegate invocation)
+    // so flipping the setting takes effect forward without a restart.
+    private readonly Func<bool>? _mirrorAccessor;
     private readonly object _gate = new();
     private readonly List<Channel<RawLogLine>> _subs = new();
     // Accumulated lines from session start to "now". Null until RunAsync has
@@ -41,12 +49,14 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
         GameConfig config,
         IDiagnosticsSink? diag = null,
         TimeProvider? time = null,
-        ISessionAnchor? sessionAnchor = null)
+        ISessionAnchor? sessionAnchor = null,
+        Func<bool>? mirrorAccessor = null)
     {
         _config = config;
         _diag = diag;
         _time = time ?? TimeProvider.System;
         _sessionAnchor = sessionAnchor;
+        _mirrorAccessor = mirrorAccessor;
         _config.PropertyChanged += OnConfigChanged;
     }
 
@@ -209,9 +219,10 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
             if (_sessionReplay is not null && lines.Count > 0) _sessionReplay.AddRange(lines);
             snapshot = _subs.ToArray();
         }
+        var mirror = _mirrorAccessor?.Invoke() ?? false;
         foreach (var line in lines)
         {
-            _diag?.Trace("PlayerLog", line.Line);
+            if (mirror) _diag?.Trace("PlayerLog", line.Line);
             foreach (var ch in snapshot) ch.Writer.TryWrite(line);
         }
     }

--- a/src/Mithril.Shared/Logging/PlayerLogStream.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogStream.cs
@@ -21,13 +21,17 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
     private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
     private readonly ISessionAnchor? _sessionAnchor;
-    // Per-line diagnostics-mirror gate. When the accessor is null OR returns
-    // false, the per-line _diag?.Trace call in Publish is skipped entirely
-    // — no DiagnosticsSink fanout, no Serilog Verbose write. Default OFF
-    // closes #507's hot-path cost; the shell wires the accessor to
+    // Diagnostics-mirror gate. When the accessor is null OR returns false,
+    // the per-line _diag?.Trace call in Publish is skipped entirely — no
+    // DiagnosticsSink fanout, no Serilog Verbose write. Default OFF closes
+    // #507's hot-path cost; the shell wires the accessor to
     // ShellSettings.MirrorRawLogLinesToDiagnostics so users can flip it on
-    // when actively debugging. Sampled per-line (cheap delegate invocation)
-    // so flipping the setting takes effect forward without a restart.
+    // when actively debugging. Sampled ONCE per Publish batch (not per
+    // line) — every line in a given batch sees the same value. Flipping
+    // the setting therefore takes effect on the next batch (one poll-tick
+    // boundary, sub-second under default PollIntervalSeconds), not the
+    // next line — a deliberate choice for consistent batch semantics and
+    // to keep the hot path one branch-on-a-cached-bool per line.
     private readonly Func<bool>? _mirrorAccessor;
     private readonly object _gate = new();
     private readonly List<Channel<RawLogLine>> _subs = new();

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -71,7 +71,7 @@ public static class ShellComposition
             .AddSingleton(o.GameConfig)
             .AddMithrilDiagnostics(o.LogDir)
             .AddMithrilPerfTrace(o.PerfDir, sp => () => sp.GetRequiredService<ShellSettings>().VerboseFrameEvents)
-            .AddMithrilGameServices()
+            .AddMithrilGameServices(sp => () => sp.GetRequiredService<ShellSettings>().MirrorRawLogLinesToDiagnostics)
             .AddMithrilLogActorPipeline(sp => () => sp.GetRequiredService<ShellSettings>().CaptureRawPlayerLogLines)
             // L1 driver — consumed by archetype-A GameState producers (#550 PR 2)
             // and the archetype-B consumer fleet (#550 PR 3..N). Registered

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -52,7 +52,8 @@ public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPers
     /// default — no per-line string allocation. Use when diagnosing an
     /// L2 / L3 parse or interpretation failure where the original line is
     /// useful at the failing datum. Flip takes effect forward (no restart).
-    /// Infra-level diagnostic; sibling to <see cref="VerboseFrameEvents"/>.</summary>
+    /// Infra-level diagnostic; sibling to <see cref="VerboseFrameEvents"/>
+    /// and <see cref="MirrorRawLogLinesToDiagnostics"/>.</summary>
     private bool _captureRawPlayerLogLines;
     public bool CaptureRawPlayerLogLines { get => _captureRawPlayerLogLines; set => Set(ref _captureRawPlayerLogLines, value); }
 

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -56,6 +56,20 @@ public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPers
     private bool _captureRawPlayerLogLines;
     public bool CaptureRawPlayerLogLines { get => _captureRawPlayerLogLines; set => Set(ref _captureRawPlayerLogLines, value); }
 
+    /// <summary>When true, every Player.log and ChatLog tail line is mirrored
+    /// into the Mithril diagnostics sink (the in-memory ring buffer powering
+    /// the live Diagnostics view + the rolling <c>mithril-*.json</c> Serilog
+    /// file at Verbose). Default OFF — when off, the per-line
+    /// <see cref="Mithril.Shared.Diagnostics.IDiagnosticsSink.Trace"/> fanout
+    /// + Serilog Verbose write disappear from the L0 poll thread, closing
+    /// #507's hot-path cost (DiagnosticsSink <c>EntryAdded</c> fanout + per-line
+    /// unbuffered disk write under bursts). Turn on only when actively
+    /// diagnosing Mithril behavior or running ad-hoc <c>mithril-logs</c> MCP
+    /// analytics; flip takes effect forward (no restart). Infra-level
+    /// diagnostic; sibling to <see cref="CaptureRawPlayerLogLines"/>.</summary>
+    private bool _mirrorRawLogLinesToDiagnostics;
+    public bool MirrorRawLogLinesToDiagnostics { get => _mirrorRawLogLinesToDiagnostics; set => Set(ref _mirrorRawLogLinesToDiagnostics, value); }
+
     private string _uiFontFamily = "Segoe UI";
     public string UiFontFamily { get => _uiFontFamily; set => Set(ref _uiFontFamily, value); }
 

--- a/src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml
+++ b/src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml
@@ -49,6 +49,22 @@
                        FontSize="{DynamicResource AppFontSizeHint}" Margin="0,8,0,4"
                        Text="Bind a hotkey to 'Toggle perf-trace recording' under Hotkeys settings to start/stop a session on demand. The status bar shows a red REC dot while a session is active."/>
 
+            <!-- Log capture (#507) — off by default; both toggles cost nothing
+                 unless explicitly enabled for debugging. -->
+            <TextBlock Text="Log capture" Foreground="#88FFFFFF" Margin="0,24,0,4" FontWeight="SemiBold"/>
+            <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF"
+                       FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8"
+                       Text="Off by default. Turn these on only when actively diagnosing Mithril or capturing data for a bug report — they add per-line cost to the log tail and grow mithril-*.json files quickly under busy PG sessions."/>
+
+            <CheckBox Content="Mirror Player.log and ChatLog lines into Mithril diagnostics"
+                      IsChecked="{Binding Settings.MirrorRawLogLinesToDiagnostics, Mode=TwoWay}"
+                      Foreground="#FFE8E8E8" Margin="0,0,0,4"
+                      ToolTip="When on, every raw line from Player.log and ChatLog is mirrored into the in-app Diagnostics view AND the rolling mithril-*.json file at Verbose. Useful for correlating Mithril warnings with the exact source line and for ad-hoc mithril-logs MCP queries. Adds DiagnosticsSink fanout + unbuffered Verbose write per line on the log-tail poll thread (#507) — leave off in normal operation."/>
+            <CheckBox Content="Capture raw line on each L0.5-classified record (Raw field)"
+                      IsChecked="{Binding Settings.CaptureRawPlayerLogLines, Mode=TwoWay}"
+                      Foreground="#FFE8E8E8" Margin="0,0,0,16"
+                      ToolTip="When on, the L0.5 classifier fills the Raw field on every classified LocalPlayer/Combat/System line with the exact source text — useful for diagnosing a parse or interpretation failure where you want the original line co-located on the failing datum. When off, Raw is null and no per-line string allocation occurs. Independent of the diagnostics mirror above."/>
+
             <TextBlock Margin="0,24,0,0" TextWrapping="Wrap" Foreground="#66FFFFFF"
                        FontSize="{DynamicResource AppFontSizeHint}"
                        Text="Changes preview live. Settings persist on shutdown."/>


### PR DESCRIPTION
## Summary

Closes #507 by implementing fix B from the original body: gate the per-line `_diag?.Trace` mirror behind a default-off ShellSettings toggle, and expose it (alongside the existing-but-unsurfaced `CaptureRawPlayerLogLines`) in DiagnosticsSettingsView.

### What changes
- **`ShellSettings.MirrorRawLogLinesToDiagnostics`** (default `false`). When OFF, `PlayerLogStream` / `ChatLogStream` skip the `_diag?.Trace(category, line)` call entirely — no `DiagnosticsSink.EntryAdded` fanout, no Serilog Verbose write, no kernel call per line.
- **`AddMithrilGameServices(...)`** gains an optional `Func<IServiceProvider, Func<bool>>?` accessor mirroring the existing pattern in `AddMithrilLogActorPipeline`. Backwards-compatible: existing test call sites that pass no args still work.
- **`PlayerLogStream` / `ChatLogStream`** constructors accept a `Func<bool>? mirrorAccessor = null`. The accessor is **sampled once per `Publish` batch** (not per line) — every line in a given poll-tick's batch sees the same value, and flipping the setting takes effect on the next batch (sub-second under the default `PollIntervalSeconds`). Per-batch sampling is a deliberate choice: consistent batch semantics, plus the hot path is one branch-on-a-cached-bool per line rather than a delegate invocation per line.
- **`DiagnosticsSettingsView`** gets a new "Log capture" section with two checkboxes (the new `MirrorRawLogLinesToDiagnostics` + the existing `CaptureRawPlayerLogLines`), each with a tooltip explaining its cost and when to enable.

### Why a toggle, not "always off"
The per-line mirror is real value when **actively debugging** Mithril: Mithril-side correlation in `mithril-*.json`, `mithril-logs` MCP analytics, the normalized-view comparison against raw Player.log. It's zero value during everyday operation. Default-off + UI opt-in matches the same "lean default, explicit diagnostic" pattern used for `EnablePerfTrace`, `VerboseFrameEvents`, and `CaptureRawPlayerLogLines`.

### What this does NOT do
- Does not address `_sessionReplay`'s unbounded growth (the long-session memory factor in the original "Contributing factors" section) — file separately if needed.
- Does not add `WriteTo.Async` to Serilog. The setting-OFF default makes the sink moot for the hot path.
- Does not migrate `ActiveCharacterLogSynchronizer` off raw `IPlayerLogStream.SubscribeAsync` — single direct consumer, regex loop, separate follow-up if zero loose ends matter.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `XamlResourceLint` — OK (121 keys)
- [x] `PlayerLogStreamTests` + `Mithril.Shell.Tests` (DI-graph self-check) — green
- [x] Shell reaches `Application started` headlessly
- [ ] **Owed to reviewer:** open the Diagnostics settings tab, confirm the new "Log capture" section renders with both checkboxes + tooltips, flip each, confirm behavior:
  - `MirrorRawLogLinesToDiagnostics` ON → `mithril-*.json` shows `PlayerLog`/`ChatLog` Verbose entries; OFF → none.
  - `CaptureRawPlayerLogLines` ON → `LocalPlayerLogLine.Raw` populated on L0.5 records; OFF → null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
