### PR TITLE
feat(legolas): thread map-zoom through calibration + Survey projection (#524)

### DIFF
--- a/src/Legolas.Module/Domain/AreaCalibration.cs
+++ b/src/Legolas.Module/Domain/AreaCalibration.cs
@@ -58,20 +58,46 @@ public sealed record AreaCalibration(
     /// calibration window's landmark "ghost" projection delegates here so the
     /// two can't drift.
     ///
-    /// <para>Uses <see cref="Scale"/> verbatim, so it is only exact at
-    /// <see cref="CalibrationZoom"/> — the long-standing zoom limitation
-    /// (the in-game zoom isn't machine-readable; OCR/CV deferred). Survey
-    /// targets are absolute identities regardless; only where the marker
-    /// <em>draws</em> carries the ±10% non-affine ceiling.</para>
+    /// <para>This parameterless overload uses <see cref="Scale"/> verbatim and
+    /// is therefore exact only at <see cref="CalibrationZoom"/>. Prefer the
+    /// <see cref="ProjectWorld(WorldCoord, double)"/> overload from any call
+    /// site that knows the live in-game zoom (#524). Retained for tests + old
+    /// call sites that don't yet know the zoom; delegating to the zoom-aware
+    /// overload with <c>currentZoom = CalibrationZoom</c> is byte-identical
+    /// because the zoomFactor collapses to <c>1.0</c>.</para>
     /// </summary>
-    public PixelPoint ProjectWorld(WorldCoord world)
+    public PixelPoint ProjectWorld(WorldCoord world) =>
+        ProjectWorld(world, CalibrationZoom);
+
+    /// <summary>
+    /// #524: zoom-aware absolute world→overlay-pixel projection. Scales
+    /// <see cref="Scale"/> by <c>currentZoom / CalibrationZoom</c>; the origin
+    /// is zoom-invariant under the no-pan assumption (the pixel that renders
+    /// world (0,0,0) depends on pan, not on zoom), so only the metric scale
+    /// changes when the user adjusts PG's map zoom between calibrate and use.
+    ///
+    /// <para>Defensive: a non-positive <paramref name="currentZoom"/> or
+    /// <see cref="CalibrationZoom"/> falls back to a factor of <c>1.0</c>
+    /// (uses <see cref="Scale"/> verbatim) so a malformed value can't crash
+    /// the per-frame projector.</para>
+    ///
+    /// <para>Load-bearing assumption: calibration is exact only at the same
+    /// map pan position used to solve. Surfaced in the wizard tooltip; the
+    /// warning chip in <c>MapOverlayViewModel</c> covers the "user changed
+    /// zoom without updating the field" case.</para>
+    /// </summary>
+    public PixelPoint ProjectWorld(WorldCoord world, double currentZoom)
     {
+        var zoomFactor = (currentZoom > 1e-6 && CalibrationZoom > 1e-6)
+            ? currentZoom / CalibrationZoom
+            : 1.0;
+        var effScale = Scale * zoomFactor;
         var east = world.X;
         var north = MirrorNorth ? -world.Z : world.Z;
         var cos = Math.Cos(RotationRadians);
         var sin = Math.Sin(RotationRadians);
         var rotE = east * cos + north * sin;
         var rotN = -east * sin + north * cos;
-        return new PixelPoint(OriginX + Scale * rotE, OriginY - Scale * rotN);
+        return new PixelPoint(OriginX + effScale * rotE, OriginY - effScale * rotN);
     }
 }

--- a/src/Legolas.Module/Domain/GhostLabelDeclutter.cs
+++ b/src/Legolas.Module/Domain/GhostLabelDeclutter.cs
@@ -36,17 +36,26 @@ public static class GhostLabelDeclutter
     private const double SeparationPx = 2.0;
 
     public static IReadOnlyList<GhostMarker> Build(
-        IEnumerable<CalibrationReference> references, AreaCalibration calibration)
+        IEnumerable<CalibrationReference> references,
+        AreaCalibration calibration,
+        double currentMapZoom = 0.0)
     {
         ArgumentNullException.ThrowIfNull(references);
         ArgumentNullException.ThrowIfNull(calibration);
+
+        // #524: thread the in-game map zoom through the projection so the
+        // validate-calibration ghosts re-scale live as the user drags PG's
+        // zoom slider (and the bound Mithril field). Unsupplied (<= 0) falls
+        // back to the calibration's own zoom — byte-identical to pre-#524 for
+        // legacy callers / tests.
+        var effectiveZoom = currentMapZoom > 1e-6 ? currentMapZoom : calibration.CalibrationZoom;
 
         var markers = new List<GhostMarker>();
         var placed = new List<Rect>();
 
         foreach (var r in references)
         {
-            var p = calibration.ProjectWorld(r.World);
+            var p = calibration.ProjectWorld(r.World, effectiveZoom);
             var name = r.Name ?? string.Empty;
             var box = new Rect(
                 p.X + LabelAnchorDx,

--- a/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
+++ b/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Legolas.Domain;
+using Legolas.ViewModels;
 using Mithril.GameState.Pins;
 
 namespace Legolas.Services;
@@ -103,6 +104,7 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
     private readonly IAreaCalibrationService _service;
     private readonly IPlayerPinTracker _pins;
     private readonly LegolasSettings _settings;
+    private readonly SessionState? _session;
     private readonly IDisposable _sub;
 
     // The accumulated solve pairs. Keyed by the MapPin (for spread + identity);
@@ -112,12 +114,18 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
     // everything else is paired (then recycled, so the user is never stuck).
     private readonly List<MapPin> _skipped = new();
 
+    // #524: SessionState carries the live in-game map zoom the user types into
+    // the wizard / overlay slider. Optional so the unit-test ctor stays
+    // unchanged (legacy callers stamp the calibration at the default 1.0,
+    // matching the pre-#524 hardcoded value).
     public PinCalibrationCoordinator(
-        IAreaCalibrationService service, IPlayerPinTracker pins, LegolasSettings settings)
+        IAreaCalibrationService service, IPlayerPinTracker pins, LegolasSettings settings,
+        SessionState? session = null)
     {
         _service = service;
         _pins = pins;
         _settings = settings;
+        _session = session;
         // Subscribe replays a Snapshot synchronously (seeds ExistingPins);
         // live notifications arrive on the tracker's ingestion thread.
         _sub = _pins.Subscribe(OnPinSetChanged);
@@ -396,9 +404,14 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
         var pairs = _pairs
             .Select(p => (new WorldCoord(p.Pin.X, 0, p.Pin.Z), p.Pixel))
             .ToList();
-        // Zoom OCR/CV is deferred (#460) — calibrate at the default zoom stamp,
-        // consistent with the standalone window's unset-zoom path.
-        var result = _service.CalibrateCurrentArea(pairs, calibrationZoom: 1.0);
+        // #524: stamp the live in-game map zoom (read off PG's "Zoom level:
+        // X.XX" readout, kept in sync by the wizard / overlay slider). The
+        // pre-#524 hardcoded 1.0 silently corrupted any session that
+        // calibrated at one zoom and surveyed at another — see issue body for
+        // the ~15× blast radius. Headless / unit-test paths without a
+        // SessionState fall back to 1.0 (the historic default).
+        var zoom = _session?.CurrentMapZoom ?? 1.0;
+        var result = _service.CalibrateCurrentArea(pairs, calibrationZoom: zoom);
         if (result is not null) Disarm();
         return result;
     }

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -375,7 +375,12 @@ public sealed class PlayerLogIngestionService : BackgroundService
         }
 
         var name = CleanName(mt.Short);
-        var pixel = cal.ProjectWorld(mt.World);
+        // #524: thread the in-game map zoom through projection so a calibration
+        // solved at one zoom places pins correctly at any other zoom (the
+        // calibration's CalibrationZoom is the captured stamp; CurrentMapZoom
+        // is the live in-game readout the user keeps in sync via the wizard /
+        // overlay slider).
+        var pixel = cal.ProjectWorld(mt.World, _session.CurrentMapZoom);
 
         if (FindDuplicateAbsolute(mt.World, _settings.MapTargetDedupRadiusMetres) is { } dup)
         {

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -200,7 +200,16 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         // the area changes or its calibration is (re)solved/cleared. Guarded
         // only on the service (independent of the #476 position tracker).
         if (_areaCalibration is not null)
+        {
             _areaCalibration.Changed += (_, _) => PostToUi(OnCalibrationChanged);
+            // Bootstrap: if the area was loaded before the VM constructed
+            // (lazy module attach + PlayerAreaState's synchronous Snapshot
+            // replay), the first Changed event already fired. Run the
+            // handler once so the calibration-stamp label + the #524 zoom
+            // auto-seed pick up the already-applied area.
+            if (_areaCalibration.CurrentCalibration is not null)
+                OnCalibrationChanged();
+        }
     }
 
     /// <summary>
@@ -415,6 +424,20 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             ? $"Calibrated at {cal.CalibrationZoom:0.00} · spread scales, positions assume same pan"
             : string.Empty;
 
+    /// <summary>#524 follow-up: short "cal @ X.XX" label rendered alongside
+    /// the title-bar zoom slider so the user can see at a glance what zoom
+    /// they calibrated this area at — pairs with the auto-seed-on-area-change
+    /// to answer "what should I dial PG's zoom to after a client restart?"
+    /// without opening the wizard. Empty when the area is uncalibrated.</summary>
+    public string CalibrationZoomLabel =>
+        _areaCalibration?.CurrentCalibration is { } cal
+            ? $"cal @ {cal.CalibrationZoom:0.00}"
+            : string.Empty;
+
+    /// <summary>Visibility gate for <see cref="CalibrationZoomLabel"/> — true
+    /// iff the area has a persisted calibration to display the stamp for.</summary>
+    public bool IsCalibrationZoomLabelVisible => _areaCalibration?.CurrentCalibration is not null;
+
     /// <summary>#524: one-time per-area hint in the wizard's Listening step,
     /// shown when the area's calibration predates zoom tracking
     /// (<c>CalibrationZoom == 1.0</c>) and the user hasn't dismissed it this
@@ -527,6 +550,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         OnPropertyChanged(nameof(CalibrationValidationStatus));
     }
 
