### PR TITLE
refactor(world-sim): convert PlayerAreaTracker to IFolder<AreaLoadingFrame> + bus event

### DIFF
--- a/src/Mithril.GameState/Areas/AreaLoadingFrame.cs
+++ b/src/Mithril.GameState/Areas/AreaLoadingFrame.cs
@@ -1,0 +1,24 @@
+namespace Mithril.GameState.Areas;
+
+/// <summary>
+/// World-simulator frame payload for the Player.log area folder
+/// (<see cref="PlayerAreaTracker"/>) — #775. A sibling
+/// <see cref="Producers.AreaLoadingFrameProducer"/> reads
+/// <see cref="Mithril.Shared.Logging.SystemSignalKind.AreaLoading"/> envelopes
+/// off the L1 driver, parses them via
+/// <see cref="Parsing.AreaTransitionParser"/>, and emits one frame per
+/// transition.
+///
+/// <para><b>Single-shape payload.</b> Unlike <see cref="Skills.SkillFrame"/> /
+/// <see cref="Inventory.PlayerInventoryFrame"/> there is only one verb shape
+/// (<c>LOADING LEVEL …</c>), so the payload is a single record rather than a
+/// closed hierarchy of subtypes. <see cref="AreaKey"/> follows the
+/// <see cref="Parsing.AreaTransitionEvent.AreaKey"/> convention: the
+/// <c>"Area*"</c> code on a real transition, or <c>null</c> for
+/// <c>ChooseCharacter</c> / disconnect / empty body.</para>
+/// </summary>
+/// <param name="AreaKey">The area code (matches <c>areas.json</c> keys
+/// exactly: <c>"AreaSerbule"</c>, <c>"AreaEltibule"</c>, …) when in a real
+/// area, or <c>null</c> for the character-select / disconnect / unknown
+/// intermediate forms.</param>
+public sealed record AreaLoadingFrame(string? AreaKey);

--- a/src/Mithril.GameState/Areas/IPlayerAreaState.cs
+++ b/src/Mithril.GameState/Areas/IPlayerAreaState.cs
@@ -1,20 +1,36 @@
 namespace Mithril.GameState.Areas;
 
 /// <summary>
-/// Read surface for the Player.log area folder (<see cref="PlayerAreaTracker"/>) —
-/// #775. Matches the world-sim folder-interface convention
-/// (<see cref="Mithril.WorldSim.IFolder{TPayload}"/>: <c>I&lt;World&gt;&lt;Domain&gt;State</c>);
-/// dual-surface delivery alongside the world bus channel — new consumers may
-/// subscribe to <c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c>
-/// directly per design notebook principle 4 (single-world consumers).
+/// Read surface for the Player.log area folder
+/// (<see cref="PlayerAreaTracker"/>) — #775. Matches the world-sim folder-
+/// interface convention (<see cref="Mithril.WorldSim.IFolder{TPayload}"/>:
+/// <c>I&lt;World&gt;&lt;Domain&gt;State</c>); dual-surface delivery alongside
+/// the world bus channel — new consumers may subscribe to
+/// <c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c> directly per
+/// design notebook principle 4 (single-world consumers).
 ///
-/// <para><b>Synchronous read preserved.</b> <see cref="CurrentArea"/> stays
-/// available for the chest-area-stamping consumer (Gandalf) and the position-
-/// driven debug refresh (Palantir): both depend on a poll-on-demand surface and
-/// neither needs the change event. The legacy
-/// <see cref="PlayerAreaTracker.Observe(string, DateTime)"/> push-in path also
-/// stays alive for the Legolas + Gandalf bridge consumers that still feed
-/// already-classified lines inline; the cross-source-correlation rules
+/// <para><b>Three consumption surfaces, one truth.</b>
+/// <list type="bullet">
+///   <item><see cref="CurrentArea"/> — synchronous read. Preserved verbatim
+///   for the chest-area-stamping consumer (Gandalf), the position-driven
+///   debug refresh (Palantir), and the startup area bridge (Legolas).</item>
+///   <item><see cref="Subscribe"/> — replay-on-attach callback. Late
+///   subscribers receive a synthetic
+///   <see cref="PlayerAreaChangeKind.Snapshot"/> notification with the
+///   current area, then live <see cref="PlayerAreaChangeKind.Changed"/>
+///   notifications on subsequent transitions. Mirrors the pattern in
+///   <c>PlayerPinTracker.Subscribe</c> / <c>PlayerWeatherTracker.Subscribe</c>.</item>
+///   <item><c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c> —
+///   typed bus channel. Carries only <see cref="PlayerAreaChangeKind.Changed"/>
+///   events (the snapshot replay is synthesized inside
+///   <see cref="Subscribe"/> and never crosses the world boundary). New
+///   cross-cutting consumers should prefer this surface; the bus delivery
+///   path is automatic via the folder's <c>Apply</c> return value.</item>
+/// </list></para>
+///
+/// <para>The legacy <see cref="PlayerAreaTracker.Observe"/> push-in path
+/// also stays alive for the Legolas + Gandalf bridge consumers that still
+/// feed already-classified lines inline; the cross-source-correlation rules
 /// continue to apply (double-feed is idempotent under last-writer-wins).</para>
 /// </summary>
 public interface IPlayerAreaState
@@ -30,12 +46,18 @@ public interface IPlayerAreaState
     string? CurrentArea { get; }
 
     /// <summary>
-    /// Raised whenever the folder applies a frame whose
-    /// <see cref="AreaLoadingFrame.AreaKey"/> differs from the prior state.
-    /// Identical-area re-emits (zone replay) produce no event. Fires
-    /// synchronously inside <see cref="PlayerAreaTracker.Apply"/> on the
-    /// world's merger thread — subscribers must not block; non-trivial / UI
-    /// work must marshal off.
+    /// Subscribe to area notifications. Late subscribers receive a
+    /// synthetic <see cref="PlayerAreaChangeKind.Snapshot"/> notification
+    /// with the current area before this method returns; subsequent
+    /// genuine transitions deliver as
+    /// <see cref="PlayerAreaChangeKind.Changed"/> notifications on the
+    /// folder's apply thread. Disposing the returned handle removes the
+    /// subscription.
+    ///
+    /// <para>Subscribers must not block — the change-event path runs on
+    /// the world's merger thread (or, for the legacy
+    /// <see cref="PlayerAreaTracker.Observe"/> bridge, the calling
+    /// ingestion thread). Non-trivial / UI work must marshal off.</para>
     /// </summary>
-    event EventHandler<PlayerAreaChanged>? AreaChanged;
+    IDisposable Subscribe(Action<PlayerAreaChanged> handler);
 }

--- a/src/Mithril.GameState/Areas/IPlayerAreaState.cs
+++ b/src/Mithril.GameState/Areas/IPlayerAreaState.cs
@@ -1,0 +1,41 @@
+namespace Mithril.GameState.Areas;
+
+/// <summary>
+/// Read surface for the Player.log area folder (<see cref="PlayerAreaTracker"/>) —
+/// #775. Matches the world-sim folder-interface convention
+/// (<see cref="Mithril.WorldSim.IFolder{TPayload}"/>: <c>I&lt;World&gt;&lt;Domain&gt;State</c>);
+/// dual-surface delivery alongside the world bus channel — new consumers may
+/// subscribe to <c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c>
+/// directly per design notebook principle 4 (single-world consumers).
+///
+/// <para><b>Synchronous read preserved.</b> <see cref="CurrentArea"/> stays
+/// available for the chest-area-stamping consumer (Gandalf) and the position-
+/// driven debug refresh (Palantir): both depend on a poll-on-demand surface and
+/// neither needs the change event. The legacy
+/// <see cref="PlayerAreaTracker.Observe(string, DateTime)"/> push-in path also
+/// stays alive for the Legolas + Gandalf bridge consumers that still feed
+/// already-classified lines inline; the cross-source-correlation rules
+/// continue to apply (double-feed is idempotent under last-writer-wins).</para>
+/// </summary>
+public interface IPlayerAreaState
+{
+    /// <summary>
+    /// Latest area key parsed from a <c>LOADING LEVEL Area*</c> line, or
+    /// <c>null</c> if the player is at character-select / disconnected /
+    /// before the first observed transition. Consumers should treat
+    /// <c>null</c> as "current area is unknown" — chest commits during a
+    /// null-area window persist with <c>Area = null</c> and self-heal on
+    /// the next portal.
+    /// </summary>
+    string? CurrentArea { get; }
+
+    /// <summary>
+    /// Raised whenever the folder applies a frame whose
+    /// <see cref="AreaLoadingFrame.AreaKey"/> differs from the prior state.
+    /// Identical-area re-emits (zone replay) produce no event. Fires
+    /// synchronously inside <see cref="PlayerAreaTracker.Apply"/> on the
+    /// world's merger thread — subscribers must not block; non-trivial / UI
+    /// work must marshal off.
+    /// </summary>
+    event EventHandler<PlayerAreaChanged>? AreaChanged;
+}

--- a/src/Mithril.GameState/Areas/PlayerAreaChangeKind.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaChangeKind.cs
@@ -1,0 +1,41 @@
+namespace Mithril.GameState.Areas;
+
+/// <summary>
+/// Discriminator on <see cref="PlayerAreaChanged"/> distinguishing late-
+/// subscriber synthetic replays from genuine transitions. Mirrors the
+/// existing GameState convention (<c>PinSetChange</c>, <c>WeatherChangeKind</c>):
+/// late subscribers receive one synthetic <see cref="Snapshot"/> on attach so
+/// they observe the same view already-attached handlers see, then live
+/// transitions arrive as <see cref="Changed"/>.
+///
+/// <para><b>Bus surface vs legacy callback.</b>
+/// <see cref="PlayerAreaTracker.Apply"/> only returns
+/// <see cref="Changed"/>-kind events, so consumers subscribed via
+/// <c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c> see live
+/// transitions only — the snapshot replay is synthesized inside the legacy
+/// <see cref="IPlayerAreaState.Subscribe"/> path and never crosses the world
+/// boundary.</para>
+/// </summary>
+public enum PlayerAreaChangeKind
+{
+    /// <summary>
+    /// Synthetic notification fired once at
+    /// <see cref="IPlayerAreaState.Subscribe"/> attach time. Carries the
+    /// current area as <see cref="PlayerAreaChanged.Current"/> with
+    /// <see cref="PlayerAreaChanged.Previous"/> = <c>null</c>; stamped with
+    /// the most-recent envelope timestamp the tracker has applied (or
+    /// <see cref="DateTimeOffset.MinValue"/> when nothing has been observed
+    /// yet — late subscribers can short-circuit on <c>Current == null</c>).
+    /// Never published on the world bus.
+    /// </summary>
+    Snapshot,
+
+    /// <summary>
+    /// Genuine area transition observed from a <c>LOADING LEVEL</c> line.
+    /// Carries the prior area as <see cref="PlayerAreaChanged.Previous"/>
+    /// and the new area as <see cref="PlayerAreaChanged.Current"/>;
+    /// <see cref="PlayerAreaChanged.At"/> is the parsed log-line instant
+    /// (never wall-clock — principle 13). Published on the world bus.
+    /// </summary>
+    Changed,
+}

--- a/src/Mithril.GameState/Areas/PlayerAreaChanged.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaChanged.cs
@@ -1,0 +1,27 @@
+using Mithril.WorldSim;
+
+namespace Mithril.GameState.Areas;
+
+/// <summary>
+/// Folder-emitted change event: the player's area transitioned. Published on
+/// the <see cref="IPlayerWorld"/> bus as <c>Frame&lt;PlayerAreaChanged&gt;</c>
+/// (per <c>docs/world-simulator.md</c> "Decisions ratified post-#642") and
+/// raised on <see cref="IPlayerAreaState.AreaChanged"/> for back-compat
+/// callers that prefer the event surface.
+///
+/// <para>Emitted from <see cref="PlayerAreaTracker.Apply"/> whenever the
+/// frame's <see cref="AreaLoadingFrame.AreaKey"/> differs from the prior
+/// state; identical-area re-emits (zone-replay no-ops) produce no change
+/// event.</para>
+/// </summary>
+/// <param name="Previous">The area key before this transition, or
+/// <c>null</c> if the player was at character-select / disconnect / pre-first
+/// observation.</param>
+/// <param name="Current">The area key after this transition, or <c>null</c>
+/// if the player just landed on character-select / disconnected.</param>
+/// <param name="At">Event time the transition represents — the parsed
+/// <c>LOADING LEVEL</c> line's timestamp, never wall-clock (principle 13).</param>
+public sealed record PlayerAreaChanged(
+    string? Previous,
+    string? Current,
+    DateTimeOffset At) : IChangeEvent;

--- a/src/Mithril.GameState/Areas/PlayerAreaChanged.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaChanged.cs
@@ -3,25 +3,40 @@ using Mithril.WorldSim;
 namespace Mithril.GameState.Areas;
 
 /// <summary>
-/// Folder-emitted change event: the player's area transitioned. Published on
-/// the <see cref="IPlayerWorld"/> bus as <c>Frame&lt;PlayerAreaChanged&gt;</c>
-/// (per <c>docs/world-simulator.md</c> "Decisions ratified post-#642") and
-/// raised on <see cref="IPlayerAreaState.AreaChanged"/> for back-compat
-/// callers that prefer the event surface.
+/// Player area notification. Two shapes, distinguished by <see cref="Kind"/>:
 ///
-/// <para>Emitted from <see cref="PlayerAreaTracker.Apply"/> whenever the
-/// frame's <see cref="AreaLoadingFrame.AreaKey"/> differs from the prior
-/// state; identical-area re-emits (zone-replay no-ops) produce no change
-/// event.</para>
+/// <list type="bullet">
+///   <item><see cref="PlayerAreaChangeKind.Snapshot"/> — synthetic replay
+///   fired by <see cref="IPlayerAreaState.Subscribe"/> on attach so late
+///   subscribers observe the same view already-attached handlers see. Never
+///   published on the world bus.</item>
+///   <item><see cref="PlayerAreaChangeKind.Changed"/> — genuine transition
+///   observed from a <c>LOADING LEVEL</c> line. Folder-emitted from
+///   <see cref="PlayerAreaTracker.Apply"/> and published on
+///   <see cref="IPlayerWorld.Bus"/> as <c>Frame&lt;PlayerAreaChanged&gt;</c>.</item>
+/// </list>
+///
+/// <para>Implements <see cref="IChangeEvent"/> so the world's bus routes
+/// folder emissions through the same publish path as other folders' change
+/// events (per the "Decisions ratified post-#642" section of
+/// <c>docs/world-simulator.md</c>).</para>
 /// </summary>
+/// <param name="Kind">Discriminator — <see cref="PlayerAreaChangeKind.Snapshot"/>
+/// for replay-on-attach, <see cref="PlayerAreaChangeKind.Changed"/> for a
+/// genuine transition.</param>
 /// <param name="Previous">The area key before this transition, or
-/// <c>null</c> if the player was at character-select / disconnect / pre-first
-/// observation.</param>
-/// <param name="Current">The area key after this transition, or <c>null</c>
-/// if the player just landed on character-select / disconnected.</param>
+/// <c>null</c> for the first observed transition / the
+/// <see cref="PlayerAreaChangeKind.Snapshot"/> form.</param>
+/// <param name="Current">The area key after this transition (or the
+/// current area on a snapshot replay), or <c>null</c> if the player is at
+/// character-select / disconnected / pre-first observation.</param>
 /// <param name="At">Event time the transition represents — the parsed
