### PR TITLE
fix(legolas): make MapOverlayView.Settings a DependencyProperty (#520 follow-up)

### DIFF
--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -17,6 +17,23 @@ public sealed partial class ControlPanelViewModel : ObservableObject
         _settings = settings;
         Session = session;
         SurveyFlow = surveyFlow;
+
+        // Mirror external mutations of LegolasSettings back to our wrapper
+        // properties. Every wrapper here is named 1:1 with its underlying
+        // LegolasSettings property, so just forward the changed name. Without
+        // this, a writer outside this VM (the #520 in-overlay nudge-pad
+        // toggle writing directly to LegolasSettings.ShowNudgePadOnOverlay,
+        // or any future cross-VM mutation of a wrapped setting) updates the
+        // model but the LegolasSettingsView checkbox bound to
+        // ControlPanel.<X> stays stale until the panel is reopened. Names
+        // that don't have a wrapper here fire a no-op PropertyChanged that
+        // no binding observes — cheaper than maintaining a per-name allow
+        // list as wrappers come and go.
+        _settings.PropertyChanged += (_, e) =>
+        {
+            if (!string.IsNullOrEmpty(e.PropertyName))
+                OnPropertyChanged(e.PropertyName);
+        };
     }
 
     public bool AutoResetWhenAllCollected

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -19,9 +19,34 @@ public partial class MapOverlayView : Window
     /// can't take NudgePadViewModel as a ctor param.</summary>
     public NudgePadViewModel? NudgePad { get; }
 
-    /// <summary>Surfaced for the overlay-local toggle binding (Visibility on the
-    /// pad's host border). Same instance as the one MapOverlayViewModel sees.</summary>
-    public LegolasSettings? Settings { get; }
+    /// <summary>Surfaced for overlay-local bindings — the nudge-pad host
+    /// <c>Border.Visibility</c> and the #520 header eye toggle's
+    /// <c>IsChecked</c>/icon both read <c>{Binding ElementName=Self,
+    /// Path=Settings.ShowNudgePadOnOverlay}</c>. Same instance as the one
+    /// <see cref="MapOverlayViewModel"/> sees.
+    ///
+    /// <para><b>Why a DependencyProperty, not a CLR auto-property.</b> The
+    /// parameterized ctor chains to the parameterless one, so
+    /// <c>InitializeComponent()</c> — which evaluates every XAML binding —
+    /// runs <em>before</em> the ctor body assigns this. A plain CLR
+    /// auto-property has no INPC, so WPF would never know <c>Settings</c>
+    /// transitioned null→instance: the bindings resolve against null at
+    /// load, then stay stuck on the null-path fallback forever (pad never
+    /// shows, toggle never writes back). Promoting to a DP makes
+    /// <c>SetValue</c> notify the binding system, so both bindings
+    /// re-resolve the moment <c>Settings</c> is assigned and pick up live
+    /// <c>ShowNudgePadOnOverlay</c> flips from then on.</para></summary>
+    public static readonly DependencyProperty SettingsProperty =
+        DependencyProperty.Register(
+            nameof(Settings),
+            typeof(LegolasSettings),
+            typeof(MapOverlayView));
+
+    public LegolasSettings? Settings
+    {
+        get => (LegolasSettings?)GetValue(SettingsProperty);
+        private set => SetValue(SettingsProperty, value);
+    }
 
     // #454: the editable player anchor is retired for Survey (absolute
     // placement needs none). Viewport interaction now:


### PR DESCRIPTION
Follow-up to #773 (closes the live-toggle gap reported by @arthur-conde during smoketest).

## What was broken

Both the pre-existing nudge-pad host \`Border.Visibility\` and the #520 header eye-toggle's \`IsChecked\` bind through \`{Binding ElementName=Self, Path=Settings.ShowNudgePadOnOverlay}\`. The \`MapOverlayView.Settings\` property was a plain CLR auto-property assigned in the parameterized ctor — which runs **after** the chained-to parameterless ctor's \`InitializeComponent()\`, so every XAML binding evaluated against \`Settings=null\` at load.

With no INPC on \`Settings\`, WPF never re-resolved the bindings when \`Settings\` later became non-null:

- The pad's \`Visibility\` binding stuck on its null-path fallback — toggling the Settings checkbox or the new eye had no visible effect on the pad.
- The eye toggle's \`IsChecked\` TwoWay write tried to push back through a null path source — the write silently failed, so the toggle never changed the setting either.

This is **latent before #520** — the Settings-checkbox-driving-pad-visibility loop was already broken on \`main\` — but #520 surfaces it because the new overlay-local toggle has the same dependency and was the user's primary observation point.

## The fix

Promote \`Settings\` to a \`DependencyProperty\`. \`SetValue\` fires DP-change notification, so the moment the parameterized ctor assigns it, both bindings re-resolve against the real instance and from then on track \`ShowNudgePadOnOverlay\`'s \`INotifyPropertyChanged\` live.

The CLR get/set surface is unchanged (same nullability, same private setter), so every existing call site keeps working without edit.

## Why a DP rather than reordering the ctor

The parameterless ctor exists for design-time / test scenarios and runs \`InitializeComponent()\` before any field can be assigned. Reordering would require either:
- Duplicating the parameterless ctor body in the parameterized one (two \`InitializeComponent\` call sites), or
- Removing the parameterless ctor (breaks the design-time / test surface).

The DP is mechanical, idiomatic WPF, and self-documents the "this property is observed by bindings" intent. \`NudgePad\` has the same root cause but uses a different escape hatch (sets \`OverlayNudgePad.DataContext\` in code) — leaving that alone since it already works.

## Verification

Skipping build/test locally per @arthur-conde — mechanical refactor with identical get/set surface. Smoketest checklist:

- [ ] Map overlay open. Eye icon shows the **on** state at the brighter foreground when the setting is on (and the nudge pad is visible), the **off** dim state otherwise.
- [ ] Click the eye in the header → pad disappears. Click again → pad reappears.
- [ ] With pad visible, open Legolas → Settings → Pin Nudge → uncheck "Show nudge pad on the map overlay" → pad disappears live (no restart). Re-check → pad reappears.
- [ ] Header eye state ↔ Settings checkbox state stay in sync both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)