+    /// <summary>#524 follow-up: the area key the last <see cref="OnCalibrationChanged"/>
+    /// resolved against. Used to detect "entered a new area" vs "recalibrated /
+    /// cleared the same area" — only the former auto-seeds the live zoom from
+    /// the new area's stamp, so a user's manual slider edit on the area they
+    /// are already in is never clobbered by a fresh Changed event.</summary>
+    private string? _lastSeenAreaKey;
+
     /// <summary>Area switched or its calibration (re)solved/cleared. Refresh
     /// the gate and live ghosts. Marshalled to the UI thread by the caller.</summary>
     private void OnCalibrationChanged()
@@ -548,6 +578,24 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         OnPropertyChanged(nameof(IsZoomMismatchWarningVisible));
         OnPropertyChanged(nameof(ZoomMismatchText));
         OnPropertyChanged(nameof(IsLegacyRecalibrateHintVisible));
+        OnPropertyChanged(nameof(CalibrationZoomLabel));
+        OnPropertyChanged(nameof(IsCalibrationZoomLabelVisible));
+
+        // #524 follow-up: on AREA change, seed the live zoom from the new
+        // area's calibration stamp — the user calibrated at some specific
+        // zoom and PG resets to a different default on client restart, so
+        // having Mithril auto-match the stamp gives the user "dial PG to
+        // this one number" instead of "find PG's current zoom AND type it
+        // into Mithril." Skipped when the area key is unchanged (a
+        // recalibrate-in-place fires Changed too; respect the user's
+        // current slider value there since it equals the new stamp anyway).
+        var key = _areaCalibration?.CurrentAreaKey;
+        if (key != _lastSeenAreaKey)
+        {
+            _lastSeenAreaKey = key;
+            if (_areaCalibration?.CurrentCalibration is { } cal)
+                _session.CurrentMapZoom = cal.CalibrationZoom;
+        }
     }
 
     /// <summary>#460/#477A: true while the guided calibration walkthrough is in

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -50,6 +50,11 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 {
                     OnPropertyChanged(nameof(IsCalibrationCapturing));
                     OnPropertyChanged(nameof(IsCalibrationDropping));
+                    // #524: the overlay zoom strip hides during the Drop
+                    // phase (click-through forced ON), and the warning chip
+                    // is suppressed while the user is actively calibrating.
+                    OnPropertyChanged(nameof(IsZoomFieldVisible));
+                    OnPropertyChanged(nameof(IsZoomMismatchWarningVisible));
                 }
                 else if (e.PropertyName is nameof(PinCalibrationCoordinator.PromptText))
                 {
@@ -68,6 +73,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 {
                     OnPropertyChanged(nameof(PinRadius));
                     OnPropertyChanged(nameof(PinDiameter));
+                }
+                // #524: full overlay click-through hides the zoom strip — the
+                // wizard surfaces remain reachable as the always-clickable
+                // fallback control plane.
+                else if (e.PropertyName == nameof(LegolasSettings.ClickThroughMap))
+                {
+                    OnPropertyChanged(nameof(IsZoomFieldVisible));
                 }
             };
         }
@@ -120,6 +132,28 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 OnPropertyChanged(nameof(PlayerMarkerPixel));
                 OnPropertyChanged(nameof(PlayerAnchorStatus));
                 OnPropertyChanged(nameof(IsPlayerAnchorStatusVisible));
+                RebuildAllWedges();
+            }
+            else if (e.PropertyName is nameof(SessionState.CurrentMapZoom))
+            {
+                // #524: dragging the bound slider live-reprojects every
+                // calibration-aware surface. The Motherlode marker pixels read
+                // CurrentMapZoom directly inside their getter, so PropertyChanged
+                // on the collection-bearing property is enough. Survey pin pixels
+                // are stamped at ProcessMapFx time (their PixelPos is cached on
+                // the survey model), so a zoom change after placement doesn't
+                // move existing pins — that matches the "calibration is the
+                // anchor" rule and avoids surprising motion on a stamp re-edit.
+                OnPropertyChanged(nameof(PlayerMarkerPixel));
+                OnPropertyChanged(nameof(MotherlodeMarkerPixels));
+                OnPropertyChanged(nameof(IsZoomMismatchWarningVisible));
+                // Re-resolve the projected Survey GPS anchor — its pixel was
+                // derived through the calibration too.
+                RefreshSurveyPlayerAnchor(fromTrackerFix: false);
+                // Validate-calibration ghosts (+ label declutter): re-projects
+                // through GhostLabelDeclutter.Build at the new zoom.
+                if (ShowCalibrationGhosts) RebuildCalibrationGhosts();
+                RebuildRouteGeometry();
                 RebuildAllWedges();
             }
         };
@@ -199,7 +233,8 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             _areaCalibration?.CurrentCalibration,
             fromTrackerFix,
             _session.SurveyPlayerIsManual,
-            _session.SurveyPlayerIsPinned);
+            _session.SurveyPlayerIsPinned,
+            _session.CurrentMapZoom);
         if (res is not { } r) return;   // keep current (manual sticky / no change)
 
         _session.SurveyPlayerPixel = r.Pixel;
@@ -234,7 +269,8 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         AreaCalibration? cal,
         bool fromTrackerFix,
         bool currentIsManual,
-        bool currentIsPinned)
+        bool currentIsPinned,
+        double currentMapZoom = 0.0)
     {
         if (pin is { } p && cal is { } pinCal)
         {
@@ -242,7 +278,11 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 fromTrackerFix && tracker is { } ft && ft.MeasuredAt > p.ObservedAt;
             if (!supersededByFresherAuto)
                 return new SurveyAnchorResolution(
-                    pinCal.ProjectWorld(p.World), p.ObservedAt,
+                    // #524: thread the in-game map zoom; zero/unset falls back
+                    // to the calibration's own zoom (zoomFactor → 1.0), keeping
+                    // pre-#524 callers byte-identical.
+                    pinCal.ProjectWorld(p.World, EffectiveZoom(currentMapZoom, pinCal)),
+                    p.ObservedAt,
                     Source: null, IsManual: true, IsPinned: true);
             // else: a genuinely newer zone-in/teleport wins over the pin.
         }
@@ -255,9 +295,15 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             return SurveyAnchorResolution.Cleared;
 
         return new SurveyAnchorResolution(
-            c.ProjectWorld(new WorldCoord(fix.X, fix.Y, fix.Z)),
+            c.ProjectWorld(new WorldCoord(fix.X, fix.Y, fix.Z), EffectiveZoom(currentMapZoom, c)),
             fix.MeasuredAt, fix.Source, IsManual: false, IsPinned: false);
     }
+
+    // #524: a caller that doesn't know the live zoom (older tests, legacy
+    // paths) gets the byte-identical no-op (factor 1.0). Live VM paths pass
+    // SessionState.CurrentMapZoom.
+    private static double EffectiveZoom(double currentMapZoom, AreaCalibration cal) =>
+        currentMapZoom > 1e-6 ? currentMapZoom : cal.CalibrationZoom;
 
     /// <summary>
     /// Record the user's "set my position" map click (#476 Option&#160;C,
@@ -322,6 +368,80 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     /// the wizard's "Validate calibration" affordance. Always false in the
     /// settings-less test ctor (no service).</summary>
     public bool IsCurrentAreaCalibrated => _areaCalibration?.IsCurrentAreaCalibrated == true;
