### PR TITLE
docs(world-sim): cite actual shipping PRs in Arwen audit row

### DIFF
--- a/docs/world-sim-migration-audit.md
+++ b/docs/world-sim-migration-audit.md
@@ -265,9 +265,9 @@ migration after the union-shaped `Subscribe` shim was already gone in #659.
   remains, but as a same-source read against the view's composed map
   (sim-coherent under the Player.log dispatch order, with the cross-source
   composition encapsulated inside the view layer per principle 4).
-- **Cross-FSM TryResolve peek**: **eliminated in #608** via the Tier-2
-  `IGiftSignalService` lift (the architectural payoff #594 / #596 created
-  the signal service for). `FavorIngestionService` now subscribes to
+- **Cross-FSM TryResolve peek**: **eliminated via #688** (closes #608)
+  on top of the Tier-2 `IGiftSignalService` lift shipped in #598 (the
+  architectural payoff #594 / #596 created the signal service for). `FavorIngestionService` now subscribes to
   `IGiftSignalService.Subscribe` for resolved gift events;
   `GiftSignalService` owns a single L1 subscription with its own
   `ProcessAddItem`-fed `instanceId → InternalName` map, correlates the
@@ -291,9 +291,10 @@ migration after the union-shaped `Subscribe` shim was already gone in #659.
   `CalibrationService` from the legacy Query-only `IInventoryService`
   injection to `IInventoryView` directly, letting the now-redundant
   `IInventoryService` interface retire.
-- **Status**: **resolved post-#608** — cross-FSM peek replaced by
-  consumption of the Tier-2 signal service that owns the verb-triple
-  correlation on a single L1 pump.
+- **Status**: **resolved via #688** (closes #608) — cross-FSM peek
+  replaced by consumption of the Tier-2 signal service (`IGiftSignalService`,
+  shipped via #598) that owns the verb-triple correlation on a single L1
+  pump.
 
 ### Saruman (Words of Power) — **SPLIT DELIVERED ([#603](https://github.com/moumantai-gg/mithril/issues/603))**
 
@@ -514,7 +515,7 @@ character-switch is a UI binding swap not a state mutation. The log-derived
 `HandleJournalLoaded` Abandoned synthesis at `:178-209` is unrelated and
 **stays** (real inference from `ProcessLoadQuests`).
 
-### 7. Arwen's `_inventory.TryResolve` peek — **RESOLVED in #608**
+### 7. Arwen's `_inventory.TryResolve` peek — **RESOLVED via #688 (closes #608)**
 
 `TryResolve` no longer called on the gift-detection path.
 `FavorIngestionService` subscribes to `IGiftSignalService.Subscribe` for


### PR DESCRIPTION
## Summary

- Audit doc Arwen row cited "#608" three times as the resolution for the TryResolve peek elimination, but #608 is the *issue*, not a PR — PR #608 doesn't exist; clicking the cite redirects to issue #608 rather than the actual shipping PR.
- Updated the three citations to read "#688 (closes #608)" and to cite #598 for the service-side lift, matching the actual git history (`af6d252 feat(gamestate): IGiftSignalService (#598)` + the #688 Arwen-side resolution that closed #608).

## Test plan

- [x] No code changes — docs-only PR.
- [x] Audit doc still renders / no markdown breakage.

Discovered during the [#766](https://github.com/moumantai-gg/mithril/issues/766) recognition-lift umbrella audit — the spawn-task verifying #599's ship status flagged the misleading citation while checking the related Arwen migration.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