-/// <c>LOADING LEVEL</c> line's timestamp, never wall-clock (principle 13).</param>
+/// <c>LOADING LEVEL</c> line's timestamp (NEVER wall-clock — principle 13).
+/// On a snapshot replay, carries the most-recent envelope timestamp the
+/// tracker has applied; <see cref="DateTimeOffset.MinValue"/> when nothing
+/// has been observed yet.</param>
 public sealed record PlayerAreaChanged(
+    PlayerAreaChangeKind Kind,
     string? Previous,
     string? Current,
     DateTimeOffset At) : IChangeEvent;

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -64,8 +64,15 @@ namespace Mithril.GameState.Areas;
 /// either path. The asymmetry only matters for bus subscribers that count
 /// emissions (e.g., a hypothetical "area-transitions-per-session" metric);
 /// consumers that read state-on-event don't notice. Resolves automatically
-/// once the two <see cref="Observe"/> callers migrate to the bus event per
-/// the #774 follow-on.</para>
+/// once the two <see cref="Observe"/> callers (Legolas + Gandalf bridges)
+/// retire under
+/// <a href="https://github.com/moumantai-gg/mithril/issues/769">#769 Phase C</a>
+/// — at which point the
+/// <c>PlayerAreaWorldRegistration</c> eager pre-warm also retires (the
+/// producer's seed becomes the merger's first emission and the bus emits
+/// <c>PlayerAreaChanged(null → seed-area)</c> normally; consumers see it via
+/// Call 1 eager bus subscriptions per <c>docs/world-simulator.md</c>
+/// "Decisions ratified post-#642" Call 1).</para>
 ///
 /// <para><b>Threading.</b> The world drives <see cref="Apply"/> from its
 /// merger thread; folder mutations + legacy handler dispatch run under

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -1,10 +1,6 @@
-using System.IO;
-using System.Text;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Game;
-using Mithril.Shared.Logging;
-using Microsoft.Extensions.Hosting;
+using Mithril.WorldSim;
 
 namespace Mithril.GameState.Areas;
 
@@ -15,293 +11,130 @@ namespace Mithril.GameState.Areas;
 /// Gandalf (chest commits stamp <c>LearnedChest.Area</c>) and Legolas
 /// (per-area survey-projection calibration), among others.
 ///
-/// <para><b>Self-feeding via the L1 driver (#556 Phase 2).</b> When an
-/// <see cref="ILogStreamDriver"/> is supplied, the tracker is a
-/// <see cref="BackgroundService"/> that subscribes to L0.5's
-/// <see cref="ISystemSignalLogStream"/> typed pipe through the L1 driver,
-/// filtered for <see cref="SystemSignalKind.AreaLoading"/>. This is the
-/// canonical update path for shared area state in production.
-/// <see cref="Observe(string,DateTime)"/> remains for the two consumers
-/// (Legolas's <c>PlayerLogIngestionService</c> and Gandalf's
-/// <c>LootIngestionService</c>) that still feed already-classified data
-/// inline; both feed paths converge on the same string-equality,
-/// last-writer-wins state, so concurrent updates against the same area
-/// key are idempotent.</para>
+/// <para><b>World-simulator migration (#775).</b> Pre-migration this class was
+/// a <see cref="Microsoft.Extensions.Hosting.BackgroundService"/> that owned
+/// its own L1 SystemSignal subscription and self-seeded via a reverse-scan of
+/// <c>Player.log</c>. Post-migration it is an <see cref="IFolder{TPayload}"/>
+/// registered with <c>IPlayerWorld</c> for the <see cref="AreaLoadingFrame"/>
+/// payload type: a sibling <see cref="Producers.AreaLoadingFrameProducer"/>
+/// owns the L1 subscription (and the pre-drain seed emission), parses every
+/// <see cref="Mithril.Shared.Logging.SystemSignalKind.AreaLoading"/> envelope
+/// via <see cref="AreaTransitionParser"/>, and emits one
+/// <see cref="AreaLoadingFrame"/> per transition. The world drives
+/// <see cref="Apply"/> per applied frame in source order; the folder returns
+/// <see cref="PlayerAreaChanged"/> change events which the world publishes on
+/// its bus (<c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c>) in
+/// addition to raising the legacy <see cref="AreaChanged"/> event.</para>
 ///
-/// <para><b>Startup seeding.</b> <see cref="PlayerLogTailReader.SeedToSessionStart"/>
-/// rewinds the live replay window to the most recent <c>ProcessAddPlayer(</c>
-/// line, which lands ~9 s <em>after</em> the <c>LOADING LEVEL</c> line for the
-/// current area — so the area code is just upstream of where playback
-/// begins. <see cref="SeedFromLog"/> closes that gap with its own one-shot
-/// reverse-scan for the most recent <c>LOADING LEVEL</c> line, applied
-/// before the live stream starts. Local change scope; no impact on other
-/// consumers tuned against <see cref="PlayerLogStream"/>'s seed.</para>
+/// <para><b>Dual-surface back-compat.</b> <see cref="CurrentArea"/>
+/// (synchronous read) is preserved verbatim — Gandalf's chest-commit path and
+/// Palantir's debug refresh both rely on it. <see cref="Observe"/> also stays
+/// alive: Legolas's <c>PlayerLogIngestionService</c> and Gandalf's
+/// <c>LootIngestionService</c> still feed already-classified lines inline
+/// during the migration window. The double-feed (live envelope routed through
+/// the producer + Observe push-in) is idempotent — both paths converge on the
+/// same string-equality, last-writer-wins state. Retirement of <c>Observe</c>
+/// is owed once the two callers migrate to the bus event (separate follow-on
+/// under #774); deleting it now would break the bridges the user's scope note
+/// explicitly puts out of this PR.</para>
 ///
-/// <para><b>Threading.</b> <see cref="Observe(string,DateTime)"/> is called
-/// from the log ingestion background thread; the L1 self-feed runs on the
-/// driver's pump thread; <see cref="CurrentArea"/> is read from
-/// chest-commit paths on whichever thread routes the bracket. A simple
-/// lock suffices — the contention is low (one area transition per
-/// minute-ish, vs. dozens of reads per chest interaction).</para>
+/// <para><b>Threading.</b> The world drives <see cref="Apply"/> from its
+/// merger thread; folder mutations + change-event dispatch run under
+/// <see cref="_lock"/>. <see cref="Observe"/> is called from the legacy
+/// ingestion paths (Legolas/Gandalf bridges) on their own pump threads;
+/// the same lock serialises with the world-driven path so the double-feed
+/// stays race-free. <see cref="CurrentArea"/> reads take the same short
+/// critical section.</para>
 /// </summary>
-public sealed class PlayerAreaTracker : BackgroundService
+public sealed class PlayerAreaTracker : IFolder<AreaLoadingFrame>, IPlayerAreaState
 {
     private readonly AreaTransitionParser _parser;
     private readonly IDiagnosticsSink? _diag;
-    private readonly GameConfig? _config;
-    private readonly ILogStreamDriver? _driver;
     private readonly object _lock = new();
-    private readonly object _seedLock = new();
-    private bool _seedAttempted;
     private string? _currentArea;
-    private ILogSubscription? _subscription;
 
     private const string DiagCategory = "GameState.Area";
 
-    /// <param name="config">Optional. When supplied, the tracker owns its own
-    /// one-shot pre-login-preamble seed (lazily, on the first
-    /// <see cref="CurrentArea"/> read or <see cref="Observe(string,DateTime)"/>)
-    /// — consumers no longer trigger <see cref="SeedFromLog"/>. Null in tests
-    /// that drive state directly.</param>
-    /// <param name="driver">Optional L1 subscription driver. When supplied,
-    /// <see cref="ExecuteAsync"/> subscribes to the L0.5 system-signal pipe
-    /// and self-feeds <see cref="SystemSignalKind.AreaLoading"/> envelopes
-    /// (#556 Phase 2). Null in tests that drive state directly via
-    /// <see cref="Observe(string,DateTime)"/>.</param>
     public PlayerAreaTracker(
         AreaTransitionParser parser,
-        IDiagnosticsSink? diag = null,
-        GameConfig? config = null,
-        ILogStreamDriver? driver = null)
+        IDiagnosticsSink? diag = null)
     {
-        _parser = parser;
+        _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         _diag = diag;
-        _config = config;
-        _driver = driver;
     }
 
-    /// <summary>
-    /// Latest area key parsed from a <c>LOADING LEVEL Area*</c> line, or
-    /// <c>null</c> if the player is at character-select / disconnected /
-    /// before the first observed transition. Consumers should treat
-    /// <c>null</c> as "current area is unknown" — chest commits during a
-    /// null-area window persist with <c>Area = null</c> and self-heal on
-    /// the next portal.
-    /// </summary>
+    /// <inheritdoc/>
     public string? CurrentArea
     {
-        get { EnsureSeeded(); lock (_lock) return _currentArea; }
+        get { lock (_lock) return _currentArea; }
+    }
+
+    /// <inheritdoc/>
+    public event EventHandler<PlayerAreaChanged>? AreaChanged;
+
+    /// <summary>
+    /// Apply one area-loading frame to internal state. Returns a single
+    /// <see cref="PlayerAreaChanged"/> when the frame's
+    /// <see cref="AreaLoadingFrame.AreaKey"/> differs from the prior value;
+    /// empty otherwise. Identical-area re-emits (zone replay) are no-ops, so
+    /// consumers stay quiet through the L1 backlog drain. The clock parameter
+    /// is unused — the change event carries the frame's own timestamp so the
+    /// state derivation stays replay-deterministic over the source stream
+    /// (principle 5 + principle 13).
+    /// </summary>
+    public IReadOnlyList<IChangeEvent> Apply(Frame<AreaLoadingFrame> frame, IWorldClock clock)
+    {
+        _ = clock;
+        return ApplyTransition(frame.Payload.AreaKey, frame.Timestamp);
     }
 
     /// <summary>
     /// Feed one log line through the area parser. Idempotent for unrelated
     /// lines (the parser's substring fast-path returns null without touching
-    /// state).
+    /// state). Legacy push-in for the Gandalf/Legolas bridges; new consumers
+    /// should subscribe to <see cref="AreaChanged"/> or the world bus instead.
     /// </summary>
     public void Observe(string line, DateTime timestamp)
     {
-        EnsureSeeded();
-        Apply(line, timestamp);
-    }
-
-    /// <summary>
-    /// Hosted-service entry point (#556 Phase 2). When an
-    /// <see cref="ILogStreamDriver"/> is configured, subscribes to L0.5's
-    /// system-signal pipe and folds every
-    /// <see cref="SystemSignalKind.AreaLoading"/> envelope into the shared
-    /// area state. When no driver is supplied (tests that drive state
-    /// directly), this method returns immediately — the
-    /// <see cref="Observe(string,DateTime)"/> path remains the source of
-    /// truth for those scenarios.
-    ///
-    /// <para>Per-envelope failures are contained by the L1 driver (the
-    /// <c>InlineBridge</c> per-handler try/catch + degraded-state SM); the
-    /// handler body itself is intentionally tiny and unlikely to throw —
-    /// <see cref="Apply"/> swallows non-matching lines via the parser's
-    /// substring fast-path.</para>
-    /// </summary>
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        if (_driver is null)
-        {
-            // Test path / no L1 driver — nothing to subscribe to. Park so
-            // the host's StartAsync await unblocks cleanly; the host will
-            // cancel on shutdown and this method unwinds.
-            try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
-            catch (OperationCanceledException) { }
-            return;
-        }
-
-        _diag?.Info(DiagCategory,
-            "Subscribing to L1 driver (SystemSignal pipe) for AreaLoading self-feed");
-
-        // Lazy-seed before the live stream starts so the reverse-scan
-        // catches a LOADING LEVEL line that sits upstream of the L1
-        // replay window. Mirrors the pre-#556 CurrentArea-read self-seed,
-        // just driven once at startup.
-        EnsureSeeded();
-
-        _subscription = _driver.Subscribe<SystemSignalLogLine>(
-            envelope =>
-            {
-                var s = envelope.Payload;
-                // The unified pipe (and the typed system pipe) carries the
-                // full SystemSignalKind set; ignore everything except
-                // AreaLoading. PG only emits one transition per actual
-                // portal, so this filter is cheap.
-                if (s.Kind == SystemSignalKind.AreaLoading)
-                {
-                    // SystemSignalLogLine.Data is the "LOADING LEVEL <area>"
-                    // tail (with the [ts] prefix eaten by L0.5). The
-                    // parser's substring guard handles unrelated content
-                    // as no-op, so feeding raw Data is safe.
-                    Apply(s.Data, s.Timestamp.UtcDateTime);
-                }
-                return ValueTask.CompletedTask;
-            },
-            new LogSubscriptionOptions
-            {
-                ReplayMode = ReplayMode.FromSessionStart,
-                DeliveryContext = DeliveryContext.Inline,
-                DiagnosticCategory = DiagCategory,
-            });
-
-        // Park until host stop; the L1 subscription runs its own pump on
-        // a Task.Run, so ExecuteAsync's only job after Subscribe is to
-        // dispose the handle on shutdown.
-        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
-        catch (OperationCanceledException) { /* expected on host stop */ }
-        finally
-        {
-            _subscription?.Dispose();
-            _subscription = null;
-        }
-    }
-
-    public override void Dispose()
-    {
-        _subscription?.Dispose();
-        _subscription = null;
-        base.Dispose();
-    }
-
-    private void Apply(string line, DateTime timestamp)
-    {
         if (_parser.TryParse(line, timestamp) is AreaTransitionEvent evt)
         {
-            lock (_lock)
-            {
-                if (_currentArea != evt.AreaKey)
-                {
-                    _currentArea = evt.AreaKey;
-                    _diag?.Trace("GameState.Area",
-                        $"Player area transition → {evt.AreaKey ?? "(none)"} at {timestamp:O}");
-                }
-            }
+            ApplyTransition(evt.AreaKey, new DateTimeOffset(
+                DateTime.SpecifyKind(timestamp, DateTimeKind.Utc)));
         }
     }
 
     /// <summary>
-    /// Idempotent, owned, one-shot pre-login-preamble seed. Runs at most once
-    /// per instance (lazily, on the first <see cref="CurrentArea"/> read or
-    /// <see cref="Observe(string,DateTime)"/>), so consumers never trigger the
-    /// scan and a new consumer can't forget to. With no log path / no
-    /// <c>LOADING LEVEL</c> found, "area unknown" is surfaced once rather than
-    /// being a silent null. See mithril#514.
+    /// Shared mutation path. Returns the change-event list both call sites
+    /// honour: the folder hands it to the world for bus publication; the
+    /// legacy <see cref="Observe"/> path drops it (the legacy callers
+    /// pre-date the bus and only observe state via <see cref="CurrentArea"/>).
+    /// Either way the <see cref="AreaChanged"/> event fires for any
+    /// subscriber that has attached to the dual-surface event channel.
     /// </summary>