+
+    // ---- #524: zoom-field surfaces ---------------------------------------
+
+    /// <summary>#524: the overlay zoom strip is hidden whenever the overlay is
+    /// fully click-through and inputs cannot reach individual WPF controls.
+    /// That covers two cases — <c>LegolasSettings.ClickThroughMap</c> on (the
+    /// user pref) and the calibration <see cref="CalibrationPhase.Drop"/>
+    /// phase (the wizard forces click-through ON so right-clicks reach the
+    /// game to drop pins). The two wizard surfaces stay reachable in either
+    /// case, so the value is never unreachable.</summary>
+    public bool IsZoomFieldVisible =>
+        !IsCalibrationDropping && _settings?.ClickThroughMap != true;
+
+    /// <summary>#524 (per-area, session-ephemeral): areas whose legacy
+    /// recalibrate hint the user dismissed during this Mithril run. Cleared on
+    /// process restart (intentional — the hint reappears if the area is still
+    /// legacy-stamped next session). Re-checked on
+    /// <see cref="IAreaCalibrationService.Changed"/>, so a successful
+    /// recalibration drops the area out (the hint condition flips to false
+    /// regardless once <c>CalibrationZoom != 1.0</c>).</summary>
+    private readonly HashSet<string> _legacyHintDismissedAreas = new(StringComparer.Ordinal);
+
+    /// <summary>#524: warning chip — shown when the live in-game zoom diverges
+    /// from the stamp the current area was calibrated at by more than half a
+    /// slider tick (~0.05). Suppressed for legacy 1.0 stamps (no deliberate
+    /// choice was ever made; the legacy-recalibrate hint replaces it) and
+    /// while the user is actively calibrating (divergence is meaningless
+    /// then). Clears automatically as the user matches the zoom or recalibrates
+    /// — no dismiss button.</summary>
+    public bool IsZoomMismatchWarningVisible
+    {
+        get
+        {
+            if (_areaCalibration?.CurrentCalibration is not { } cal) return false;
+            if (_pinCal?.IsArmed == true) return false;
+            if (Math.Abs(cal.CalibrationZoom - 1.0) < 1e-6) return false;   // legacy stamp
+            return Math.Abs(_session.CurrentMapZoom - cal.CalibrationZoom) > 0.05;
+        }
+    }
+
+    /// <summary>#524: surfaced verbatim by both the overlay chip and the
+    /// wizard Listening panel row, so the message is single-sourced.</summary>
+    public string ZoomMismatchText =>
+        _areaCalibration?.CurrentCalibration is { } cal
+            ? $"Calibrated at {cal.CalibrationZoom:0.00} · spread scales, positions assume same pan"
+            : string.Empty;
+
+    /// <summary>#524: one-time per-area hint in the wizard's Listening step,
+    /// shown when the area's calibration predates zoom tracking
+    /// (<c>CalibrationZoom == 1.0</c>) and the user hasn't dismissed it this
+    /// session. Drops out the moment they recalibrate (the stamp moves off
+    /// 1.0) or click "Got it".</summary>
+    public bool IsLegacyRecalibrateHintVisible
+    {
+        get
+        {
+            if (_areaCalibration?.CurrentCalibration is not { } cal) return false;
+            if (Math.Abs(cal.CalibrationZoom - 1.0) > 1e-6) return false;
+            var key = _areaCalibration.CurrentAreaKey;
+            return key is not null && !_legacyHintDismissedAreas.Contains(key);
+        }
+    }
+
+    /// <summary>#524: dismiss the legacy hint for the current area for the
+    /// rest of this Mithril session. No persistence (a fresh process gets the
+    /// hint back; recalibrating clears the underlying condition outright).</summary>
+    [RelayCommand]
+    private void DismissLegacyRecalibrateHint()
+    {
+        var key = _areaCalibration?.CurrentAreaKey;
+        if (key is null) return;
+        _legacyHintDismissedAreas.Add(key);
+        OnPropertyChanged(nameof(IsLegacyRecalibrateHintVisible));
+    }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CalibrationValidationStatus))]
@@ -398,7 +518,11 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     {
         CalibrationGhosts.Clear();
         if (_areaCalibration?.CurrentCalibration is not { } cal) return;
-        foreach (var g in GhostLabelDeclutter.Build(_areaCalibration.CurrentAreaReferences, cal))
+        // #524: pass the live in-game zoom so dragging the bound slider live-
+        // reprojects the ghosts (the validate loop is precisely the diagnostic
+        // for surfacing zoom drift after a change).
+        foreach (var g in GhostLabelDeclutter.Build(
+                     _areaCalibration.CurrentAreaReferences, cal, _session.CurrentMapZoom))
             CalibrationGhosts.Add(g);
         OnPropertyChanged(nameof(CalibrationValidationStatus));
     }
@@ -418,6 +542,12 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             RebuildCalibrationGhosts();
         }
         OnPropertyChanged(nameof(CalibrationValidationStatus));
+        // #524: area switch / recalibrate flips warning + legacy-hint conditions
+        // (a recalibration moves CalibrationZoom off 1.0; an area change makes
+        // the per-area dismissal set re-evaluate against the new key).
+        OnPropertyChanged(nameof(IsZoomMismatchWarningVisible));
+        OnPropertyChanged(nameof(ZoomMismatchText));
+        OnPropertyChanged(nameof(IsLegacyRecalibrateHintVisible));
     }
 
     /// <summary>#460/#477A: true while the guided calibration walkthrough is in
@@ -643,9 +773,10 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 return Array.Empty<PixelPoint>();
 
             List<PixelPoint>? list = null;
+            var zoom = _session.CurrentMapZoom;
             foreach (var s in _motherlode.Snapshot().Surveys)
                 if (!s.Collected && s.SolvedWorld is { } w)
-                    (list ??= new()).Add(cal.ProjectWorld(w));
+                    (list ??= new()).Add(cal.ProjectWorld(w, zoom));
             return list ?? (IReadOnlyList<PixelPoint>)Array.Empty<PixelPoint>();
         }
     }

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -131,6 +131,24 @@ public sealed partial class SessionState : ObservableObject
     // "pinned" and so the pin-sourced manual ends with the pin (a genuine
     // pixel-click manual — IsManual && !IsPinned — keeps its #476 stickiness).
     [ObservableProperty] private bool _surveyPlayerIsPinned;
+
+    // #524: the in-game map zoom (PG's "Zoom level: X.XX" readout). Used by
+    // AreaCalibration.ProjectWorld(world, currentZoom) so a calibration solved
+    // at one zoom can place pins at another. Ephemeral — defaults to PG's max
+    // (2.00) on every Mithril restart, matching the accuracy-optimal stamp the
+    // user is expected to use when calibrating. Range mirrors PG's slider hard
+    // stops [0.13, 2.00]; the clamp keeps direct VM mutation honest even though
+    // the bound slider already enforces the range visually. Lives on
+    // SessionState (not LegolasSettings) so it stays a cross-mode shared
+    // observable both Survey and Motherlode read.
+    [ObservableProperty] private double _currentMapZoom = 2.0;
+
+    partial void OnCurrentMapZoomChanged(double value)
+    {
+        if (value < 0.13) CurrentMapZoom = 0.13;
+        else if (value > 2.0) CurrentMapZoom = 2.0;
+    }
+
     [ObservableProperty] private string _lastLogEvent = "(waiting)";
     [ObservableProperty] private bool _showBearingWedges = true;
     [ObservableProperty] private bool _showRouteLines = true;

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -76,7 +76,7 @@
                         </Border>
                         <Border Padding="6,2" CornerRadius="3"
                                 Background="#FF1A1A1A" BorderBrush="#FF505050" BorderThickness="1"
-                                ToolTip="In-game map zoom (PG's 'Zoom level: X.XX' readout). Calibration captures this stamp; surveys re-scale to whatever you set here. Assumes you haven't panned the map between calibrating and using it.">
+                                ToolTip="In-game map zoom (PG's 'Zoom level: X.XX' readout). Calibration captures this stamp; surveys re-scale to whatever you set here. After a PG restart, dial PG's zoom to the cal stamp shown beside the textbox.">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                 <TextBlock Text="Zoom" Foreground="#FFCCCCCC" FontSize="11"
                                            VerticalAlignment="Center" Margin="0,0,6,0" />
@@ -90,6 +90,17 @@
                                          BorderBrush="#FF505050" BorderThickness="1"
                                          FontSize="11" Padding="2,0"
                                          Text="{Binding Session.CurrentMapZoom, Mode=TwoWay, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />
