### PR TITLE
refactor(legolas, gandalf): consume area state via IPlayerAreaState.Subscribe (#789, #790)

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -87,8 +87,8 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<InteractionDelayLoopParser>();
         services.AddSingleton<InteractionWaitParser>();
         // Area parser + IPlayerAreaState are registered once in
-        // AddMithrilGameState() (shared live game-state); consumers here
-        // resolve IPlayerAreaState only (#789).
+        // AddMithrilGameState() (shared live game-state); LootSource queries
+        // CurrentArea directly at chest-commit time (#790).
         services.AddSingleton<BossKillCreditParser>();
         services.AddSingleton<DefeatCooldownParser>();
         services.AddSingleton<LootBracketTracker>();
@@ -96,6 +96,7 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<DerivedTimerProgressService>(),
             sp.GetRequiredService<ISettingsStore<LootCatalogCache>>(),
             sp.GetRequiredService<LootCatalogCache>(),
+            areaState: sp.GetService<Mithril.GameState.Areas.IPlayerAreaState>(),
             refData: sp.GetService<Mithril.Shared.Reference.IReferenceDataService>(),
             time: null,
             diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>(),

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -4,7 +4,6 @@ using Gandalf.Parsing;
 using Gandalf.Services;
 using Gandalf.ViewModels;
 using Gandalf.Views;
-using Mithril.GameState.Areas;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
 // Mithril.GameState now owns the quest parsers + IPlayerQuestJournalState;
@@ -87,8 +86,9 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<InteractionEndParser>();
         services.AddSingleton<InteractionDelayLoopParser>();
         services.AddSingleton<InteractionWaitParser>();
-        // AreaTransitionParser + PlayerAreaTracker now registered once in
-        // AddMithrilGameState() (shared live game-state) — injected here.
+        // Area parser + IPlayerAreaState are registered once in
+        // AddMithrilGameState() (shared live game-state); consumers here
+        // resolve IPlayerAreaState only (#789).
         services.AddSingleton<BossKillCreditParser>();
         services.AddSingleton<DefeatCooldownParser>();
         services.AddSingleton<LootBracketTracker>();
@@ -96,7 +96,6 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<DerivedTimerProgressService>(),
             sp.GetRequiredService<ISettingsStore<LootCatalogCache>>(),
             sp.GetRequiredService<LootCatalogCache>(),
-            areaTracker: sp.GetService<PlayerAreaTracker>(),
             refData: sp.GetService<Mithril.Shared.Reference.IReferenceDataService>(),
             time: null,
             diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>(),

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -1,5 +1,4 @@
 using Gandalf.Parsing;
-using Mithril.GameState.Areas;
 using Microsoft.Extensions.Hosting;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
@@ -19,20 +18,12 @@ namespace Gandalf.Services;
 /// anchor (the <see cref="DefeatCooldownParser"/> rejection text remains as
 /// a diagnostic-only "cooldown still active" observation).
 ///
-/// <para><b>Area→chest-stamp bridge (#789).</b> Subscribes to
-/// <see cref="IPlayerAreaState"/> on <c>StartAsync</c> and forwards every
-/// notification to <see cref="LootSource.UpdateCurrentArea"/> so a chest
-/// commit (<see cref="LootBracketTracker"/> → <see cref="LootSource.OnChestInteraction"/>)
-/// stamps <c>LearnedChest.Area</c> with the area the player was in at
-/// commit time (#178). The Snapshot replay synthesised by
-/// <see cref="IPlayerAreaState.Subscribe"/> on attach delivers the seed
-/// area before any chest interaction can reach the bracket tracker — so
-/// session-start commits stamp the correct area without a separate eager
-/// read of <see cref="IPlayerAreaState.CurrentArea"/>. Subscribing here
-/// (NOT via <c>IPlayerWorld.Bus</c>) is load-bearing while the eager
-/// pre-warm in <c>PlayerAreaWorldRegistration</c> is still active — its
-/// retirement is the follow-on PR once both consumer migrations land
-/// (#769).</para>
+/// <para><b>Area→chest-stamp bridge (#790).</b> Owned by <see cref="LootSource"/>
+/// directly — it injects <c>IPlayerAreaState</c> and queries
+/// <c>CurrentArea</c> at chest-commit time. This service no longer has any
+/// area dep; the per-line area-tracker push-in retired in #790 because
+/// the producer's L1 subscription already owns the <c>LOADING LEVEL</c>
+/// envelope path end-to-end.</para>
 ///
 /// <para><b>L1 migration disposition (#549 Gandalf row, #550 PR 3 archetype-B).</b>
 /// <list type="bullet">
@@ -76,11 +67,9 @@ public sealed class LootIngestionService : BackgroundService
     private readonly LootBracketTracker _bracket;
     private readonly BossKillCreditParser _bossKill;
     private readonly DefeatCooldownParser _defeatCooldown;
-    private readonly IPlayerAreaState _areaState;
     private readonly LootSource _source;
     private readonly IDiagnosticsSink? _diag;
     private ILogSubscription? _subscription;
-    private IDisposable? _areaSub;
     private bool _firstObservationLogged;
 
     public LootIngestionService(
@@ -88,7 +77,6 @@ public sealed class LootIngestionService : BackgroundService
         LootBracketTracker bracket,
         BossKillCreditParser bossKill,
         DefeatCooldownParser defeatCooldown,
-        IPlayerAreaState areaState,
         LootSource source,
         IDiagnosticsSink? diag = null)
     {
@@ -96,29 +84,8 @@ public sealed class LootIngestionService : BackgroundService
         _bracket = bracket;
         _bossKill = bossKill;
         _defeatCooldown = defeatCooldown;
-        _areaState = areaState ?? throw new ArgumentNullException(nameof(areaState));
         _source = source;
         _diag = diag;
-    }
-
-    public override Task StartAsync(CancellationToken cancellationToken)
-    {
-        // Area bridge first — Subscribe fires a synthetic Snapshot inside
-        // the call carrying the seed area, so LootSource sees the correct
-        // area before any chest commit can reach it from the L1 subscription
-        // below. Subscribing here (NOT via IPlayerWorld.Bus) is load-bearing
-        // while the eager pre-warm in PlayerAreaWorldRegistration is still
-        // active — bus subscribers never see the seed because that
-        // transition is applied directly to the folder and bypasses the bus.
-        _areaSub = _areaState.Subscribe(OnAreaChanged);
-        return base.StartAsync(cancellationToken);
-    }
-
-    public override async Task StopAsync(CancellationToken cancellationToken)
-    {
-        _areaSub?.Dispose();
-        _areaSub = null;
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -153,20 +120,8 @@ public sealed class LootIngestionService : BackgroundService
     {
         _subscription?.Dispose();
         _subscription = null;
-        _areaSub?.Dispose();
-        _areaSub = null;
         base.Dispose();
     }
-
-    /// <summary>
-    /// Forward area notifications to <see cref="LootSource"/>. Both
-    /// <see cref="PlayerAreaChangeKind.Snapshot"/> (seed on attach) and
-    /// <see cref="PlayerAreaChangeKind.Changed"/> (live transition) carry
-    /// only the latest <see cref="PlayerAreaChanged.Current"/> we care
-    /// about for stamping chest commits.
-    /// </summary>
-    private void OnAreaChanged(PlayerAreaChanged evt) =>
-        _source.UpdateCurrentArea(evt.Current);
 
     private void Dispatch(LocalPlayerLogLine payload)
     {

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -19,15 +19,20 @@ namespace Gandalf.Services;
 /// anchor (the <see cref="DefeatCooldownParser"/> rejection text remains as
 /// a diagnostic-only "cooldown still active" observation).
 ///
-/// Also feeds <see cref="PlayerAreaTracker"/> so chest commits stamp the
-/// player's current area on <c>LearnedChest.Area</c> (#178). The tracker
-/// self-seeds via <see cref="PlayerAreaTracker.CurrentArea"/>'s lazy
-/// pre-login-preamble scan (#514); the bare <c>LocalPlayerLogLine.Data</c>
-/// we hand it here is a no-op for non-area lines (no <c>LOADING LEVEL</c>
-/// lives on the LocalPlayer pipe — that's a SystemSignal kind). The
-/// canonical live-area updates flow through <c>PlayerPositionTracker</c> /
-/// <c>PlayerWeatherTracker</c> / <c>PlayerPinTracker</c>, which still consume
-/// <see cref="IPlayerLogStream"/> directly and feed the same shared tracker.
+/// <para><b>Area→chest-stamp bridge (#789).</b> Subscribes to
+/// <see cref="IPlayerAreaState"/> on <c>StartAsync</c> and forwards every
+/// notification to <see cref="LootSource.UpdateCurrentArea"/> so a chest
+/// commit (<see cref="LootBracketTracker"/> → <see cref="LootSource.OnChestInteraction"/>)
+/// stamps <c>LearnedChest.Area</c> with the area the player was in at
+/// commit time (#178). The Snapshot replay synthesised by
+/// <see cref="IPlayerAreaState.Subscribe"/> on attach delivers the seed
+/// area before any chest interaction can reach the bracket tracker — so
+/// session-start commits stamp the correct area without a separate eager
+/// read of <see cref="IPlayerAreaState.CurrentArea"/>. Subscribing here
+/// (NOT via <c>IPlayerWorld.Bus</c>) is load-bearing while the eager
+/// pre-warm in <c>PlayerAreaWorldRegistration</c> is still active — its
+/// retirement is the follow-on PR once both consumer migrations land
+/// (#769).</para>
 ///
 /// <para><b>L1 migration disposition (#549 Gandalf row, #550 PR 3 archetype-B).</b>
 /// <list type="bullet">
@@ -71,10 +76,11 @@ public sealed class LootIngestionService : BackgroundService
     private readonly LootBracketTracker _bracket;
     private readonly BossKillCreditParser _bossKill;
     private readonly DefeatCooldownParser _defeatCooldown;
-    private readonly PlayerAreaTracker _areaTracker;
+    private readonly IPlayerAreaState _areaState;
     private readonly LootSource _source;
     private readonly IDiagnosticsSink? _diag;
     private ILogSubscription? _subscription;
+    private IDisposable? _areaSub;
     private bool _firstObservationLogged;
 
     public LootIngestionService(
@@ -82,7 +88,7 @@ public sealed class LootIngestionService : BackgroundService
         LootBracketTracker bracket,
         BossKillCreditParser bossKill,
         DefeatCooldownParser defeatCooldown,
-        PlayerAreaTracker areaTracker,
+        IPlayerAreaState areaState,
         LootSource source,
         IDiagnosticsSink? diag = null)
     {
@@ -90,9 +96,29 @@ public sealed class LootIngestionService : BackgroundService
         _bracket = bracket;
         _bossKill = bossKill;
         _defeatCooldown = defeatCooldown;
-        _areaTracker = areaTracker;
+        _areaState = areaState ?? throw new ArgumentNullException(nameof(areaState));
         _source = source;
         _diag = diag;
+    }
+
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Area bridge first — Subscribe fires a synthetic Snapshot inside
+        // the call carrying the seed area, so LootSource sees the correct
+        // area before any chest commit can reach it from the L1 subscription
+        // below. Subscribing here (NOT via IPlayerWorld.Bus) is load-bearing
+        // while the eager pre-warm in PlayerAreaWorldRegistration is still
+        // active — bus subscribers never see the seed because that
+        // transition is applied directly to the folder and bypasses the bus.
+        _areaSub = _areaState.Subscribe(OnAreaChanged);
+        return base.StartAsync(cancellationToken);
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _areaSub?.Dispose();
+        _areaSub = null;
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -127,8 +153,20 @@ public sealed class LootIngestionService : BackgroundService
     {
         _subscription?.Dispose();
         _subscription = null;
+        _areaSub?.Dispose();
+        _areaSub = null;
         base.Dispose();
     }
+
+    /// <summary>
+    /// Forward area notifications to <see cref="LootSource"/>. Both
+    /// <see cref="PlayerAreaChangeKind.Snapshot"/> (seed on attach) and
+    /// <see cref="PlayerAreaChangeKind.Changed"/> (live transition) carry
+    /// only the latest <see cref="PlayerAreaChanged.Current"/> we care
+    /// about for stamping chest commits.
+    /// </summary>
+    private void OnAreaChanged(PlayerAreaChanged evt) =>
+        _source.UpdateCurrentArea(evt.Current);
 
     private void Dispatch(LocalPlayerLogLine payload)
     {
@@ -139,16 +177,6 @@ public sealed class LootIngestionService : BackgroundService
         var line = payload.Data;
         var ts = payload.Timestamp.UtcDateTime;
 
-        // Area transitions update the tracker BEFORE the bracket sees the
-        // line, so any subsequent chest interaction in the same dispatch
-        // batch reads the correct CurrentArea. The LocalPlayer pipe never
-        // carries LOADING LEVEL (that's a SystemSignal), so this call is a
-        // no-op for the area-source case — PlayerAreaTracker.CurrentArea
-        // self-seeds via #514 and the canonical live-area updates flow
-        // through GameState trackers that still consume IPlayerLogStream
-        // directly. Calling Observe here is defence-in-depth (the parser's
-        // substring guard makes the no-op cheap).
-        _areaTracker.Observe(line, ts);
         _bracket.Observe(line, ts);
 
         if (_bossKill.TryParse(line, ts) is BossKillCreditEvent kill)

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
-using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
@@ -50,7 +49,6 @@ public sealed class LootSource : ITimerSource, IDisposable
     private readonly DerivedTimerProgressService _derived;
     private readonly ISettingsStore<LootCatalogCache> _cacheStore;
     private readonly LootCatalogCache _cache;
-    private readonly PlayerAreaTracker? _areaTracker;
     private readonly IReferenceDataService? _refData;
     private readonly TimeProvider _time;
     private readonly IWorldClock? _worldClock;
@@ -62,11 +60,19 @@ public sealed class LootSource : ITimerSource, IDisposable
     private IReadOnlyDictionary<string, TimerCatalogEntry> _lastCatalogByKey;
     private IReadOnlyDictionary<string, TimerProgressEntry> _lastProgressByKey;
 
+    // Cache the player's current area, updated via UpdateCurrentArea from
+    // LootIngestionService's IPlayerAreaState subscription (#789). Read
+    // lock-free on the chest-commit hot path (OnChestInteraction +
+    // OnChestCooldownObserved) — reference-sized writes are atomic in
+    // .NET and the IPlayerAreaState dispatch lock already serialises
+    // writes against the area folder's mutations, so the consumer side
+    // doesn't need its own lock for the simple read-latest semantic.
+    private string? _cachedArea;
+
     public LootSource(
         DerivedTimerProgressService derived,
         ISettingsStore<LootCatalogCache> cacheStore,
         LootCatalogCache cache,
-        PlayerAreaTracker? areaTracker = null,
         IReferenceDataService? refData = null,
         TimeProvider? time = null,
         IDiagnosticsSink? diag = null,
@@ -75,7 +81,6 @@ public sealed class LootSource : ITimerSource, IDisposable
         _derived = derived;
         _cacheStore = cacheStore;
         _cache = cache;
-        _areaTracker = areaTracker;
         _refData = refData;
         _time = time ?? TimeProvider.System;
         _worldClock = playerWorld?.Clock;
@@ -86,6 +91,16 @@ public sealed class LootSource : ITimerSource, IDisposable
 
         _derived.ProgressChanged += OnDerivedProgressChanged;
     }
+
+    /// <summary>
+    /// Forward the player's current area into <see cref="_cachedArea"/> so
+    /// chest commits stamp <c>LearnedChest.Area</c> with the right zone
+    /// (#178). Called by <see cref="LootIngestionService"/> for both the
+    /// initial Snapshot replay (seed) and live transitions; a <c>null</c>
+    /// argument clears the cache (character-select / disconnect) and
+    /// subsequent commits stamp <c>Area = null</c> until the next portal.
+    /// </summary>
+    public void UpdateCurrentArea(string? area) => _cachedArea = area;
 
     public string SourceId => Id;
     public IReadOnlyList<TimerCatalogEntry> Catalog => _catalog;
@@ -125,7 +140,7 @@ public sealed class LootSource : ITimerSource, IDisposable
         // defeat-cooldown auto-learn path). Area is stamped sticky-once-known
         // (#178) — first commit wins so the same internal name in two zones
         // doesn't ping-pong its area attribution.
-        var currentArea = _areaTracker?.CurrentArea;
+        var currentArea = _cachedArea;
         var learnedChanged = false;
         lock (_catalogLock)
         {
@@ -238,7 +253,7 @@ public sealed class LootSource : ITimerSource, IDisposable
         {
             if (prior is null)
             {
-                var currentArea = _areaTracker?.CurrentArea;
+                var currentArea = _cachedArea;
                 lock (_catalogLock)
                 {
                     if (!_cache.LearnedChests.TryGetValue(chestInternalName, out var entry))

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
+using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
@@ -49,6 +50,7 @@ public sealed class LootSource : ITimerSource, IDisposable
     private readonly DerivedTimerProgressService _derived;
     private readonly ISettingsStore<LootCatalogCache> _cacheStore;
     private readonly LootCatalogCache _cache;
+    private readonly IPlayerAreaState? _areaState;
     private readonly IReferenceDataService? _refData;
     private readonly TimeProvider _time;
     private readonly IWorldClock? _worldClock;
@@ -60,19 +62,11 @@ public sealed class LootSource : ITimerSource, IDisposable
     private IReadOnlyDictionary<string, TimerCatalogEntry> _lastCatalogByKey;
     private IReadOnlyDictionary<string, TimerProgressEntry> _lastProgressByKey;
 
-    // Cache the player's current area, updated via UpdateCurrentArea from
-    // LootIngestionService's IPlayerAreaState subscription (#789). Read
-    // lock-free on the chest-commit hot path (OnChestInteraction +
-    // OnChestCooldownObserved) — reference-sized writes are atomic in
-    // .NET and the IPlayerAreaState dispatch lock already serialises
-    // writes against the area folder's mutations, so the consumer side
-    // doesn't need its own lock for the simple read-latest semantic.
-    private string? _cachedArea;
-
     public LootSource(
         DerivedTimerProgressService derived,
         ISettingsStore<LootCatalogCache> cacheStore,
         LootCatalogCache cache,
+        IPlayerAreaState? areaState = null,
         IReferenceDataService? refData = null,
         TimeProvider? time = null,
         IDiagnosticsSink? diag = null,
@@ -81,6 +75,7 @@ public sealed class LootSource : ITimerSource, IDisposable
         _derived = derived;
         _cacheStore = cacheStore;
         _cache = cache;
+        _areaState = areaState;
         _refData = refData;
         _time = time ?? TimeProvider.System;
         _worldClock = playerWorld?.Clock;
@@ -91,16 +86,6 @@ public sealed class LootSource : ITimerSource, IDisposable
 
         _derived.ProgressChanged += OnDerivedProgressChanged;
     }
-
-    /// <summary>
-    /// Forward the player's current area into <see cref="_cachedArea"/> so
-    /// chest commits stamp <c>LearnedChest.Area</c> with the right zone
-    /// (#178). Called by <see cref="LootIngestionService"/> for both the
-    /// initial Snapshot replay (seed) and live transitions; a <c>null</c>
-    /// argument clears the cache (character-select / disconnect) and
-    /// subsequent commits stamp <c>Area = null</c> until the next portal.
-    /// </summary>
-    public void UpdateCurrentArea(string? area) => _cachedArea = area;
 
     public string SourceId => Id;
     public IReadOnlyList<TimerCatalogEntry> Catalog => _catalog;
@@ -140,7 +125,7 @@ public sealed class LootSource : ITimerSource, IDisposable
         // defeat-cooldown auto-learn path). Area is stamped sticky-once-known
         // (#178) — first commit wins so the same internal name in two zones
         // doesn't ping-pong its area attribution.
-        var currentArea = _cachedArea;
+        var currentArea = _areaState?.CurrentArea;
         var learnedChanged = false;
         lock (_catalogLock)
         {
@@ -253,7 +238,7 @@ public sealed class LootSource : ITimerSource, IDisposable
         {
             if (prior is null)
             {
-                var currentArea = _cachedArea;
+                var currentArea = _areaState?.CurrentArea;
                 lock (_catalogLock)
                 {
                     if (!_cache.LearnedChests.TryGetValue(chestInternalName, out var entry))

--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -93,7 +93,7 @@ public sealed record MotherlodeUseDetected(
     string? MapName = null) : GameEvent(Timestamp);
 
 // The chat-log area banner ("******* Entering Area: <FriendlyName>") was
-// retired in #605. PlayerAreaTracker (Mithril.GameState.Areas) is the
+// retired in #605. IPlayerAreaState (Mithril.GameState.Areas) is the
 // authoritative area-key source, fed by Player.log's LOADING LEVEL line, and
-// PlayerLogIngestionService.ApplyAreaIfChanged drives the calibration service
+// PlayerLogIngestionService.OnAreaChanged drives the calibration service
 // directly. See #531 for the redundancy analysis.

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -135,8 +135,8 @@ public sealed class LegolasModule : IMithrilModule
                 sp.GetService<ICharacterPinAnchor>(),
                 // Shared GameState current-area: a confirmed area change
                 // invalidates the area-local-frame measurement (maps are
-                // area-specific). Same tracker Gandalf consumes.
-                sp.GetService<PlayerAreaTracker>(),
+                // area-specific). Same source Gandalf consumes (#789).
+                sp.GetService<IPlayerAreaState>(),
                 sp.GetService<IDiagnosticsSink>()));
 
         // End-of-run report (text + PNG + JSON + share link). Singleton so the

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -38,11 +38,12 @@ public interface IAreaCalibrationService
 
     /// <summary>
     /// Set the current area by internal key. The Player.log-driven
-    /// <c>PlayerLogIngestionService.ApplyAreaIfChanged</c> bridge calls this
-    /// whenever <see cref="Mithril.GameState.Areas.PlayerAreaTracker.CurrentArea"/>
-    /// changes (#605 — the prior chat <c>Entering Area:</c> banner path is gone;
-    /// <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/> is the
-    /// authoritative source). Also used by the manual area-picker UI.
+    /// <c>PlayerLogIngestionService.OnAreaChanged</c> bridge calls this
+    /// whenever <see cref="Mithril.GameState.Areas.IPlayerAreaState"/> emits a
+    /// new <see cref="Mithril.GameState.Areas.PlayerAreaChanged"/> notification
+    /// (#605 — the prior chat <c>Entering Area:</c> banner path is gone;
+    /// <c>IPlayerAreaState</c> is the authoritative source). Also used by the
+    /// manual area-picker UI.
     /// </summary>
     void SelectArea(string areaKey);
 
@@ -78,8 +79,8 @@ public interface IAreaCalibrationService
 
 /// <summary>
 /// Owns the per-area calibration lifecycle: area-key handoff (from the
-/// <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/>-driven
-/// <c>PlayerLogIngestionService.ApplyAreaIfChanged</c> bridge or the manual
+/// <see cref="Mithril.GameState.Areas.IPlayerAreaState"/>-driven
+/// <c>PlayerLogIngestionService.OnAreaChanged</c> bridge or the manual
 /// area-picker UI) &#8594; apply persisted <see cref="AreaCalibration"/> on entry,
 /// and the solve/persist path the calibration window drives. Reference points
 /// come from <see cref="IReferenceDataService"/> (landmarks + NPCs with a
@@ -87,7 +88,7 @@ public interface IAreaCalibrationService
 /// positions the player in (verified 2026-05-18).
 ///
 /// <para>The chat-log <c>Entering Area:</c> banner path was retired in #605 —
-/// per #531, <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/> already
+/// per #531, <see cref="Mithril.GameState.Areas.IPlayerAreaState"/> already
 /// exposes the same signal authoritatively from Player.log's
 /// <c>LOADING LEVEL</c> line.</para>
 /// </summary>

--- a/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
+++ b/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
@@ -121,7 +121,7 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     private readonly IMultilaterationSolver _solver;
     private readonly MotherlodeFlowController _flow;
     private readonly ICharacterPinAnchor? _characterPin;
-    private readonly PlayerAreaTracker? _areaTracker;
+    private readonly IPlayerAreaState? _areaState;
     private readonly IDiagnosticsSink? _diag;
     private readonly IReferenceDataService? _refData;
     private readonly LegolasSettings? _settings;
@@ -180,13 +180,13 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         IReferenceDataService? refData = null,
         LegolasSettings? settings = null,
         ICharacterPinAnchor? characterPin = null,
-        PlayerAreaTracker? areaTracker = null,
+        IPlayerAreaState? areaState = null,
         IDiagnosticsSink? diag = null)
     {
         _solver = solver;
         _flow = flow;
         _characterPin = characterPin;
-        _areaTracker = areaTracker;
+        _areaState = areaState;
         _refData = refData;
         _settings = settings;
         _diag = diag;
@@ -332,7 +332,7 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
             // fix/slot — clear the measurement (keep the session dug count).
             // Null = area unknown (char-select / pre-transition) → don't reset;
             // self-heals on the next confirmed area.
-            var cur = _areaTracker?.CurrentArea;
+            var cur = _areaState?.CurrentArea;
             if (cur is not null)
             {
                 if (_sessionArea is not null && cur != _sessionArea)

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -20,8 +20,8 @@ namespace Legolas.Services;
 ///
 /// <para><b>Responsibilities.</b>
 /// <list type="bullet">
-///   <item><b>Area→calibration bridge.</b> Feeds the shared
-///   <see cref="PlayerAreaTracker"/> and, whenever the player's area changes,
+///   <item><b>Area→calibration bridge.</b> Subscribes to the shared
+///   <see cref="IPlayerAreaState"/> and, whenever the player's area changes,
 ///   applies that area's persisted <see cref="Domain.AreaCalibration"/> via
 ///   <see cref="IAreaCalibrationService.SelectArea"/>.</item>
 ///   <item><b><c>ProcessMapFx</c> placement (#454).</b> Absolute
@@ -50,16 +50,21 @@ namespace Legolas.Services;
 /// envelopes whose <c>Sequence</c> we've already processed in a prior
 /// session — closing the resurrection-on-restart edge the in-memory cutoff
 /// never covered. The area bridge survives the <c>LiveOnly</c> tightening
-/// because <see cref="PlayerAreaTracker"/> self-seeds (#514) from the most
-/// recent <c>LOADING LEVEL</c> line in the log before this subscription
-/// reads its first live envelope.</para>
+/// because <see cref="IPlayerAreaState.Subscribe"/>'s late-subscriber
+/// Snapshot replay synthesizes the current area on attach (the production
+/// seed is delivered by <c>PlayerAreaWorldRegistration</c>'s eager
+/// pre-warm; retirement of that pre-warm is the follow-on after this
+/// migration and Gandalf's sibling consumer migrate — see #769 / Call 1 in
+/// <c>docs/world-simulator.md</c>).</para>
 ///
-/// <para><b>Mixed-handler subscription (#549 Divergence 2 option a).</b>
-/// One subscription handles both the area bridge (formerly accepted replay
-/// to apply pre-live area state, now satisfied by #514) and the live-only
-/// survey/motherlode dispatch. Per #549's recommendation this stays a single
-/// subscription — <c>LiveOnly</c> serves both purposes once the tracker
-/// self-seeds.</para>
+/// <para><b>Area subscription decoupled from the log pipe (#789).</b> Area
+/// state arrives via <see cref="IPlayerAreaState.Subscribe"/> on a separate
+/// attach during <c>StartAsync</c> — the per-line handler no longer feeds
+/// already-classified <c>LOADING LEVEL</c> lines into a concrete tracker.
+/// The producer-side <see cref="Producers.AreaLoadingFrameProducer"/>
+/// already owns the L1 subscription that turns those envelopes into
+/// <c>AreaLoadingFrame</c> emissions; the bridge here just consumes the
+/// resulting state notifications.</para>
 ///
 /// <para>Subscribes eagerly during <c>StartAsync</c> (#695 Call 1). The
 /// <c>"legolas"</c> module gate no longer gates state subscription; UI
@@ -81,13 +86,19 @@ namespace Legolas.Services;
 /// by calibration VMs. The L1
 /// <see cref="DeliveryContext.Marshaled"/> option marshals every envelope
 /// onto the WPF dispatcher before handler invocation, replacing the
-/// hand-rolled <c>PostToUi</c> helper (#550 capability E).</para>
+/// hand-rolled <c>PostToUi</c> helper (#550 capability E). Area-change
+/// notifications fire on the world's merger thread (or the producing
+/// thread on the synthetic <see cref="PlayerAreaChangeKind.Snapshot"/>
+/// replay-on-attach inside <see cref="IPlayerAreaState.Subscribe"/>);
+/// <see cref="IAreaCalibrationService.SelectArea"/> itself does not
+/// marshal, but the VMs it raises Changed for already dispatch their own
+/// UI work.</para>
 /// </summary>
 public sealed class PlayerLogIngestionService : BackgroundService
 {
     private readonly ILogStreamDriver _driver;
     private readonly PlayerLogParser _parser;
-    private readonly PlayerAreaTracker _areaTracker;
+    private readonly IPlayerAreaState _areaState;
     private readonly IAreaCalibrationService _areaCalibration;
     private readonly SurveyFlowController _flow;
     private readonly SessionState _session;
@@ -97,7 +108,8 @@ public sealed class PlayerLogIngestionService : BackgroundService
     private readonly PerCharacterStore<LegolasIngestionState>? _ingestionStore;
     private readonly IDiagnosticsSink? _diag;
 
-    private string? _lastAppliedArea;
+    private string? _cachedArea;
+    private IDisposable? _areaSub;
     private ILogSubscription? _subscription;
 
     // High-water bookkeeping. Updated per envelope under no lock — the L1
@@ -115,7 +127,7 @@ public sealed class PlayerLogIngestionService : BackgroundService
     public PlayerLogIngestionService(
         ILogStreamDriver driver,
         PlayerLogParser parser,
-        PlayerAreaTracker areaTracker,
+        IPlayerAreaState areaState,
         IAreaCalibrationService areaCalibration,
         SurveyFlowController flow,
         SessionState session,
@@ -127,7 +139,7 @@ public sealed class PlayerLogIngestionService : BackgroundService
     {
         _driver = driver;
         _parser = parser;
-        _areaTracker = areaTracker;
+        _areaState = areaState ?? throw new ArgumentNullException(nameof(areaState));
         _areaCalibration = areaCalibration;
         _flow = flow;
         _session = session;
@@ -163,12 +175,18 @@ public sealed class PlayerLogIngestionService : BackgroundService
         // active at attach time. See "Character-switch caveat" below.
         var initialHighWater = ResolveInitialHighWater();
 
-        // Area is seeded by the shared PlayerAreaTracker itself (one-shot,
-        // owned — mithril#514); this consumer only reads it. ApplyAreaIfChanged
-        // reads CurrentArea, which triggers PlayerAreaTracker.EnsureSeeded
-        // on first call — so even though LiveOnly drops the replay drain
-        // we still pick up the current area before any live envelope arrives.
-        ApplyAreaIfChanged();
+        // Area bridge: IPlayerAreaState.Subscribe fires a synthetic Snapshot
+        // notification synchronously inside the call so a late subscriber
+        // observes the same view already-attached handlers see — that's how
+        // the production seed (PlayerAreaWorldRegistration's eager pre-warm
+        // applies the producer's reverse-scan seed before our StartAsync
+        // runs) reaches OnAreaChanged before any live LOADING LEVEL envelope.
+        // Subscribing here (NOT via IPlayerWorld.Bus) is load-bearing while
+        // the pre-warm is still active — bus subscribers never see the seed
+        // because that transition is applied directly to the folder and
+        // bypasses the bus. Retiring the pre-warm is the follow-on after
+        // both this consumer and Gandalf's sibling migrate (#769).
+        _areaSub = _areaState.Subscribe(OnAreaChanged);
 
         var dispatcher = Application.Current?.Dispatcher;
         // archetype-B per #549 Legolas/PlayerLog disposition:
@@ -191,12 +209,14 @@ public sealed class PlayerLogIngestionService : BackgroundService
                 var ts = payload.Timestamp.UtcDateTime;
                 var line = payload.Data;
 
-                // Area first — a target line in the same batch must read the
-                // correct current-area calibration. PlayerAreaTracker takes
-                // the bare envelope-stripped payload (L0.5 owns the actor
-                // envelope; downstream never re-matches it).
-                _areaTracker.Observe(line, ts);
-                ApplyAreaIfChanged();
+                // Area state is no longer fed from this per-line handler
+                // (#789): the producer's L1 subscription owns the
+                // LOADING-LEVEL envelope path, and IPlayerAreaState.Subscribe
+                // delivers the change notifications above. The trailing
+                // map-fx / motherlode handlers below read the cached current
+                // area implicitly via IAreaCalibrationService when they need
+                // it (SelectArea already ran from OnAreaChanged for the
+                // current area before any live envelope reaches here).
 
                 // Map pins (ProcessMapPin{Add,Remove}) are owned by the
                 // GameState-tier PlayerPinTracker (#468); this service handles
@@ -278,6 +298,8 @@ public sealed class PlayerLogIngestionService : BackgroundService
         {
             _subscription?.Dispose();
             _subscription = null;
+            _areaSub?.Dispose();
+            _areaSub = null;
             // Final synchronous flush so an in-flight debounce doesn't lose
             // the last few Sequence advances on a clean shutdown.
             _highWaterFlush.Stop();
@@ -289,6 +311,8 @@ public sealed class PlayerLogIngestionService : BackgroundService
     {
         _subscription?.Dispose();
         _subscription = null;
+        _areaSub?.Dispose();
+        _areaSub = null;
         _highWaterFlush.Stop();
         _highWaterFlush.Dispose();
         base.Dispose();
@@ -408,25 +432,28 @@ public sealed class PlayerLogIngestionService : BackgroundService
 
     /// <summary>
     /// Apply the current area's persisted calibration when (and only when) the
-    /// tracker's area actually changes. A null area (character-select /
-    /// disconnect) resets the latch so re-entering the same area later
-    /// re-applies — defensive against any intervening projector reset.
+    /// area actually changes. A null area (character-select / disconnect)
+    /// resets the latch so re-entering the same area later re-applies —
+    /// defensive against any intervening projector reset.
+    ///
+    /// <para>Fires for both the synthetic
+    /// <see cref="PlayerAreaChangeKind.Snapshot"/> replay on subscribe (which
+    /// delivers the seed area) and live
+    /// <see cref="PlayerAreaChangeKind.Changed"/> transitions; the
+    /// previous-equals-current short-circuit means a Snapshot whose
+    /// <c>Current</c> matches an already-applied area is silently dropped,
+    /// matching the pre-#789 idempotent <c>ApplyAreaIfChanged</c> behaviour.</para>
     /// </summary>
-    private void ApplyAreaIfChanged()
+    private void OnAreaChanged(PlayerAreaChanged evt)
     {
-        // First read triggers PlayerAreaTracker.EnsureSeeded (#514) — the
-        // tracker self-scans the log for the most recent LOADING LEVEL and
-        // resolves the current area before returning. So even though we
-        // subscribe LiveOnly (no replay drain), the area we read here is
-        // the *real* current area, not null.
-        var area = _areaTracker.CurrentArea;
+        var area = evt.Current;
         if (area is null)
         {
-            _lastAppliedArea = null;
+            _cachedArea = null;
             return;
         }
-        if (area == _lastAppliedArea) return;
-        _lastAppliedArea = area;
+        if (area == _cachedArea) return;
+        _cachedArea = area;
         _areaCalibration.SelectArea(area);
     }
 

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -108,7 +108,6 @@ public sealed class PlayerLogIngestionService : BackgroundService
     private readonly PerCharacterStore<LegolasIngestionState>? _ingestionStore;
     private readonly IDiagnosticsSink? _diag;
 
-    private string? _cachedArea;
     private IDisposable? _areaSub;
     private ILogSubscription? _subscription;
 
@@ -431,30 +430,19 @@ public sealed class PlayerLogIngestionService : BackgroundService
         $"{CleanName(mt.Short)} @ ({mt.World.X:0},{mt.World.Z:0})";
 
     /// <summary>
-    /// Apply the current area's persisted calibration when (and only when) the
-    /// area actually changes. A null area (character-select / disconnect)
-    /// resets the latch so re-entering the same area later re-applies —
-    /// defensive against any intervening projector reset.
-    ///
-    /// <para>Fires for both the synthetic
-    /// <see cref="PlayerAreaChangeKind.Snapshot"/> replay on subscribe (which
-    /// delivers the seed area) and live
-    /// <see cref="PlayerAreaChangeKind.Changed"/> transitions; the
-    /// previous-equals-current short-circuit means a Snapshot whose
-    /// <c>Current</c> matches an already-applied area is silently dropped,
-    /// matching the pre-#789 idempotent <c>ApplyAreaIfChanged</c> behaviour.</para>
+    /// Apply the current area's persisted calibration. Fires for both the
+    /// synthetic <see cref="PlayerAreaChangeKind.Snapshot"/> replay on
+    /// subscribe (which delivers the seed area) and live
+    /// <see cref="PlayerAreaChangeKind.Changed"/> transitions. Same-area
+    /// dedup lives upstream — <see cref="IPlayerAreaState.Subscribe"/>
+    /// only delivers Changed events on genuine transitions, and Snapshot
+    /// fires exactly once on attach. A null <see cref="PlayerAreaChanged.Current"/>
+    /// (character-select / disconnect / pre-first-observation) is a
+    /// no-op; the next non-null transition re-applies.
     /// </summary>
     private void OnAreaChanged(PlayerAreaChanged evt)
     {
-        var area = evt.Current;
-        if (area is null)
-        {
-            _cachedArea = null;
-            return;
-        }
-        if (area == _cachedArea) return;
-        _cachedArea = area;
-        _areaCalibration.SelectArea(area);
+        if (evt.Current is not null) _areaCalibration.SelectArea(evt.Current);
     }
 
     /// <summary>

--- a/tests/Gandalf.Tests/FakePlayerAreaState.cs
+++ b/tests/Gandalf.Tests/FakePlayerAreaState.cs
@@ -1,0 +1,73 @@
+using Mithril.GameState.Areas;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Minimal <see cref="IPlayerAreaState"/> test double for the #789-era
+/// consumer migration: holds a <see cref="CurrentArea"/> and a list of
+/// subscribers. <see cref="Subscribe"/> fires the synthetic
+/// <see cref="PlayerAreaChangeKind.Snapshot"/> replay before attaching
+/// (so a late subscriber sees whatever <see cref="SetArea"/> set
+/// pre-subscribe); <see cref="SetArea"/> dispatches a
+/// <see cref="PlayerAreaChangeKind.Changed"/> notification to every
+/// attached handler. Mirrors the production
+/// <see cref="PlayerAreaTracker"/> contract closely enough that consumers
+/// cannot distinguish the test double from the real folder.
+/// </summary>
+internal sealed class FakePlayerAreaState : IPlayerAreaState
+{
+    private readonly object _lock = new();
+    private readonly List<Action<PlayerAreaChanged>> _handlers = new();
+    private string? _current;
+
+    public string? CurrentArea
+    {
+        get { lock (_lock) return _current; }
+    }
+
+    public IDisposable Subscribe(Action<PlayerAreaChanged> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            handler(new PlayerAreaChanged(
+                PlayerAreaChangeKind.Snapshot, Previous: null, Current: _current,
+                At: DateTimeOffset.MinValue));
+            _handlers.Add(handler);
+            return new Sub(this, handler);
+        }
+    }
+
+    public void SetArea(string? area, DateTimeOffset? at = null)
+    {
+        Action<PlayerAreaChanged>[] toFire;
+        PlayerAreaChanged change;
+        lock (_lock)
+        {
+            if (_current == area) return;
+            var prev = _current;
+            _current = area;
+            change = new PlayerAreaChanged(
+                PlayerAreaChangeKind.Changed, prev, area, at ?? DateTimeOffset.UtcNow);
+            toFire = _handlers.ToArray();
+        }
+        foreach (var h in toFire) h(change);
+    }
+
+    private sealed class Sub : IDisposable
+    {
+        private FakePlayerAreaState? _owner;
+        private readonly Action<PlayerAreaChanged> _handler;
+        public Sub(FakePlayerAreaState owner, Action<PlayerAreaChanged> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
+        }
+    }
+}

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -1,10 +1,7 @@
 using System.IO;
 using FluentAssertions;
 using Gandalf.Domain;
-using Gandalf.Parsing;
 using Gandalf.Services;
-using Mithril.GameState.Areas;
-using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
@@ -34,7 +31,7 @@ public class LootSourceTests : IDisposable
     }
 
     private (LootSource src, DerivedTimerProgressService derived, FakeActiveCharacterService active, ManualTime time)
-        Build(PlayerAreaTracker? areaTracker = null, IReferenceDataService? refData = null)
+        Build(IReferenceDataService? refData = null)
     {
         var active = new FakeActiveCharacterService();
         active.SetActiveCharacter("Arthur", "Kwatoxi");
@@ -49,7 +46,7 @@ public class LootSourceTests : IDisposable
             LootCatalogCacheJsonContext.Default.LootCatalogCache);
         var cache = cacheStore.Load();
         var src = new LootSource(derived, cacheStore, cache,
-            areaTracker: areaTracker, refData: refData, time: time);
+            refData: refData, time: time);
 
         return (src, derived, active, time);
     }
@@ -686,12 +683,13 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_stamps_current_area_on_LearnedChest()
     {
-        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
-        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-
-        var (src, derived, _, time) = Build(areaTracker);
+        // Post-#789: area is forwarded from LootIngestionService's
+        // IPlayerAreaState subscription via UpdateCurrentArea; unit-fixture
+        // tests drive it directly.
+        var (src, derived, _, time) = Build();
         try
         {
+            src.UpdateCurrentArea("AreaSerbule");
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
 
             var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
@@ -705,7 +703,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_with_unknown_area_persists_null()
     {
-        // No area tracker injected → CurrentArea is null path.
+        // No UpdateCurrentArea call → _cachedArea stays null path.
         var (src, derived, _, time) = Build();
         try
         {
@@ -721,17 +719,16 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_area_is_sticky_once_known()
     {
-        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
-        var (src, derived, _, time) = Build(areaTracker);
+        var (src, derived, _, time) = Build();
         try
         {
             // First commit while in AreaSerbule.
-            areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+            src.UpdateCurrentArea("AreaSerbule");
             src.OnChestInteraction("LootChest1", time.GetUtcNow().UtcDateTime);
 
             // Player ports to AreaTomb1, then loots a same-named chest. Sticky:
             // first commit's area wins so the cache doesn't ping-pong.
-            areaTracker.Observe("LOADING LEVEL AreaTomb1", DateTime.UtcNow);
+            src.UpdateCurrentArea("AreaTomb1");
             time.Advance(TimeSpan.FromMinutes(5));
             src.OnChestInteraction("LootChest1", time.GetUtcNow().UtcDateTime);
 
@@ -745,16 +742,15 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_stamps_area_late_when_first_commit_was_unknown()
     {
-        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
-        var (src, derived, _, time) = Build(areaTracker);
+        var (src, derived, _, time) = Build();
         try
         {
-            // First commit happens before any LOADING LEVEL → Area is null.
+            // First commit happens before any UpdateCurrentArea → Area is null.
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
 
             // Player transitions, then re-loots the same chest. Sticky-once-known
             // means we DON'T overwrite known Area, but we DO populate from null.
-            areaTracker.Observe("LOADING LEVEL AreaEltibule", DateTime.UtcNow);
+            src.UpdateCurrentArea("AreaEltibule");
             time.Advance(TimeSpan.FromHours(4));
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
 
@@ -772,12 +768,10 @@ public class LootSourceTests : IDisposable
         refData.StringsRaw["npc_AreaSerbule/Cow_Moolanda_Name"] = "Wanda";
         refData.StringsRaw["npc_AreaSerbule/Cow_Bessie_Name"] = "Bessie";
 
-        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
-        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-
-        var (src, derived, _, time) = Build(areaTracker, refData);
+        var (src, derived, _, time) = Build(refData);
         try
         {
+            src.UpdateCurrentArea("AreaSerbule");
             src.OnChestInteraction("Cow_Moolanda", time.GetUtcNow().UtcDateTime);
             src.OnChestInteraction("Cow_Bessie", time.GetUtcNow().UtcDateTime);
 
@@ -797,12 +791,10 @@ public class LootSourceTests : IDisposable
         refData.StringsRaw["npc_LootBackpack1_Name"] = "Adventurer's Pack";
         // No npc_AreaSerbule/LootBackpack1_Name entry — global prefab.
 
-        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
-        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-
-        var (src, derived, _, time) = Build(areaTracker, refData);
+        var (src, derived, _, time) = Build(refData);
         try
         {
+            src.UpdateCurrentArea("AreaSerbule");
             src.OnChestInteraction("LootBackpack1", time.GetUtcNow().UtcDateTime);
             var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("LootBackpack1"));
             entry.DisplayName.Should().Be("Adventurer's Pack");
@@ -830,12 +822,10 @@ public class LootSourceTests : IDisposable
         var refData = new Mithril.TestSupport.FakeReferenceData();
         refData.AreasRaw["AreaSerbule"] = new AreaEntry("AreaSerbule", "Serbule", "Serbule");
 
-        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
-        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
-
-        var (src, derived, _, time) = Build(areaTracker, refData);
+        var (src, derived, _, time) = Build(refData);
         try
         {
+            src.UpdateCurrentArea("AreaSerbule");
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
             var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("EltibuleSecretChest"));
             entry.Region.Should().Be("Serbule");

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -30,7 +30,7 @@ public class LootSourceTests : IDisposable
         try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
     }
 
-    private (LootSource src, DerivedTimerProgressService derived, FakeActiveCharacterService active, ManualTime time)
+    private (LootSource src, DerivedTimerProgressService derived, FakeActiveCharacterService active, ManualTime time, FakePlayerAreaState areaState)
         Build(IReferenceDataService? refData = null)
     {
         var active = new FakeActiveCharacterService();
@@ -45,16 +45,17 @@ public class LootSourceTests : IDisposable
         var cacheStore = new JsonSettingsStore<LootCatalogCache>(_cachePath,
             LootCatalogCacheJsonContext.Default.LootCatalogCache);
         var cache = cacheStore.Load();
+        var areaState = new FakePlayerAreaState();
         var src = new LootSource(derived, cacheStore, cache,
-            refData: refData, time: time);
+            areaState: areaState, refData: refData, time: time);
 
-        return (src, derived, active, time);
+        return (src, derived, active, time, areaState);
     }
 
     [Fact]
     public void First_loot_of_unknown_chest_creates_unverified_placeholder_row()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // No rejection observed yet → row stamps with PlaceholderChestDuration,
@@ -80,7 +81,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Rejection_after_placeholder_loot_upgrades_duration_and_preserves_StartedAt()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // Loot at T0 with no prior rejection → placeholder row anchored at T0.
@@ -112,7 +113,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Rejection_with_shorter_real_duration_fires_TimerReady_when_already_elapsed()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             var lootTime = time.GetUtcNow().UtcDateTime;
@@ -138,7 +139,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Rejection_after_placeholder_loot_does_not_refire_when_still_cooling()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
@@ -161,7 +162,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Subsequent_loot_after_rejection_uses_verified_duration()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
@@ -186,7 +187,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Past_anchored_chest_loot_yields_correct_remaining()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
@@ -207,7 +208,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void BossKillCredit_auto_discovers_and_stamps_with_placeholder_when_uncalibrated()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // No calibration overlay → falls back to PlaceholderDefeatDuration,
@@ -230,7 +231,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Calibration_overlay_supplies_verified_duration_and_area()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OverlayDefeatCalibration(
@@ -260,7 +261,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Calibration_overlay_applied_after_discovery_re_projects_existing_rows()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // Discovery first → placeholder row.
@@ -286,7 +287,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void BossKillCredit_within_window_does_not_reset_clock()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OverlayDefeatCalibration(
@@ -312,7 +313,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Replay_of_dismissed_boss_kill_preserves_dismissal()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             var killTime = time.GetUtcNow().UtcDateTime;
@@ -338,7 +339,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Genuine_re_kill_after_dismissal_resurrects_the_row()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnBossKillCredit("Megaspider", time.GetUtcNow().UtcDateTime);
@@ -365,7 +366,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Replay_of_dismissed_chest_loot_preserves_dismissal()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
@@ -388,7 +389,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void DefeatCooldownActive_is_diagnostic_only_does_not_mutate_progress()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnDefeatCooldownActive("Megaspider", time.GetUtcNow().UtcDateTime);
@@ -404,7 +405,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Source_id_is_stable()
     {
-        var (src, derived, _, _) = Build();
+        var (src, derived, _, _, _) = Build();
         try
         {
             src.SourceId.Should().Be("gandalf.loot");
@@ -419,7 +420,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Catalog_includes_both_chest_and_defeat_entries_under_one_source()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
@@ -472,7 +473,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Forget_chest_drops_catalog_progress_and_cache_entries()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
@@ -504,7 +505,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Forget_defeat_drops_learned_entry_and_progress()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnBossKillCredit("Den Mother", time.GetUtcNow().UtcDateTime);
@@ -531,7 +532,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Forget_emits_single_Removed_delta()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestInteraction("Chair", time.GetUtcNow().UtcDateTime);
@@ -560,7 +561,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Forget_then_re_observe_resurrects_cleanly()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // User wipes a false-positive entry. If the parser later re-emits
@@ -589,7 +590,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Forget_of_unknown_key_is_noop()
     {
-        var (src, derived, _, _) = Build();
+        var (src, derived, _, _, _) = Build();
         try
         {
             var batches = new List<IReadOnlyList<TimerRowDelta>>();
@@ -610,7 +611,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_emits_RowsChanged_with_added_delta()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             var batches = new List<IReadOnlyList<TimerRowDelta>>();
@@ -641,7 +642,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OverlayDefeatCalibration_emits_one_batched_RowsChanged()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // Pre-populate the catalog with a few learned defeats so the overlay
@@ -683,13 +684,13 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_stamps_current_area_on_LearnedChest()
     {
-        // Post-#789: area is forwarded from LootIngestionService's
-        // IPlayerAreaState subscription via UpdateCurrentArea; unit-fixture
-        // tests drive it directly.
-        var (src, derived, _, time) = Build();
+        // Post-#790: LootSource queries IPlayerAreaState.CurrentArea at
+        // chest-commit time; the test double's SetArea mirrors the
+        // production folder's Apply.
+        var (src, derived, _, time, areaState) = Build();
         try
         {
-            src.UpdateCurrentArea("AreaSerbule");
+            areaState.SetArea("AreaSerbule");
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
 
             var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
@@ -703,8 +704,8 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_with_unknown_area_persists_null()
     {
-        // No UpdateCurrentArea call → _cachedArea stays null path.
-        var (src, derived, _, time) = Build();
+        // No SetArea call → CurrentArea stays null → Area stamp = null.
+        var (src, derived, _, time, _) = Build();
         try
         {
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
@@ -719,16 +720,16 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_area_is_sticky_once_known()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, areaState) = Build();
         try
         {
             // First commit while in AreaSerbule.
-            src.UpdateCurrentArea("AreaSerbule");
+            areaState.SetArea("AreaSerbule");
             src.OnChestInteraction("LootChest1", time.GetUtcNow().UtcDateTime);
 
             // Player ports to AreaTomb1, then loots a same-named chest. Sticky:
             // first commit's area wins so the cache doesn't ping-pong.
-            src.UpdateCurrentArea("AreaTomb1");
+            areaState.SetArea("AreaTomb1");
             time.Advance(TimeSpan.FromMinutes(5));
             src.OnChestInteraction("LootChest1", time.GetUtcNow().UtcDateTime);
 
@@ -742,15 +743,15 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void OnChestInteraction_stamps_area_late_when_first_commit_was_unknown()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, areaState) = Build();
         try
         {
-            // First commit happens before any UpdateCurrentArea → Area is null.
+            // First commit happens before any SetArea → Area is null.
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
 
             // Player transitions, then re-loots the same chest. Sticky-once-known
             // means we DON'T overwrite known Area, but we DO populate from null.
-            src.UpdateCurrentArea("AreaEltibule");
+            areaState.SetArea("AreaEltibule");
             time.Advance(TimeSpan.FromHours(4));
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
 
@@ -768,10 +769,10 @@ public class LootSourceTests : IDisposable
         refData.StringsRaw["npc_AreaSerbule/Cow_Moolanda_Name"] = "Wanda";
         refData.StringsRaw["npc_AreaSerbule/Cow_Bessie_Name"] = "Bessie";
 
-        var (src, derived, _, time) = Build(refData);
+        var (src, derived, _, time, areaState) = Build(refData);
         try
         {
-            src.UpdateCurrentArea("AreaSerbule");
+            areaState.SetArea("AreaSerbule");
             src.OnChestInteraction("Cow_Moolanda", time.GetUtcNow().UtcDateTime);
             src.OnChestInteraction("Cow_Bessie", time.GetUtcNow().UtcDateTime);
 
@@ -791,10 +792,10 @@ public class LootSourceTests : IDisposable
         refData.StringsRaw["npc_LootBackpack1_Name"] = "Adventurer's Pack";
         // No npc_AreaSerbule/LootBackpack1_Name entry — global prefab.
 
-        var (src, derived, _, time) = Build(refData);
+        var (src, derived, _, time, areaState) = Build(refData);
         try
         {
-            src.UpdateCurrentArea("AreaSerbule");
+            areaState.SetArea("AreaSerbule");
             src.OnChestInteraction("LootBackpack1", time.GetUtcNow().UtcDateTime);
             var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("LootBackpack1"));
             entry.DisplayName.Should().Be("Adventurer's Pack");
@@ -806,7 +807,7 @@ public class LootSourceTests : IDisposable
     public void BuildCatalog_falls_back_to_internal_name_when_strings_all_misses_entirely()
     {
         var refData = new Mithril.TestSupport.FakeReferenceData(); // empty Strings
-        var (src, derived, _, time) = Build(refData: refData);
+        var (src, derived, _, time, _) = Build(refData: refData);
         try
         {
             src.OnChestInteraction("UnknownChest1", time.GetUtcNow().UtcDateTime);
@@ -822,10 +823,10 @@ public class LootSourceTests : IDisposable
         var refData = new Mithril.TestSupport.FakeReferenceData();
         refData.AreasRaw["AreaSerbule"] = new AreaEntry("AreaSerbule", "Serbule", "Serbule");
 
-        var (src, derived, _, time) = Build(refData);
+        var (src, derived, _, time, areaState) = Build(refData);
         try
         {
-            src.UpdateCurrentArea("AreaSerbule");
+            areaState.SetArea("AreaSerbule");
             src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
             var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("EltibuleSecretChest"));
             entry.Region.Should().Be("Serbule");
@@ -836,7 +837,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Cow_rejection_with_no_prior_row_anchors_at_rejection_time()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             var rejectionAt = time.GetUtcNow().UtcDateTime;
@@ -860,7 +861,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Cow_rejection_leaves_active_prior_row_alone()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // Successful milking 10 min ago.
@@ -886,7 +887,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Cow_rejection_refreshes_stale_prior_anchor_to_rejection_time()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // Milking 2 h ago — cooldown of 1 h would have made the row Done at +1 h.
@@ -913,7 +914,7 @@ public class LootSourceTests : IDisposable
     [Fact]
     public void Cow_rejection_replays_idempotently_when_row_still_active()
     {
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             // Milking 10 min ago, 1 h cooldown — row is still in flight.
@@ -943,7 +944,7 @@ public class LootSourceTests : IDisposable
         // Forward-looking chest grammar gives us absolute info — the row's
         // existing StartedAt is more accurate than the rejection timestamp.
         // Default anchorFromRejection=false preserves today's behaviour.
-        var (src, derived, _, time) = Build();
+        var (src, derived, _, time, _) = Build();
         try
         {
             var lootAt = time.GetUtcNow().UtcDateTime;

--- a/tests/Gandalf.Tests/Services/LootIngestionServiceTests.cs
+++ b/tests/Gandalf.Tests/Services/LootIngestionServiceTests.cs
@@ -4,7 +4,6 @@ using Gandalf.Domain;
 using Gandalf.Parsing;
 using Gandalf.Services;
 using Mithril.GameState.Areas;
-using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Character;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Settings;
@@ -259,7 +258,7 @@ public sealed class LootIngestionServiceTests : IDisposable
         public LootSource Source { get; }
         public DerivedTimerProgressService Derived { get; }
         public LootBracketTracker Bracket { get; }
-        public PlayerAreaTracker AreaTracker { get; }
+        public FakePlayerAreaState AreaState { get; }
         public BossKillCreditParser BossKill { get; } = new();
         public DefeatCooldownParser DefeatCooldown { get; } = new();
 
@@ -283,9 +282,9 @@ public sealed class LootIngestionServiceTests : IDisposable
             var cacheStore = new JsonSettingsStore<LootCatalogCache>(cachePath,
                 LootCatalogCacheJsonContext.Default.LootCatalogCache);
             var cache = cacheStore.Load();
-            AreaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+            AreaState = new FakePlayerAreaState();
             Source = new LootSource(Derived, cacheStore, cache,
-                areaTracker: AreaTracker, refData: null, time: time);
+                refData: null, time: time);
             Bracket = new LootBracketTracker(
                 Source,
                 new ChestInteractionParser(),
@@ -299,7 +298,7 @@ public sealed class LootIngestionServiceTests : IDisposable
         public async Task<(LootIngestionService svc, Task exec)> StartServiceAsync(FakeLogStreamDriver driver)
         {
             var svc = new LootIngestionService(driver, Bracket, BossKill, DefeatCooldown,
-                AreaTracker, Source);
+                AreaState, Source);
             var exec = svc.StartAsync(CancellationToken.None);
             // Gandalf is eager — no module gate to open. Subscription happens
             // synchronously inside ExecuteAsync; wait for it to land.
@@ -361,6 +360,77 @@ public sealed class LootIngestionServiceTests : IDisposable
             public LogSubscriptionDiagnostics Diagnostics => new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
             public event EventHandler? StateChanged { add { } remove { } }
             public void Dispose() => _onDispose();
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IPlayerAreaState"/> test double for the #789
+    /// migration: holds a <see cref="CurrentArea"/> and a list of
+    /// subscribers; <see cref="Subscribe"/> fires the synthetic
+    /// <see cref="PlayerAreaChangeKind.Snapshot"/> replay before attaching
+    /// (so a late subscriber sees whatever <see cref="SetArea"/> set
+    /// pre-subscribe); <see cref="SetArea"/> dispatches a
+    /// <see cref="PlayerAreaChangeKind.Changed"/> notification to every
+    /// attached handler. Mirrors the production
+    /// <see cref="PlayerAreaTracker"/> contract closely enough that the
+    /// service under test cannot distinguish the test double from the real
+    /// folder.
+    /// </summary>
+    private sealed class FakePlayerAreaState : IPlayerAreaState
+    {
+        private readonly object _lock = new();
+        private readonly List<Action<PlayerAreaChanged>> _handlers = new();
+        private string? _current;
+
+        public string? CurrentArea
+        {
+            get { lock (_lock) return _current; }
+        }
+
+        public IDisposable Subscribe(Action<PlayerAreaChanged> handler)
+        {
+            ArgumentNullException.ThrowIfNull(handler);
+            lock (_lock)
+            {
+                handler(new PlayerAreaChanged(
+                    PlayerAreaChangeKind.Snapshot, Previous: null, Current: _current,
+                    At: DateTimeOffset.MinValue));
+                _handlers.Add(handler);
+                return new Sub(this, handler);
+            }
+        }
+
+        public void SetArea(string? area, DateTimeOffset? at = null)
+        {
+            Action<PlayerAreaChanged>[] toFire;
+            PlayerAreaChanged change;
+            lock (_lock)
+            {
+                if (_current == area) return;
+                var prev = _current;
+                _current = area;
+                change = new PlayerAreaChanged(
+                    PlayerAreaChangeKind.Changed, prev, area, at ?? DateTimeOffset.UtcNow);
+                toFire = _handlers.ToArray();
+            }
+            foreach (var h in toFire) h(change);
+        }
+
+        private sealed class Sub : IDisposable
+        {
+            private FakePlayerAreaState? _owner;
+            private readonly Action<PlayerAreaChanged> _handler;
+            public Sub(FakePlayerAreaState owner, Action<PlayerAreaChanged> handler)
+            {
+                _owner = owner;
+                _handler = handler;
+            }
+            public void Dispose()
+            {
+                var owner = Interlocked.Exchange(ref _owner, null);
+                if (owner is null) return;
+                lock (owner._lock) { owner._handlers.Remove(_handler); }
+            }
         }
     }
 }

--- a/tests/Gandalf.Tests/Services/LootIngestionServiceTests.cs
+++ b/tests/Gandalf.Tests/Services/LootIngestionServiceTests.cs
@@ -284,7 +284,7 @@ public sealed class LootIngestionServiceTests : IDisposable
             var cache = cacheStore.Load();
             AreaState = new FakePlayerAreaState();
             Source = new LootSource(Derived, cacheStore, cache,
-                refData: null, time: time);
+                areaState: AreaState, refData: null, time: time);
             Bracket = new LootBracketTracker(
                 Source,
                 new ChestInteractionParser(),
@@ -297,8 +297,7 @@ public sealed class LootIngestionServiceTests : IDisposable
 
         public async Task<(LootIngestionService svc, Task exec)> StartServiceAsync(FakeLogStreamDriver driver)
         {
-            var svc = new LootIngestionService(driver, Bracket, BossKill, DefeatCooldown,
-                AreaState, Source);
+            var svc = new LootIngestionService(driver, Bracket, BossKill, DefeatCooldown, Source);
             var exec = svc.StartAsync(CancellationToken.None);
             // Gandalf is eager — no module gate to open. Subscription happens
             // synchronously inside ExecuteAsync; wait for it to land.
@@ -360,77 +359,6 @@ public sealed class LootIngestionServiceTests : IDisposable
             public LogSubscriptionDiagnostics Diagnostics => new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
             public event EventHandler? StateChanged { add { } remove { } }
             public void Dispose() => _onDispose();
-        }
-    }
-
-    /// <summary>
-    /// Minimal <see cref="IPlayerAreaState"/> test double for the #789
-    /// migration: holds a <see cref="CurrentArea"/> and a list of
-    /// subscribers; <see cref="Subscribe"/> fires the synthetic
-    /// <see cref="PlayerAreaChangeKind.Snapshot"/> replay before attaching
-    /// (so a late subscriber sees whatever <see cref="SetArea"/> set
-    /// pre-subscribe); <see cref="SetArea"/> dispatches a
-    /// <see cref="PlayerAreaChangeKind.Changed"/> notification to every
-    /// attached handler. Mirrors the production
-    /// <see cref="PlayerAreaTracker"/> contract closely enough that the
-    /// service under test cannot distinguish the test double from the real
-    /// folder.
-    /// </summary>
-    private sealed class FakePlayerAreaState : IPlayerAreaState
-    {
-        private readonly object _lock = new();
-        private readonly List<Action<PlayerAreaChanged>> _handlers = new();
-        private string? _current;
-
-        public string? CurrentArea
-        {
-            get { lock (_lock) return _current; }
-        }
-
-        public IDisposable Subscribe(Action<PlayerAreaChanged> handler)
-        {
-            ArgumentNullException.ThrowIfNull(handler);
-            lock (_lock)
-            {
-                handler(new PlayerAreaChanged(
-                    PlayerAreaChangeKind.Snapshot, Previous: null, Current: _current,
-                    At: DateTimeOffset.MinValue));
-                _handlers.Add(handler);
-                return new Sub(this, handler);
-            }
-        }
-
-        public void SetArea(string? area, DateTimeOffset? at = null)
-        {
-            Action<PlayerAreaChanged>[] toFire;
-            PlayerAreaChanged change;
-            lock (_lock)
-            {
-                if (_current == area) return;
-                var prev = _current;
-                _current = area;
-                change = new PlayerAreaChanged(
-                    PlayerAreaChangeKind.Changed, prev, area, at ?? DateTimeOffset.UtcNow);
-                toFire = _handlers.ToArray();
-            }
-            foreach (var h in toFire) h(change);
-        }
-
-        private sealed class Sub : IDisposable
-        {
-            private FakePlayerAreaState? _owner;
-            private readonly Action<PlayerAreaChanged> _handler;
-            public Sub(FakePlayerAreaState owner, Action<PlayerAreaChanged> handler)
-            {
-                _owner = owner;
-                _handler = handler;
-            }
-            public void Dispose()
-            {
-                var owner = Interlocked.Exchange(ref _owner, null);
-                if (owner is null) return;
-                lock (owner._lock) { owner._handlers.Remove(_handler); }
-            }
         }
     }
 }

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -7,7 +7,6 @@ using Legolas.Services;
 using Legolas.Tests.TestSupport;
 using Legolas.ViewModels;
 using Mithril.GameState.Areas;
-using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Game;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
@@ -51,7 +50,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         SpyAreaCalibration Spy,
         SessionState Session,
         SurveyFlowController Flow,
-        PlayerAreaTracker Tracker,
+        FakePlayerAreaState AreaState,
         ModuleGates Gates);
 
     private static Fixture Build(
@@ -59,18 +58,14 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         bool openGate = true)
     {
         var driver = new TestLogStreamDriver();
-        // #775: the tracker's lazy self-seed retired; the production seed
-        // path is PlayerAreaWorldRegistration.StartAsync (eager pre-warm
-        // via AreaLoadingFrameProducer.TryBuildSeedFrame -> folder.Apply).
-        // For the unit test fixture that exercises Legolas directly without
-        // wiring a producer/world, the eager pre-warm is faked via a single
-        // Observe() call before constructing the service — same semantics,
-        // simpler scaffolding.
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
-        if (preSeededArea is not null)
-        {
-            tracker.Observe($"LOADING LEVEL {preSeededArea}", DateTime.UtcNow);
-        }
+        // #789: the area bridge consumes IPlayerAreaState.Subscribe instead
+        // of feeding a concrete tracker. preSeededArea is staged BEFORE
+        // building the service so the Subscribe call's synthetic Snapshot
+        // replay delivers it to OnAreaChanged — mirrors production where
+        // PlayerAreaWorldRegistration's eager pre-warm seeds the folder
+        // before any consumer attaches.
+        var areaState = new FakePlayerAreaState();
+        if (preSeededArea is not null) areaState.SetArea(preSeededArea);
         var spy = new SpyAreaCalibration(calibration);
         var session = new SessionState();
         var settings = new LegolasSettings();
@@ -81,10 +76,10 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             new MultilaterationSolver(), new MotherlodeFlowController(session),
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
-            driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
+            driver, new PlayerLogParser(), areaState, spy, flow, session, motherlode,
             settings,
             activeChar: null, ingestionStore: null);
-        return new Fixture(svc, driver, spy, session, flow, tracker, gates);
+        return new Fixture(svc, driver, spy, session, flow, areaState, gates);
     }
 
     /// <summary>
@@ -171,9 +166,12 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         var run = f.Service.StartAsync(cts.Token);
         try
         {
-            f.Driver.PushLive(LiveLine("[08:25:13] LOADING LEVEL AreaEltibule"));
-            f.Driver.PushLive(LiveLine("[08:30:00] LOADING LEVEL AreaEltibule"));
-            await f.Driver.DrainLocalPlayerAsync();
+            // #789: area transitions arrive via IPlayerAreaState.Subscribe,
+            // not via per-line LOADING LEVEL envelopes on the L1 pipe; the
+            // fake area state dispatches a Changed event identical to what
+            // the production folder emits on Apply.
+            f.AreaState.SetArea("AreaEltibule");
+            f.AreaState.SetArea("AreaEltibule"); // same-area re-emit = no-op
             f.Spy.SelectedAreas.Should().Equal("AreaEltibule");
         }
         finally { await Stop(f, run, cts); }
@@ -187,9 +185,8 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         var run = f.Service.StartAsync(cts.Token);
         try
         {
-            f.Driver.PushLive(LiveLine("[08:25:13] LOADING LEVEL AreaEltibule"));
-            f.Driver.PushLive(LiveLine("[08:57:37] LOADING LEVEL AreaSerbule"));
-            await f.Driver.DrainLocalPlayerAsync();
+            f.AreaState.SetArea("AreaEltibule");
+            f.AreaState.SetArea("AreaSerbule");
             f.Spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaSerbule");
         }
         finally { await Stop(f, run, cts); }
@@ -203,26 +200,27 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         var run = f.Service.StartAsync(cts.Token);
         try
         {
-            f.Driver.PushLive(LiveLine("[08:25:13] LOADING LEVEL AreaEltibule"));
-            f.Driver.PushLive(LiveLine("[08:57:00] LOADING LEVEL ChooseCharacter"));
-            f.Driver.PushLive(LiveLine("[09:00:39] LOADING LEVEL AreaEltibule"));
-            await f.Driver.DrainLocalPlayerAsync();
+            f.AreaState.SetArea("AreaEltibule");
+            // ChooseCharacter / disconnect surfaces as a null-area transition
+            // from the production parser; OnAreaChanged resets the latch so
+            // the next non-null re-applies.
+            f.AreaState.SetArea(null);
+            f.AreaState.SetArea("AreaEltibule");
             f.Spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaEltibule");
         }
         finally { await Stop(f, run, cts); }
     }
 
     /// <summary>
-    /// #514 + #550 LiveOnly composition + #775 eager pre-warm:
-    /// <see cref="PlayerAreaTracker"/>'s current area is populated BEFORE
-    /// Legolas's <c>StartAsync</c> runs (in production: the
-    /// <c>PlayerAreaWorldRegistration</c> hosted service eagerly applies the
-    /// producer's reverse-scan seed during its own <c>StartAsync</c>, which
-    /// runs before Legolas's per registration order). The L1 subscription
-    /// is LiveOnly so we do NOT pump replay envelopes — the eager pre-warm
-    /// delivers the area before any live envelope. The unit fixture fakes
-    /// the pre-warm via <see cref="PlayerAreaTracker.Observe"/>; the
-    /// production seed shape is covered by
+    /// #789 + #775 eager pre-warm: the seed area is staged on the fake area
+    /// state BEFORE Legolas's <c>StartAsync</c> runs. The
+    /// <see cref="IPlayerAreaState.Subscribe"/> contract fires a synthetic
+    /// <see cref="PlayerAreaChangeKind.Snapshot"/> notification synchronously
+    /// inside the call carrying the current area, so
+    /// <c>OnAreaChanged</c> applies it before any live envelope arrives.
+    /// Production: <c>PlayerAreaWorldRegistration</c>'s eager pre-warm
+    /// applies the producer's reverse-scan seed during its own
+    /// <c>StartAsync</c>; the seed shape is covered by
     /// <c>AreaLoadingFrameProducerTests.Seed_picks_the_LATEST_LOADING_LEVEL_with_its_parsed_log_timestamp</c>.
     /// </summary>
     [Fact]
@@ -532,7 +530,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         });
 
         var driver = new TestLogStreamDriver();
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var areaState = new FakePlayerAreaState();
         var spy = new SpyAreaCalibration(Identity());
         var session = new SessionState();
         var settings = new LegolasSettings();
@@ -543,7 +541,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             new MultilaterationSolver(), new MotherlodeFlowController(session),
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
-            driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
+            driver, new PlayerLogParser(), areaState, spy, flow, session, motherlode,
             settings,
             activeChar: activeChar, ingestionStore: store);
 
@@ -598,7 +596,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         var activeChar = new FakeActiveCharacterService("Bob", "Beta");
 
         var driver = new TestLogStreamDriver();
-        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var areaState = new FakePlayerAreaState();
         var spy = new SpyAreaCalibration(Identity());
         var session = new SessionState();
         var settings = new LegolasSettings();
@@ -609,7 +607,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             new MultilaterationSolver(), new MotherlodeFlowController(session),
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
-            driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
+            driver, new PlayerLogParser(), areaState, spy, flow, session, motherlode,
             settings,
             activeChar: activeChar, ingestionStore: store);
 
@@ -682,6 +680,77 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         public List<(string Name, MetreOffset Offset)> NotedSurveys { get; } = new();
         public void NoteSurvey(string name, MetreOffset offset) => NotedSurveys.Add((name, offset));
         public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IPlayerAreaState"/> test double for the #789
+    /// migration: holds a <see cref="CurrentArea"/> and a list of
+    /// subscribers; <see cref="Subscribe"/> fires the synthetic
+    /// <see cref="PlayerAreaChangeKind.Snapshot"/> replay before attaching
+    /// (so a late subscriber sees whatever <see cref="SetArea"/> set
+    /// pre-subscribe), and <see cref="SetArea"/> dispatches a
+    /// <see cref="PlayerAreaChangeKind.Changed"/> notification to every
+    /// attached handler. Mirrors the production
+    /// <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/> contract
+    /// closely enough that the service under test cannot distinguish the
+    /// test double from the real folder.
+    /// </summary>
+    private sealed class FakePlayerAreaState : IPlayerAreaState
+    {
+        private readonly object _lock = new();
+        private readonly List<Action<PlayerAreaChanged>> _handlers = new();
+        private string? _current;
+
+        public string? CurrentArea
+        {
+            get { lock (_lock) return _current; }
+        }
+
+        public IDisposable Subscribe(Action<PlayerAreaChanged> handler)
+        {
+            ArgumentNullException.ThrowIfNull(handler);
+            lock (_lock)
+            {
+                handler(new PlayerAreaChanged(
+                    PlayerAreaChangeKind.Snapshot, Previous: null, Current: _current,
+                    At: DateTimeOffset.MinValue));
+                _handlers.Add(handler);
+                return new Sub(this, handler);
+            }
+        }
+
+        public void SetArea(string? area, DateTimeOffset? at = null)
+        {
+            Action<PlayerAreaChanged>[] toFire;
+            PlayerAreaChanged change;
+            lock (_lock)
+            {
+                if (_current == area) return;
+                var prev = _current;
+                _current = area;
+                change = new PlayerAreaChanged(
+                    PlayerAreaChangeKind.Changed, prev, area, at ?? DateTimeOffset.UtcNow);
+                toFire = _handlers.ToArray();
+            }
+            foreach (var h in toFire) h(change);
+        }
+
+        private sealed class Sub : IDisposable
+        {
+            private FakePlayerAreaState? _owner;
+            private readonly Action<PlayerAreaChanged> _handler;
+            public Sub(FakePlayerAreaState owner, Action<PlayerAreaChanged> handler)
+            {
+                _owner = owner;
+                _handler = handler;
+            }
+            public void Dispose()
+            {
+                var owner = Interlocked.Exchange(ref _owner, null);
+                if (owner is null) return;
+                lock (owner._lock) { owner._handlers.Remove(_handler); }
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Phase C of the recognition-lift umbrella ([#769](https://github.com/moumantai-gg/mithril/issues/769)) — paired consumer migration for [#775](https://github.com/moumantai-gg/mithril/issues/775)/[#787](https://github.com/moumantai-gg/mithril/pull/787)'s `PlayerAreaTracker → IFolder<AreaLoadingFrame>` conversion.

Each consumer uses only the native `IPlayerAreaState` surfaces its access pattern actually needs — no parallel local caches, no push APIs, no Subscribe-and-forward plumbing.

**Legolas — surfaces: inject + `Subscribe`.** `PlayerLogIngestionService` swaps its `PlayerAreaTracker` dep for `IPlayerAreaState`, attaches `Subscribe(OnAreaChanged)` in `StartAsync`, and calls `_areaCalibration.SelectArea(evt.Current)` on every non-null notification. The `Snapshot` replay synthesised by `Subscribe` on attach delivers the seed area before any live envelope reaches the handler — same effective behaviour as the old `ApplyAreaIfChanged` at `StartAsync`. The per-line `tracker.Observe(line, ts)` push-in is gone; the producer's L1 subscription owns `LOADING LEVEL` envelopes end-to-end. `MotherlodeMeasurementCoordinator` + the DI registration in `LegolasModule` also swap their concrete dep to `IPlayerAreaState`; the read-on-`OnUse` semantic (area change invalidates the area-local-frame measurement) is unchanged.

**Gandalf — surfaces: inject + `.CurrentArea` read.** `LootSource` takes `IPlayerAreaState? areaState` directly and reads `_areaState?.CurrentArea` at chest-commit time (`OnChestInteraction` + the cow-rejection anchor-from-rejection branch in `OnChestCooldownObserved`). `LootIngestionService` has no area dep at all — after the `Observe` push-in retired, this service had no area work to do.

This is a defensible deviation from [#790](https://github.com/moumantai-gg/mithril/issues/790)'s spec body, which prescribed a Subscribe + `_cachedArea` + `UpdateCurrentArea` cached-callback pattern matching Legolas. The first commit on this branch (f825e3f) implemented that literally; the follow-up (16992c2) collapsed it after a design review. Gandalf's access pattern is a one-shot synchronous read on a human-rate event (chest commit), not a reactive flow wanting live transition notifications. The cached-callback machinery the spec prescribed was pure plumbing for that pattern — direct `IPlayerAreaState.CurrentArea` read is thread-safe (the folder's internal lock serialises against folder mutations), atomic for reference-sized reads regardless, and contention-free at chest-commit rates. See [the comment on #790](https://github.com/moumantai-gg/mithril/issues/790) for the per-acceptance-bullet checklist of what shipped vs the spec.

**Pre-warm in `PlayerAreaWorldRegistration` intentionally retained** — its retirement is the follow-on PR once both consumers migrate. Per the Call 1 framing in [PlayerAreaTracker.cs](src/Mithril.GameState/Areas/PlayerAreaTracker.cs)'s XML doc, `Subscribe` (not `IPlayerWorld.Bus`) is load-bearing for the Legolas bridge while the pre-warm is active: the pre-warm applies the seed-area transition directly to the folder and bypasses the bus, so bus subscribers would never see the seed. `Subscribe`'s late-subscriber `Snapshot` replay synthesises the current area on attach, so the seed reaches `OnAreaChanged` correctly regardless of pre-warm status.

Tests: small `FakePlayerAreaState` test double (`CurrentArea` + `Subscribe`-with-`Snapshot` + `SetArea` that fires `Changed`). Legolas's `preSeededArea: "AreaEltibule"` fixture pattern from [#787](https://github.com/moumantai-gg/mithril/pull/787) stages the area via `SetArea` pre-construction so `Subscribe`'s `Snapshot` delivers it — mirrors production's pre-warm timing. Gandalf's `LootSourceTests` area-driven tests call `areaState.SetArea(...)` then `src.OnChestInteraction(...)`; the stamp reads `_areaState.CurrentArea` synchronously.

Closes #789
Closes #790

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors; warnings-as-errors enforced)
- [x] `dotnet test Mithril.slnx` — all 22 test projects green (no skips, no failures)
- [x] `grep --include='*.cs' "PlayerAreaTracker" src/Legolas.Module/ src/Gandalf.Module/` returns no hits (concrete class no longer referenced from either consumer module; only `IPlayerAreaState`)
- [x] `grep --include='*.cs' "UpdateCurrentArea\|_cachedArea" src/Legolas.Module/ src/Gandalf.Module/` returns no hits (no parallel caches, no push APIs)
- [x] `grep "\.Observe(" src/Legolas.Module/Services/ src/Gandalf.Module/Services/` only matches `LootBracketTracker.Observe` (legitimate, unrelated)
- [x] `Mithril.GameState` untouched in the diff stat — `PlayerAreaWorldRegistration` pre-warm intentionally retained for the follow-on
- [x] `PlayerLogIngestionServiceTests.Startup_seed_applies_current_area_before_live_lines` passes via the new `FakePlayerAreaState` Snapshot replay path (19/19 in the filtered run)
- [x] `LootSourceTests` area-stamping tests (sticky-once-known, stamps-late-when-unknown, area-scoped friendly-name, region resolution) all pass via `SetArea`-then-commit driver; `LootSource` reads `_areaState?.CurrentArea` at commit time
- [x] `LootIngestionServiceTests` byte-equivalence (replay-then-live = all-live) still green — Gandalf's chest-commit area read is on a separate concern from the per-key idempotent-upsert path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