-    private void EnsureSeeded()
+    private IReadOnlyList<IChangeEvent> ApplyTransition(string? areaKey, DateTimeOffset at)
     {
-        lock (_seedLock)
+        PlayerAreaChanged? change = null;
+        lock (_lock)
         {
-            if (_seedAttempted) return;
-            _seedAttempted = true;
+            if (_currentArea == areaKey) return Array.Empty<IChangeEvent>();
+            var previous = _currentArea;
+            _currentArea = areaKey;
+            change = new PlayerAreaChanged(previous, areaKey, at);
+            _diag?.Trace(DiagCategory,
+                $"Player area transition → {areaKey ?? "(none)"} at {at:O}");
         }
-
-        var path = _config?.PlayerLogPath;
-        if (!string.IsNullOrEmpty(path)) ScanForArea(path);
-
-        bool unknown;
-        lock (_lock) unknown = _currentArea is null;
-        if (unknown)
-            _diag?.Info("GameState.Area",
-                "Area unknown after one-shot preamble seed (no LOADING LEVEL " +
-                "found / no log path) — null until the first live transition");
+        RaiseAreaChanged(change);
+        return new IChangeEvent[] { change };
     }
 
-    /// <summary>
-    /// One-shot startup seed. Reads <paramref name="logPath"/> backward in
-    /// chunks looking for the most recent <c>LOADING LEVEL</c> line, parses
-    /// it, and sets <see cref="CurrentArea"/>. No-op if the file is missing
-    /// or no <c>LOADING LEVEL</c> line exists in the scanned region.
-    /// </summary>
-    /// <remarks>
-    /// Scan bound: <see cref="ScanChunkBytes"/> (10 MB, mirrored from
-    /// <see cref="PlayerLogTailReader.SessionScanChunkBytes"/>) per chunk.
-    /// The full file is walked in chunks until the marker is found or the
-    /// start of the file is reached, so the scan is bounded by file size,
-    /// not the chunk constant.
-    /// </remarks>
-    /// <summary>
-    /// Explicit one-shot seed. Retained for tests and any caller that already
-    /// holds the log path; marks the seed attempted so the lazy
-    /// <see cref="EnsureSeeded"/> path won't re-scan. Production consumers do
-    /// <b>not</b> call this — the tracker self-seeds (mithril#514).
-    /// </summary>
-    public void SeedFromLog(string logPath)
+    private void RaiseAreaChanged(PlayerAreaChanged change)
     {
-        lock (_seedLock) _seedAttempted = true;
-        ScanForArea(logPath);
-    }
-
-    private void ScanForArea(string logPath)
-    {
-        if (!File.Exists(logPath)) return;
-
-        var size = new FileInfo(logPath).Length;
-        if (size == 0) return;
-
-        try
+        var handler = AreaChanged;
+        if (handler is null) return;
+        try { handler.Invoke(this, change); }
+        catch (Exception ex)
         {
-            using var fs = new FileStream(
-                logPath, FileMode.Open, FileAccess.Read,
-                FileShare.ReadWrite | FileShare.Delete);
-
-            var overlap = Marker.Length;
-            var end = size;
-            while (end > 0)
-            {
-                var chunkSize = (int)Math.Min(ScanChunkBytes, end);
-                var scanFrom = end - chunkSize;
-                fs.Seek(scanFrom, SeekOrigin.Begin);
-                var buf = new byte[chunkSize];
-                var read = fs.Read(buf, 0, buf.Length);
-                var text = Encoding.UTF8.GetString(buf, 0, read);
-                var idx = text.LastIndexOf(Marker, StringComparison.Ordinal);
-                if (idx >= 0)
-                {
-                    var lineStart = text.LastIndexOf('\n', idx);
-                    var startInChunk = lineStart < 0 ? 0 : lineStart + 1;
-                    var lineEnd = text.IndexOf('\n', idx);
-                    if (lineEnd < 0) lineEnd = text.Length;
-                    var line = text.Substring(startInChunk, lineEnd - startInChunk).TrimEnd('\r');
-
-                    // Best-effort timestamp. The line itself may carry an
-                    // "[HH:MM:SS]" prefix but PlayerLogTailReader strips it
-                    // before normal parsing; for the seed we only care about
-                    // the AreaKey, not the timestamp, so wall-clock-now is fine.
-                    Apply(line, DateTime.UtcNow);
-                    return;
-                }
-                if (scanFrom == 0) break;
-                end = scanFrom + overlap;
-            }
-        }
-        catch (IOException ex)
-        {
-            _diag?.Warn("GameState.Area", $"SeedFromLog failed: {ex.Message}");
+            _diag?.Warn(DiagCategory, $"AreaChanged subscriber threw: {ex.Message}");
         }
     }
-
-    private const string Marker = "LOADING LEVEL";
-    private const int ScanChunkBytes = 10 * 1024 * 1024;
 }

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -17,41 +17,65 @@ namespace Mithril.GameState.Areas;
 /// <c>Player.log</c>. Post-migration it is an <see cref="IFolder{TPayload}"/>
 /// registered with <c>IPlayerWorld</c> for the <see cref="AreaLoadingFrame"/>
 /// payload type: a sibling <see cref="Producers.AreaLoadingFrameProducer"/>
-/// owns the L1 subscription (and the pre-drain seed emission), parses every
+/// owns the L1 subscription, parses every
 /// <see cref="Mithril.Shared.Logging.SystemSignalKind.AreaLoading"/> envelope
 /// via <see cref="AreaTransitionParser"/>, and emits one
 /// <see cref="AreaLoadingFrame"/> per transition. The world drives
 /// <see cref="Apply"/> per applied frame in source order; the folder returns
 /// <see cref="PlayerAreaChanged"/> change events which the world publishes on
 /// its bus (<c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c>) in
-/// addition to raising the legacy <see cref="AreaChanged"/> event.</para>
+/// addition to fanning out to legacy <see cref="Subscribe"/> handlers.</para>
 ///
-/// <para><b>Dual-surface back-compat.</b> <see cref="CurrentArea"/>
-/// (synchronous read) is preserved verbatim — Gandalf's chest-commit path and
-/// Palantir's debug refresh both rely on it. <see cref="Observe"/> also stays
-/// alive: Legolas's <c>PlayerLogIngestionService</c> and Gandalf's
-/// <c>LootIngestionService</c> still feed already-classified lines inline
-/// during the migration window. The double-feed (live envelope routed through
-/// the producer + Observe push-in) is idempotent — both paths converge on the
-/// same string-equality, last-writer-wins state. Retirement of <c>Observe</c>
-/// is owed once the two callers migrate to the bus event (separate follow-on
-/// under #774); deleting it now would break the bridges the user's scope note
-/// explicitly puts out of this PR.</para>
+/// <para><b>Three consumer channels, one truth.</b>
+/// <see cref="CurrentArea"/> (synchronous read) and <see cref="Subscribe"/>
+/// (legacy callback with replay-on-attach) remain the idiomatic surfaces for
+/// snapshot / event delivery. The world's bus carries the same
+/// <see cref="PlayerAreaChanged"/> stream — restricted to
+/// <see cref="PlayerAreaChangeKind.Changed"/>-kind events (snapshot replays
+/// are synthesized inside <see cref="Subscribe"/> and never cross the world
+/// boundary) — for cross-cutting consumers that prefer the architectural
+/// <c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c> path. Both
+/// channels fire on identical content for genuine transitions; back-compat
+/// consumers keep working; new code can choose either.</para>
+///
+/// <para><b>Legacy <see cref="Observe"/> push-in.</b> Legolas's
+/// <c>PlayerLogIngestionService</c> and Gandalf's <c>LootIngestionService</c>
+/// still feed already-classified lines inline during the migration window.
+/// The double-feed (live envelope routed through the producer + Observe
+/// push-in) is idempotent — both paths converge on the same string-equality,
+/// last-writer-wins state, and the legacy <see cref="Subscribe"/> handlers
+/// fire from either path. Retirement of <see cref="Observe"/> is owed once
+/// the two callers migrate to the bus event (separate follow-on under
+/// #774).</para>
 ///
 /// <para><b>Threading.</b> The world drives <see cref="Apply"/> from its
-/// merger thread; folder mutations + change-event dispatch run under
+/// merger thread; folder mutations + legacy handler dispatch run under
 /// <see cref="_lock"/>. <see cref="Observe"/> is called from the legacy
-/// ingestion paths (Legolas/Gandalf bridges) on their own pump threads;
-/// the same lock serialises with the world-driven path so the double-feed
-/// stays race-free. <see cref="CurrentArea"/> reads take the same short
-/// critical section.</para>
+/// ingestion paths on their own pump threads; the same lock serialises with
+/// the world-driven path so the double-feed stays race-free.
+/// <see cref="CurrentArea"/> reads take the same short critical section.
+/// <see cref="Subscribe"/> replays and attaches atomically under the lock
+/// the dispatch loop fires under, which closes the late-subscribe race.</para>
 /// </summary>
 public sealed class PlayerAreaTracker : IFolder<AreaLoadingFrame>, IPlayerAreaState
 {
     private readonly AreaTransitionParser _parser;
     private readonly IDiagnosticsSink? _diag;
     private readonly object _lock = new();
+    private readonly List<Action<PlayerAreaChanged>> _handlers = [];
     private string? _currentArea;
+
+    // Most-recent envelope timestamp the tracker has applied (area
+    // transition observed via Apply or Observe). Subscribe-replay stamps
+    // its synthetic Snapshot notification with this so late subscribers
+    // observe the same envelope-time view already-attached handlers were
+    // given (principle 13: never leak wall clock into world-event-driven
+    // state). Mirrors PlayerPinTracker._lastObservedAt /
+    // PlayerWeatherTracker._lastObservedAt. Default (DateTimeOffset.MinValue)
+    // when no envelope has been applied yet — the snapshot's
+    // Current is also null in that case, so the stamp is never meaningful
+    // in isolation.
+    private DateTimeOffset _lastObservedAt;
 
     private const string DiagCategory = "GameState.Area";
 
@@ -70,17 +94,35 @@ public sealed class PlayerAreaTracker : IFolder<AreaLoadingFrame>, IPlayerAreaSt
     }
 
     /// <inheritdoc/>
-    public event EventHandler<PlayerAreaChanged>? AreaChanged;
+    public IDisposable Subscribe(Action<PlayerAreaChanged> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // Replay the current area as a Snapshot before going live so a
+            // late subscriber observes the same view already-attached
+            // handlers see. The stamp comes from the most-recent envelope
+            // the tracker has applied (NOT wall-clock — principle 13);
+            // see _lastObservedAt's field doc.
+            Invoke(handler, new PlayerAreaChanged(
+                PlayerAreaChangeKind.Snapshot,
+                Previous: null,
+                Current: _currentArea,
+                At: _lastObservedAt));
+            _handlers.Add(handler);
+            return new Subscription(this, handler);
+        }
+    }
 
     /// <summary>
     /// Apply one area-loading frame to internal state. Returns a single
-    /// <see cref="PlayerAreaChanged"/> when the frame's
-    /// <see cref="AreaLoadingFrame.AreaKey"/> differs from the prior value;
-    /// empty otherwise. Identical-area re-emits (zone replay) are no-ops, so
-    /// consumers stay quiet through the L1 backlog drain. The clock parameter
-    /// is unused — the change event carries the frame's own timestamp so the
-    /// state derivation stays replay-deterministic over the source stream
-    /// (principle 5 + principle 13).
+    /// <see cref="PlayerAreaChanged"/> (<see cref="PlayerAreaChangeKind.Changed"/>)
+    /// when the frame's <see cref="AreaLoadingFrame.AreaKey"/> differs from
+    /// the prior value; empty otherwise. Identical-area re-emits (zone
+    /// replay) are no-ops, so consumers stay quiet through the L1 backlog
+    /// drain. The clock parameter is unused — the change event carries the
+    /// frame's own timestamp so state derivation stays replay-deterministic
+    /// over the source stream (principle 5 + principle 13).
     /// </summary>
     public IReadOnlyList<IChangeEvent> Apply(Frame<AreaLoadingFrame> frame, IWorldClock clock)
     {
@@ -92,7 +134,7 @@ public sealed class PlayerAreaTracker : IFolder<AreaLoadingFrame>, IPlayerAreaSt
     /// Feed one log line through the area parser. Idempotent for unrelated
     /// lines (the parser's substring fast-path returns null without touching
     /// state). Legacy push-in for the Gandalf/Legolas bridges; new consumers
-    /// should subscribe to <see cref="AreaChanged"/> or the world bus instead.
+    /// should subscribe via <see cref="Subscribe"/> or the world bus instead.
     /// </summary>
     public void Observe(string line, DateTime timestamp)
     {
@@ -104,37 +146,55 @@ public sealed class PlayerAreaTracker : IFolder<AreaLoadingFrame>, IPlayerAreaSt
     }
 
     /// <summary>
-    /// Shared mutation path. Returns the change-event list both call sites
-    /// honour: the folder hands it to the world for bus publication; the
-    /// legacy <see cref="Observe"/> path drops it (the legacy callers
-    /// pre-date the bus and only observe state via <see cref="CurrentArea"/>).
-    /// Either way the <see cref="AreaChanged"/> event fires for any
-    /// subscriber that has attached to the dual-surface event channel.
+    /// Shared mutation path. Returns the change-event list the folder hands
+    /// to the world for bus publication; the legacy <see cref="Subscribe"/>
+    /// handlers fire from the same path under <see cref="_lock"/>.
     /// </summary>
     private IReadOnlyList<IChangeEvent> ApplyTransition(string? areaKey, DateTimeOffset at)
     {
-        PlayerAreaChanged? change = null;
+        PlayerAreaChanged change;
+        Action<PlayerAreaChanged>[] toFire;
         lock (_lock)
         {
             if (_currentArea == areaKey) return Array.Empty<IChangeEvent>();
             var previous = _currentArea;
             _currentArea = areaKey;
-            change = new PlayerAreaChanged(previous, areaKey, at);
+            _lastObservedAt = at;
+            change = new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed, previous, areaKey, at);
             _diag?.Trace(DiagCategory,
                 $"Player area transition → {areaKey ?? "(none)"} at {at:O}");
+            toFire = _handlers.ToArray();
         }
-        RaiseAreaChanged(change);
+        foreach (var h in toFire) Invoke(h, change);
         return new IChangeEvent[] { change };
     }
 
-    private void RaiseAreaChanged(PlayerAreaChanged change)
+    private void Invoke(Action<PlayerAreaChanged> handler, PlayerAreaChanged change)
     {
-        var handler = AreaChanged;
-        if (handler is null) return;
-        try { handler.Invoke(this, change); }
+        try { handler(change); }
         catch (Exception ex)
         {
-            _diag?.Warn(DiagCategory, $"AreaChanged subscriber threw: {ex.Message}");
+            _diag?.Warn(DiagCategory, $"Subscriber threw: {ex.Message}");
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private PlayerAreaTracker? _owner;
+        private readonly Action<PlayerAreaChanged> _handler;
+
+        public Subscription(PlayerAreaTracker owner, Action<PlayerAreaChanged> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
         }
     }
 }

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -42,11 +42,30 @@ namespace Mithril.GameState.Areas;
 /// <c>PlayerLogIngestionService</c> and Gandalf's <c>LootIngestionService</c>
 /// still feed already-classified lines inline during the migration window.
 /// The double-feed (live envelope routed through the producer + Observe
