### PR TITLE
feat(legolas): in-overlay toggle to hide/show the nudge pad (#520)

### DIFF
--- a/src/Legolas.Module/Controls/ClickThrough.cs
+++ b/src/Legolas.Module/Controls/ClickThrough.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
@@ -10,6 +11,8 @@ internal static class ClickThrough
     private const int GWL_EXSTYLE = -20;
     private const int WS_EX_TRANSPARENT = 0x00000020;
     private const int WS_EX_LAYERED = 0x00080000;
+    private const int WM_NCHITTEST = 0x0084;
+    private const int HTTRANSPARENT = -1;
 
     private static readonly IntPtr HWND_TOPMOST = new(-1);
     private const uint SWP_NOMOVE = 0x0002;
@@ -28,16 +31,116 @@ internal static class ClickThrough
     private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter,
         int X, int Y, int cx, int cy, uint uFlags);
 
-    public static void Apply(Window window, bool clickThrough)
+    public static void Apply(Window window, bool clickThrough) =>
+        Apply(window, clickThrough, interactiveRegion: null);
+
+    /// <summary>
+    /// Apply click-through to <paramref name="window"/>, optionally carving out
+    /// an <paramref name="interactiveRegion"/> that stays clickable while the
+    /// rest of the window passes clicks to whatever sits behind it.
+    ///
+    /// <para>Two modes:</para>
+    /// <list type="bullet">
+    /// <item><b>Full-window click-through</b> (<paramref name="interactiveRegion"/>
+    /// null): toggles the legacy <c>WS_EX_TRANSPARENT</c> flag — every pixel
+    /// passes clicks through. The inventory overlay relies on this.</item>
+    /// <item><b>Partial click-through</b> (region supplied): leaves
+    /// <c>WS_EX_TRANSPARENT</c> off and installs a <c>WM_NCHITTEST</c> hook
+    /// that returns <c>HTTRANSPARENT</c> for points outside the region's live
+    /// screen bounds. The map overlay uses this so its header chrome (drag
+    /// handle, #520 nudge-pad toggle) stays reachable while the body still
+    /// passes clicks to the game — covers both the user's ClickThroughMap
+    /// preference and the calibration Drop phase's forced-on click-through.
+    /// The two paths are mutually exclusive: <c>WS_EX_TRANSPARENT</c> would
+    /// win over <c>HTTRANSPARENT</c> at the OS hit-test level, so the partial
+    /// path explicitly clears it. The hook re-queries the region's live
+    /// bounds each call, so window-resize / chrome-content changes Just Work
+    /// without re-applying.</item>
+    /// </list>
+    /// </summary>
+    public static void Apply(Window window, bool clickThrough, FrameworkElement? interactiveRegion)
     {
         var hwnd = new WindowInteropHelper(window).EnsureHandle();
         if (hwnd == IntPtr.Zero) return;
+
+        var state = _hookState.GetValue(window, _ => new HookState());
+        state.ClickThrough = clickThrough;
+        state.Region = interactiveRegion;
+
+        var partial = clickThrough && interactiveRegion is not null;
+
+        // WS_EX_TRANSPARENT is global to the window. Use it ONLY for the
+        // legacy full-window mode; the partial mode relies on WM_NCHITTEST
+        // and would be defeated by WS_EX_TRANSPARENT.
         var style = GetWindowLong(hwnd, GWL_EXSTYLE);
-        var desired = clickThrough
+        var desired = (clickThrough && !partial)
             ? style | WS_EX_TRANSPARENT | WS_EX_LAYERED
             : style & ~WS_EX_TRANSPARENT;
         if (desired != style) SetWindowLong(hwnd, GWL_EXSTYLE, desired);
+
+        // Install the hook lazily on first partial Apply. It stays installed
+        // for the window's lifetime (HwndSource lifetime); when ClickThrough
+        // is off or Region is null, the hook short-circuits to a no-op, so a
+        // window that toggles between modes doesn't churn hooks.
+        if (state.Hook is null && partial)
+        {
+            var source = HwndSource.FromHwnd(hwnd);
+            if (source is null) return;
+            state.Hook = (IntPtr _, int msg, IntPtr _, IntPtr lParam, ref bool handled) =>
+            {
+                if (msg != WM_NCHITTEST || !state.ClickThrough || state.Region is not { } region)
+                    return IntPtr.Zero;
+                // lParam packs screen X (low word) and Y (high word) as
+                // signed shorts — sign-extend so multi-monitor setups with
+                // negative screen coords still resolve correctly.
+                var raw = lParam.ToInt64();
+                var physX = (short)(raw & 0xFFFF);
+                var physY = (short)((raw >> 16) & 0xFFFF);
+                try
+                {
+                    // WM_NCHITTEST is in physical pixels; WPF's
+                    // PointFromScreen expects DIP. Route through the
+                    // composition target's device transform first (no-op at
+                    // 100% DPI, correct at every per-monitor scale).
+                    if (PresentationSource.FromVisual(region) is not HwndSource regionSource
+                        || regionSource.CompositionTarget is null)
+                        return IntPtr.Zero;
+                    var dip = regionSource.CompositionTarget.TransformFromDevice
+                        .Transform(new Point(physX, physY));
+                    var local = region.PointFromScreen(dip);
+                    if (local.X >= 0 && local.X < region.ActualWidth &&
+                        local.Y >= 0 && local.Y < region.ActualHeight)
+                    {
+                        // Inside the interactive region — let WPF's normal
+                        // hit-test win.
+                        return IntPtr.Zero;
+                    }
+                }
+                catch
+                {
+                    // Mid-resize / pre-arrange / detached visual — fail safe
+                    // to "interactive", so a transient layout glitch can't
+                    // strand the user (the toggle stays reachable instead of
+                    // disappearing into a black hole).
+                    return IntPtr.Zero;
+                }
+                handled = true;
+                return new IntPtr(HTTRANSPARENT);
+            };
+            source.AddHook(state.Hook);
+        }
     }
