### PR TITLE
fix(world-sim): make splitter + classifier per-subscriber channels unbounded

### DIFF
--- a/src/Mithril.Shared/Logging/PlayerLogClassifier.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogClassifier.cs
@@ -129,9 +129,15 @@ public sealed class PlayerLogClassifier : IClassifiedPlayerLogStream, IDisposabl
         PipeRegistry<T> pipe, [EnumeratorCancellation] CancellationToken ct)
         where T : class
     {
-        var channel = Channel.CreateBounded<T>(new BoundedChannelOptions(1024)
+        // Unbounded with single-reader / single-writer. A previous bounded
+        // 1024 + DropOldest configuration silently lost replay backlog when
+        // the subscriber's pump (today: the splitter's RunAsync) couldn't
+        // drain fast enough during a long-session cold start. See the
+        // matching rationale + the regression test in PlayerLogPipeSplitter
+        // / PlayerLogPipelineTests. PG's source-stream rate is human-
+        // bounded, so unbounded growth is bounded in practice by the source.
+        var channel = Channel.CreateUnbounded<T>(new UnboundedChannelOptions
         {
-            FullMode = BoundedChannelFullMode.DropOldest,
             SingleReader = true,
             SingleWriter = true,
         });

--- a/src/Mithril.Shared/Logging/PlayerLogPipeSplitter.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogPipeSplitter.cs
@@ -105,9 +105,20 @@ public sealed class PlayerLogPipeSplitter :
         PipeRegistry<T> pipe, [EnumeratorCancellation] CancellationToken ct)
         where T : class
     {
-        var channel = Channel.CreateBounded<T>(new BoundedChannelOptions(1024)
+        // Unbounded with single-reader / single-writer. The previous bounded
+        // 1024 + DropOldest configuration silently lost replay backlog when a
+        // long-session cold-start replayed > 1024 LocalPlayer (or other-Kind)
+        // lines faster than the subscriber's pump could drain — see #XXX, in
+        // which the inventory producer's ~134-item ProcessAddItem block was
+        // evicted by later ProcessCombatModeStatus ticks during a 12-minute
+        // session, wedging the world merger on inventory's PendingFetch.
+        // Unbounded mirrors the producer-side channels (SkillFrameProducer,
+        // AreaLoadingFrameProducer, …): PG's source-stream rate is human-
+        // bounded, so unbounded growth is bounded in practice by the source.
+        // A subscriber that genuinely stalls is a bug to surface via L1
+        // diagnostics, not data to silently drop.
+        var channel = Channel.CreateUnbounded<T>(new UnboundedChannelOptions
         {
-            FullMode = BoundedChannelFullMode.DropOldest,
             SingleReader = true,
             SingleWriter = true,
         });
@@ -148,9 +159,13 @@ public sealed class PlayerLogPipeSplitter :
         PipeRegistry<T> pipe, [EnumeratorCancellation] CancellationToken ct)
         where T : class
     {
-        var channel = Channel.CreateBounded<MarkerItem<T>>(new BoundedChannelOptions(1024)
+        // Unbounded — see the rationale on <see cref="Subscribe{T}"/>. The
+        // marker variant carries identical drop risk under bounded sizing
+        // because the L1 driver's pump runs through this surface; a long-
+        // session cold-start replay can dispatch many thousands of typed
+        // envelopes before the L1 pump invokes its first consumer handler.
+        var channel = Channel.CreateUnbounded<MarkerItem<T>>(new UnboundedChannelOptions
         {
-            FullMode = BoundedChannelFullMode.DropOldest,
             SingleReader = true,
             SingleWriter = true,
         });

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogPipeSplitterTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogPipeSplitterTests.cs
@@ -165,6 +165,70 @@ public sealed class PlayerLogPipeSplitterTests
     }
 
     [Fact]
+    public async Task Long_backlog_through_typed_pipe_delivers_every_envelope()
+    {
+        // Regression test for the silent-drop bug surfaced during
+        // world-sim debugging. Pre-fix, each per-subscriber typed-pipe
+        // channel was bounded at 1024 with FullMode=DropOldest, so a
+        // long-session cold-start replay that dispatched >1024
+        // LocalPlayer lines faster than the subscriber's pump could
+        // drain would silently evict the earliest items. The concrete
+        // failure: the PlayerInventoryFrameProducer's L1 subscription
+        // received the live ProcessCombatModeStatus tail of a 12-minute
+        // session but had its ~134-item ProcessAddItem replay block
+        // evicted, which left its iterator channel empty, which left
+        // the world merger blocked on inv.PendingFetch, which starved
+        // every downstream producer (notably the area producer — the
+        // user-visible symptom was "area changes don't reach Palantir
+        // or Legolas").
+        //
+        // Post-fix the channel is unbounded — every envelope arrives.
+        var classified = new StubClassifiedStream();
+        using var splitter = new PlayerLogPipeSplitter(classified);
+
+        const int count = 5000; // ~5× the previous 1024 capacity
+        for (var i = 1; i <= count; i++)
+        {
+            classified.PushLive(new LocalPlayerLogLine(Ts, $"L{i}", i, 0));
+        }
+
+        var received = await CollectAsync(
+            ((ILocalPlayerLogStream)splitter).SubscribeAsync, count,
+            TimeSpan.FromSeconds(30));
+
+        received.Should().HaveCount(count, because: "no envelope may be silently dropped under a long replay backlog");
+        received.Select(x => x.Sequence).Should().BeInAscendingOrder();
+        received.Select(x => x.Sequence).Should().Equal(
+            Enumerable.Range(1, count).Select(i => (long)i),
+            because: "every Sequence in the input set must reach the subscriber");
+    }
+
+    [Fact]
+    public async Task Long_backlog_through_marker_variant_delivers_every_envelope()
+    {
+        // Same regression, marker variant (the L1-driver-facing path).
+        var classified = new StubClassifiedStream();
+        using var splitter = new PlayerLogPipeSplitter(classified);
+
+        const int count = 5000;
+        for (var i = 1; i <= count; i++)
+        {
+            classified.Push(new LocalPlayerLogLine(Ts, $"L{i}", i, 0), isReplay: true);
+        }
+
+        var received = await CollectMarkerAsync(
+            ((ILocalPlayerLogStream)splitter).SubscribeWithReplayMarkerAsync, count,
+            TimeSpan.FromSeconds(30));
+
+        received.Should().HaveCount(count, because: "no envelope may be silently dropped under a long replay backlog");
+        received.Select(e => e.Payload.Sequence).Should().Equal(
+            Enumerable.Range(1, count).Select(i => (long)i),
+            because: "every Sequence in the input set must reach the subscriber, in source order");
+        received.Should().OnlyContain(e => e.IsReplay,
+            because: "the marker bit forwarded unchanged from the upstream-replay envelopes");
+    }
+
+    [Fact]
     public async Task Handler_throw_in_typed_subscriber_does_not_kill_splitter_pump()
     {
         // The splitter's per-envelope try/catch contains Dispatch throws so


### PR DESCRIPTION
## Summary
Switches the L0.5 splitter + classifier per-subscriber channels from `Bounded(1024) + DropOldest` to `Unbounded`. The previous configuration was silently dropping replay-window envelopes when a long-session cold-start dispatched more LocalPlayer lines than the L1 driver's pump could drain in the same window, which (via the world merger's sequential per-producer await) wedged the entire `PlayerWorld` merger and prevented every frame — area, inventory, skill, words-of-power — from reaching its folder.

## Root cause

The user-visible symptom was "area changes are not reaching Palantir or Legolas". A long debugging session traced the failure backward through the world-sim layers:

1. **`PlayerAreaTracker.ApplyTransition`** was only fired by the eager pre-warm in `PlayerAreaWorldRegistration.StartAsync`, never by live `LOADING LEVEL` envelopes through the merger.
2. **`AreaLoadingFrameProducer`'s L1 callback was firing** — frames were being written to its inner (unbounded) channel correctly on every map change.
3. The **world merger** was blocked at `await s.PendingFetch` on `PlayerWorld.cs:139` — sequential per-producer await design.
4. **The stuck `ProducerAdapter` was `PlayerInventoryFrame`**, not the area producer. Inventory was the blocker; area was downstream of it in the foreach order and therefore couldn't dispatch even though it had frames buffered.
5. **The inventory producer's L1 callback was firing** for `ProcessCombatModeStatus(NotInCombat, [])` lines starting at byte offset 29694700, but never for any of the 134 `ProcessAddItem` lines PG emits after every `ProcessAddPlayer`. The latest `ProcessAddPlayer` before the user's boot was at byte 29331107 — ~360KB of LocalPlayer lines between the session anchor and the first envelope the inventory producer saw were silently missing.
6. **The drop happened in `PlayerLogPipeSplitter.SubscribeWithMarker`'s per-subscriber bounded channel**: capacity 1024, `FullMode = DropOldest`. During a long-session backlog with >1024 LocalPlayer lines, the channel overflowed and DropOldest evicted the earliest items — exactly the inventory replay block.

The same drop existed in the classifier's per-subscriber channel and in the splitter's plain `Subscribe<T>` — all three fixed here.

## Why unbounded

Mirrors the precedent set by the Phase 1+ producer-side channels (`SkillFrameProducer`, `AreaLoadingFrameProducer`, `PlayerInventoryFrameProducer`, ...): PG's source-stream rate is human-bounded, so unbounded growth is bounded in practice by the source. A genuinely-stalled subscriber is a bug to surface via L1 diagnostics, not data to silently drop.

The L1 driver's `MarshaledBridge` keeps its bounded 1024 queue — those drops are recorded via `RecordDrop` and surface on `LogSubscriptionDiagnostics`, a different design point (intentional visible backpressure) from the silent drops fixed here.

## Out of scope (filed as follow-ups)

- **The world merger's "every producer must have a head" invariant** is structurally over-restrictive for a single-source world. The L1 source-`Sequence` is already a total order; an N-way merger contributes no ordering guarantee the L1 driver doesn't already provide. After this fix, the same blocking pattern still applies if any registered producer is silent for a long stretch (e.g., `AreaLoadingFrameProducer` between portals — by design it never emits during the L1 replay window). Design-notebook entry covering this rethink will follow.
- **`PlayerLogStream` and `ChatLogStream`** use the same 1024 + DropOldest pattern but have a snapshot-bypass for late-joining subscribers. Live drops there are mitigated; not in this PR's scope.

## Test plan

- [x] ``dotnet build Mithril.slnx`` — clean (0 warnings, 0 errors, warnings-as-errors enforced)
- [x] ``dotnet test Mithril.slnx`` — clean across all 25 test projects (3,818 tests total)
- [x] Two new regression tests in ``PlayerLogPipeSplitterTests`` push 5000 LocalPlayer envelopes through both the plain ``Subscribe<T>`` path and the L1-driver-facing ``SubscribeWithMarker<T>`` path; subscriber must receive every Sequence in source order
- [ ] Manual: launch Mithril against a long PG session, observe live area changes reach Palantir + Legolas

🤖 Generated with [Claude Code](https://claude.com/claude-code)