-/// push-in) is idempotent — both paths converge on the same string-equality,
-/// last-writer-wins state, and the legacy <see cref="Subscribe"/> handlers
-/// fire from either path. Retirement of <see cref="Observe"/> is owed once
-/// the two callers migrate to the bus event (separate follow-on under
-/// #774).</para>
+/// push-in) is <b>state-idempotent</b> — both paths converge on the same
+/// string-equality, last-writer-wins <see cref="CurrentArea"/>, and the
+/// legacy <see cref="Subscribe"/> handlers fire from either path. Retirement
+/// of <see cref="Observe"/> is owed once the two callers migrate to the bus
+/// event (separate follow-on under
+/// <a href="https://github.com/moumantai-gg/mithril/issues/774">#774</a>).</para>
+///
+/// <para><b>Asymmetry: bus emission is NOT idempotent across the double-feed.</b>
+/// A transition routed through the producer → merger → <see cref="Apply"/>
+/// path publishes a <see cref="PlayerAreaChanged"/> frame on
+/// <c>IPlayerWorld.Bus</c>. The same transition routed through
+/// <see cref="Observe"/> does not — <see cref="ApplyTransition"/> returns the
+/// change list, but the legacy callers discard it (there's no world to hand it
+/// to from a push-in context). So if <see cref="Observe"/> lands FIRST for a
+/// given transition, the subsequent <see cref="Apply"/> sees the state already
+/// matches and returns empty, and the bus emits ZERO frames for that
+/// transition; if <see cref="Apply"/> lands first, the bus emits one frame
+/// and <see cref="Observe"/> is the no-op. <see cref="CurrentArea"/> and the
+/// <see cref="Subscribe"/> callback path are unaffected — both fire from
+/// either path. The asymmetry only matters for bus subscribers that count
+/// emissions (e.g., a hypothetical "area-transitions-per-session" metric);
+/// consumers that read state-on-event don't notice. Resolves automatically
+/// once the two <see cref="Observe"/> callers migrate to the bus event per
+/// the #774 follow-on.</para>
 ///
 /// <para><b>Threading.</b> The world drives <see cref="Apply"/> from its
 /// merger thread; folder mutations + legacy handler dispatch run under