+
+    private sealed class HookState
+    {
+        public bool ClickThrough;
+        public FrameworkElement? Region;
+        public HwndSourceHook? Hook;
+    }
+
+    // Keyed on Window so per-window state lives exactly as long as the window
+    // — no manual disposal, no static leak across module reloads.
+    private static readonly ConditionalWeakTable<Window, HookState> _hookState = new();
 
     /// <summary>
     /// Forces the window to TOPMOST z-order without activating it. WPF's

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -764,9 +764,6 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         }
     }
 
-    public double Scale => _projector.Scale;
-    public double RotationDegrees => _projector.RotationRadians * 180.0 / Math.PI;
-
     // The slider value is treated as pixel radius for predictable on-screen sizing —
     // multiplying by projector.Scale caused the pin to visibly shrink/grow after
     // every refit, which felt like a bug to the user.

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -7,6 +7,7 @@
         xmlns:converters="clr-namespace:Legolas.Views.Converters"
         xmlns:views="clr-namespace:Legolas.Views"
         xmlns:rendering="clr-namespace:Legolas.Rendering"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
         Title="Map Overlay"
         WindowStyle="None"
         AllowsTransparency="True"
@@ -29,21 +30,63 @@
         <DockPanel>
             <Border DockPanel.Dock="Top" Background="#FF252525" Padding="8,4"
                     MouseLeftButtonDown="Header_MouseLeftButtonDown">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="Map" Foreground="White" FontWeight="SemiBold" />