+                                <!-- #524 follow-up: the calibration's stamp,
+                                     surfaced inline so the user can read off
+                                     the target value when dialling PG's zoom
+                                     to match (PG resets zoom on client
+                                     restart). Hidden when the area is
+                                     uncalibrated — nothing to compare to. -->
+                                <TextBlock Text="{Binding CalibrationZoomLabel}"
+                                           Foreground="#FF999999" FontSize="11"
+                                           VerticalAlignment="Center" Margin="6,0,0,0"
+                                           Visibility="{Binding IsCalibrationZoomLabelVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                                           ToolTip="The zoom this area was calibrated at. Mithril's slider auto-syncs to this on area change; dial PG to the same value for accurate pin placement." />
                             </StackPanel>
                         </Border>
                     </StackPanel>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -35,6 +35,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Orientation="Horizontal">
                         <TextBlock Text="Map" Foreground="White" FontWeight="SemiBold" />
@@ -46,12 +47,58 @@
                         <TextBlock Text="{Binding PlayerAnchorStatus}" Foreground="#FFCCCCCC"
                                    Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
                     </StackPanel>
+                    <!-- #524: zoom strip lives in the title bar. The title bar
+                         is a deliberate "control plane" already (drag handle +
+                         the #520 nudge-pad toggle), so the zoom field sits
+                         here rather than competing with the validate banner /
+                         nudge pad on the viewport. Click-through state still
+                         applies — the carve-out for HeaderChrome in
+                         ApplyClickThrough keeps the strip reachable when the
+                         viewport is fully click-through, but
+                         IsZoomFieldVisible additionally hides the strip during
+                         the calibration Drop phase since interacting with it
+                         is meaningless mid-calibration. -->
+                    <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                VerticalAlignment="Center" Margin="0,0,8,0"
+                                Visibility="{Binding IsZoomFieldVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <!-- Amber warning chip — appears when the live zoom
+                             diverges from the calibration stamp by > half a
+                             tick (suppressed for legacy 1.0 stamps + during
+                             active calibration). Clears as the user matches
+                             the zoom or recalibrates; no dismiss button. -->
+                        <Border Margin="0,0,8,0" Padding="6,2" CornerRadius="3"
+                                Background="#CC4A3A0A" BorderBrush="#FFC99A2E" BorderThickness="1"
+                                VerticalAlignment="Center"
+                                Visibility="{Binding IsZoomMismatchWarningVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                                ToolTip="{Binding ZoomMismatchText}">
+                            <icon:PackIconLucide Kind="TriangleAlert" Width="11" Height="11"
+                                                 Foreground="#FFFFE6B3" />
+                        </Border>
+                        <Border Padding="6,2" CornerRadius="3"
+                                Background="#FF1A1A1A" BorderBrush="#FF505050" BorderThickness="1"
+                                ToolTip="In-game map zoom (PG's 'Zoom level: X.XX' readout). Calibration captures this stamp; surveys re-scale to whatever you set here. Assumes you haven't panned the map between calibrating and using it.">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="Zoom" Foreground="#FFCCCCCC" FontSize="11"
+                                           VerticalAlignment="Center" Margin="0,0,6,0" />
+                                <Slider Minimum="0.13" Maximum="2.0"
+                                        SmallChange="0.01" LargeChange="0.1"
+                                        Width="100" VerticalAlignment="Center" Margin="0,0,6,0"
+                                        Focusable="False"
+                                        Value="{Binding Session.CurrentMapZoom, Mode=TwoWay}" />
+                                <TextBox Width="38" VerticalAlignment="Center"
+                                         Background="#FF101010" Foreground="#FFE0E0E0"
+                                         BorderBrush="#FF505050" BorderThickness="1"
+                                         FontSize="11" Padding="2,0"
+                                         Text="{Binding Session.CurrentMapZoom, Mode=TwoWay, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
                     <!-- #520: in-overlay toggle mirroring LegolasSettings.ShowNudgePadOnOverlay,
                          so the user can hide/show the nudge pad without alt-tabbing to
                          Settings. Symmetric: re-enabling stays in reach when hidden. The
                          ToggleButton handles its own click and stops MouseLeftButtonDown
                          from reaching the parent Border's drag handler. -->
-                    <ToggleButton Grid.Column="1" VerticalAlignment="Center"
+                    <ToggleButton Grid.Column="2" VerticalAlignment="Center"
                                   IsChecked="{Binding ElementName=Self, Path=Settings.ShowNudgePadOnOverlay, Mode=TwoWay}"
                                   Background="Transparent" BorderThickness="0"
                                   Padding="4,2" Cursor="Hand" Focusable="False">
@@ -264,45 +311,6 @@
                          pad's Command/IsChecked bindings, so we set it deterministically. -->
                     <views:NudgePadView x:Name="OverlayNudgePad" />
                 </Border>
-
-                <!-- #524: bottom-right zoom strip. Width-capped + right-
-                     aligned so it doesn't fight the centred magenta
-                     validate-calibration banner. Hidden when the overlay is
-                     fully click-through (window-level WS_EX_TRANSPARENT means
-                     individual WPF controls can't override hit-testing):
-                     IsZoomFieldVisible folds Settings.ClickThroughMap and the
-                     calibration Drop-phase forced click-through into one
-                     gate. The wizard surfaces stay reachable in that state. -->
-                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            Orientation="Horizontal" Margin="0,0,16,72"
-                            Visibility="{Binding IsZoomFieldVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                    <!-- Amber warning chip — same condition as the wizard
-                         Listening row; hidden when stamps match. -->
-                    <Border Margin="0,0,8,0" Padding="8,4" CornerRadius="3"
-                            Background="#CC4A3A0A" BorderBrush="#FFC99A2E" BorderThickness="1"
-                            VerticalAlignment="Center"
-                            Visibility="{Binding IsZoomMismatchWarningVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                        <TextBlock Text="{Binding ZoomMismatchText}"
-                                   Foreground="#FFFFE6B3" FontSize="11"
-                                   TextWrapping="Wrap" MaxWidth="220" />
-                    </Border>
-                    <Border Padding="8,4" CornerRadius="3"
-                            Background="#CC101010" BorderBrush="#FF505050" BorderThickness="1"
-                            ToolTip="In-game map zoom (PG's 'Zoom level: X.XX' readout). Calibration captures it as a stamp; surveys re-scale to whatever you set here. Assumes you haven't panned the map between calibrating and using it.">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock Text="Zoom" Foreground="#FFCCCCCC" FontSize="11"
-                                       VerticalAlignment="Center" Margin="0,0,6,0" />
-                            <Slider Minimum="0.13" Maximum="2.0"
-                                    SmallChange="0.01" LargeChange="0.1"
-                                    Width="100" VerticalAlignment="Center" Margin="0,0,6,0"
-                                    Value="{Binding Session.CurrentMapZoom, Mode=TwoWay}" />
-                            <TextBox Width="38" VerticalAlignment="Center"
-                                     Background="#FF1A1A1A" Foreground="#FFE0E0E0"
-                                     BorderBrush="#FF505050" BorderThickness="1"
-                                     Text="{Binding Session.CurrentMapZoom, Mode=TwoWay, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />
-                        </StackPanel>
-                    </Border>
-                </StackPanel>
 
                 <!-- On-overlay hint banner. Shown only during AwaitingPosition
                      and Listening-with-no-surveys (where a freshly-projected

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -265,6 +265,45 @@
                     <views:NudgePadView x:Name="OverlayNudgePad" />
                 </Border>
 
+                <!-- #524: bottom-right zoom strip. Width-capped + right-
+                     aligned so it doesn't fight the centred magenta
+                     validate-calibration banner. Hidden when the overlay is
+                     fully click-through (window-level WS_EX_TRANSPARENT means
+                     individual WPF controls can't override hit-testing):
+                     IsZoomFieldVisible folds Settings.ClickThroughMap and the
+                     calibration Drop-phase forced click-through into one
+                     gate. The wizard surfaces stay reachable in that state. -->
+                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                            Orientation="Horizontal" Margin="0,0,16,72"
+                            Visibility="{Binding IsZoomFieldVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                    <!-- Amber warning chip — same condition as the wizard
+                         Listening row; hidden when stamps match. -->
+                    <Border Margin="0,0,8,0" Padding="8,4" CornerRadius="3"
+                            Background="#CC4A3A0A" BorderBrush="#FFC99A2E" BorderThickness="1"
+                            VerticalAlignment="Center"
+                            Visibility="{Binding IsZoomMismatchWarningVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <TextBlock Text="{Binding ZoomMismatchText}"
+                                   Foreground="#FFFFE6B3" FontSize="11"
+                                   TextWrapping="Wrap" MaxWidth="220" />
+                    </Border>
+                    <Border Padding="8,4" CornerRadius="3"
+                            Background="#CC101010" BorderBrush="#FF505050" BorderThickness="1"
+                            ToolTip="In-game map zoom (PG's 'Zoom level: X.XX' readout). Calibration captures it as a stamp; surveys re-scale to whatever you set here. Assumes you haven't panned the map between calibrating and using it.">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock Text="Zoom" Foreground="#FFCCCCCC" FontSize="11"
+                                       VerticalAlignment="Center" Margin="0,0,6,0" />
+                            <Slider Minimum="0.13" Maximum="2.0"
+                                    SmallChange="0.01" LargeChange="0.1"
+                                    Width="100" VerticalAlignment="Center" Margin="0,0,6,0"
+                                    Value="{Binding Session.CurrentMapZoom, Mode=TwoWay}" />
+                            <TextBox Width="38" VerticalAlignment="Center"
+                                     Background="#FF1A1A1A" Foreground="#FFE0E0E0"
+                                     BorderBrush="#FF505050" BorderThickness="1"
+                                     Text="{Binding Session.CurrentMapZoom, Mode=TwoWay, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
                 <!-- On-overlay hint banner. Shown only during AwaitingPosition
                      and Listening-with-no-surveys (where a freshly-projected
                      anchor can land off-screen). IsHitTestVisible=False so the

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -363,7 +363,7 @@
                             </Button.Template>
                             <Button.Style>
                                 <Style TargetType="Button">
-                                    <Setter Property="ToolTip" Value="Show known landmarks/NPCs on the map to check the calibration still lines up — a consistent offset means recalibrate. Available between runs, not while surveying or plotting motherlodes." />
+                                    <Setter Property="ToolTip" Value="Show known landmarks/NPCs on the map to check the calibration still lines up — a consistent offset means recalibrate. Tip: after a PG client restart, leave Mithril's zoom slider at the calibration stamp and drag PG's zoom slider until the ghosts align with their real landmarks — once they do, PG matches Mithril without typing numbers. Available between runs, not while surveying or plotting motherlodes." />
                                     <Setter Property="Opacity" Value="1" />
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding MapOverlay.ShowCalibrationGhosts}" Value="True">

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -31,6 +31,29 @@
                 <Setter Property="Margin" Value="10,0" />
             </Style>
 
+            <!-- #524: shared map-zoom slider+textbox surface. Two-way bound
+                 to Session.CurrentMapZoom so any of the three host sites
+                 (header strip, Calibrating body, overlay corner) edits the
+                 same value live. Compact horizontal shape mirrors PG's own
+                 zoom slider (- [slider] +). UpdateSourceTrigger=LostFocus on
+                 the textbox so per-keystroke edits don't fire reprojection
+                 storms; the slider is continuous. Range pinned to PG's hard
+                 stops [0.13, 2.00], step 0.01, two-decimal display. -->
+            <DataTemplate x:Key="ZoomFieldSurface">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                            ToolTip="The in-game map zoom you're at (PG's 'Zoom level: X.XX' readout). Calibration captures this stamp; surveys re-scale to whatever zoom you set here so a calibration solved at one zoom places pins correctly at another. Assumes you haven't panned the map between calibrating and using it.">
+                    <TextBlock Text="Zoom" VerticalAlignment="Center" Margin="0,0,6,0"
+                               Foreground="{StaticResource TextSecondaryBrush}"
+                               FontSize="{DynamicResource AppFontSizeSmall}" />
+                    <Slider Minimum="0.13" Maximum="2.0"
+                            SmallChange="0.01" LargeChange="0.1" TickFrequency="0.1"
+                            Width="120" VerticalAlignment="Center" Margin="0,0,6,0"
+                            Value="{Binding Session.CurrentMapZoom, Mode=TwoWay}" />
+                    <TextBox Width="42" VerticalAlignment="Center"
+                             Text="{Binding Session.CurrentMapZoom, Mode=TwoWay, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />
+                </StackPanel>
+            </DataTemplate>
+
             <!-- #476 Option C: shared "set my position" affordance, hosted in
                  both the Listening and Gathering panels (the two phases the
                  SurveyFlow SettingPosition detour returns to). DataContext is
@@ -246,8 +269,21 @@
              calibration-state chip on the right — the user-facing way to see
              calibration state (the calibration overlay is experimental). When
              the area is known but uncalibrated the chip is clickable and
-             starts the guided Drop/Pair calibration. -->
+             starts the guided Drop/Pair calibration. #524: the map-zoom
+             strip docks alongside; it's always reachable here (this panel is
+             a normal opaque window, never click-through). -->
         <DockPanel DockPanel.Dock="Top" Margin="20,16,20,0">
+            <!-- #524: map-zoom strip — always reachable on the wizard
+                 (opaque, never click-through). Declared first so it docks to
+                 the rightmost slot, sitting to the right of the chip + the
+                 Validate toggle. Hidden until a mode is picked so the bare
+                 PickMode step doesn't show controls that have no consequence
+                 yet. -->
+            <ContentControl DockPanel.Dock="Right" Content="{Binding}"
+                            ContentTemplate="{StaticResource ZoomFieldSurface}"
+                            VerticalAlignment="Center" Margin="10,0,0,0"
+                            Visibility="{Binding HasPickedMode, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
+
             <!-- #501: the chip is the single calibrate/recalibrate entry
                  point. Uncalibrated → guided cold-start; calibrated → arms the
                  #477B confirm guard surfaced as the popup below (anchored
@@ -669,6 +705,20 @@
                                FontSize="{DynamicResource AppFontSizeBody}"
                                Foreground="{StaticResource TextSecondaryBrush}" />
 
+                    <!-- #524: zoom stamp captured at Confirm time. Reads off
+                         PG's "Zoom level: X.XX" readout — set it BEFORE
+                         confirming so the calibration is stamped at the zoom
+                         you actually solved at. Mirrors the header strip
+                         (same Session.CurrentMapZoom) so adjustments here
+                         flow back out. -->
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,12">
+                        <TextBlock Text="In-game map zoom: " VerticalAlignment="Center"
+                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                   FontSize="{DynamicResource AppFontSizeBody}" />
+                        <ContentControl Content="{Binding}" ContentTemplate="{StaticResource ZoomFieldSurface}"
+                                        VerticalAlignment="Center" />
+                    </StackPanel>
+
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button Content="Confirm" Style="{StaticResource WizardPrimaryButton}"
                                 Command="{Binding ConfirmCalibrationCommand}"
@@ -705,6 +755,45 @@
                 <!-- Listening (#454: no AwaitingPosition step — placement is
                      absolute via ProcessMapFx; no anchor click) -->
                 <StackPanel Visibility="{Binding CurrentStep, Converter={x:Static controls:EnumMatchConverter.ToVisibility}, ConverterParameter=Listening}">
+
+                    <!-- #524: zoom-mismatch warning. Live in-game zoom diverges
+                         from the captured calibration stamp by more than half
+                         a slider tick. No dismiss — clears automatically as
+                         the user matches the zoom or recalibrates. Suppressed
+                         for legacy 1.0 stamps (the recalibrate hint below
+                         handles those). -->
+                    <Border Margin="0,0,0,12" Padding="12,8" CornerRadius="3"
+                            Background="{StaticResource AccentSoftBrush}"
+                            BorderBrush="{StaticResource AccentBrush}" BorderThickness="1"
+                            HorizontalAlignment="Center" MaxWidth="520"
+                            Visibility="{Binding MapOverlay.IsZoomMismatchWarningVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <TextBlock Text="{Binding MapOverlay.ZoomMismatchText}"
+                                   TextWrapping="Wrap" TextAlignment="Center"
+                                   Foreground="{StaticResource AccentSoftTextBrush}"
+                                   FontSize="{DynamicResource AppFontSizeBody}" />
+                    </Border>
+
+                    <!-- #524: legacy-stamp recalibrate hint. One-time per area
+                         per session (Got it dismisses for the rest of the
+                         session; drops on recalibrate). Not surfaced as a
+                         warning — the calibration still works at the stamp's
+                         zoom; recalibrating just unlocks cross-zoom placement. -->
+                    <Border Margin="0,0,0,12" Padding="12,8" CornerRadius="3"
+                            Background="{StaticResource BgSurfaceBrush}"
+                            BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
+                            HorizontalAlignment="Center" MaxWidth="520"
+                            Visibility="{Binding MapOverlay.IsLegacyRecalibrateHintVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <StackPanel>
+                            <TextBlock Text="This area's calibration predates zoom tracking — recalibrate to enable cross-zoom placement."
+                                       TextWrapping="Wrap" TextAlignment="Center"
+                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                       FontSize="{DynamicResource AppFontSizeBody}" Margin="0,0,0,6" />
+                            <Button Content="Got it" HorizontalAlignment="Center"
+                                    Padding="10,3"
+                                    Command="{Binding MapOverlay.DismissLegacyRecalibrateHintCommand}" />
+                        </StackPanel>
+                    </Border>
+
                     <StackPanel HorizontalAlignment="Center" Margin="0,0,0,16">
                         <TextBlock Text="From your inventory, work through the surveys in order:"
                                    TextWrapping="Wrap" TextAlignment="Center"

--- a/tests/Legolas.Tests/Projection/AreaCalibrationProjectWorldTests.cs
+++ b/tests/Legolas.Tests/Projection/AreaCalibrationProjectWorldTests.cs
@@ -73,4 +73,75 @@ public class AreaCalibrationProjectWorldTests
         plus.ProjectWorld(w).Should().Be(new PixelPoint(10, -7));
         minus.ProjectWorld(w).Should().Be(new PixelPoint(10, 7));
     }
+
+    // ---- #524: zoom-aware overload --------------------------------------
+
+    [Theory]
+    [InlineData(0.13, 1.0)]
+    [InlineData(0.5, 1.0)]
+    [InlineData(1.0, 1.0)]
+    [InlineData(2.0, 1.0)]
+    [InlineData(0.13, 2.0)]
+    [InlineData(0.5, 2.0)]
+    [InlineData(1.0, 2.0)]
+    [InlineData(2.0, 2.0)]
+    public void ProjectWorld_AppliesZoomFactor_AcrossRange(double currentZoom, double calibrationZoom)
+    {
+        // Scale 2 px/unit, no rotation, origin (100, 200). The effective scale
+        // at currentZoom is 2 * (currentZoom / calibrationZoom).
+        var cal = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = calibrationZoom };
+        var w = new WorldCoord(10, 0, 5);
+        var factor = currentZoom / calibrationZoom;
+
+        var projected = cal.ProjectWorld(w, currentZoom);
+
+        // East = X * eff, North = Z * eff. Mirror-north default false → Y = Oy - Scale*eff*Z.
+        projected.X.Should().BeApproximately(100 + 2.0 * factor * 10, 1e-9);
+        projected.Y.Should().BeApproximately(200 - 2.0 * factor * 5, 1e-9);
+    }
+
+    [Fact]
+    public void ProjectWorld_NoOpWhenZoomMatchesCalibration()
+    {
+        // Back-compat: a current zoom equal to the calibration's stamp is the
+        // byte-identical no-op the parameterless overload always produced.
+        var cal = new AreaCalibration(1.7, 0.4, 50, -30, 3, 0) { CalibrationZoom = 1.5 };
+        var w = new WorldCoord(12.5, 0, -7.25);
+
+        var legacy = cal.ProjectWorld(w);
+        var zoomAware = cal.ProjectWorld(w, 1.5);
+
+        zoomAware.X.Should().Be(legacy.X);
+        zoomAware.Y.Should().Be(legacy.Y);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(-0.13)]
+    public void ProjectWorld_GuardsInvalidZoom(double badZoom)
+    {
+        // Defensive: a non-positive zoom falls back to factor 1.0 — same pixel
+        // as ProjectWorld(world) using Scale verbatim. Keeps a malformed value
+        // from crashing the per-frame projector.
+        var cal = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 0.5 };
+        var w = new WorldCoord(10, 0, 5);
+
+        var guarded = cal.ProjectWorld(w, badZoom);
+        // factor = 1.0 ⇒ effScale = Scale verbatim.
+        guarded.X.Should().BeApproximately(100 + 2.0 * 10, 1e-9);
+        guarded.Y.Should().BeApproximately(200 - 2.0 * 5, 1e-9);
+    }
+
+    [Fact]
+    public void ProjectWorld_LegacyOverload_DelegatesToZoomAware_WithCalibrationZoom()
+    {
+        // The parameterless overload must equal the zoom-aware overload at
+        // currentZoom = CalibrationZoom. This is the back-compat seam — every
+        // pre-#524 call site retains its pixels.
+        var cal = new AreaCalibration(0.85, -0.2, 320, 480, 4, 0) { CalibrationZoom = 1.75, MirrorNorth = true };
+        var w = new WorldCoord(123, 0, -456);
+
+        cal.ProjectWorld(w).Should().Be(cal.ProjectWorld(w, cal.CalibrationZoom));
+    }
 }