--- a/src/Mithril.GameState/Areas/Producers/AreaLoadingFrameProducer.cs
+++ b/src/Mithril.GameState/Areas/Producers/AreaLoadingFrameProducer.cs
@@ -1,0 +1,327 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Channels;
+using Mithril.GameState.Areas.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim;
+
+namespace Mithril.GameState.Areas.Producers;
+
+/// <summary>
+/// World-simulator producer that adapts the L1 driver's
+/// <see cref="ILogStreamDriver"/> push-based <c>SystemSignal</c> subscription
+/// into the world's pull-based <see cref="IFrameProducer{TPayload}"/> contract
+/// for the Player.log area folder (#775). Filters
+/// <see cref="SystemSignalKind.AreaLoading"/> envelopes, parses each via
+/// <see cref="AreaTransitionParser"/>, and emits one
+/// <see cref="AreaLoadingFrame"/> per transition; non-area system-signal kinds
+/// (LoginBanner / PlayerAdded / SessionLifecycle) are dropped at this
+/// boundary so the world sees only area frames.
+///
+/// <para><b>Eager pre-warm seed (separate from L1 stream).</b> Mithril's L1
+/// driver rewinds the session-replay window to the most recent
+/// <c>ProcessAddPlayer(</c> line, which lands ~9 s <em>after</em> the
+/// <c>LOADING LEVEL</c> line for the current area — so a pure-L1
+/// subscription would never see the current area's transition. The producer
+/// exposes <see cref="TryBuildSeedFrame"/> as a pure helper: a one-shot
+/// reverse-scan of <see cref="GameConfig.PlayerLogPath"/> for the most recent
+/// <c>LOADING LEVEL</c> line, parsing its embedded <c>[HH:MM:SS]</c> prefix
+/// (combined with the file's mtime to recover the UTC date — same fallback
+/// shape as <c>PlayerLogClock.EnsureAnchored</c>'s mtime path). The
+/// <c>PlayerAreaWorldRegistration</c> hosted service drives this synchronously
+/// at its own <c>StartAsync</c> and applies the result directly to the folder,
+/// so the back-compat <see cref="IPlayerAreaState.CurrentArea"/> read returns
+/// the correct area BEFORE any consumer's <c>StartAsync</c> runs later in
+/// the hosted-service registration order (Legolas's
+/// <c>PlayerLogIngestionService.ApplyAreaIfChanged</c> being the relevant
+/// caller).</para>
+///
+/// <para>The seed is NOT yielded through <see cref="SubscribeAsync"/> — it
+/// would no-op at the folder anyway (Apply on the already-current area
+/// returns an empty change list) and would arrive only after the merger
+/// drains, defeating the eager-attach point. World-bus consumers reading
+/// the seed snapshot use the same pattern as the skill folder:
+/// <see cref="IPlayerAreaState.CurrentArea"/> for initial state,
+/// <c>IPlayerWorld.Bus.Subscribe&lt;PlayerAreaChanged&gt;</c> for
+/// subsequent transitions.</para>
+///
+/// <para><b>Mode awareness.</b> Mirrors
+/// <see cref="Mithril.GameState.Skills.Producers.SkillFrameProducer"/>'s shape
+/// — <see cref="ReachedLive"/> completes the moment the producer reads the
+/// first non-replay envelope from the L1 driver. PG only emits a transition
+/// per actual portal (~ once per minute at most); a player idle in one area
+/// could go indefinitely without a live area-frame and we mustn't stall the
+/// world's mode flip waiting for one. The seed frame itself does NOT flip the
+/// mode (it is emitted before the L1 subscription opens).</para>
+///
+/// <para><b>L1 subscription disposition.</b> Archetype-A defaults
+/// (<see cref="ReplayMode.FromSessionStart"/> +
+/// <see cref="DeliveryContext.Inline"/>), matching the pre-migration
+/// <c>PlayerAreaTracker</c> exactly — the L0.5 router strips the envelope,
+/// the parser consumes <see cref="SystemSignalLogLine.Data"/> directly, and
+/// L1 owns containment around each handler invocation.</para>
+///
+/// <para><b>Channel buffer.</b> An unbounded single-reader channel sits
+/// between the push-callback and the IAsyncEnumerable yield. The L1 driver
+/// already throttles by source-stream rate (Player.log area transitions are
+/// human-portal-bounded — minutes apart at most), so unbounded is acceptable
+/// and avoids the deadlock risk a bounded buffer would introduce.</para>
+/// </summary>
+public sealed class AreaLoadingFrameProducer
+    : IFrameProducer<AreaLoadingFrame>, IModeAwareFrameProducer<AreaLoadingFrame>
+{
+    private readonly ILogStreamDriver _driver;
+    private readonly AreaTransitionParser _parser;
+    private readonly GameConfig? _config;
+    private readonly IDiagnosticsSink? _diag;
+    private readonly TaskCompletionSource _reachedLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private const string DiagCategory = "GameState.Area";
+    private const string Marker = "LOADING LEVEL";
+
+    // Mirrored from the pre-migration PlayerAreaTracker.ScanChunkBytes
+    // (originally mirrored from PlayerLogTailReader.SessionScanChunkBytes).
+    // 10 MB chunk, then walk backward in chunks until either the marker is
+    // found or the start of the file is reached — bounded by file size, not
+    // by the chunk constant.
+    private const int ScanChunkBytes = 10 * 1024 * 1024;
+
+    public AreaLoadingFrameProducer(
+        ILogStreamDriver driver,
+        AreaTransitionParser parser,
+        GameConfig? config = null,
+        IDiagnosticsSink? diag = null)
+    {
+        _driver = driver ?? throw new ArgumentNullException(nameof(driver));
+        _parser = parser ?? throw new ArgumentNullException(nameof(parser));
+        _config = config;
+        _diag = diag;
+    }
+
+    /// <summary>
+    /// Producer priority for the merger's tie-breaking. Matches the
+    /// classified-pipe producers' priority (0) — same source, same ordering
+    /// rights.
+    /// </summary>
+    public int Priority => 0;
+
+    public Task ReachedLive => _reachedLive.Task;
+
+    public async IAsyncEnumerable<Frame<AreaLoadingFrame>> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        // SingleReader: only the world's merger reads via the async enumerator.
+        // Unbounded: see the class-doc rationale (L1 already paces by source).
+        var channel = Channel.CreateUnbounded<Frame<AreaLoadingFrame>>(
+            new UnboundedChannelOptions { SingleReader = true });
+
+        _diag?.Info(DiagCategory,
+            "AreaLoadingFrameProducer subscribing to L1 driver (SystemSignal pipe) for AreaLoading frames");
+
+        var subscription = _driver.Subscribe<SystemSignalLogLine>(
+            envelope =>
+            {
+                // Mode flip is driven by envelope-shape, not area-shape (see
+                // class doc). The L1 contract guarantees IsReplay transitions
+                // once and never re-arms, so TrySetResult is idempotent past
+                // that boundary. Idle players in one area can go arbitrarily
+                // long without an AreaLoading envelope; the flip must not
+                // depend on one ever arriving.
+                if (!envelope.IsReplay)
+                {
+                    _reachedLive.TrySetResult();
+                }
+
+                var line = envelope.Payload;
+                if (line.Kind != SystemSignalKind.AreaLoading)
+                {
+                    return ValueTask.CompletedTask;
+                }
+
+                if (_parser.TryParse(line.Data, line.Timestamp.UtcDateTime)
+                    is not AreaTransitionEvent evt)
+                {
+                    return ValueTask.CompletedTask;
+                }
+
+                // TryWrite on an unbounded channel can only fail post-Complete,
+                // and we never complete from inside the callback. Discarding
+                // the result keeps the hot path branch-free.
+                _ = channel.Writer.TryWrite(new Frame<AreaLoadingFrame>(
+                    line.Timestamp, new AreaLoadingFrame(evt.AreaKey)));
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        try
+        {
+            await foreach (var frame in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return frame;
+            }
+        }
+        finally
+        {
+            subscription.Dispose();
+            // Guarantee ReachedLive completes even if the stream ended without
+            // ever flipping (degenerate test fixture, or a replay-only file
+            // tail). Matches SkillFrameProducer's terminal fallback.
+            _reachedLive.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Reverse-scan the configured Player.log for the most recent
+    /// <c>LOADING LEVEL</c> line, parse its embedded timestamp + area, and
+    /// return a seed frame. Returns <c>null</c> when there's no config, no
+    /// file, or no marker — those all reduce to "area unknown at startup,"
+    /// which is a valid and self-healing state. Pure function: safe to call
+    /// from any thread; performs file I/O but mutates no producer state.
+    ///
+    /// <para>Called synchronously by
+    /// <c>PlayerAreaWorldRegistration.StartAsync</c>; result is applied
+    /// directly to the folder so back-compat synchronous-read consumers
+    /// (Gandalf's chest-area stamp, Legolas's
+    /// <c>ApplyAreaIfChanged</c>, Palantir's debug refresh) see the correct
+    /// area at THEIR own <c>StartAsync</c> later in registration order.</para>
+    /// </summary>
+    public Frame<AreaLoadingFrame>? TryBuildSeedFrame()
+    {
+        var path = _config?.PlayerLogPath;
+        if (string.IsNullOrEmpty(path) || !File.Exists(path)) return null;
+
+        var info = new FileInfo(path);
+        if (info.Length == 0) return null;
+
+        string? seedLine;
+        try
+        {
+            seedLine = ScanForMostRecentMarker(path, info.Length);
+        }
+        catch (IOException ex)
+        {
+            _diag?.Warn(DiagCategory, $"Pre-drain seed scan failed: {ex.Message}");
+            return null;
+        }
+
+        if (seedLine is null)
+        {
+            _diag?.Info(DiagCategory,
+                "Pre-drain seed: no LOADING LEVEL marker in scanned region — folder starts area-unknown");
+            return null;
+        }
+
+        var stamp = ResolveSeedTimestamp(seedLine, info.LastWriteTimeUtc);
+        if (_parser.TryParse(seedLine, stamp.UtcDateTime)
+            is not AreaTransitionEvent evt)
+        {
+            // Marker matched but the parser rejected the line shape. Surface
+            // it so a future grammar drift is investigable; no seed frame.
+            _diag?.Warn(DiagCategory,
+                $"Pre-drain seed: marker found but parser rejected line: {seedLine}");
+            return null;
+        }
+
+        return new Frame<AreaLoadingFrame>(stamp, new AreaLoadingFrame(evt.AreaKey));
+    }
+
+    /// <summary>
+    /// Walk the file backward in chunks until the most recent
+    /// <see cref="Marker"/> is found; return the surrounding full line (no
+    /// trailing newline). Returns <c>null</c> when no marker is present.
+    /// </summary>
+    private static string? ScanForMostRecentMarker(string logPath, long size)
+    {
+        using var fs = new FileStream(
+            logPath, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+
+        var overlap = Marker.Length;
+        var end = size;
+        while (end > 0)
+        {
+            var chunkSize = (int)Math.Min(ScanChunkBytes, end);
+            var scanFrom = end - chunkSize;
+            fs.Seek(scanFrom, SeekOrigin.Begin);
+            var buf = new byte[chunkSize];
+            var read = fs.Read(buf, 0, buf.Length);
+            var text = Encoding.UTF8.GetString(buf, 0, read);
+            var idx = text.LastIndexOf(Marker, StringComparison.Ordinal);
+            if (idx >= 0)
+            {
+                var lineStart = text.LastIndexOf('\n', idx);
+                var startInChunk = lineStart < 0 ? 0 : lineStart + 1;
+                var lineEnd = text.IndexOf('\n', idx);
+                if (lineEnd < 0) lineEnd = text.Length;
+                return text.Substring(startInChunk, lineEnd - startInChunk).TrimEnd('\r');
+            }
+            if (scanFrom == 0) break;
+            end = scanFrom + overlap;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Recover a full <see cref="DateTimeOffset"/> from a seed line's
+    /// <c>[HH:MM:SS]</c> prefix anchored against the file's UTC mtime. PG's
+    /// Player.log carries time-of-day only; this fold mirrors
+    /// <c>PlayerLogClock.EnsureAnchored</c>'s mtime-anchor fallback: if the
+    /// parsed time-of-day is later than mtime's time-of-day, the line falls
+    /// on the previous UTC day; otherwise the same day. Either way the
+    /// resulting timestamp is bounded by the file write window, which is the
+    /// most defensible anchor available without already consuming the L1
+    /// session-banner stream (the producer runs before that).
+    ///
+    /// <para>When the prefix is missing or malformed, fall back to the file's
+    /// mtime. The seed-line shape comes from PG itself — every gameplay line
+    /// carries the prefix — so the fallback is a defence-in-depth path.</para>
+    /// </summary>
+    private static DateTimeOffset ResolveSeedTimestamp(string seedLine, DateTime mtimeUtc)
+    {
+        if (!TryParseTimestampPrefix(seedLine, out var tod))
+        {
+            return new DateTimeOffset(
+                DateTime.SpecifyKind(mtimeUtc, DateTimeKind.Utc));
+        }
+
+        var anchorDate = DateOnly.FromDateTime(mtimeUtc);
+        if (tod > mtimeUtc.TimeOfDay) anchorDate = anchorDate.AddDays(-1);
+
+        var utc = new DateTime(
+            anchorDate.Year, anchorDate.Month, anchorDate.Day,
+            tod.Hours, tod.Minutes, tod.Seconds, DateTimeKind.Utc);
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// Parse the <c>[HH:MM:SS] </c> prefix every PG gameplay line carries.
+    /// Inlined from the internal <c>PlayerLogClock.TryParseTimestampPrefix</c>
+    /// helper rather than crossing an assembly boundary for a fixed-width
+    /// 11-byte parse — the format is bolted into PG's logging code and
+    /// hasn't drifted in years, so the small duplication is bounded.
+    /// </summary>
+    private static bool TryParseTimestampPrefix(string line, out TimeSpan tod)
+    {
+        tod = default;
+        if (line.Length < 11) return false;
+        if (line[0] != '[' || line[3] != ':' || line[6] != ':' || line[9] != ']' || line[10] != ' ') return false;
+        if (!IsAsciiDigit(line[1]) || !IsAsciiDigit(line[2])) return false;
+        if (!IsAsciiDigit(line[4]) || !IsAsciiDigit(line[5])) return false;
+        if (!IsAsciiDigit(line[7]) || !IsAsciiDigit(line[8])) return false;
+        var h = (line[1] - '0') * 10 + (line[2] - '0');
+        var m = (line[4] - '0') * 10 + (line[5] - '0');
+        var s = (line[7] - '0') * 10 + (line[8] - '0');
+        if (h >= 24 || m >= 60 || s >= 60) return false;
+        tod = new TimeSpan(h, m, s);
+        return true;
+    }
+
+    private static bool IsAsciiDigit(char c) => (uint)(c - '0') <= 9;
+}

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Areas.Producers;
 using Mithril.GameState.Celestial;
 using Mithril.GameState.Celestial.Parsing;
 using Mithril.GameState.Chat;
@@ -144,16 +145,36 @@ public static class GameStateServiceCollectionExtensions
 
         // Area tracking is shared live game-state (Gandalf chest-area
         // stamping, Legolas per-area survey calibration, …). One parser,
-        // one tracker, registered once here — consumers inject the tracker.
-        // Self-feeding hosted service since #556 Phase 2 — subscribes to
-        // the L0.5 SystemSignal pipe through the L1 driver and folds
-        // AreaLoading envelopes into CurrentArea. Pin/Weather/Position
-        // still call Observe(raw) until Phase 3 retires that surface;
-        // the double-feed is idempotent under last-writer-wins.
+        // one tracker, registered once here — consumers inject the tracker
+        // (concrete for back-compat) or IPlayerAreaState (new code).
+        //
+        // World-simulator migration (#775): the service is now an
+        // IFolder<AreaLoadingFrame> registered with IPlayerWorld; a sibling
+        // AreaLoadingFrameProducer owns the L1 SystemSignal subscription,
+        // pre-drains a seed frame for the most recent LOADING LEVEL upstream
+        // of L1's session-start anchor, and feeds AreaLoading frames into
+        // the world's merger. The PlayerAreaWorldRegistration hosted
+        // service wires both into the world during the chain's
+        // IHostedService.StartAsync phase, before the trailing
+        // WorldMergerStartHostedService (appended by ShellComposition's
+        // AddMithrilApp — #696 Call 2) calls IWorld.StartMerger and the
+        // merger drain begins.
+        //
+        // The legacy Observe(string, DateTime) push-in stays alive: Legolas's
+        // PlayerLogIngestionService.ApplyAreaIfChanged and Gandalf's
+        // LootIngestionService.Dispatch still feed already-classified lines
+        // inline. The double-feed (live envelope routed through the producer
+        // + the bridge's Observe push-in) is idempotent under last-writer-
+        // wins — both paths converge on the same string-equality state.
+        // Retiring Observe is owed under the #774 follow-on sweep once the
+        // two bridges migrate to the bus event.
         services.AddSingleton<AreaTransitionParser>();
         services
             .AddSingleton<PlayerAreaTracker>()
-            .AddHostedService(sp => sp.GetRequiredService<PlayerAreaTracker>());
+            .AddSingleton<IPlayerAreaState>(sp => sp.GetRequiredService<PlayerAreaTracker>())
+            .AddSingleton<IFolder<AreaLoadingFrame>>(sp => sp.GetRequiredService<PlayerAreaTracker>())
+            .AddSingleton<AreaLoadingFrameProducer>()
+            .AddHostedService<PlayerAreaWorldRegistration>();
 
         // Shared live skill state from Player.log (ProcessLoadSkills /
         // ProcessUpdateSkill) — no character re-export required. Single parser,
@@ -323,6 +344,75 @@ public static class GameStateServiceCollectionExtensions
             .AddHostedService<WordOfPowerViewRegistration>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Hosted service that wires <see cref="PlayerAreaTracker"/> (folder) +
+    /// <see cref="AreaLoadingFrameProducer"/> (producer) into the
+    /// <see cref="IPlayerWorld"/> singleton at host start (#775). Mirrors
+    /// <see cref="PlayerSkillStateWorldRegistration"/>'s shape (the canonical
+    /// Phase 1 template) with one addition: an eager synchronous pre-warm of
+    /// the folder from the producer's reverse-scan seed.
+    ///
+    /// <para><b>Eager pre-warm rationale.</b> Mithril's L1 driver rewinds the
+    /// session-replay window to the most recent <c>ProcessAddPlayer(</c>
+    /// line, which lands ~9 s AFTER the relevant <c>LOADING LEVEL</c> line,
+    /// so a pure-L1 subscription would never see the current area's
+    /// transition. The producer's <c>TryBuildSeedFrame</c> closes that gap
+    /// with a reverse-scan of <c>Player.log</c>. Dispatching the seed via the
+    /// world's merger means the folder's state stays empty until
+    /// <c>WorldMergerStartHostedService</c> (the trailing #696 Call 2 service)
+    /// runs and drains the producer's queue — which is AFTER every other
+    /// hosted service's <c>StartAsync</c>, including Legolas's
+    /// <c>PlayerLogIngestionService</c> whose startup
+    /// <c>ApplyAreaIfChanged</c> needs the area NOW. Pre-warming the folder
+    /// directly inside this registration's <c>StartAsync</c> (which runs
+    /// BEFORE Legolas's per hosted-service registration order) restores the
+    /// pre-#775 synchronous-read semantics: by the time any downstream
+    /// <c>StartAsync</c> reads <see cref="IPlayerAreaState.CurrentArea"/>,
+    /// the folder is hot. The seed is NOT yielded through the producer's
+    /// <c>SubscribeAsync</c> — it would no-op at the folder anyway (Apply on
+    /// the already-current area returns empty) and would arrive only after
+    /// the merger drains, defeating the eager-attach point.</para>
+    /// </summary>
+    private sealed class PlayerAreaWorldRegistration : IHostedService
+    {
+        private readonly IPlayerWorld _world;
+        private readonly PlayerAreaTracker _folder;
+        private readonly AreaLoadingFrameProducer _producer;
+
+        public PlayerAreaWorldRegistration(
+            IPlayerWorld world,
+            PlayerAreaTracker folder,
+            AreaLoadingFrameProducer producer)
+        {
+            _world = world;
+            _folder = folder;
+            _producer = producer;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Eager pre-warm: synchronously scan Player.log for the current
+            // area and apply directly to the folder so back-compat
+            // synchronous-read consumers (Legolas's startup
+            // ApplyAreaIfChanged, Gandalf's chest-area stamp, Palantir's
+            // debug refresh) see the right area when THEIR StartAsync runs
+            // later in registration order. The seed frame carries the parsed
+            // [HH:MM:SS] log instant — not wall-clock — so the folder's
+            // state derivation is replay-deterministic over the source
+            // stream (principle 5 + principle 13).
+            if (_producer.TryBuildSeedFrame() is { } seed)
+            {
+                _ = _folder.Apply(seed, _world.Clock);
+            }
+
+            _world.RegisterProducer(_producer);
+            _world.RegisterFolder(_folder);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
     /// <summary>

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -55,15 +55,22 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         ModuleGates Gates);
 
     private static Fixture Build(
-        AreaCalibration? calibration = null, GameConfig? config = null,
+        AreaCalibration? calibration = null, string? preSeededArea = null,
         bool openGate = true)
     {
         var driver = new TestLogStreamDriver();
-        // #514: the shared tracker owns its one-shot seed. Route the test's
-        // config to the tracker so a startup-seed test drives the owned
-        // self-seed (lazy-on-first-read of CurrentArea — which
-        // ApplyAreaIfChanged does at gate-open).
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), config: config);
+        // #775: the tracker's lazy self-seed retired; the production seed
+        // path is PlayerAreaWorldRegistration.StartAsync (eager pre-warm
+        // via AreaLoadingFrameProducer.TryBuildSeedFrame -> folder.Apply).
+        // For the unit test fixture that exercises Legolas directly without
+        // wiring a producer/world, the eager pre-warm is faked via a single
+        // Observe() call before constructing the service — same semantics,
+        // simpler scaffolding.
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        if (preSeededArea is not null)
+        {
+            tracker.Observe($"LOADING LEVEL {preSeededArea}", DateTime.UtcNow);
+        }
         var spy = new SpyAreaCalibration(calibration);
         var session = new SessionState();
         var settings = new LegolasSettings();
@@ -206,23 +213,22 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     }
 
     /// <summary>
-    /// #514 + #550 LiveOnly composition: PlayerAreaTracker self-seeds on
-    /// first <see cref="PlayerAreaTracker.CurrentArea"/> read. The L1
-    /// subscription is LiveOnly so we do NOT pump replay envelopes — the
-    /// tracker's own log scan delivers the area before any live envelope.
+    /// #514 + #550 LiveOnly composition + #775 eager pre-warm:
+    /// <see cref="PlayerAreaTracker"/>'s current area is populated BEFORE
+    /// Legolas's <c>StartAsync</c> runs (in production: the
+    /// <c>PlayerAreaWorldRegistration</c> hosted service eagerly applies the
+    /// producer's reverse-scan seed during its own <c>StartAsync</c>, which
+    /// runs before Legolas's per registration order). The L1 subscription
+    /// is LiveOnly so we do NOT pump replay envelopes — the eager pre-warm
+    /// delivers the area before any live envelope. The unit fixture fakes
+    /// the pre-warm via <see cref="PlayerAreaTracker.Observe"/>; the
+    /// production seed shape is covered by
+    /// <c>AreaLoadingFrameProducerTests.Seed_picks_the_LATEST_LOADING_LEVEL_with_its_parsed_log_timestamp</c>.
     /// </summary>
     [Fact]
     public async Task Startup_seed_applies_current_area_before_live_lines()
     {
-        var logPath = Path.Combine(_tempDir, "Player.log");
-        File.WriteAllText(
-            logPath,
-            "LocalPlayer: ProcessAddItem(Apple(1), -1, True)\n" +
-            "LOADING LEVEL AreaEltibule\n" +
-            "LocalPlayer: ProcessAddPlayer(...)\n",
-            new UTF8Encoding(false));
-
-        var f = Build(config: new GameConfig { GameRoot = _tempDir });
+        var f = Build(preSeededArea: "AreaEltibule");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = f.Service.StartAsync(cts.Token);
         try

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
@@ -1,38 +1,32 @@
-using System.IO;
-using System.Text;
 using FluentAssertions;
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
-using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Game;
-using Mithril.Shared.Logging;
+using Mithril.WorldSim;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Areas;
 
-[Trait("Category", "FileIO")]
-[Collection("FileIO")]
-public sealed class PlayerAreaTrackerTests : IDisposable
+/// <summary>
+/// Unit tests for the folder + dual-surface event behaviour of
+/// <see cref="PlayerAreaTracker"/> after the #775 conversion. The producer-side
+/// behaviour (reverse-scan pre-drain, L1 SystemSignal forwarding, ReachedLive
+/// flip) lives in <see cref="AreaLoadingFrameProducerTests"/>; the end-to-end
+/// replay-determinism integration lives in
+/// <see cref="PlayerAreaWorldIntegrationTests"/>.
+/// </summary>
+public sealed class PlayerAreaTrackerTests
 {
-    private readonly string _tempDir;
-
-    public PlayerAreaTrackerTests()
-    {
-        _tempDir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_area_tracker");
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
-    }
-
     private static PlayerAreaTracker Build() => new(new AreaTransitionParser());
+
+    private static readonly IWorldClock UnusedClock = new StubClock();
 
     [Fact]
     public void Initial_state_is_null()
     {
         Build().CurrentArea.Should().BeNull();
     }
+
+    // ── Legacy Observe path (Legolas + Gandalf bridges still call this) ───
 
     [Fact]
     public void Observe_real_area_sets_CurrentArea()
@@ -80,296 +74,138 @@ public sealed class PlayerAreaTrackerTests : IDisposable
     }
 
     [Fact]
-    public void SeedFromLog_picks_up_most_recent_area()
-    {
-        var path = WriteLog(
-            "LocalPlayer: ProcessAddItem(Apple(1), -1, True)",
-            "LOADING LEVEL AreaSerbule",
-            "LocalPlayer: ProcessAddPlayer(...)",
-            "LOADING LEVEL AreaEltibule",
-            "LocalPlayer: ProcessAddPlayer(...)",
-            "(more game noise)");
-        var tracker = Build();
-        tracker.SeedFromLog(path);
-        tracker.CurrentArea.Should().Be("AreaEltibule");
-    }
-
-    [Fact]
-    public void SeedFromLog_with_disconnect_clears_area()
-    {
-        var path = WriteLog(
-            "LOADING LEVEL AreaSerbule",
-            "(player plays for a while)",
-            "LOADING LEVEL ");
-        var tracker = Build();
-        tracker.SeedFromLog(path);
-        tracker.CurrentArea.Should().BeNull();
-    }
-
-    [Fact]
-    public void SeedFromLog_with_no_marker_is_noop()
-    {
-        var path = WriteLog(
-            "LocalPlayer: ProcessAddItem(Apple(1), -1, True)",
-            "LocalPlayer: ProcessAddPlayer(...)",
-            "(no area transition lines)");
-        var tracker = Build();
-        tracker.SeedFromLog(path);
-        tracker.CurrentArea.Should().BeNull();
-    }
-
-    [Fact]
-    public void SeedFromLog_missing_file_is_noop()
+    public void Observe_raises_AreaChanged_with_log_line_timestamp()
     {
         var tracker = Build();
-        tracker.SeedFromLog(Path.Combine(_tempDir, "does-not-exist.log"));
-        tracker.CurrentArea.Should().BeNull();
+        var observed = new List<PlayerAreaChanged>();
+        tracker.AreaChanged += (_, e) => observed.Add(e);
+
+        var when = new DateTime(2026, 5, 23, 14, 11, 10, DateTimeKind.Utc);
+        tracker.Observe("LOADING LEVEL AreaSerbule", when);
+
+        observed.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                Previous: null,
+                Current: "AreaSerbule",
+                At: new DateTimeOffset(when, TimeSpan.Zero)));
     }
 
     [Fact]
-    public void SeedFromLog_then_live_observe_advances_state()
+    public void Observe_re_emitting_same_area_does_not_raise_event()
     {
-        var path = WriteLog(
-            "LOADING LEVEL AreaSerbule");
         var tracker = Build();
-        tracker.SeedFromLog(path);
-        tracker.CurrentArea.Should().Be("AreaSerbule");
+        var observed = new List<PlayerAreaChanged>();
+        tracker.AreaChanged += (_, e) => observed.Add(e);
 
-        // Live tail then observes a fresh portal.
-        tracker.Observe("LOADING LEVEL AreaTomb1", DateTime.UtcNow);
-        tracker.CurrentArea.Should().Be("AreaTomb1");
-    }
-
-    // ---- #514: tracker owns its one-shot seed; consumers only read --------
-
-    private sealed class CapturingSink : IDiagnosticsSink
-    {
-        public List<(DiagnosticLevel Level, string Category, string Message)> Entries { get; } = new();
-        public void Write(DiagnosticLevel level, string category, string message) =>
-            Entries.Add((level, category, message));
-        public IReadOnlyList<DiagnosticEntry> Snapshot() => Array.Empty<DiagnosticEntry>();
-        public event EventHandler<DiagnosticEntry>? EntryAdded { add { } remove { } }
-    }
-
-    /// <summary>Writes <c>Player.log</c> into a fresh dir and returns a
-    /// <see cref="GameConfig"/> whose <c>PlayerLogPath</c> points at it.</summary>
-    private (GameConfig cfg, string logPath) WriteGameRoot(params string[] lines)
-    {
-        var root = Path.Combine(_tempDir, Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        var path = Path.Combine(root, "Player.log");
-        File.WriteAllText(path, string.Join('\n', lines) + "\n", new UTF8Encoding(false));
-        return (new GameConfig { GameRoot = root }, path);
-    }
-
-    [Fact]
-    public void Self_seeds_lazily_on_first_CurrentArea_read_without_explicit_SeedFromLog()
-    {
-        var (cfg, _) = WriteGameRoot(
-            "LOADING LEVEL AreaSerbule",
-            "LocalPlayer: ProcessAddPlayer(...)");
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), diag: null, config: cfg);
-
-        // No consumer calls SeedFromLog — the read triggers the owned seed.
-        tracker.CurrentArea.Should().Be("AreaSerbule");
-    }
-
-    [Fact]
-    public void Self_seeds_lazily_on_first_Observe()
-    {
-        var (cfg, _) = WriteGameRoot("LOADING LEVEL AreaEltibule");
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), diag: null, config: cfg);
-
-        tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", DateTime.UtcNow);
-
-        tracker.CurrentArea.Should().Be("AreaEltibule");
-    }
-
-    [Fact]
-    public void Self_seed_runs_at_most_once()
-    {
-        var (cfg, logPath) = WriteGameRoot("LOADING LEVEL AreaSerbule");
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), diag: null, config: cfg);
-
-        tracker.CurrentArea.Should().Be("AreaSerbule");          // seeds once
-
-        // Rewrite the log; a second read must NOT re-scan (idempotent one-shot).
-        File.WriteAllText(logPath, "LOADING LEVEL AreaEltibule\n", new UTF8Encoding(false));
-        tracker.CurrentArea.Should().Be("AreaSerbule");
-    }
-
-    [Fact]
-    public void Unknown_area_after_seed_is_surfaced_once_not_a_silent_null()
-    {
-        var sink = new CapturingSink();
-        // GameRoot set but no Player.log written ⇒ seed finds nothing.
-        var root = Path.Combine(_tempDir, Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        var tracker = new PlayerAreaTracker(
-            new AreaTransitionParser(), sink, new GameConfig { GameRoot = root });
-
-        tracker.CurrentArea.Should().BeNull();
-        _ = tracker.CurrentArea;     // second read must not re-warn
-
-        sink.Entries.Should().ContainSingle()
-            .Which.Should().Match<(DiagnosticLevel Level, string Category, string Message)>(
-                e => e.Level == DiagnosticLevel.Info
-                  && e.Category == "GameState.Area"
-                  && e.Message.Contains("Area unknown"));
-    }
-
-    [Fact]
-    public void Explicit_SeedFromLog_suppresses_the_later_lazy_rescan()
-    {
-        var (cfg, _) = WriteGameRoot("LOADING LEVEL AreaSerbule");
-        var otherPath = WriteLog("LOADING LEVEL AreaTomb1");
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), diag: null, config: cfg);
-
-        tracker.SeedFromLog(otherPath);                 // explicit seed marks attempted
-        tracker.CurrentArea.Should().Be("AreaTomb1");   // lazy seed must NOT override with cfg's area
-    }
-
-    private string WriteLog(params string[] lines)
-    {
-        var path = Path.Combine(_tempDir, $"player_{Guid.NewGuid():N}.log");
-        // Real Player.log doesn't carry a UTF-8 BOM; Encoding.UTF8 in .NET
-        // emits one by default (﻿ prefix), which would defeat the
-        // parser's "^" anchor. Use BOM-less UTF-8 to mirror live shape.
-        File.WriteAllText(path, string.Join('\n', lines) + "\n", new UTF8Encoding(false));
-        return path;
-    }
-
-    // ---- #556 Phase 2: L1 self-feed via SystemSignal pipe -----------------
-
-    private static SystemSignalLogLine MakeAreaLoading(string area, long seq) =>
-        new(
-            Timestamp: DateTimeOffset.UtcNow,
-            Kind: SystemSignalKind.AreaLoading,
-            Data: $"LOADING LEVEL {area}",
-            Sequence: seq,
-            ReadMonotonicTicks: 0);
-
-    private static SystemSignalLogLine MakeSignal(SystemSignalKind kind, string data, long seq) =>
-        new(
-            Timestamp: DateTimeOffset.UtcNow,
-            Kind: kind,
-            Data: data,
-            Sequence: seq,
-            ReadMonotonicTicks: 0);
-
-    [Fact]
-    public async Task L1_self_feed_updates_CurrentArea_from_AreaLoading_envelopes()
-    {
-        // Phase 2 — AreaTracker subscribes via the L1 driver to the typed
-        // SystemSignal pipe and folds AreaLoading envelopes into CurrentArea.
-        // No other producer needs to call Observe(raw) for this state to
-        // stay live.
-        using var driver = new Mithril.GameState.Tests.TestSupport.TestLogStreamDriver();
-        driver.PushReplay(MakeAreaLoading("AreaSerbule", seq: 1));
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), driver: driver);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await tracker.StartAsync(cts.Token);
-        try
-        {
-            await driver.DrainSystemAsync();
-            tracker.CurrentArea.Should().Be("AreaSerbule");
-
-            driver.PushLive(MakeAreaLoading("AreaEltibule", seq: 2));
-            await driver.DrainSystemAsync();
-            tracker.CurrentArea.Should().Be("AreaEltibule");
-        }
-        finally
-        {
-            await tracker.StopAsync(CancellationToken.None);
-            tracker.Dispose();
-        }
-    }
-
-    [Fact]
-    public async Task L1_self_feed_ignores_non_AreaLoading_kinds()
-    {
-        // The handler filters for Kind == AreaLoading; other SystemSignal
-        // kinds (LoginBanner, PlayerAdded, SessionLifecycle) must not
-        // overwrite CurrentArea even when the typed pipe carries them.
-        using var driver = new Mithril.GameState.Tests.TestSupport.TestLogStreamDriver();
-        driver.PushReplay(MakeAreaLoading("AreaSerbule", seq: 1));
-        driver.PushReplay(MakeSignal(SystemSignalKind.LoginBanner,
-            "Logged in as character X. Time UTC=...", seq: 2));
-        driver.PushReplay(MakeSignal(SystemSignalKind.PlayerAdded,
-            "ProcessAddPlayer(...)", seq: 3));
-        driver.PushReplay(MakeSignal(SystemSignalKind.SessionLifecycle,
-            "loginCharacter", seq: 4));
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), driver: driver);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await tracker.StartAsync(cts.Token);
-        try
-        {
-            await driver.DrainSystemAsync();
-            tracker.CurrentArea.Should().Be("AreaSerbule");
-        }
-        finally
-        {
-            await tracker.StopAsync(CancellationToken.None);
-            tracker.Dispose();
-        }
-    }
-
-    [Fact]
-    public async Task L1_self_feed_and_Observe_double_feed_is_idempotent()
-    {
-        // Load-bearing Phase 2 safety: during the Phase 3 migration window
-        // both feed paths are live (L1 self-feed AND Pin/Weather/Position
-        // calling Observe(raw)). The double-feed must be idempotent under
-        // string-equality / last-writer-wins on the area key.
-        using var driver = new Mithril.GameState.Tests.TestSupport.TestLogStreamDriver();
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), driver: driver);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await tracker.StartAsync(cts.Token);
-        try
-        {
-            // Both paths see the same transition. Observe(string, DateTime)
-            // is still alive — used by Legolas / Gandalf — so the
-            // double-feed regression remains relevant. (#556 Phase 3
-            // retired Observe(RawLogLine); Pin/Weather/Position now
-            // self-feed via the L1 unified pipe.)
-            driver.PushLive(MakeAreaLoading("AreaSerbule", seq: 1));
-            await driver.DrainSystemAsync();
-            tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-            tracker.CurrentArea.Should().Be("AreaSerbule");
-
-            // Race on the next transition: Observe lands first, then L1.
-            tracker.Observe("LOADING LEVEL AreaEltibule", DateTime.UtcNow);
-            tracker.CurrentArea.Should().Be("AreaEltibule");
-
-            driver.PushLive(MakeAreaLoading("AreaEltibule", seq: 2));
-            await driver.DrainSystemAsync();
-            // Same area key — last-writer-wins is a no-op.
-            tracker.CurrentArea.Should().Be("AreaEltibule");
-        }
-        finally
-        {
-            await tracker.StopAsync(CancellationToken.None);
-            tracker.Dispose();
-        }
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_with_null_driver_parks_cleanly()
-    {
-        // Test-path constructors omit the driver. ExecuteAsync must still
-        // start and stop cleanly without throwing.
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-
-        await tracker.StartAsync(cts.Token);
-        // Observe path still works while parked.
         tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-        tracker.CurrentArea.Should().Be("AreaSerbule");
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
 
-        await tracker.StopAsync(CancellationToken.None);
-        tracker.Dispose();
+        observed.Should().ContainSingle();
+    }
+
+    // ── Folder Apply path (world-driven) ──────────────────────────────────
+
+    [Fact]
+    public void Apply_first_frame_updates_state_and_emits_change()
+    {
+        var tracker = Build();
+        var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+
+        var changes = tracker.Apply(
+            new Frame<AreaLoadingFrame>(ts, new AreaLoadingFrame("AreaSerbule")),
+            UnusedClock);
+
+        tracker.CurrentArea.Should().Be("AreaSerbule");
+        changes.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(null, "AreaSerbule", ts));
+    }
+
+    [Fact]
+    public void Apply_unchanged_area_returns_empty_change_list()
+    {
+        var tracker = Build();
+        var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        var ts2 = new DateTimeOffset(2026, 5, 23, 14, 31, 0, TimeSpan.Zero);
+
+        tracker.Apply(new Frame<AreaLoadingFrame>(ts1, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
+        var changes = tracker.Apply(
+            new Frame<AreaLoadingFrame>(ts2, new AreaLoadingFrame("AreaSerbule")),
+            UnusedClock);
+
+        changes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Apply_carries_previous_area_in_change_event()
+    {
+        var tracker = Build();
+        var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        var ts2 = new DateTimeOffset(2026, 5, 23, 14, 31, 0, TimeSpan.Zero);
+
+        tracker.Apply(new Frame<AreaLoadingFrame>(ts1, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
+        var changes = tracker.Apply(
+            new Frame<AreaLoadingFrame>(ts2, new AreaLoadingFrame("AreaEltibule")),
+            UnusedClock);
+
+        changes.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged("AreaSerbule", "AreaEltibule", ts2));
+    }
+
+    [Fact]
+    public void Apply_null_area_signals_character_select_or_disconnect()
+    {
+        var tracker = Build();
+        var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        var ts2 = new DateTimeOffset(2026, 5, 23, 14, 35, 0, TimeSpan.Zero);
+
+        tracker.Apply(new Frame<AreaLoadingFrame>(ts1, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
+        var changes = tracker.Apply(
+            new Frame<AreaLoadingFrame>(ts2, new AreaLoadingFrame(null)),
+            UnusedClock);
+
+        tracker.CurrentArea.Should().BeNull();
+        changes.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged("AreaSerbule", null, ts2));
+    }
+
+    [Fact]
+    public void Apply_raises_AreaChanged_event_too()
+    {
+        var tracker = Build();
+        var observed = new List<PlayerAreaChanged>();
+        tracker.AreaChanged += (_, e) => observed.Add(e);
+
+        var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        tracker.Apply(new Frame<AreaLoadingFrame>(ts, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
+
+        observed.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(null, "AreaSerbule", ts));
+    }
+
+    // ── Cross-path idempotency (double-feed during migration window) ──────
+
+    [Fact]
+    public void Apply_then_Observe_same_area_is_idempotent()
+    {
+        // The producer's frame and the legacy bridge's Observe push-in both
+        // land at the same area key on a zone transition. Last-writer-wins
+        // — neither path raises a redundant event past the first.
+        var tracker = Build();
+        var observed = new List<PlayerAreaChanged>();
+        tracker.AreaChanged += (_, e) => observed.Add(e);
+
+        var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        tracker.Apply(new Frame<AreaLoadingFrame>(ts, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
+        tracker.Observe("LOADING LEVEL AreaSerbule", ts.UtcDateTime);
+
+        observed.Should().ContainSingle();
+        tracker.CurrentArea.Should().Be("AreaSerbule");
+    }
+
+    private sealed class StubClock : IWorldClock
+    {
+        public DateTimeOffset Now => DateTimeOffset.MinValue;
+        public long Frame => 0;
+        public WorldMode Mode => WorldMode.Live;
     }
 }

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
@@ -7,10 +7,11 @@ using Xunit;
 namespace Mithril.GameState.Tests.Areas;
 
 /// <summary>
-/// Unit tests for the folder + dual-surface event behaviour of
+/// Unit tests for the folder + three-surface event behaviour of
 /// <see cref="PlayerAreaTracker"/> after the #775 conversion. The producer-side
-/// behaviour (reverse-scan pre-drain, L1 SystemSignal forwarding, ReachedLive
-/// flip) lives in <see cref="AreaLoadingFrameProducerTests"/>; the end-to-end
+/// behaviour (reverse-scan pre-warm helper, L1 SystemSignal forwarding,
+/// ReachedLive flip) lives in
+/// <see cref="Producers.AreaLoadingFrameProducerTests"/>; the end-to-end
 /// replay-determinism integration lives in
 /// <see cref="PlayerAreaWorldIntegrationTests"/>.
 /// </summary>
@@ -24,6 +25,74 @@ public sealed class PlayerAreaTrackerTests
     public void Initial_state_is_null()
     {
         Build().CurrentArea.Should().BeNull();
+    }
+
+    // ── Subscribe: replay-on-attach + live callbacks ──────────────────────
+
+    [Fact]
+    public void Subscribe_replays_a_Snapshot_with_current_area_on_attach()
+    {
+        var tracker = Build();
+        tracker.Observe("LOADING LEVEL AreaSerbule",
+            new DateTime(2026, 5, 23, 14, 11, 10, DateTimeKind.Utc));
+
+        var observed = new List<PlayerAreaChanged>();
+        using var _sub = tracker.Subscribe(observed.Add);
+
+        observed.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Snapshot,
+                Previous: null,
+                Current: "AreaSerbule",
+                At: new DateTimeOffset(2026, 5, 23, 14, 11, 10, TimeSpan.Zero)));
+    }
+
+    [Fact]
+    public void Subscribe_replays_a_Snapshot_with_null_area_before_any_observation()
+    {
+        var tracker = Build();
+        var observed = new List<PlayerAreaChanged>();
+        using var _sub = tracker.Subscribe(observed.Add);
+
+        observed.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Snapshot,
+                Previous: null,
+                Current: null,
+                At: DateTimeOffset.MinValue));
+    }
+
+    [Fact]
+    public void Subscribe_fires_Changed_notifications_for_subsequent_transitions()
+    {
+        var tracker = Build();
+        var observed = new List<PlayerAreaChanged>();
+        using var _sub = tracker.Subscribe(observed.Add);
+        observed.Clear(); // discard the Snapshot replay
+
+        var ts = new DateTime(2026, 5, 23, 14, 11, 10, DateTimeKind.Utc);
+        tracker.Observe("LOADING LEVEL AreaSerbule", ts);
+
+        observed.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed,
+                Previous: null,
+                Current: "AreaSerbule",
+                At: new DateTimeOffset(ts, TimeSpan.Zero)));
+    }
+
+    [Fact]
+    public void Subscribe_dispose_stops_subsequent_callbacks()
+    {
+        var tracker = Build();
+        var observed = new List<PlayerAreaChanged>();
+        var sub = tracker.Subscribe(observed.Add);
+        observed.Clear();
+
+        sub.Dispose();
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+
+        observed.Should().BeEmpty();
     }
 
     // ── Legacy Observe path (Legolas + Gandalf bridges still call this) ───
@@ -74,39 +143,24 @@ public sealed class PlayerAreaTrackerTests
     }
 
     [Fact]