-                    <TextBlock Text=" | Scale: " Foreground="#FF888888" Margin="12,0,0,0" />
-                    <TextBlock Text="{Binding Scale, StringFormat=0.00}" Foreground="#FFCCCCCC" />
-                    <TextBlock Text=" px/m, Rot: " Foreground="#FF888888" />
-                    <TextBlock Text="{Binding RotationDegrees, StringFormat=0.0}" Foreground="#FFCCCCCC" />
-                    <TextBlock Text="°" Foreground="#FF888888" />
-                    <!-- #476: Survey player-GPS staleness. Sparse signal
-                         (zone-in / teleport only) — surfaced honestly so the
-                         marker is never read as live. -->
-                    <TextBlock Text=" | " Foreground="#FF888888"
-                               Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
-                    <TextBlock Text="{Binding PlayerAnchorStatus}" Foreground="#FFCCCCCC"
-                               Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
-                </StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal">
+                        <TextBlock Text="Map" Foreground="White" FontWeight="SemiBold" />
+                        <!-- #476: Survey player-GPS staleness. Sparse signal
+                             (zone-in / teleport only) — surfaced honestly so the
+                             marker is never read as live. -->
+                        <TextBlock Text=" | " Foreground="#FF888888"
+                                   Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
+                        <TextBlock Text="{Binding PlayerAnchorStatus}" Foreground="#FFCCCCCC"
+                                   Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
+                    </StackPanel>
+                    <!-- #520: in-overlay toggle mirroring LegolasSettings.ShowNudgePadOnOverlay,
+                         so the user can hide/show the nudge pad without alt-tabbing to
+                         Settings. Symmetric: re-enabling stays in reach when hidden. The
+                         ToggleButton handles its own click and stops MouseLeftButtonDown
+                         from reaching the parent Border's drag handler. -->
+                    <ToggleButton Grid.Column="1" VerticalAlignment="Center"
+                                  IsChecked="{Binding ElementName=Self, Path=Settings.ShowNudgePadOnOverlay, Mode=TwoWay}"
+                                  Background="Transparent" BorderThickness="0"
+                                  Padding="4,2" Cursor="Hand" Focusable="False">
+                        <ToggleButton.Template>
+                            <ControlTemplate TargetType="ToggleButton">
+                                <Border Background="{TemplateBinding Background}"
+                                        Padding="{TemplateBinding Padding}">
+                                    <ContentPresenter HorizontalAlignment="Center"
+                                                      VerticalAlignment="Center" />
+                                </Border>
+                            </ControlTemplate>
+                        </ToggleButton.Template>
+                        <ToggleButton.Style>
+                            <Style TargetType="ToggleButton">
+                                <Setter Property="ToolTip" Value="Hide the on-overlay nudge pad. Mirror of Legolas → Settings → Pin Nudge → Show nudge pad on the map overlay." />
+                                <Style.Triggers>
+                                    <Trigger Property="IsChecked" Value="False">
+                                        <Setter Property="ToolTip" Value="Show the on-overlay nudge pad." />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ToggleButton.Style>
+                        <icon:PackIconLucide Width="13" Height="13" Kind="Eye">
+                            <icon:PackIconLucide.Style>
+                                <Style TargetType="icon:PackIconLucide">
+                                    <Setter Property="Foreground" Value="#FFE0E0E0" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ElementName=Self, Path=Settings.ShowNudgePadOnOverlay}" Value="False">
+                                            <Setter Property="Foreground" Value="#FF666666" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </icon:PackIconLucide.Style>
+                        </icon:PackIconLucide>
+                    </ToggleButton>
+                </Grid>
             </Border>
 
             <Grid x:Name="ViewportRoot" ClipToBounds="True" Background="Transparent">

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -28,7 +28,8 @@
                    Opacity="{Binding Session.MapOpacity, FallbackValue=1.0}" />
         <Border BorderBrush="#FF303030" BorderThickness="1">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF252525" Padding="8,4"
+            <Border x:Name="HeaderChrome"
+                    DockPanel.Dock="Top" Background="#FF252525" Padding="8,4"
                     MouseLeftButtonDown="Header_MouseLeftButtonDown">
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -196,7 +196,15 @@ public partial class MapOverlayView : Window
     /// <summary>The calibration phase overrides the user's click-through
     /// preference: Drop ⇒ click-through ON (right-clicks reach the game), Pair
     /// ⇒ OFF (the overlay captures the pairing/correction left-clicks). Outside
-    /// calibration, honour <see cref="LegolasSettings.ClickThroughMap"/>.</summary>
+    /// calibration, honour <see cref="LegolasSettings.ClickThroughMap"/>.
+    ///
+    /// <para>#520: pass the header strip as an <em>interactive region</em>,
+    /// so when click-through is in effect (either the user setting or the
+    /// calibration Drop force-on) the chrome — drag handle + nudge-pad
+    /// toggle — stays reachable while the body still passes clicks to the
+    /// game underneath. Without the carve-out, enabling click-through also
+    /// locked out the toggle that's supposed to let the user dismiss the
+    /// pad without alt-tabbing.</para></summary>
     private void ApplyClickThrough()
     {
         var clickThrough = Settings?.ClickThroughMap ?? false;
@@ -205,7 +213,7 @@ public partial class MapOverlayView : Window
             if (vm.IsCalibrationDropping) clickThrough = true;
             else if (vm.IsCalibrationCapturing) clickThrough = false;
         }
-        ClickThrough.Apply(this, clickThrough);
+        ClickThrough.Apply(this, clickThrough, HeaderChrome);
     }
 
     private static Color ParseColor(string hex) => LegolasBrushes.Parse(hex);


### PR DESCRIPTION
Closes #520.

## Summary