--- a/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Services;
+using Legolas.ViewModels;
 using Mithril.Shared.Reference;
 using Xunit;
 using PinShape = Mithril.GameState.Pins.PinShape;
@@ -22,6 +23,15 @@ public class PinCalibrationCoordinatorTests
         var pins = new FakePlayerPinTracker();
         var settings = new LegolasSettings();
         return (new PinCalibrationCoordinator(calib, pins, settings), calib, pins, settings);
+    }
+
+    private static (PinCalibrationCoordinator coord, FakeCalib calib, FakePlayerPinTracker pins, SessionState session) BuildWithSession()
+    {
+        var calib = new FakeCalib();
+        var pins = new FakePlayerPinTracker();
+        var settings = new LegolasSettings();
+        var session = new SessionState();
+        return (new PinCalibrationCoordinator(calib, pins, settings, session), calib, pins, session);
     }
 
     // A well-conditioned scale-only transform: pixel = (100 + 2X, 100 - 2Z),
@@ -306,6 +316,46 @@ public class PinCalibrationCoordinatorTests
         });
     }
 
+    // ---- #524: zoom stamp ------------------------------------------------
+
+    [Fact]
+    public void Persist_StampsCurrentMapZoom_FromSessionState()
+    {
+        var (coord, calib, pins, session) = BuildWithSession();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        session.CurrentMapZoom = 1.5;
+        coord.Arm();
+        // Walk the spread-suggested order so each pin maps to its OWN perfect
+        // pixel (residual ~0 ⇒ Confirm is ungated).
+        PairAllPerfectly(coord);
+
+        var result = coord.Confirm();
+
+        result.Should().NotBeNull();
+        calib.LastCalibrationZoom.Should().Be(1.5, "the live in-game zoom must be stamped, not the pre-#524 hardcoded 1.0");
+        result!.CalibrationZoom.Should().Be(1.5);
+    }
+
+    [Fact]
+    public void Persist_WithoutSessionState_FallsBackToOne()
+    {
+        // Legacy ctor (no SessionState) still works — preserves headless /
+        // unit-test paths and the pre-#524 default stamp.
+        var (coord, calib, pins, _) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        coord.Arm();
+        PairAllPerfectly(coord);
+
+        coord.Confirm().Should().NotBeNull();
+        calib.LastCalibrationZoom.Should().Be(1.0);
+    }
+
     [Fact]
     public void Arm_clears_stale_state()
     {
@@ -328,15 +378,17 @@ public class PinCalibrationCoordinatorTests
     private sealed class FakeCalib : IAreaCalibrationService
     {
         public List<(WorldCoord, PixelPoint)>? LastPairs { get; private set; }
+        public double LastCalibrationZoom { get; private set; }
         public int ChangedCount { get; private set; }
 
         public AreaCalibration? CalibrateCurrentArea(
             IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0)
         {
             LastPairs = placements.Select(p => (p.World, p.Pixel)).ToList();
+            LastCalibrationZoom = calibrationZoom;
             ChangedCount++;
             Changed?.Invoke(this, EventArgs.Empty);
-            return new AreaCalibration(1, 0, 0, 0, placements.Count, 0);
+            return new AreaCalibration(1, 0, 0, 0, placements.Count, 0) { CalibrationZoom = calibrationZoom };
         }
 
         public string? CurrentAreaKey => "AreaTest";

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -68,6 +68,10 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         if (preSeededArea is not null) areaState.SetArea(preSeededArea);
         var spy = new SpyAreaCalibration(calibration);
         var session = new SessionState();
+        // #524: tests build calibrations with the default CalibrationZoom = 1.0;
+        // pin the live zoom to 1.0 so projection zoomFactor is 1.0 and the
+        // pre-#524 pixel assertions stay byte-identical.
+        session.CurrentMapZoom = 1.0;
         var settings = new LegolasSettings();
         var flow = new SurveyFlowController(session, settings);
         var gates = new ModuleGates();

--- a/tests/Legolas.Tests/ViewModels/ManualAnchorNudgeTests.cs
+++ b/tests/Legolas.Tests/ViewModels/ManualAnchorNudgeTests.cs
@@ -26,6 +26,10 @@ public class ManualAnchorNudgeTests
         BuildSut()
     {
         var session = new SessionState { Mode = SessionMode.Survey };
+        // #524: legacy CalibrationZoom = 1.0 stamp ⇒ pin live zoom to 1.0 so
+        // a fresh tracker fix re-projects with zoomFactor 1.0 and the
+        // pre-#524 nudge assertions still hold.
+        session.CurrentMapZoom = 1.0;
         var settings = new LegolasSettings();
         var surveyFlow = new SurveyFlowController(session, settings);
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());

--- a/tests/Legolas.Tests/ViewModels/MapOverlayCalibrationValidationTests.cs
+++ b/tests/Legolas.Tests/ViewModels/MapOverlayCalibrationValidationTests.cs
@@ -19,6 +19,10 @@ public class MapOverlayCalibrationValidationTests
     private static (MapOverlayViewModel map, FakeAreaCalibrationService cal, SessionState session) Build()
     {
         var session = new SessionState();
+        // #524: these tests build calibrations with the default (legacy)
+        // CalibrationZoom = 1.0; pin the live zoom to match so the projection
+        // zoomFactor is 1.0 and the assertions stay byte-identical to pre-#524.
+        session.CurrentMapZoom = 1.0;
         var settings = new LegolasSettings();
         var surveyFlow = new SurveyFlowController(session, settings);
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());

--- a/tests/Legolas.Tests/ViewModels/MapOverlayPinnedAnchorTests.cs
+++ b/tests/Legolas.Tests/ViewModels/MapOverlayPinnedAnchorTests.cs
@@ -27,6 +27,10 @@ public class MapOverlayPinnedAnchorTests
         BuildSut(bool calibrated)
     {
         var session = new SessionState();
+        // #524: legacy CalibrationZoom = 1.0 stamp ⇒ pin live zoom to 1.0 so
+        // the projection zoomFactor is 1.0 and the pre-#524 byte-identical
+        // assertions still hold.
+        session.CurrentMapZoom = 1.0;
         var settings = new LegolasSettings();
         var surveyFlow = new SurveyFlowController(session, settings);
         var projector = new CoordinateProjector();

--- a/tests/Legolas.Tests/ViewModels/MapOverlayZoomReactivityTests.cs
+++ b/tests/Legolas.Tests/ViewModels/MapOverlayZoomReactivityTests.cs
@@ -109,6 +109,44 @@ public class MapOverlayZoomReactivityTests
     }
 
     [Fact]
+    public void Auto_seeds_CurrentMapZoom_from_calibration_stamp_on_area_change()
+    {
+        // Fresh session defaults to 2.0. Loading an area whose calibration
+        // stamp is 0.5 should pull the slider to 0.5 — the user's "what
+        // zoom should I dial PG to after restart?" answer comes from the
+        // stamp, surfaced via auto-seed.
+        var calibration = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 0.5 };
+        var (map, cal, session) = Build();
+        session.CurrentMapZoom.Should().Be(2.0, "default before any calibration is loaded");
+
+        cal.SetCalibration(calibration);
+
+        session.CurrentMapZoom.Should().Be(0.5);
+        map.CalibrationZoomLabel.Should().Contain("0.50");
+        map.IsCalibrationZoomLabelVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Recalibrating_same_area_does_not_clobber_user_slider_value()
+    {
+        // After area-load auto-seed sets slider to 0.5, the user might have
+        // manually moved it to 1.5 (e.g., they changed PG's zoom). A fresh
+        // Changed event from a recalibration of the SAME area must not pull
+        // the slider back — it's the user's value now.
+        var calibration = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 0.5 };
+        var (_, cal, session) = Build();
+        cal.SetCalibration(calibration);            // first load → seed to 0.5
+        session.CurrentMapZoom.Should().Be(0.5);
+
+        session.CurrentMapZoom = 1.5;               // user moved the slider
+
+        // Recalibrate the same area (key unchanged) — Changed fires again.
+        cal.SetCalibration(new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 0.5 });
+
+        session.CurrentMapZoom.Should().Be(1.5, "same-area Changed must not clobber user edits");
+    }
+
+    [Fact]
     public void IsZoomFieldVisible_hides_when_overlay_click_through_is_on()
     {
         var (map, _, _) = Build();

--- a/tests/Legolas.Tests/ViewModels/MapOverlayZoomReactivityTests.cs
+++ b/tests/Legolas.Tests/ViewModels/MapOverlayZoomReactivityTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+using Xunit;
+
+namespace Legolas.Tests.ViewModels;
+
+/// <summary>
+/// #524: dragging <see cref="SessionState.CurrentMapZoom"/> live-reprojects
+/// every calibration-aware surface (player marker, Motherlode markers,
+/// validate-calibration ghosts) and updates the zoom-mismatch warning chip
+/// + legacy-recalibrate hint without a debounce / refresh button.
+/// </summary>
+public class MapOverlayZoomReactivityTests
+{
+    private static (MapOverlayViewModel map, FakeAreaCalibrationService cal, SessionState session)
+        Build(AreaCalibration? seedCal = null)
+    {
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(settings);
+        var cal = new FakeAreaCalibrationService();
+        if (seedCal is not null) cal.SetCalibration(seedCal);
+        var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes,
+            settings, pinCalibration: null, positionTracker: null, areaCalibration: cal);
+        return (map, cal, session);
+    }
+
+    [Fact]
+    public void CurrentMapZoom_change_fires_relevant_PropertyChanged_events()
+    {
+        // Seed a calibration so the warning chip + marker pixels participate.
+        var calibration = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 2.0 };
+        var (map, _, session) = Build(calibration);
+
+        var fired = new HashSet<string>();
+        map.PropertyChanged += (_, e) => { if (e.PropertyName is { } n) fired.Add(n); };
+
+        session.CurrentMapZoom = 1.0;
+
+        // The player marker / motherlode markers / validate ghosts collection /
+        // warning chip all depend on the live zoom, so they must all refresh.
+        fired.Should().Contain(nameof(MapOverlayViewModel.PlayerMarkerPixel));
+        fired.Should().Contain(nameof(MapOverlayViewModel.MotherlodeMarkerPixels));
+        fired.Should().Contain(nameof(MapOverlayViewModel.IsZoomMismatchWarningVisible));
+    }
+
+    [Fact]
+    public void Warning_chip_appears_when_zoom_diverges_from_calibration_stamp()
+    {
+        var calibration = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 2.0 };
+        var (map, _, session) = Build(calibration);
+
+        // Stamped at 2.0; matching zoom — no warning.
+        session.CurrentMapZoom = 2.0;
+        map.IsZoomMismatchWarningVisible.Should().BeFalse();
+
+        // Within the half-tick epsilon — still no warning.
+        session.CurrentMapZoom = 1.96;
+        map.IsZoomMismatchWarningVisible.Should().BeFalse();
+
+        // Beyond the epsilon — warning fires.
+        session.CurrentMapZoom = 1.5;
+        map.IsZoomMismatchWarningVisible.Should().BeTrue();
+        map.ZoomMismatchText.Should().Contain("2.00");
+    }
+
+    [Fact]
+    public void Warning_chip_suppressed_on_legacy_one_point_zero_stamp()
+    {
+        // A pre-#524 calibration (CalibrationZoom = 1.0 default) must NOT
+        // flag a warning when the user is at the default 2.0 — they had no
+        // way to set the stamp deliberately. The legacy hint handles that.
+        var legacy = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0); // CalibrationZoom defaults 1.0
+        var (map, _, _) = Build(legacy);
+
+        map.IsZoomMismatchWarningVisible.Should().BeFalse(
+            "legacy stamps never trigger the warning — the recalibrate hint covers them");
+        map.IsLegacyRecalibrateHintVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Legacy_hint_dismissal_is_session_ephemeral_per_area()
+    {
+        var legacy = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0);
+        var (map, _, _) = Build(legacy);
+
+        map.IsLegacyRecalibrateHintVisible.Should().BeTrue();
+        map.DismissLegacyRecalibrateHintCommand.Execute(null);
+        map.IsLegacyRecalibrateHintVisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Legacy_hint_disappears_when_recalibration_lifts_stamp_off_one()
+    {
+        var legacy = new AreaCalibration(2.0, 0.0, 100, 200, 3, 0);
+        var (map, cal, _) = Build(legacy);
+        map.IsLegacyRecalibrateHintVisible.Should().BeTrue();
+
+        // Recalibrate at 2.0 — stamp moves off 1.0.
+        cal.SetCalibration(new AreaCalibration(2.0, 0.0, 100, 200, 3, 0) { CalibrationZoom = 2.0 });
+
+        map.IsLegacyRecalibrateHintVisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsZoomFieldVisible_hides_when_overlay_click_through_is_on()
+    {
+        var (map, _, _) = Build();
+        map.IsZoomFieldVisible.Should().BeTrue("default settings: click-through off");
+
+        // We need a settings handle — grab via reflection-free path by
+        // constructing with the same settings instance.
+        var session = new SessionState();
+        var settings = new LegolasSettings { ClickThroughMap = true };
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(settings);
+        var cal = new FakeAreaCalibrationService();
+        var map2 = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes,
+            settings, pinCalibration: null, positionTracker: null, areaCalibration: cal);
+
+        map2.IsZoomFieldVisible.Should().BeFalse("ClickThroughMap=true hides the overlay strip");
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/SessionStateZoomTests.cs
+++ b/tests/Legolas.Tests/ViewModels/SessionStateZoomTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Legolas.ViewModels;
+using Xunit;
+
+namespace Legolas.Tests.ViewModels;
+
+/// <summary>
+/// #524: SessionState.CurrentMapZoom — the live in-game map zoom the user
+/// types into the wizard / overlay slider. Defaults to PG's max (2.00),
+/// clamps to [0.13, 2.00].
+/// </summary>
+public class SessionStateZoomTests
+{
+    [Fact]
+    public void CurrentMapZoom_Defaults_ToTwo()
+    {
+        var s = new SessionState();
+        s.CurrentMapZoom.Should().Be(2.0,
+            "PG's max zoom is the accuracy-optimal default — finest px-per-metre, " +
+            "lowest click-quantization in the fit residual");
+    }
+
+    [Theory]
+    [InlineData(-1.0, 0.13)]
+    [InlineData(0.0, 0.13)]
+    [InlineData(0.12, 0.13)]
+    [InlineData(0.13, 0.13)]
+    [InlineData(0.5, 0.5)]
+    [InlineData(1.0, 1.0)]
+    [InlineData(2.0, 2.0)]
+    [InlineData(2.01, 2.0)]
+    [InlineData(99.0, 2.0)]
+    public void CurrentMapZoom_Clamps_ToPgRange(double assigned, double expected)
+    {
+        var s = new SessionState();
+        s.CurrentMapZoom = assigned;
+        s.CurrentMapZoom.Should().BeApproximately(expected, 1e-9);
+    }
+
+    [Fact]
+    public void CurrentMapZoom_RaisesPropertyChanged_OnLegitimateMove()
+    {
+        var s = new SessionState();
+        var fired = 0;
+        s.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(SessionState.CurrentMapZoom)) fired++;
+        };
+
+        s.CurrentMapZoom = 1.0;
+        // INPC fires once on the actual set; the clamp's no-op write inside the
+        // partial method is the value already, so it doesn't re-fire.
+        fired.Should().BeGreaterThanOrEqualTo(1);
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/SurveyPlayerGpsTests.cs
+++ b/tests/Legolas.Tests/ViewModels/SurveyPlayerGpsTests.cs
@@ -37,6 +37,10 @@ public class SurveyPlayerGpsTests
             PlayerPositionSource source = PlayerPositionSource.Spawn)
     {
         var session = new SessionState();
+        // #524: this suite's calibration uses the default CalibrationZoom = 1.0,
+        // so pin the live zoom to 1.0 → zoomFactor 1.0 → projections stay
+        // byte-identical to pre-#524.
+        session.CurrentMapZoom = 1.0;
         var settings = new LegolasSettings();
         var surveyFlow = new SurveyFlowController(session, settings);
         var opt = new CapturingOptimizer();


### PR DESCRIPTION
## Summary

- Threads the in-game map zoom through every Legolas projection: `SessionState.CurrentMapZoom` (clamped to PG's `[0.13, 2.00]`) feeds `AreaCalibration.ProjectWorld(world, currentZoom)`, which scales by `currentZoom / CalibrationZoom`. The parameterless overload still exists and delegates with `currentZoom = CalibrationZoom` (byte-identical for legacy saves).
- `PinCalibrationCoordinator.Persist()` now stamps `SessionState.CurrentMapZoom` instead of the pre-#524 hardcoded `1.0` — the silent ~15× corruption blast radius the issue body quantified.
- Five live `ProjectWorld` call sites migrated (`PlayerLogIngestionService` ProcessMapFx placement, `ResolveSurveyAnchor`'s two projections, `MotherlodeMarkerPixels`, `GhostLabelDeclutter.Build`). `CalibrationSessionViewModel` intentionally untouched (unreachable-in-product per `fb98567`).
- Three slider+textbox UI surfaces (wizard header strip, Calibrating step body, overlay bottom-right corner), all two-way bound to `Session.CurrentMapZoom`. The overlay strip hides when the overlay is fully click-through; the wizard surfaces stay reachable as the always-on fallback. Reactive: dragging any slider live-reprojects pins, ghosts, motherlode markers, and the player marker.
- Warning chip when live zoom diverges from the calibration stamp by >0.05 (suppressed for legacy `1.0` stamps and during active calibration). One-time per-area legacy-recalibrate hint on the Listening step.

## Test plan

### Unit (all 494 Legolas tests green; full `Mithril.slnx` suite green)

- [x] `AreaCalibrationProjectWorldTests.ProjectWorld_AppliesZoomFactor_AcrossRange` — `currentZoom ∈ {0.13, 0.5, 1.0, 2.0}` × `CalibrationZoom ∈ {1.0, 2.0}`.
- [x] `AreaCalibrationProjectWorldTests.ProjectWorld_NoOpWhenZoomMatchesCalibration` — back-compat: `ProjectWorld(w, CalibrationZoom) == ProjectWorld(w)`.
- [x] `AreaCalibrationProjectWorldTests.ProjectWorld_GuardsInvalidZoom` — `currentZoom ≤ 0` falls back to factor `1.0`.
- [x] `AreaCalibrationProjectWorldTests.ProjectWorld_LegacyOverload_DelegatesToZoomAware_WithCalibrationZoom`.
- [x] `PinCalibrationCoordinatorTests.Persist_StampsCurrentMapZoom_FromSessionState`.
- [x] `PinCalibrationCoordinatorTests.Persist_WithoutSessionState_FallsBackToOne`.
- [x] `SessionStateZoomTests.CurrentMapZoom_Defaults_ToTwo`.
- [x] `SessionStateZoomTests.CurrentMapZoom_Clamps_ToPgRange`.
- [x] `MapOverlayZoomReactivityTests.CurrentMapZoom_change_fires_relevant_PropertyChanged_events`.
- [x] `MapOverlayZoomReactivityTests.Warning_chip_appears_when_zoom_diverges_from_calibration_stamp`.
- [x] `MapOverlayZoomReactivityTests.Warning_chip_suppressed_on_legacy_one_point_zero_stamp`.
- [x] `MapOverlayZoomReactivityTests.Legacy_hint_dismissal_is_session_ephemeral_per_area`.
- [x] `MapOverlayZoomReactivityTests.Legacy_hint_disappears_when_recalibration_lifts_stamp_off_one`.
- [x] `MapOverlayZoomReactivityTests.IsZoomFieldVisible_hides_when_overlay_click_through_is_on`.

### Manual smoke (owed to reviewer — could not run live PG in dev environment)

- [ ] **Math sanity.** In Serbule, recalibrate at zoom 2.00, toggle Validate → ghosts align (baseline). Drag PG to zoom 1.00, set the bound field to 1.00, toggle Validate → ghosts stay within ±10%.
  - Aligned ⇒ linearity holds; math right.
  - Radial drift around a fixed point ⇒ centring right, linearity off → file a follow-up to fit `s(zoom)` empirically.
  - Wholesale drift ⇒ user panned between calibrate and validate (this is the documented warning-chip case).
- [ ] **Survey regression.** Calibrate at 2.00, Survey at 0.13 → pins land near the real targets (vs the pre-#524 ~15× silent error).
- [ ] **Legacy back-compat.** Open a pre-existing calibrated area (stamp `1.0` from before this feature) → no warning chip; one-time recalibrate hint shows on the Listening step. Dismiss → hint hides for session. Recalibrate at 2.0 → hint clears; warning chip now appears if the live zoom diverges from 2.0 without updating the bound field.
- [ ] **Click-through interaction.** Overlay zoom strip hidden when `IsCalibrationDropping || ClickThroughMap`; visible otherwise. Wizard sliders always reachable.

### Out-of-scope (intentional)

- `CalibrationSessionViewModel.cs:536` — the unreachable-in-product standalone window (commit `fb98567`); leaving its local `MapZoom` alone preserves the option to revive it later.

## Notes for reviewer

- Pre-existing tests that built calibrations with the default `CalibrationZoom = 1.0` had to pin `session.CurrentMapZoom = 1.0` after `new SessionState()` so the projection `zoomFactor` stays at `1.0` and the byte-identical assertions still hold (5 fixture updates, all annotated with a `// #524:` comment).
- The `SessionState` ctor param on `PinCalibrationCoordinator` is optional so the existing test harness ctor `(service, pins, settings)` still works.
- `ResolveSurveyAnchor`'s new `double currentMapZoom = 0.0` parameter is optional with a sentinel — unset / `<= 0` falls back to `cal.CalibrationZoom` (zoomFactor `1.0`), so the 8 existing `SurveyAnchorResolutionTests` are byte-identical without edits.

Closes #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