-    public void Observe_raises_AreaChanged_with_log_line_timestamp()
+    public void Observe_re_emitting_same_area_does_not_fire_Changed_callback()
     {
         var tracker = Build();
         var observed = new List<PlayerAreaChanged>();
-        tracker.AreaChanged += (_, e) => observed.Add(e);
+        using var _sub = tracker.Subscribe(observed.Add);
+        observed.Clear(); // discard the Snapshot replay
 
-        var when = new DateTime(2026, 5, 23, 14, 11, 10, DateTimeKind.Utc);
-        tracker.Observe("LOADING LEVEL AreaSerbule", when);
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
 
         observed.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
-                Previous: null,
-                Current: "AreaSerbule",
-                At: new DateTimeOffset(when, TimeSpan.Zero)));
-    }
-
-    [Fact]
-    public void Observe_re_emitting_same_area_does_not_raise_event()
-    {
-        var tracker = Build();
-        var observed = new List<PlayerAreaChanged>();
-        tracker.AreaChanged += (_, e) => observed.Add(e);
-
-        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-
-        observed.Should().ContainSingle();
+            .Which.Kind.Should().Be(PlayerAreaChangeKind.Changed);
     }
 
     // ── Folder Apply path (world-driven) ──────────────────────────────────
 
     [Fact]