- Adds an eye-icon `ToggleButton` to the map-overlay header strip that two-way-binds `LegolasSettings.ShowNudgePadOnOverlay` — the user can hide or re-show the on-overlay nudge pad without alt-tabbing to Settings.
- Removes the stale `Scale: … px/m, Rot: …°` header readout (bound off the post-#488 vestigial `CoordinateProjector`; the numbers didn't reflect the live `AreaCalibration` used for placement).

## Design choice (issue invited the call during implementation)

Picked option 2 (header toggle), not option 1 (× on the pad itself), because:

- **Symmetric show/hide** keeps the re-enable affordance in reach when hidden — option 1 would still force an alt-tab to Settings to bring the pad back, which is the very loop the issue is closing.
- Matches the in-repo precedent the issue cited (#494/#495 "Validate calibration" toggle docked into the wizard header).
- Single property, no new persisted state, no schema-version bump.

## Acceptance criteria

- [x] A visible affordance on the map overlay window toggles/hides the on-overlay nudge pad — eye-icon ToggleButton in the header (right-aligned).
- [x] Binds `LegolasSettings.ShowNudgePadOnOverlay` two-way; no new setting, no schema bump.
- [x] Doesn't steal clicks intended for the map/pins — the ToggleButton is in the header `Border`, not over the `Viewport`, and it sets `Handled=true` on its own MouseLeftButtonDown so the header's `Header_MouseLeftButtonDown` drag handler still fires for the rest of the strip.
- [x] Hidden state is purely visual — only the `Border.Visibility` binding flips. Keyboard `legolas.pin.nudge.*` hotkeys, the wizard-panel pad, and the shared `NudgePadViewModel` instance (with its `SelectedStep`) are unaffected. The pad-on-overlay is a mirror, not the source of nudging.
- [x] The `Scale: … px/m, Rot: …°` segment is gone; `MapOverlayViewModel.Scale` + `RotationDegrees` (their only consumers were the deleted XAML bindings — LSP findReferences confirmed) deleted. The internal `_projector.Scale` / `_projector.RotationRadians` used for wedge sizing/bearing math at `MapOverlayViewModel.cs:850` and `:858` are untouched. No new orphaned-binding warnings; XamlResourceLint clean.
- [x] Full `dotnet test Mithril.slnx` green — 3.6k+ tests across all projects, Legolas 462/462.

## Implementation notes

- Header `StackPanel` became a `Grid` with two columns (`*`, `Auto`) so the toggle right-aligns without disturbing the existing left-side content (Map | PlayerAnchorStatus).
- Icon: Lucide `Eye`, color modulated by `DataTrigger` on `Settings.ShowNudgePadOnOverlay` (bright `#FFE0E0E0` when on, dim `#FF666666` when off). Tooltip swaps via a Trigger on `IsChecked` so it always names the action the click will perform.
- `Focusable="False"` so Tab doesn't land on it and the overlay's `OnPreviewKeyDown` Escape handler keeps working unchanged.
- The pad's existing `Border.Visibility` binding (`ElementName=Self, Path=Settings.ShowNudgePadOnOverlay`) is the same property and the same source — both controls observe `LegolasSettings.PropertyChanged`, so toggling either the new header button or the Settings checkbox updates the other live (and `SettingsAutoSaver<LegolasSettings>` persists the flip).

## Verification

**Mechanically verified by me:**

- ✅ `dotnet build Mithril.slnx` — 0 warnings, 0 errors. XamlResourceLint OK (121 keys).
- ✅ `dotnet test Mithril.slnx` — every project passed; Legolas 462/462. No regressions.

**Owed by reviewer (WPF UI — can't run from CLI):**

- [ ] Open the map overlay. Eye icon visible at the right of the header strip.
- [ ] Click the eye → nudge pad disappears (and re-shows on click). Icon brightness shifts; tooltip updates.
- [ ] In Legolas → Settings → Pin Nudge, toggle "Show nudge pad on the map overlay" — header eye state updates live.
- [ ] Drag the overlay by the header (away from the eye) — window-drag still works. Click the eye — drag does NOT fire.
- [ ] Hide the pad, restart Mithril — pad still hidden (persisted).
- [ ] Hide the pad → `legolas.pin.nudge.*` hotkeys still nudge (pad visibility is mirror-only).
- [ ] Confirm the `Scale: 1.00 px/m, Rot: 0.0°` segment is gone from the header. Output window has no new binding warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)