-    public void Apply_first_frame_updates_state_and_emits_change()
+    public void Apply_first_frame_updates_state_and_emits_Changed()
     {
         var tracker = Build();
         var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
@@ -117,7 +171,8 @@ public sealed class PlayerAreaTrackerTests
 
         tracker.CurrentArea.Should().Be("AreaSerbule");
         changes.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(null, "AreaSerbule", ts));
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed, null, "AreaSerbule", ts));
     }
 
     [Fact]
@@ -136,7 +191,7 @@ public sealed class PlayerAreaTrackerTests
     }
 
     [Fact]
-    public void Apply_carries_previous_area_in_change_event()
+    public void Apply_carries_previous_area_in_Changed_event()
     {
         var tracker = Build();
         var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
@@ -148,7 +203,8 @@ public sealed class PlayerAreaTrackerTests
             UnusedClock);
 
         changes.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new PlayerAreaChanged("AreaSerbule", "AreaEltibule", ts2));
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed, "AreaSerbule", "AreaEltibule", ts2));
     }
 
     [Fact]
@@ -165,21 +221,24 @@ public sealed class PlayerAreaTrackerTests
 
         tracker.CurrentArea.Should().BeNull();
         changes.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new PlayerAreaChanged("AreaSerbule", null, ts2));
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed, "AreaSerbule", null, ts2));
     }
 
     [Fact]
-    public void Apply_raises_AreaChanged_event_too()
+    public void Apply_also_fires_legacy_Subscribe_handlers_with_Changed_kind()
     {
         var tracker = Build();
         var observed = new List<PlayerAreaChanged>();
-        tracker.AreaChanged += (_, e) => observed.Add(e);
+        using var _sub = tracker.Subscribe(observed.Add);
+        observed.Clear();
 
         var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
         tracker.Apply(new Frame<AreaLoadingFrame>(ts, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
 
         observed.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(null, "AreaSerbule", ts));
+            .Which.Should().BeEquivalentTo(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed, null, "AreaSerbule", ts));
     }
 
     // ── Cross-path idempotency (double-feed during migration window) ──────
@@ -189,16 +248,18 @@ public sealed class PlayerAreaTrackerTests
     {
         // The producer's frame and the legacy bridge's Observe push-in both
         // land at the same area key on a zone transition. Last-writer-wins
-        // — neither path raises a redundant event past the first.
+        // — neither path fires a redundant callback past the first.
         var tracker = Build();
         var observed = new List<PlayerAreaChanged>();
-        tracker.AreaChanged += (_, e) => observed.Add(e);
+        using var _sub = tracker.Subscribe(observed.Add);
+        observed.Clear();
 
         var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
         tracker.Apply(new Frame<AreaLoadingFrame>(ts, new AreaLoadingFrame("AreaSerbule")), UnusedClock);
         tracker.Observe("LOADING LEVEL AreaSerbule", ts.UtcDateTime);
 
-        observed.Should().ContainSingle();
+        observed.Should().ContainSingle()
+            .Which.Kind.Should().Be(PlayerAreaChangeKind.Changed);
         tracker.CurrentArea.Should().Be("AreaSerbule");
     }
 

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaWorldIntegrationTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaWorldIntegrationTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Areas.Producers;
+using Mithril.GameState.Tests.TestSupport;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Areas;
+
+/// <summary>
+/// End-to-end tests that wire <see cref="AreaLoadingFrameProducer"/> →
+/// <see cref="PlayerWorld"/> → <see cref="PlayerAreaTracker"/> folder →
+/// <see cref="IWorldEventBus"/> together (#775). Pins the replay-determinism
+/// contract: N AreaLoading envelopes through the pipeline yield exactly N
+/// <see cref="PlayerAreaChanged"/> events on the world bus, with timestamps
+/// drawn from the L1 envelopes (NOT from <see cref="DateTime.UtcNow"/>).
+/// </summary>
+public sealed class PlayerAreaWorldIntegrationTests
+{
+    [Fact]
+    public async Task Replay_N_portal_transitions_yield_N_PlayerAreaChanged_events_with_log_timestamps()
+    {
+        // Fixture: three distinct area transitions in replay order. The
+        // pipeline must surface three PlayerAreaChanged emissions on the
+        // bus, each timestamped from the source envelope's log instant.
+        using var driver = new TestLogStreamDriver();
+        var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        var ts2 = new DateTimeOffset(2026, 5, 23, 14, 35, 0, TimeSpan.Zero);
+        var ts3 = new DateTimeOffset(2026, 5, 23, 14, 40, 0, TimeSpan.Zero);
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", ts1, seq: 1));
+        driver.PushReplay(MakeAreaLoading("AreaEltibule", ts2, seq: 2));
+        driver.PushReplay(MakeAreaLoading("AreaTomb1", ts3, seq: 3));
+
+        var folder = new PlayerAreaTracker(new AreaTransitionParser());
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var observed = new List<Frame<PlayerAreaChanged>>();
+        var allReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        const int expectedCount = 3;
+        using var _sub = world.Bus.Subscribe<PlayerAreaChanged>(frame =>
+        {
+            observed.Add(frame);
+            if (observed.Count >= expectedCount) allReceived.TrySetResult();
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = world.StartMerger(cts.Token);
+
+        await driver.DrainSystemAsync(TimeSpan.FromSeconds(5));
+        await allReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        try { await run; } catch (OperationCanceledException) { }
+
+        observed.Should().HaveCount(expectedCount);
+
+        // Timestamps reflect log-line instants, NOT wall-clock — replay-
+        // determinism contract per principle 5 + principle 13.
+        observed[0].Timestamp.Should().Be(ts1);
+        observed[1].Timestamp.Should().Be(ts2);
+        observed[2].Timestamp.Should().Be(ts3);
+        observed[0].Payload.Should().BeEquivalentTo(new PlayerAreaChanged(null, "AreaSerbule", ts1));
+        observed[1].Payload.Should().BeEquivalentTo(new PlayerAreaChanged("AreaSerbule", "AreaEltibule", ts2));
+        observed[2].Payload.Should().BeEquivalentTo(new PlayerAreaChanged("AreaEltibule", "AreaTomb1", ts3));
+
+        // CurrentArea is preserved as the synchronous read surface for the
+        // back-compat consumers (Gandalf / Palantir).
+        folder.CurrentArea.Should().Be("AreaTomb1");
+    }
+
+    [Fact]
+    public async Task Re_emitted_unchanged_AreaLoading_envelopes_do_not_re_fire_change_events()
+    {
+        // PG re-emits the current area's LOADING LEVEL on every login / zone
+        // replay; that re-emission must be a folder-state no-op so consumers
+        // stay quiet through the L1 backlog.
+        using var driver = new TestLogStreamDriver();
+        var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        var ts2 = new DateTimeOffset(2026, 5, 23, 14, 30, 5, TimeSpan.Zero);
+        var ts3 = new DateTimeOffset(2026, 5, 23, 14, 35, 0, TimeSpan.Zero);
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", ts1, seq: 1));
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", ts2, seq: 2));   // duplicate
+        driver.PushReplay(MakeAreaLoading("AreaEltibule", ts3, seq: 3));
+
+        var folder = new PlayerAreaTracker(new AreaTransitionParser());
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var observed = new List<Frame<PlayerAreaChanged>>();
+        var allReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        const int expectedCount = 2;
+        using var _sub = world.Bus.Subscribe<PlayerAreaChanged>(frame =>
+        {
+            observed.Add(frame);
+            if (observed.Count >= expectedCount) allReceived.TrySetResult();
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = world.StartMerger(cts.Token);
+
+        await driver.DrainSystemAsync(TimeSpan.FromSeconds(5));
+        await allReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        try { await run; } catch (OperationCanceledException) { }
+
+        // Exactly two events — duplicate AreaSerbule envelope was a no-op.
+        observed.Should().HaveCount(2);
+        observed[0].Timestamp.Should().Be(ts1);
+        observed[1].Timestamp.Should().Be(ts3);
+    }
+
+    private static SystemSignalLogLine MakeAreaLoading(string area, DateTimeOffset ts, long seq) =>
+        new(Timestamp: ts, Kind: SystemSignalKind.AreaLoading,
+            Data: $"LOADING LEVEL {area}", Sequence: seq, ReadMonotonicTicks: 0);
+}

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaWorldIntegrationTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaWorldIntegrationTests.cs
@@ -66,9 +66,16 @@ public sealed class PlayerAreaWorldIntegrationTests
         observed[0].Timestamp.Should().Be(ts1);
         observed[1].Timestamp.Should().Be(ts2);
         observed[2].Timestamp.Should().Be(ts3);
-        observed[0].Payload.Should().BeEquivalentTo(new PlayerAreaChanged(null, "AreaSerbule", ts1));
-        observed[1].Payload.Should().BeEquivalentTo(new PlayerAreaChanged("AreaSerbule", "AreaEltibule", ts2));
-        observed[2].Payload.Should().BeEquivalentTo(new PlayerAreaChanged("AreaEltibule", "AreaTomb1", ts3));
+        observed[0].Payload.Should().BeEquivalentTo(new PlayerAreaChanged(
+            PlayerAreaChangeKind.Changed, null, "AreaSerbule", ts1));
+        observed[1].Payload.Should().BeEquivalentTo(new PlayerAreaChanged(
+            PlayerAreaChangeKind.Changed, "AreaSerbule", "AreaEltibule", ts2));
+        observed[2].Payload.Should().BeEquivalentTo(new PlayerAreaChanged(
+            PlayerAreaChangeKind.Changed, "AreaEltibule", "AreaTomb1", ts3));
+
+        // Snapshot-kind events are synthesized inside Subscribe and never
+        // cross the world boundary — the bus carries Changed only.
+        observed.Should().OnlyContain(f => f.Payload.Kind == PlayerAreaChangeKind.Changed);
 
         // CurrentArea is preserved as the synchronous read surface for the
         // back-compat consumers (Gandalf / Palantir).

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaWorldIntegrationTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaWorldIntegrationTests.cs
@@ -127,6 +127,60 @@ public sealed class PlayerAreaWorldIntegrationTests
         observed[1].Timestamp.Should().Be(ts3);
     }
 
+    [Fact]
+    public async Task Observe_then_Apply_double_feed_emits_only_zero_bus_frames_for_that_transition()
+    {
+        // Pins the bus-emission asymmetry across the double-feed window
+        // (PlayerAreaTracker XML doc — "Asymmetry: bus emission is NOT
+        // idempotent across the double-feed"). State + Subscribe callbacks
+        // are unaffected; only the bus count differs depending on which
+        // path lands first. This test exercises the Observe-first case:
+        // Observe mutates state to AreaSerbule; the producer's later
+        // AreaLoading envelope for the same area is a folder no-op (state
+        // already matches) and the bus emits ZERO frames for that
+        // transition. Captures the asymmetry so a future audit doesn't
+        // experience it as a surprise.
+        using var driver = new TestLogStreamDriver();
+        var folder = new PlayerAreaTracker(new AreaTransitionParser());
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        // Observe lands FIRST — outside the world's merger, mutates state
+        // directly. Simulates a Legolas/Gandalf bridge call arriving before
+        // the world's drain reaches the corresponding L1 envelope.
+        var when = new DateTime(2026, 5, 23, 14, 30, 0, DateTimeKind.Utc);
+        folder.Observe("LOADING LEVEL AreaSerbule", when);
+        folder.CurrentArea.Should().Be("AreaSerbule");
+
+        // Now the producer queues the SAME transition via L1. The folder's
+        // Apply sees state already matches and returns empty — no bus frame.
+        var ts = new DateTimeOffset(when, TimeSpan.Zero);
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", ts, seq: 1));
+
+        var busFrames = new List<Frame<PlayerAreaChanged>>();
+        using var _sub = world.Bus.Subscribe<PlayerAreaChanged>(busFrames.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = world.StartMerger(cts.Token);
+        await driver.DrainSystemAsync(TimeSpan.FromSeconds(5));
+
+        // Brief settle window — the merger dispatches the no-op frame
+        // through the folder but the folder returns empty, so nothing
+        // surfaces on the bus.
+        await Task.Delay(TimeSpan.FromMilliseconds(150));
+
+        cts.Cancel();
+        try { await run; } catch (OperationCanceledException) { }
+
+        busFrames.Should().BeEmpty(
+            because: "Observe-first wins the state race; the subsequent " +
+            "Apply on the same area returns empty and the bus emits zero.");
+        folder.CurrentArea.Should().Be("AreaSerbule");
+    }
+
     private static SystemSignalLogLine MakeAreaLoading(string area, DateTimeOffset ts, long seq) =>
         new(Timestamp: ts, Kind: SystemSignalKind.AreaLoading,
             Data: $"LOADING LEVEL {area}", Sequence: seq, ReadMonotonicTicks: 0);

--- a/tests/Mithril.GameState.Tests/Areas/Producers/AreaLoadingFrameProducerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/Producers/AreaLoadingFrameProducerTests.cs
@@ -1,0 +1,281 @@
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Areas.Producers;
+using Mithril.GameState.Tests.TestSupport;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Areas.Producers;
+
+/// <summary>
+/// Unit tests for <see cref="AreaLoadingFrameProducer"/> — #775. Covers two
+/// surfaces:
+/// <list type="bullet">
+///   <item><see cref="AreaLoadingFrameProducer.TryBuildSeedFrame"/> — pure
+///   reverse-scan helper. The hosted-service registration calls this
+///   synchronously at its own <c>StartAsync</c> to pre-warm the folder
+///   before downstream consumers' synchronous-read paths run.</item>
+///   <item><see cref="AreaLoadingFrameProducer.SubscribeAsync"/> — L1
+///   SystemSignal forwarding + mode flip. Pure-L1: no seed frame is
+///   yielded through the async enumerator (the eager pre-warm path handles
+///   that).</item>
+/// </list>
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class AreaLoadingFrameProducerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public AreaLoadingFrameProducerTests()
+    {
+        _tempDir = Mithril.TestSupport.TestPaths.CreateTempDir("area_loading_producer");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ── TryBuildSeedFrame: pure reverse-scan helper ────────────────────────
+
+    [Fact]
+    public void Seed_picks_the_LATEST_LOADING_LEVEL_with_its_parsed_log_timestamp()
+    {
+        // Fixture with two LOADING LEVEL lines; the seed must come from the
+        // LATER line (the reverse-scan returns the last marker before EOF)
+        // and be stamped with that line's parsed [HH:MM:SS] anchored to the
+        // file's mtime. The earlier line is ignored.
+        var fileMtime = new DateTime(2026, 5, 23, 18, 30, 0, DateTimeKind.Utc);
+        var path = WriteLog(fileMtime,
+            "[17:11:10] LOADING LEVEL AreaSerbule",
+            "[17:11:11] LocalPlayer: ProcessAddPlayer(...)",
+            "[18:28:06] LOADING LEVEL AreaEltibule",
+            "[18:28:07] LocalPlayer: ProcessAddPlayer(...)",
+            "[18:30:00] LocalPlayer: ProcessNewPosition(0, 0, 0)");
+
+        using var driver = new TestLogStreamDriver();
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(),
+            new GameConfig { GameRoot = _tempDir });
+
+        var seed = producer.TryBuildSeedFrame();
+
+        seed.Should().NotBeNull();
+        seed!.Value.Payload.AreaKey.Should().Be("AreaEltibule");
+        seed.Value.Timestamp.Should().Be(
+            new DateTimeOffset(2026, 5, 23, 18, 28, 6, TimeSpan.Zero),
+            because: "the seed must stamp the LATER line's parsed [HH:MM:SS], not wall-clock");
+    }
+
+    [Fact]
+    public void Seed_handles_ChooseCharacter_as_null_area()
+    {
+        var fileMtime = new DateTime(2026, 5, 23, 19, 0, 0, DateTimeKind.Utc);
+        WriteLog(fileMtime,
+            "[17:11:10] LOADING LEVEL AreaSerbule",
+            "[18:30:35] LOADING LEVEL ChooseCharacter");
+
+        using var driver = new TestLogStreamDriver();
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(),
+            new GameConfig { GameRoot = _tempDir });
+
+        var seed = producer.TryBuildSeedFrame();
+
+        seed.Should().NotBeNull();
+        seed!.Value.Payload.AreaKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Seed_is_null_when_no_GameConfig()
+    {
+        using var driver = new TestLogStreamDriver();
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+
+        producer.TryBuildSeedFrame().Should().BeNull();
+    }
+
+    [Fact]
+    public void Seed_is_null_when_no_log_file()
+    {
+        using var driver = new TestLogStreamDriver();
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(),
+            new GameConfig { GameRoot = Path.Combine(_tempDir, "no-such-dir") });
+
+        producer.TryBuildSeedFrame().Should().BeNull();
+    }
+
+    [Fact]
+    public void Seed_is_null_when_no_LOADING_LEVEL_marker()
+    {
+        var fileMtime = new DateTime(2026, 5, 23, 19, 0, 0, DateTimeKind.Utc);
+        WriteLog(fileMtime,
+            "[18:00:00] LocalPlayer: ProcessAddItem(Apple(1), -1, True)",
+            "[18:30:00] LocalPlayer: ProcessAddPlayer(...)");
+
+        using var driver = new TestLogStreamDriver();
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(),
+            new GameConfig { GameRoot = _tempDir });
+
+        producer.TryBuildSeedFrame().Should().BeNull();
+    }
+
+    // ── SubscribeAsync: L1 forwarding (no seed in the stream) ──────────────
+
+    [Fact]
+    public async Task SubscribeAsync_does_NOT_yield_a_seed_frame()
+    {
+        // Even with a valid Player.log on disk, the seed comes through the
+        // pre-warm path, NOT the async enumerator. Pushing zero L1
+        // envelopes => zero yielded frames, even when TryBuildSeedFrame()
+        // would have produced one.
+        var fileMtime = new DateTime(2026, 5, 23, 18, 30, 0, DateTimeKind.Utc);
+        WriteLog(fileMtime, "[17:11:10] LOADING LEVEL AreaSerbule");
+
+        using var driver = new TestLogStreamDriver();
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(),
+            new GameConfig { GameRoot = _tempDir });
+
+        var frames = await CollectAvailableAsync(producer, expectedCount: 0);
+
+        frames.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Forwards_AreaLoading_envelopes_as_frames()
+    {
+        using var driver = new TestLogStreamDriver();
+        var ts1 = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        var ts2 = new DateTimeOffset(2026, 5, 23, 14, 35, 0, TimeSpan.Zero);
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", ts1, seq: 1));
+        driver.PushReplay(MakeAreaLoading("AreaEltibule", ts2, seq: 2));
+
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+
+        var frames = await CollectAvailableAsync(producer, expectedCount: 2);
+
+        frames.Should().HaveCount(2);
+        frames[0].Payload.AreaKey.Should().Be("AreaSerbule");
+        frames[0].Timestamp.Should().Be(ts1);
+        frames[1].Payload.AreaKey.Should().Be("AreaEltibule");
+        frames[1].Timestamp.Should().Be(ts2);
+    }
+
+    [Fact]
+    public async Task Ignores_non_AreaLoading_SystemSignal_kinds()
+    {
+        using var driver = new TestLogStreamDriver();
+        var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        driver.PushReplay(MakeSignal(SystemSignalKind.LoginBanner,
+            "Logged in as character X. Time UTC=...", ts, seq: 1));
+        driver.PushReplay(MakeSignal(SystemSignalKind.PlayerAdded,
+            "ProcessAddPlayer(...)", ts, seq: 2));
+        driver.PushReplay(MakeSignal(SystemSignalKind.SessionLifecycle,
+            "loginCharacter", ts, seq: 3));
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", ts, seq: 4));
+
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+
+        var frames = await CollectAvailableAsync(producer, expectedCount: 1);
+
+        frames.Should().ContainSingle()
+            .Which.Payload.AreaKey.Should().Be("AreaSerbule");
+    }
+
+    // ── Mode awareness ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ReachedLive_flips_on_first_non_replay_envelope_regardless_of_kind()
+    {
+        using var driver = new TestLogStreamDriver();
+        var ts = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.Zero);
+        // Live LoginBanner — not an AreaLoading frame but still drives the
+        // mode flip per the producer's class-doc rationale.
+        driver.PushLive(MakeSignal(SystemSignalKind.LoginBanner,
+            "Logged in as character X.", ts, seq: 1));
+
+        var producer = new AreaLoadingFrameProducer(
+            driver, new AreaTransitionParser(), config: null);
+
+        producer.ReachedLive.IsCompleted.Should().BeFalse();
+
+        // IAsyncEnumerable lazy-evaluates: the iterator body (which opens
+        // the L1 subscription) doesn't run until MoveNextAsync is invoked.
+        // Calling MoveNextAsync explicitly drives the iterator body
+        // synchronously through _driver.Subscribe, starting the L1 pump
+        // before we proceed. Mirrors how PlayerWorld's merger primes each
+        // producer at registration.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var iter = producer.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var pending = iter.MoveNextAsync();
+        try
+        {
+            await driver.DrainSystemAsync();
+            await producer.ReachedLive.WaitAsync(TimeSpan.FromSeconds(2));
+            producer.ReachedLive.IsCompleted.Should().BeTrue();
+        }
+        finally
+        {
+            cts.Cancel();
+            try { _ = await pending; } catch (OperationCanceledException) { /* expected */ }
+            try { await iter.DisposeAsync(); } catch (OperationCanceledException) { /* expected */ }
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private string WriteLog(DateTime mtimeUtc, params string[] lines)
+    {
+        var path = Path.Combine(_tempDir, "Player.log");
+        File.WriteAllText(path, string.Join('\n', lines) + "\n", new UTF8Encoding(false));
+        File.SetLastWriteTimeUtc(path, mtimeUtc);
+        return path;
+    }
+
+    private static SystemSignalLogLine MakeAreaLoading(string area, DateTimeOffset ts, long seq) =>
+        new(Timestamp: ts, Kind: SystemSignalKind.AreaLoading,
+            Data: $"LOADING LEVEL {area}", Sequence: seq, ReadMonotonicTicks: 0);
+
+    private static SystemSignalLogLine MakeSignal(
+        SystemSignalKind kind, string data, DateTimeOffset ts, long seq) =>
+        new(Timestamp: ts, Kind: kind, Data: data, Sequence: seq, ReadMonotonicTicks: 0);
+
+    private static async Task<List<Frame<AreaLoadingFrame>>> CollectAvailableAsync(
+        AreaLoadingFrameProducer producer, int expectedCount = 0)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var frames = new List<Frame<AreaLoadingFrame>>();
+        var collectionTask = Task.Run(async () =>
+        {
+            await foreach (var f in producer.SubscribeAsync(cts.Token).ConfigureAwait(false))
+            {
+                frames.Add(f);
+                if (expectedCount > 0 && frames.Count >= expectedCount) break;
+            }
+        }, cts.Token);
+
+        if (expectedCount == 0)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+            cts.Cancel();
+            try { await collectionTask; } catch (OperationCanceledException) { }
+            return frames;
+        }
+
+        try { await collectionTask; }
+        catch (OperationCanceledException) { /* surfaced via the asserts */ }
+        return frames;
+    }
+}


### PR DESCRIPTION
## Summary

Convert `PlayerAreaTracker` from `BackgroundService` to
`IFolder<AreaLoadingFrame>` registered with `IPlayerWorld`, plus a new
`PlayerAreaChanged` change event on the world bus. Sibling
`AreaLoadingFrameProducer` owns the L1 `SystemSignal` subscription and
exposes a `TryBuildSeedFrame()` reverse-scan helper that
`PlayerAreaWorldRegistration` calls synchronously at `StartAsync` to
eagerly pre-warm the folder.

Three things landed together:

1. **Folder + bus event.** `PlayerAreaTracker` now implements
   `IFolder<AreaLoadingFrame>` and the new `IPlayerAreaState` interface;
   `Apply()` emits `PlayerAreaChanged` change events which the world
   auto-publishes on `IPlayerWorld.Bus`. Legacy `AreaChanged` event surface
   is preserved for new dual-surface consumers.

2. **Producer with parsed-timestamp seed.** `AreaLoadingFrameProducer` is
   pure-L1 in `SubscribeAsync`; the seed work moves to a separate
   `TryBuildSeedFrame()` pure helper that reverse-scans `Player.log` for the
   most recent `LOADING LEVEL` line and parses its embedded `[HH:MM:SS]`
   prefix (anchored against the file mtime — same fallback shape as
   `PlayerLogClock.EnsureAnchored`'s mtime path). The old tracker's
   `DateTime.UtcNow` stamp on the seed retires — replay-determinism win
   per principle 5 + principle 13.

3. **Eager pre-warm preserves the synchronous-read contract.**
   `PlayerAreaWorldRegistration.StartAsync` (registered before downstream
   hosted services per `AddMithrilGameState` order) calls
   `producer.TryBuildSeedFrame()` and applies the result directly to the
   folder. By the time Legolas's `PlayerLogIngestionService.StartAsync`
   reads `CurrentArea` later in registration order, the folder is hot.
   Gandalf's chest-area stamp, Palantir's debug refresh, and Legolas's
   area bridge all keep working unchanged.

The seed frame itself does NOT flow through the producer's
`IAsyncEnumerable` — it would no-op at the folder anyway (Apply on the
already-current area returns an empty change list) and would only arrive
after the trailing `WorldMergerStartHostedService` drains, defeating the
eager-attach point.

### Scope notes

- `Observe(string, DateTime)` legacy push-in is retained, not deleted as
  the issue acceptance bullet #5 suggests. Both call sites
  (`Legolas.PlayerLogIngestionService:198`, `Gandalf.LootIngestionService:151`)
  are still active. Per the user's scope direction, the
  `ApplyAreaIfChanged` bridge swap and the Pin/Weather/Position
  sibling-tracker collapses are out of this PR — to be filed as
  follow-ons under [#774](https://github.com/moumantai-gg/mithril/issues/774)
  once the bridges migrate to the bus event.

- The `docs/world-sim-migration-audit.md` spot-check #4 wording
  ("`PlayerAreaTracker.Changed`") becomes accurate post-merge: it cited
  the event surface as if it existed; now it does.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors (warnings-as-errors enforced).
- [x] `dotnet test Mithril.slnx` — every project Passed, 0 failures across ~4000 tests.
- [x] Folder unit tests (`PlayerAreaTrackerTests`): Apply emits
      `PlayerAreaChanged` on transition; idempotent no-op on unchanged
      area; Observe back-compat path; double-feed (Apply + Observe) is
      idempotent.
- [x] Producer unit tests (`AreaLoadingFrameProducerTests`): `TryBuildSeedFrame()`
      picks the LATEST `LOADING LEVEL` with its parsed log timestamp;
      handles `ChooseCharacter`/missing-file/no-marker as null; pure-L1
      `SubscribeAsync` does NOT yield a seed frame; `AreaLoading` envelopes
      forward; non-area `SystemSignal` kinds dropped; `ReachedLive` flips on
      first non-replay envelope.
- [x] End-to-end integration test (`PlayerAreaWorldIntegrationTests`):
      N portal transitions through `Producer → PlayerWorld → folder →
      Bus` yield exactly N `PlayerAreaChanged` events with timestamps
      drawn from the L1 envelopes (NOT wall-clock — replay-determinism
      pin); duplicate `AreaSerbule → AreaSerbule` re-emit is a no-op.
- [x] All five `CurrentArea` consumer test files in the spec verified
      green: `PlayerAreaTrackerTests`, `AreaCalibrationServiceTests`,
      `PlayerLogIngestionServiceTests`, `LootSourceTests`,
      `WorldStateViewModelTests`.

Closes #775.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
