### PR TITLE
Halt Arda on grammar drift; preserve last-known-good snapshots

### DIFF
--- a/src/Arda/Arda.Composition/CompositionExtensions.cs
+++ b/src/Arda/Arda.Composition/CompositionExtensions.cs
@@ -45,6 +45,7 @@ public static class CompositionExtensions
             }
 
             return new InventoryComposer(bus, store,
+                sp.GetService<IGrammarBreakSignal>(),
                 loggerFactory?.CreateLogger("InventoryComposer"));
         });
         services.AddSingleton<IInventoryAccumulatorState>(sp =>
@@ -69,6 +70,7 @@ public static class CompositionExtensions
             var resolver = recipeKeyResolverFactory?.Invoke(sp);
 
             return new PlayerProgressionComposer(bus, playerState, store, resolver,
+                sp.GetService<IGrammarBreakSignal>(),
                 loggerFactory?.CreateLogger("PlayerProgressionComposer"));
         });
         services.AddSingleton<IPlayerProgressionState>(sp =>
@@ -93,6 +95,7 @@ public static class CompositionExtensions
             }
 
             return new NpcStateComposer(bus, npcStore,
+                sp.GetService<IGrammarBreakSignal>(),
                 loggerFactory?.CreateLogger("NpcStateComposer"));
         });
         services.AddSingleton<INpcStateTracker>(sp => sp.GetRequiredService<NpcStateComposer>());

--- a/src/Arda/Arda.Composition/Internal/InventoryComposer.cs
+++ b/src/Arda/Arda.Composition/Internal/InventoryComposer.cs
@@ -261,10 +261,10 @@ internal sealed class InventoryComposer : IInventoryAccumulatorState, IDisposabl
         if (_store is null || _currentCharacter is null || _currentServer is null)
             return;
 
-        if (_grammarSignal?.IsRaised == true)
+        if (_grammarSignal?.HasObservedBreak == true)
         {
             _logger?.LogWarning(
-                "Skipping accumulator snapshot save for {Character}/{Server}: grammar break in this session",
+                "Skipping accumulator snapshot save for {Character}/{Server}: grammar break observed in this session",
                 _currentCharacter, _currentServer);
             return;
         }

--- a/src/Arda/Arda.Composition/Internal/InventoryComposer.cs
+++ b/src/Arda/Arda.Composition/Internal/InventoryComposer.cs
@@ -25,6 +25,7 @@ internal sealed class InventoryComposer : IInventoryAccumulatorState, IDisposabl
 
     private readonly IDomainEventBus _bus;
     private readonly PerCharacterStore<AccumulatorSnapshot>? _store;
+    private readonly IGrammarBreakSignal? _grammarSignal;
     private readonly ILogger? _logger;
 
     // ── Correlation state ─────────────────────────────────────────────────
@@ -50,10 +51,12 @@ internal sealed class InventoryComposer : IInventoryAccumulatorState, IDisposabl
     public InventoryComposer(
         IDomainEventBus bus,
         PerCharacterStore<AccumulatorSnapshot>? store = null,
+        IGrammarBreakSignal? grammarSignal = null,
         ILogger? logger = null)
     {
         _bus = bus;
         _store = store;
+        _grammarSignal = grammarSignal;
         _logger = logger;
 
         _addSub = bus.Subscribe<InventoryItemAdded>(OnItemAdded);
@@ -257,6 +260,14 @@ internal sealed class InventoryComposer : IInventoryAccumulatorState, IDisposabl
     {
         if (_store is null || _currentCharacter is null || _currentServer is null)
             return;
+
+        if (_grammarSignal?.IsRaised == true)
+        {
+            _logger?.LogWarning(
+                "Skipping accumulator snapshot save for {Character}/{Server}: grammar break in this session",
+                _currentCharacter, _currentServer);
+            return;
+        }
 
         var snapshot = new AccumulatorSnapshot();
         foreach (var (id, item) in _items)

--- a/src/Arda/Arda.Composition/Internal/NpcStateComposer.cs
+++ b/src/Arda/Arda.Composition/Internal/NpcStateComposer.cs
@@ -221,10 +221,10 @@ internal sealed class NpcStateComposer : INpcStateTracker, IDisposable
         if (_store is null || _currentCharacter is null || _currentServer is null)
             return;
 
-        if (_grammarSignal?.IsRaised == true)
+        if (_grammarSignal?.HasObservedBreak == true)
         {
             _logger?.LogWarning(
-                "Skipping NPC state snapshot save for {Character}/{Server}: grammar break in this session",
+                "Skipping NPC state snapshot save for {Character}/{Server}: grammar break observed in this session",
                 _currentCharacter, _currentServer);
             return;
         }

--- a/src/Arda/Arda.Composition/Internal/NpcStateComposer.cs
+++ b/src/Arda/Arda.Composition/Internal/NpcStateComposer.cs
@@ -17,6 +17,7 @@ internal sealed class NpcStateComposer : INpcStateTracker, IDisposable
 {
     private readonly IDomainEventBus _bus;
     private readonly PerCharacterStore<NpcStateSnapshot>? _store;
+    private readonly IGrammarBreakSignal? _grammarSignal;
     private readonly ILogger? _logger;
 
     private readonly Dictionary<string, NpcRecord> _npcs = new(StringComparer.Ordinal);
@@ -36,10 +37,12 @@ internal sealed class NpcStateComposer : INpcStateTracker, IDisposable
     public NpcStateComposer(
         IDomainEventBus bus,
         PerCharacterStore<NpcStateSnapshot>? store = null,
+        IGrammarBreakSignal? grammarSignal = null,
         ILogger? logger = null)
     {
         _bus = bus;
         _store = store;
+        _grammarSignal = grammarSignal;
         _logger = logger;
 
         _interactionSub = bus.Subscribe<InteractionStarted>(OnInteractionStarted);
@@ -217,6 +220,14 @@ internal sealed class NpcStateComposer : INpcStateTracker, IDisposable
     {
         if (_store is null || _currentCharacter is null || _currentServer is null)
             return;
+
+        if (_grammarSignal?.IsRaised == true)
+        {
+            _logger?.LogWarning(
+                "Skipping NPC state snapshot save for {Character}/{Server}: grammar break in this session",
+                _currentCharacter, _currentServer);
+            return;
+        }
 
         var snapshot = new NpcStateSnapshot();
         foreach (var (key, record) in _npcs)

--- a/src/Arda/Arda.Composition/Internal/PlayerProgressionComposer.cs
+++ b/src/Arda/Arda.Composition/Internal/PlayerProgressionComposer.cs
@@ -20,6 +20,7 @@ internal sealed class PlayerProgressionComposer : IPlayerProgressionState, IDisp
     private readonly IPlayerState _playerState;
     private readonly PerCharacterStore<ProgressionSnapshot>? _store;
     private readonly Func<int, string?>? _recipeKeyResolver;
+    private readonly IGrammarBreakSignal? _grammarSignal;
     private readonly ILogger? _logger;
 
     // ── Live state ────────────────────────────────────────────────────────
@@ -44,12 +45,14 @@ internal sealed class PlayerProgressionComposer : IPlayerProgressionState, IDisp
         IPlayerState playerState,
         PerCharacterStore<ProgressionSnapshot>? store = null,
         Func<int, string?>? recipeKeyResolver = null,
+        IGrammarBreakSignal? grammarSignal = null,
         ILogger? logger = null)
     {
         _bus = bus;
         _playerState = playerState;
         _store = store;
         _recipeKeyResolver = recipeKeyResolver;
+        _grammarSignal = grammarSignal;
         _logger = logger;
 
         _skillsLoadedSub = bus.Subscribe<SkillsLoaded>(OnSkillsLoaded);
@@ -169,6 +172,14 @@ internal sealed class PlayerProgressionComposer : IPlayerProgressionState, IDisp
     {
         if (!CanPersist)
             return;
+
+        if (_grammarSignal?.IsRaised == true)
+        {
+            _logger?.LogWarning(
+                "Skipping progression snapshot save for {Character}/{Server}: grammar break in this session",
+                _currentCharacter, _currentServer);
+            return;
+        }
 
         var store = _store!;
         var character = _currentCharacter!;

--- a/src/Arda/Arda.Composition/Internal/PlayerProgressionComposer.cs
+++ b/src/Arda/Arda.Composition/Internal/PlayerProgressionComposer.cs
@@ -173,10 +173,10 @@ internal sealed class PlayerProgressionComposer : IPlayerProgressionState, IDisp
         if (!CanPersist)
             return;
 
-        if (_grammarSignal?.IsRaised == true)
+        if (_grammarSignal?.HasObservedBreak == true)
         {
             _logger?.LogWarning(
-                "Skipping progression snapshot save for {Character}/{Server}: grammar break in this session",
+                "Skipping progression snapshot save for {Character}/{Server}: grammar break observed in this session",
                 _currentCharacter, _currentServer);
             return;
         }

--- a/src/Arda/Arda.Contracts/State/Health/GrammarBreak.cs
+++ b/src/Arda/Arda.Contracts/State/Health/GrammarBreak.cs
@@ -1,0 +1,13 @@
+namespace Arda.Contracts.State.Health;
+
+/// <summary>
+/// Captured details of a grammar drift that halted an Arda driver. Surfaced
+/// via <see cref="IWorldHealthView.Break"/> for the shell banner.
+/// </summary>
+public sealed record GrammarBreak(
+    string SourceFamily,
+    string Verb,
+    string SourceLine,
+    string TokenExcerpt,
+    string ParserHint,
+    DateTimeOffset At);

--- a/src/Arda/Arda.Contracts/State/Health/IWorldHealthView.cs
+++ b/src/Arda/Arda.Contracts/State/Health/IWorldHealthView.cs
@@ -17,8 +17,18 @@ public interface IWorldHealthView
     bool AllLive { get; }
 
     /// <summary>
+    /// Non-null when the Arda pipeline has halted on a grammar drift. The shell
+    /// surfaces a blocking banner in this state; module tabs continue to render
+    /// whatever state they accumulated pre-halt but no new events arrive.
+    /// </summary>
+    GrammarBreak? Break { get; }
+
+    /// <summary>True when <see cref="Break"/> is non-null.</summary>
+    bool IsHalted { get; }
+
+    /// <summary>
     /// Fires after any health state mutation. Consumers should re-read the
-    /// <see cref="Player"/> and <see cref="Chat"/> properties.
+    /// <see cref="Player"/>, <see cref="Chat"/>, and <see cref="Break"/> properties.
     /// </summary>
     event EventHandler? Changed;
 }

--- a/src/Arda/Arda.Contracts/State/Health/IWorldHealthView.cs
+++ b/src/Arda/Arda.Contracts/State/Health/IWorldHealthView.cs
@@ -17,18 +17,37 @@ public interface IWorldHealthView
     bool AllLive { get; }
 
     /// <summary>
-    /// Non-null when the Arda pipeline has halted on a grammar drift. The shell
-    /// surfaces a blocking banner in this state; module tabs continue to render
-    /// whatever state they accumulated pre-halt but no new events arrive.
+    /// Non-null when at least one grammar break has been observed this session
+    /// (either via halt or via tolerant-mode observation). The shell uses this
+    /// to populate banner copy.
     /// </summary>
     GrammarBreak? Break { get; }
 
-    /// <summary>True when <see cref="Break"/> is non-null.</summary>
+    /// <summary>
+    /// True when the Arda pipeline has halted on a grammar drift (default
+    /// mode). The shell surfaces a blocking halt banner in this state.
+    /// </summary>
     bool IsHalted { get; }
 
     /// <summary>
+    /// True when the pipeline has observed at least one grammar break but is
+    /// running in tolerant mode (<c>MITHRIL_GRAMMAR_TOLERANT=1</c>) and is
+    /// therefore not halted. The shell surfaces an amber warning banner to
+    /// keep the developer honest about what the env var is hiding.
+    /// </summary>
+    bool IsTolerantBreakActive { get; }
+
+    /// <summary>
+    /// Total breaks observed this session (halt + tolerant combined). Drives
+    /// the "{N} parse failures so far" copy in the tolerant banner.
+    /// </summary>
+    int ObservedBreakCount { get; }
+
+    /// <summary>
     /// Fires after any health state mutation. Consumers should re-read the
-    /// <see cref="Player"/>, <see cref="Chat"/>, and <see cref="Break"/> properties.
+    /// <see cref="Player"/>, <see cref="Chat"/>, <see cref="Break"/>,
+    /// <see cref="IsHalted"/>, <see cref="IsTolerantBreakActive"/>, and
+    /// <see cref="ObservedBreakCount"/> properties.
     /// </summary>
     event EventHandler? Changed;
 }

--- a/src/Arda/Arda.Contracts/State/Health/WorldHealth.cs
+++ b/src/Arda/Arda.Contracts/State/Health/WorldHealth.cs
@@ -23,5 +23,11 @@ public enum WorldMode
     Replaying,
 
     /// <summary>Caught up; tailing live log output.</summary>
-    Live
+    Live,
+
+    /// <summary>
+    /// Halted on a <c>GrammarException</c>. The driver has stopped consuming;
+    /// the world model is frozen at the last successfully-processed line.
+    /// </summary>
+    Halted
 }

--- a/src/Arda/Arda.Dispatch/ArgTokenizer.cs
+++ b/src/Arda/Arda.Dispatch/ArgTokenizer.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Arda.Dispatch;
 
 /// <summary>
@@ -7,12 +9,30 @@ namespace Arda.Dispatch;
 /// Typical usage: construct with the args span (starting at '('), call
 /// <see cref="SkipOpen"/>, then call <c>Next*</c> methods in positional order.
 /// </para>
+/// <para>
+/// <c>Next*</c> methods throw <see cref="GrammarException"/> on malformed
+/// input — the default for required fields. Use the <c>TryNext*</c> siblings
+/// only for fields that are legitimately optional (e.g. trailing args added
+/// in newer game versions, unknown enum tokens).
+/// </para>
 /// </summary>
 public ref struct ArgTokenizer
 {
     private ReadOnlySpan<char> _remaining;
+    private readonly string _verb;
+    private readonly string _sourceLog;
 
-    public ArgTokenizer(ReadOnlySpan<char> args) => _remaining = args;
+    /// <summary>
+    /// Construct a tokenizer with verb + source-line context for throw
+    /// reporting. The verb is allocated to a string at construction (cold
+    /// path is the throw path; this keeps the throw site simple).
+    /// </summary>
+    public ArgTokenizer(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog)
+    {
+        _remaining = args;
+        _verb = verb.ToString();
+        _sourceLog = sourceLog;
+    }
 
     /// <summary>Skip past the opening '(' if present.</summary>
     public void SkipOpen()
@@ -21,32 +41,97 @@ public ref struct ArgTokenizer
             _remaining = _remaining[1..];
     }
 
-    /// <summary>Read next token as <see cref="long"/>. Advances past trailing delimiter.</summary>
+    /// <summary>Read next token as <see cref="long"/>. Throws <see cref="GrammarException"/> on parse failure.</summary>
     public long NextLong()
     {
         var token = NextRawToken();
-        return long.Parse(token, System.Globalization.CultureInfo.InvariantCulture);
+        if (!long.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            throw GrammarFail(token, "expected long");
+        return value;
     }
 
-    /// <summary>Read next token as <see cref="int"/>. Advances past trailing delimiter.</summary>
+    /// <summary>Read next token as <see cref="int"/>. Throws <see cref="GrammarException"/> on parse failure.</summary>
     public int NextInt()
     {
         var token = NextRawToken();
-        return int.Parse(token, System.Globalization.CultureInfo.InvariantCulture);
+        if (!int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            throw GrammarFail(token, "expected int");
+        return value;
     }
 
-    /// <summary>Read next token as <see cref="double"/>. Advances past trailing delimiter.</summary>
+    /// <summary>Read next token as <see cref="double"/>. Throws <see cref="GrammarException"/> on parse failure.</summary>
     public double NextDouble()
     {
         var token = NextRawToken();
-        return double.Parse(token, System.Globalization.CultureInfo.InvariantCulture);
+        if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+            throw GrammarFail(token, "expected double");
+        return value;
     }
 
-    /// <summary>Read next token as <see cref="bool"/>. Advances past trailing delimiter.</summary>
+    /// <summary>Read next token as <see cref="bool"/>.</summary>
     public bool NextBool()
     {
         var token = NextRawToken();
         return token is "True" or "true" or "1";
+    }
+
+    /// <summary>
+    /// Try-variant of <see cref="NextLong"/>. Returns <c>false</c> without
+    /// throwing if no token remains or the token cannot be parsed. Reserved
+    /// for legitimately-optional fields.
+    /// </summary>
+    public bool TryNextLong(out long value)
+    {
+        if (!TryPeekRawToken(out var token) ||
+            !long.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+        {
+            value = 0;
+            return false;
+        }
+
+        ConsumeRawToken();
+        return true;
+    }
+
+    /// <summary>Try-variant of <see cref="NextInt"/>. See <see cref="TryNextLong"/>.</summary>
+    public bool TryNextInt(out int value)
+    {
+        if (!TryPeekRawToken(out var token) ||
+            !int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+        {
+            value = 0;
+            return false;
+        }
+
+        ConsumeRawToken();
+        return true;
+    }
+
+    /// <summary>Try-variant of <see cref="NextDouble"/>. See <see cref="TryNextLong"/>.</summary>
+    public bool TryNextDouble(out double value)
+    {
+        if (!TryPeekRawToken(out var token) ||
+            !double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out value))
+        {
+            value = 0;
+            return false;
+        }
+
+        ConsumeRawToken();
+        return true;
+    }
+
+    /// <summary>Try-variant of <see cref="NextBool"/>. Always consumes the token if present.</summary>
+    public bool TryNextBool(out bool value)
+    {
+        if (!HasMore)
+        {
+            value = false;
+            return false;
+        }
+
+        value = NextBool();
+        return true;
     }
 
     /// <summary>
@@ -60,7 +145,7 @@ public ref struct ArgTokenizer
         if (_remaining.Length == 0 || _remaining[0] != '"')
             return NextRawToken();
 
-        _remaining = _remaining[1..]; // skip opening quote
+        _remaining = _remaining[1..];
         var closeIdx = _remaining.IndexOf('"');
         if (closeIdx < 0)
         {
@@ -77,6 +162,38 @@ public ref struct ArgTokenizer
 
     /// <summary>Read next unquoted token as a span (no allocation).</summary>
     public ReadOnlySpan<char> NextTokenSpan() => NextRawToken();
+
+    /// <summary>
+    /// Try-variant of <see cref="NextTokenSpan"/>. Returns <c>false</c> when
+    /// no more tokens remain.
+    /// </summary>
+    public bool TryNextTokenSpan(out ReadOnlySpan<char> token)
+    {
+        if (!HasMore)
+        {
+            token = ReadOnlySpan<char>.Empty;
+            return false;
+        }
+
+        token = NextRawToken();
+        return true;
+    }
+
+    /// <summary>
+    /// Try-variant of <see cref="NextQuotedSpan"/>. Returns <c>false</c> when
+    /// no more tokens remain.
+    /// </summary>
+    public bool TryNextQuotedSpan(out ReadOnlySpan<char> value)
+    {
+        if (!HasMore)
+        {
+            value = ReadOnlySpan<char>.Empty;
+            return false;
+        }
+
+        value = NextQuotedSpan();
+        return true;
+    }
 
     /// <summary>Read a bracketed array [...] as a span (no allocation).</summary>
     public ReadOnlySpan<char> NextBracketedSpan() => NextBalanced('[', ']');
@@ -132,6 +249,32 @@ public ref struct ArgTokenizer
         return token;
     }
 
+    private bool TryPeekRawToken(out ReadOnlySpan<char> token)
+    {
+        SkipWhitespace();
+        if (_remaining.Length == 0 || _remaining[0] == ')')
+        {
+            token = ReadOnlySpan<char>.Empty;
+            return false;
+        }
+
+        var end = _remaining.IndexOfAny(',', ')');
+        token = end < 0 ? _remaining.TrimEnd() : _remaining[..end].TrimEnd();
+        return true;
+    }
+
+    private void ConsumeRawToken()
+    {
+        var end = _remaining.IndexOfAny(',', ')');
+        if (end < 0)
+        {
+            _remaining = ReadOnlySpan<char>.Empty;
+            return;
+        }
+        _remaining = _remaining[end..];
+        SkipDelimiter();
+    }
+
     private ReadOnlySpan<char> NextBalanced(char open, char close)
     {
         SkipWhitespace();
@@ -146,14 +289,14 @@ public ref struct ArgTokenizer
 
             if (depth == 0)
             {
-                var value = _remaining[1..i]; // exclude outer brackets
+                var value = _remaining[1..i];
                 _remaining = _remaining[(i + 1)..];
                 SkipDelimiter();
                 return value;
             }
         }
 
-        var all = _remaining[1..]; // unclosed — return everything after open
+        var all = _remaining[1..];
         _remaining = ReadOnlySpan<char>.Empty;
         return all;
     }
@@ -171,4 +314,7 @@ public ref struct ArgTokenizer
             SkipWhitespace();
         }
     }
+
+    private GrammarException GrammarFail(ReadOnlySpan<char> token, string hint) =>
+        new(_verb, _sourceLog, token.ToString(), hint);
 }

--- a/src/Arda/Arda.Dispatch/DispatchTable.cs
+++ b/src/Arda/Arda.Dispatch/DispatchTable.cs
@@ -27,8 +27,11 @@ internal sealed class DispatchTable
     /// <summary>
     /// Parse and dispatch a line to registered handlers. If the line has no
     /// recognizable verb, or no handler is registered, it is silently discarded
-    /// (zero allocation). A throwing handler is caught and logged — it does not
-    /// prevent subsequent handlers from executing.
+    /// (zero allocation). A handler bug is caught and logged — it does not
+    /// prevent subsequent handlers from executing on the same line. A
+    /// <see cref="GrammarException"/> is NOT caught here: it propagates out so
+    /// the surrounding <c>WorldDriver</c> can halt the simulation, since a
+    /// grammar drift means the in-memory world model is no longer trustworthy.
     /// </summary>
     public void Dispatch(ParsedVerb parsed, string sourceLog, LogLineMetadata metadata)
     {
@@ -44,10 +47,19 @@ internal sealed class DispatchTable
             {
                 handler.Handle(parsed.Args, parsed.Verb, sourceLog, metadata);
             }
+            catch (GrammarException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Handler {Handler} threw on verb dispatch", handler.GetType().Name);
+                _logger.LogError(ex,
+                    "Handler {Handler} threw on verb {Verb}: {Excerpt}",
+                    handler.GetType().Name, parsed.Verb.ToString(), Excerpt(sourceLog));
             }
         }
     }
+
+    private static string Excerpt(string log) =>
+        log.Length <= 200 ? log : log[..200] + "…";
 }

--- a/src/Arda/Arda.Dispatch/DispatchTable.cs
+++ b/src/Arda/Arda.Dispatch/DispatchTable.cs
@@ -42,7 +42,7 @@ internal sealed class DispatchTable
         {
             try
             {
-                handler.Handle(parsed.Args, sourceLog, metadata);
+                handler.Handle(parsed.Args, parsed.Verb, sourceLog, metadata);
             }
             catch (Exception ex)
             {

--- a/src/Arda/Arda.Dispatch/GrammarException.cs
+++ b/src/Arda/Arda.Dispatch/GrammarException.cs
@@ -1,0 +1,34 @@
+namespace Arda.Dispatch;
+
+/// <summary>
+/// Thrown when <see cref="ArgTokenizer"/> encounters a token it cannot parse
+/// against the expected grammar. Propagates out of <see cref="DispatchTable"/>
+/// so <c>WorldDriver</c> can halt the simulation — this is not a recoverable
+/// per-handler failure.
+/// </summary>
+public sealed class GrammarException : Exception
+{
+    private const int MaxExcerptLength = 256;
+
+    public string Verb { get; }
+    public string SourceLine { get; }
+    public string TokenExcerpt { get; }
+    public string ParserHint { get; }
+
+    public GrammarException(
+        string verb,
+        string sourceLine,
+        string tokenExcerpt,
+        string parserHint,
+        Exception? inner = null)
+        : base($"Grammar drift on verb {verb}: {parserHint} (token '{Truncate(tokenExcerpt, 64)}')", inner)
+    {
+        Verb = verb;
+        SourceLine = Truncate(sourceLine, MaxExcerptLength);
+        TokenExcerpt = Truncate(tokenExcerpt, MaxExcerptLength);
+        ParserHint = parserHint;
+    }
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max] + "…";
+}

--- a/src/Arda/Arda.Dispatch/IFrameHandler.cs
+++ b/src/Arda/Arda.Dispatch/IFrameHandler.cs
@@ -4,12 +4,16 @@ namespace Arda.Dispatch;
 
 /// <summary>
 /// Handles a dispatched verb from the L2 driver. Receives the args span
-/// (everything after the verb in the log line) and the line metadata.
+/// (everything after the verb in the log line), the verb span (for
+/// constructing tokenizers + error reporting), the source line, and metadata.
 /// The handler tokenizes positionally on the span and emits domain events.
 /// <para>
 /// Implementations should avoid allocating strings for values they don't
 /// need to persist. Use <see cref="ArgTokenizer"/> for positional parsing
-/// and <see cref="InternPool"/> for known identifier families.
+/// and <see cref="InternPool"/> for known identifier families. Construct
+/// <c>ArgTokenizer</c> with the supplied <paramref name="verb"/> and
+/// <paramref name="sourceLog"/> so parse failures throw a
+/// <see cref="GrammarException"/> with the necessary context.
 /// </para>
 /// </summary>
 public interface IFrameHandler
@@ -17,8 +21,11 @@ public interface IFrameHandler
     /// <summary>
     /// Process a dispatched line. <paramref name="args"/> contains everything
     /// after the verb (including the opening parenthesis for Process* verbs).
-    /// <paramref name="sourceLog"/> is the full <see cref="LogLine.Log"/> string,
-    /// available for <see cref="ReadOnlyMemory{T}"/> slicing in passthrough handlers.
+    /// <paramref name="verb"/> is the dispatched verb span (e.g.
+    /// <c>"ProcessAddItem"</c>). <paramref name="sourceLog"/> is the full
+    /// <see cref="LogLine.Log"/> string, available for <see cref="ReadOnlyMemory{T}"/>
+    /// slicing in passthrough handlers and for <see cref="GrammarException"/>
+    /// context.
     /// </summary>
-    void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata);
+    void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata);
 }

--- a/src/Arda/Arda.Dispatch/IGrammarBreakSignal.cs
+++ b/src/Arda/Arda.Dispatch/IGrammarBreakSignal.cs
@@ -4,16 +4,56 @@ using Microsoft.Extensions.Logging;
 namespace Arda.Dispatch;
 
 /// <summary>
-/// One-shot signal raised when the first <see cref="GrammarException"/> escapes
-/// a <c>WorldDriver</c>. Subscribers (the companion driver, the shell health
-/// view) react to <see cref="Raised"/> to halt cooperatively.
+/// Reports grammar drift observed by the Arda pipeline.
+/// <para>
+/// Two channels:
+/// <list type="bullet">
+///   <item><see cref="IsRaised"/> — halt requested. Companion driver stops at
+///   its next loop iteration; the shell shows a blocking halt banner. Set only
+///   in the default (non-tolerant) mode via <see cref="Raise"/>.</item>
+///   <item><see cref="HasObservedBreak"/> — any break has been seen this
+///   session. Gates composer snapshot writes; set by both <see cref="Raise"/>
+///   and <see cref="MarkObserved"/> (the tolerant-mode path). Without this gate,
+///   tolerant mode would silently persist divergent state to per-character
+///   stores on next launch.</item>
+/// </list>
+/// <see cref="Raise"/> is a superset of <see cref="MarkObserved"/>: raising
+/// also marks the break as observed, so halt-mode persistence stays gated.
+/// </para>
 /// </summary>
 public interface IGrammarBreakSignal
 {
+    /// <summary>The first break captured this session, or null if none.</summary>
     GrammarBreak? Current { get; }
+
+    /// <summary>True once <see cref="Raise"/> has been called. Drives halt.</summary>
     bool IsRaised { get; }
+
+    /// <summary>
+    /// True once either <see cref="Raise"/> or <see cref="MarkObserved"/> has
+    /// been called. Drives composer persistence gating and the shell's
+    /// tolerant-mode banner.
+    /// </summary>
+    bool HasObservedBreak { get; }
+
+    /// <summary>Total breaks seen this session (halt + tolerant combined).</summary>
+    int ObservedCount { get; }
+
+    /// <summary>Default mode: halt + observe. Idempotent on Current.</summary>
     void Raise(GrammarBreak breakDetails);
+
+    /// <summary>Tolerant mode: observe only. Loop continues; halt is not requested.</summary>
+    void MarkObserved(GrammarBreak breakDetails);
+
+    /// <summary>Fires on the first <see cref="Raise"/> (halt transition).</summary>
     event EventHandler? Raised;
+
+    /// <summary>
+    /// Fires on every <see cref="Raise"/> or <see cref="MarkObserved"/> call.
+    /// Use for UI surfaces that want to update on every tolerant-mode break
+    /// (e.g. "{ObservedCount} parse failures so far" in the banner).
+    /// </summary>
+    event EventHandler? ObservedBreakChanged;
 }
 
 internal sealed class GrammarBreakSignal : IGrammarBreakSignal
@@ -21,6 +61,8 @@ internal sealed class GrammarBreakSignal : IGrammarBreakSignal
     private readonly object _gate = new();
     private readonly ILogger<GrammarBreakSignal>? _logger;
     private GrammarBreak? _current;
+    private bool _raised;
+    private int _observedCount;
 
     public GrammarBreakSignal(ILogger<GrammarBreakSignal>? logger = null) => _logger = logger;
 
@@ -31,36 +73,52 @@ internal sealed class GrammarBreakSignal : IGrammarBreakSignal
 
     public bool IsRaised
     {
-        get { lock (_gate) return _current is not null; }
+        get { lock (_gate) return _raised; }
+    }
+
+    public bool HasObservedBreak
+    {
+        get { lock (_gate) return _observedCount > 0; }
+    }
+
+    public int ObservedCount
+    {
+        get { lock (_gate) return _observedCount; }
     }
 
     public event EventHandler? Raised;
+    public event EventHandler? ObservedBreakChanged;
 
     public void Raise(GrammarBreak breakDetails)
     {
-        bool first;
+        bool firstRaise;
         lock (_gate)
         {
-            if (_current is null)
-            {
-                _current = breakDetails;
-                first = true;
-            }
-            else
-            {
-                first = false;
-            }
+            firstRaise = !_raised;
+            _raised = true;
+            _current ??= breakDetails;
+            _observedCount++;
         }
 
-        if (first)
-        {
-            Raised?.Invoke(this, EventArgs.Empty);
-        }
-        else
+        if (!firstRaise)
         {
             _logger?.LogDebug(
-                "Subsequent grammar break for {Verb} ignored; first break ({FirstVerb}) stands",
+                "Subsequent grammar break for {Verb} ignored for halt purposes; first break ({FirstVerb}) stands",
                 breakDetails.Verb, _current!.Verb);
         }
+
+        ObservedBreakChanged?.Invoke(this, EventArgs.Empty);
+        if (firstRaise)
+            Raised?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void MarkObserved(GrammarBreak breakDetails)
+    {
+        lock (_gate)
+        {
+            _current ??= breakDetails;
+            _observedCount++;
+        }
+        ObservedBreakChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/Arda/Arda.Dispatch/IGrammarBreakSignal.cs
+++ b/src/Arda/Arda.Dispatch/IGrammarBreakSignal.cs
@@ -1,0 +1,66 @@
+using Arda.Contracts.State.Health;
+using Microsoft.Extensions.Logging;
+
+namespace Arda.Dispatch;
+
+/// <summary>
+/// One-shot signal raised when the first <see cref="GrammarException"/> escapes
+/// a <c>WorldDriver</c>. Subscribers (the companion driver, the shell health
+/// view) react to <see cref="Raised"/> to halt cooperatively.
+/// </summary>
+public interface IGrammarBreakSignal
+{
+    GrammarBreak? Current { get; }
+    bool IsRaised { get; }
+    void Raise(GrammarBreak breakDetails);
+    event EventHandler? Raised;
+}
+
+internal sealed class GrammarBreakSignal : IGrammarBreakSignal
+{
+    private readonly object _gate = new();
+    private readonly ILogger<GrammarBreakSignal>? _logger;
+    private GrammarBreak? _current;
+
+    public GrammarBreakSignal(ILogger<GrammarBreakSignal>? logger = null) => _logger = logger;
+
+    public GrammarBreak? Current
+    {
+        get { lock (_gate) return _current; }
+    }
+
+    public bool IsRaised
+    {
+        get { lock (_gate) return _current is not null; }
+    }
+
+    public event EventHandler? Raised;
+
+    public void Raise(GrammarBreak breakDetails)
+    {
+        bool first;
+        lock (_gate)
+        {
+            if (_current is null)
+            {
+                _current = breakDetails;
+                first = true;
+            }
+            else
+            {
+                first = false;
+            }
+        }
+
+        if (first)
+        {
+            Raised?.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            _logger?.LogDebug(
+                "Subsequent grammar break for {Verb} ignored; first break ({FirstVerb}) stands",
+                breakDetails.Verb, _current!.Verb);
+        }
+    }
+}

--- a/src/Arda/Arda.Dispatch/WorldDriver.cs
+++ b/src/Arda/Arda.Dispatch/WorldDriver.cs
@@ -1,4 +1,5 @@
 using Arda.Abstractions.Logs;
+using Arda.Contracts.State.Health;
 using Microsoft.Extensions.Logging;
 
 namespace Arda.Dispatch;
@@ -8,6 +9,14 @@ namespace Arda.Dispatch;
 /// extracts verbs via <see cref="VerbExtractor"/>, and routes to the
 /// <see cref="DispatchTable"/>. Optionally signals when the stream transitions
 /// from replay to live (first line with <c>IsReplay = false</c>).
+/// <para>
+/// On a <see cref="GrammarException"/> escaping the dispatch table, the
+/// driver records a <see cref="GrammarBreak"/> on the shared
+/// <see cref="IGrammarBreakSignal"/> and returns — the companion driver
+/// halts cooperatively at its next loop iteration. With
+/// <paramref name="tolerantGrammar"/>=true, the exception is downgraded
+/// to a throttled warning and the loop continues (dev escape hatch).
+/// </para>
 /// </summary>
 internal sealed class WorldDriver : IWorldDriver
 {
@@ -17,6 +26,9 @@ internal sealed class WorldDriver : IWorldDriver
     private readonly IReadOnlyList<ILineObserver> _observers;
     private readonly ILogger? _logger;
     private readonly string? _sourceFamily;
+    private readonly IGrammarBreakSignal? _grammarSignal;
+    private readonly TimeProvider _time;
+    private readonly bool _tolerantGrammar;
     private long _lineCount;
 
     public WorldDriver(
@@ -25,7 +37,10 @@ internal sealed class WorldDriver : IWorldDriver
         Action? onLiveTransition = null,
         IReadOnlyList<ILineObserver>? observers = null,
         ILogger? logger = null,
-        string? sourceFamily = null)
+        string? sourceFamily = null,
+        IGrammarBreakSignal? grammarSignal = null,
+        TimeProvider? time = null,
+        bool tolerantGrammar = false)
     {
         _source = source;
         _dispatch = dispatch;
@@ -33,14 +48,27 @@ internal sealed class WorldDriver : IWorldDriver
         _observers = observers ?? [];
         _logger = logger;
         _sourceFamily = sourceFamily;
+        _grammarSignal = grammarSignal;
+        _time = time ?? TimeProvider.System;
+        _tolerantGrammar = tolerantGrammar;
     }
 
     public async Task RunAsync(CancellationToken ct)
     {
         var liveSignalled = _onLiveTransition is null;
+        var halted = false;
 
         await foreach (var line in _source.Lines(ct).WithCancellation(ct))
         {
+            if (_grammarSignal?.IsRaised == true)
+            {
+                _logger?.LogInformation(
+                    "Halting {SourceFamily} driver: companion driver raised grammar break",
+                    _sourceFamily ?? "unknown");
+                halted = true;
+                break;
+            }
+
             _lineCount++;
 
             if (!liveSignalled && !line.Metadata.IsReplay)
@@ -56,15 +84,43 @@ internal sealed class WorldDriver : IWorldDriver
                 observer.Observe(line.Log, line.Metadata);
 
             var parsed = VerbExtractor.Parse(line.Log.AsSpan());
-            _dispatch.Dispatch(parsed, line.Log, line.Metadata);
+            try
+            {
+                _dispatch.Dispatch(parsed, line.Log, line.Metadata);
+            }
+            catch (GrammarException ex)
+            {
+                if (_tolerantGrammar)
+                {
+                    _logger?.LogWarning(
+                        "Tolerant grammar mode: skipping line on {SourceFamily} (verb={Verb}, hint={Hint})",
+                        _sourceFamily ?? "unknown", ex.Verb, ex.ParserHint);
+                    continue;
+                }
+
+                _grammarSignal?.Raise(new GrammarBreak(
+                    _sourceFamily ?? "unknown",
+                    ex.Verb,
+                    ex.SourceLine,
+                    ex.TokenExcerpt,
+                    ex.ParserHint,
+                    _time.GetUtcNow()));
+
+                _logger?.LogError(ex,
+                    "Grammar break halted {SourceFamily} driver (verb={Verb}, hint={Hint})",
+                    _sourceFamily ?? "unknown", ex.Verb, ex.ParserHint);
+
+                halted = true;
+                break;
+            }
         }
 
         // Only force a live transition if the source ran genuinely dry
-        // (finite stream — typical of tests). On cancellation the live
-        // signal would resolve replay-complete latches and trigger
-        // flush-on-replay subscribers (e.g. PerCharacterStore) to write
-        // a partial snapshot, so we must not fire it during shutdown.
-        if (!liveSignalled && !ct.IsCancellationRequested)
+        // (finite stream — typical of tests). On cancellation OR halt the
+        // live signal would resolve replay-complete latches and trigger
+        // flush-on-replay subscribers (e.g. PerCharacterStore) to write a
+        // partial snapshot, so we must not fire it during shutdown / halt.
+        if (!liveSignalled && !ct.IsCancellationRequested && !halted)
         {
             _logger?.LogWarning(
                 "Live transition forced at end of stream for {SourceFamily} ({LineCount} lines processed)",
@@ -74,8 +130,9 @@ internal sealed class WorldDriver : IWorldDriver
         }
 
         _logger?.LogInformation(
-            "World driver completed for {SourceFamily} ({LineCount} lines processed)",
+            "World driver completed for {SourceFamily} ({LineCount} lines processed, halted={Halted})",
             _sourceFamily ?? "unknown",
-            _lineCount);
+            _lineCount,
+            halted);
     }
 }

--- a/src/Arda/Arda.Dispatch/WorldDriver.cs
+++ b/src/Arda/Arda.Dispatch/WorldDriver.cs
@@ -90,21 +90,24 @@ internal sealed class WorldDriver : IWorldDriver
             }
             catch (GrammarException ex)
             {
+                var details = new GrammarBreak(
+                    _sourceFamily ?? "unknown",
+                    ex.Verb,
+                    ex.SourceLine,
+                    ex.TokenExcerpt,
+                    ex.ParserHint,
+                    _time.GetUtcNow());
+
                 if (_tolerantGrammar)
                 {
+                    _grammarSignal?.MarkObserved(details);
                     _logger?.LogWarning(
                         "Tolerant grammar mode: skipping line on {SourceFamily} (verb={Verb}, hint={Hint})",
                         _sourceFamily ?? "unknown", ex.Verb, ex.ParserHint);
                     continue;
                 }
 
-                _grammarSignal?.Raise(new GrammarBreak(
-                    _sourceFamily ?? "unknown",
-                    ex.Verb,
-                    ex.SourceLine,
-                    ex.TokenExcerpt,
-                    ex.ParserHint,
-                    _time.GetUtcNow()));
+                _grammarSignal?.Raise(details);
 
                 _logger?.LogError(ex,
                     "Grammar break halted {SourceFamily} driver (verb={Verb}, hint={Hint})",

--- a/src/Arda/Arda.Hosting/ArdaRuntimeOptions.cs
+++ b/src/Arda/Arda.Hosting/ArdaRuntimeOptions.cs
@@ -1,0 +1,8 @@
+namespace Arda.Hosting;
+
+/// <summary>
+/// Runtime-only knobs derived from environment / process state, not from
+/// <see cref="ArdaOptions"/> (which is user-supplied configuration). Resolved
+/// once during <c>AddArda</c> and injected into the driver hosted services.
+/// </summary>
+public sealed record ArdaRuntimeOptions(bool TolerantGrammar);

--- a/src/Arda/Arda.Hosting/ArdaServiceCollectionExtensions.cs
+++ b/src/Arda/Arda.Hosting/ArdaServiceCollectionExtensions.cs
@@ -46,6 +46,10 @@ public static class ArdaServiceCollectionExtensions
         services.AddSingleton<IDomainEventSubscriber>(sp => sp.GetRequiredService<DomainEventBus>());
         services.AddSingleton<IDomainEventPublisher>(sp => sp.GetRequiredService<DomainEventBus>());
 
+        // Grammar-break signal (one-shot, halts both drivers on grammar drift)
+        services.AddSingleton<IGrammarBreakSignal>(sp =>
+            new GrammarBreakSignal(sp.GetService<ILogger<GrammarBreakSignal>>()));
+
         // Replay progress (shared, bindable from WPF splash)
         services.AddSingleton(sp =>
             new ReplayProgress(sp.GetService<ILogger<ReplayProgress>>()));

--- a/src/Arda/Arda.Hosting/ArdaServiceCollectionExtensions.cs
+++ b/src/Arda/Arda.Hosting/ArdaServiceCollectionExtensions.cs
@@ -50,6 +50,15 @@ public static class ArdaServiceCollectionExtensions
         services.AddSingleton<IGrammarBreakSignal>(sp =>
             new GrammarBreakSignal(sp.GetService<ILogger<GrammarBreakSignal>>()));
 
+        // Runtime-only toggles derived from process env (read once at startup)
+        var tolerant = string.Equals(
+            Environment.GetEnvironmentVariable("MITHRIL_GRAMMAR_TOLERANT"),
+            "1", StringComparison.Ordinal);
+        services.AddSingleton(new ArdaRuntimeOptions(TolerantGrammar: tolerant));
+
+        // TimeProvider — registered if the host hasn't already supplied one.
+        services.AddSingleton(TimeProvider.System);
+
         // Replay progress (shared, bindable from WPF splash)
         services.AddSingleton(sp =>
             new ReplayProgress(sp.GetService<ILogger<ReplayProgress>>()));

--- a/src/Arda/Arda.Hosting/Internal/ChatWorldService.cs
+++ b/src/Arda/Arda.Hosting/Internal/ChatWorldService.cs
@@ -12,6 +12,9 @@ internal sealed class ChatWorldService(
     ChatLogSource source,
     DispatchTable dispatchTable,
     ReplayProgress progress,
+    IGrammarBreakSignal grammarSignal,
+    ArdaRuntimeOptions runtimeOptions,
+    TimeProvider time,
     ILogger<ChatWorldService> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -24,7 +27,10 @@ internal sealed class ChatWorldService(
                 dispatchTable,
                 onLiveTransition: () => progress.MarkComplete(ReplayProgress.SourceFamily.Chat),
                 logger: logger,
-                sourceFamily: "Chat");
+                sourceFamily: "Chat",
+                grammarSignal: grammarSignal,
+                time: time,
+                tolerantGrammar: runtimeOptions.TolerantGrammar);
 
             await driver.RunAsync(stoppingToken).ConfigureAwait(false);
         }

--- a/src/Arda/Arda.Hosting/Internal/PlayerWorldService.cs
+++ b/src/Arda/Arda.Hosting/Internal/PlayerWorldService.cs
@@ -13,6 +13,9 @@ internal sealed class PlayerWorldService(
     DispatchTable dispatchTable,
     ReplayProgress progress,
     IReadOnlyList<ILineObserver> lineObservers,
+    IGrammarBreakSignal grammarSignal,
+    ArdaRuntimeOptions runtimeOptions,
+    TimeProvider time,
     ILogger<PlayerWorldService> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -26,7 +29,10 @@ internal sealed class PlayerWorldService(
                 onLiveTransition: () => progress.MarkComplete(ReplayProgress.SourceFamily.Player),
                 observers: lineObservers,
                 logger: logger,
-                sourceFamily: "Player");
+                sourceFamily: "Player",
+                grammarSignal: grammarSignal,
+                time: time,
+                tolerantGrammar: runtimeOptions.TolerantGrammar);
 
             await driver.RunAsync(stoppingToken).ConfigureAwait(false);
         }

--- a/src/Arda/Arda.World.Chat/Internal/ChatInventory.cs
+++ b/src/Arda/Arda.World.Chat/Internal/ChatInventory.cs
@@ -25,7 +25,7 @@ internal sealed class ChatInventory : IFrameHandler
 
     public ChatInventory(IDomainEventPublisher bus) => _bus = bus;
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         // args is the full line: "[Status] Apple x2 added to inventory."
         if (!args.StartsWith(Prefix) || !args.EndsWith(Suffix))

--- a/src/Arda/Arda.World.Chat/Internal/ChatLine.cs
+++ b/src/Arda/Arda.World.Chat/Internal/ChatLine.cs
@@ -17,7 +17,7 @@ internal sealed class ChatLine : IFrameHandler
 
     public ChatLine(IDomainEventPublisher bus) => _bus = bus;
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         if (args.Length < 3 || args[0] != '[')
             return;

--- a/src/Arda/Arda.World.Chat/Internal/ChatSession.cs
+++ b/src/Arda/Arda.World.Chat/Internal/ChatSession.cs
@@ -27,7 +27,7 @@ internal sealed class ChatSession : IFrameHandler, IChatSessionState
 
     public ChatSession(IDomainEventPublisher bus) => _bus = bus;
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         // args is the full line for chat verbs: "**** Logged In As Emraell. Server Laeth. ..."
         var loginIdx = args.IndexOf(LoggedInAs);

--- a/src/Arda/Arda.World.Player/Internal/AddItemHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/AddItemHandler.cs
@@ -8,6 +8,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class AddItemHandler(Inventory inventory) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => inventory.OnAddItem(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/Celestial.cs
+++ b/src/Arda/Arda.World.Player/Internal/Celestial.cs
@@ -30,9 +30,9 @@ internal sealed class Celestial : IFrameHandler, ICelestialState
         MeasuredAt = null;
     }
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var phaseSpan = tok.NextTokenSpan();

--- a/src/Arda/Arda.World.Player/Internal/DelayLoopHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/DelayLoopHandler.cs
@@ -12,9 +12,9 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class DelayLoopHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var seconds = tok.NextDouble();

--- a/src/Arda/Arda.World.Player/Internal/DeleteItemHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/DeleteItemHandler.cs
@@ -8,6 +8,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class DeleteItemHandler(Inventory inventory) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => inventory.OnDeleteItem(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/DeltaFavorHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/DeltaFavorHandler.cs
@@ -10,6 +10,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class DeltaFavorHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => npc.OnDeltaFavor(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => npc.OnDeltaFavor(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/Effects.cs
+++ b/src/Arda/Arda.World.Player/Internal/Effects.cs
@@ -42,9 +42,9 @@ internal sealed class Effects : IEffectsState
     /// <summary>
     /// <c>ProcessAddEffects(targetCharId, sourceCharId, "[catalogId1, catalogId2, ...]", bool)</c>
     /// </summary>
-    private void OnAdd(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnAdd(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         tok.Skip(1); // targetCharId
@@ -79,9 +79,9 @@ internal sealed class Effects : IEffectsState
     /// <summary>
     /// <c>ProcessUpdateEffectName(targetCharId, instanceId, "displayName")</c>
     /// </summary>
-    private void OnUpdateName(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnUpdateName(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         tok.Skip(1); // targetCharId
@@ -124,9 +124,9 @@ internal sealed class Effects : IEffectsState
     /// <summary>
     /// <c>ProcessRemoveEffects(targetCharId, [instanceId1, instanceId2, ...])</c>
     /// </summary>
-    private void OnRemove(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnRemove(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         tok.Skip(1); // targetCharId
@@ -193,19 +193,19 @@ internal sealed class Effects : IEffectsState
 
     private sealed class AddVerb(Effects owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnAdd(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnAdd(args, verb, sourceLog, metadata);
     }
 
     private sealed class RemoveVerb(Effects owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnRemove(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnRemove(args, verb, sourceLog, metadata);
     }
 
     private sealed class UpdateNameVerb(Effects owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnUpdateName(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnUpdateName(args, verb, sourceLog, metadata);
     }
 }

--- a/src/Arda/Arda.World.Player/Internal/EnableInteractorsHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/EnableInteractorsHandler.cs
@@ -12,9 +12,9 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class EnableInteractorsHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         tok.NextBracketedSpan(); // skip first [] (always empty)
 

--- a/src/Arda/Arda.World.Player/Internal/EndInteractionHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/EndInteractionHandler.cs
@@ -11,9 +11,9 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class EndInteractionHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         var entityId = tok.NextLong();
         bus.Publish(new InteractionEnded(entityId, metadata));

--- a/src/Arda/Arda.World.Player/Internal/ErrorMessageHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/ErrorMessageHandler.cs
@@ -13,13 +13,13 @@ internal sealed class ErrorMessageHandler(IDomainEventPublisher bus) : IFrameHan
 {
     private static ReadOnlySpan<char> PlantingCapMarker => "maximum of that type of plant growing";
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         if (!args.Contains(PlantingCapMarker, StringComparison.Ordinal))
             return;
 
         // Extract seed display name from: (ItemUnusable, "SeedName can't be used: ...")
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         tok.NextTokenSpan(); // "ItemUnusable"
         var msgSpan = tok.NextQuotedSpan();

--- a/src/Arda/Arda.World.Player/Internal/Map.cs
+++ b/src/Arda/Arda.World.Player/Internal/Map.cs
@@ -37,7 +37,7 @@ internal sealed class Map : IFrameHandler, IAreaState
         _areaPool = areaPool;
     }
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         // InitializingArea args start with '(' (instance id prefix).
         // LOADING_LEVEL args are either empty or a bare area key.

--- a/src/Arda/Arda.World.Player/Internal/MapFxHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/MapFxHandler.cs
@@ -13,12 +13,12 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class MapFxHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         if (!TryExtractPosition(args, out var x, out var y, out var z, out var afterTuple))
             return;
 
-        var tok = new ArgTokenizer(afterTuple);
+        var tok = new ArgTokenizer(afterTuple, verb, sourceLog);
         tok.Skip(2); // two unknown ints between position tuple and short name
         var shortSpan = tok.NextQuotedSpan();
         var catSpan = tok.NextTokenSpan();

--- a/src/Arda/Arda.World.Player/Internal/MapPins.cs
+++ b/src/Arda/Arda.World.Player/Internal/MapPins.cs
@@ -34,18 +34,18 @@ internal sealed class MapPins : IMapPinState
 
     internal void Reset() => _pins.Clear();
 
-    private void OnAdd(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnAdd(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        if (!TryParsePin(args, out var x, out var z, out var label, out var shape, out var color))
+        if (!TryParsePin(args, verb, sourceLog, out var x, out var z, out var label, out var shape, out var color))
             return;
 
         _pins.Add(new MapPinEntry(x, z, label, shape, color));
         _bus.Publish(new MapPinAdded(x, z, label, shape, color, metadata));
     }
 
-    private void OnRemove(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnRemove(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        if (!TryParsePin(args, out var x, out var z, out var label, out _, out _))
+        if (!TryParsePin(args, verb, sourceLog, out var x, out var z, out var label, out _, out _))
             return;
 
         for (var i = _pins.Count - 1; i >= 0; i--)
@@ -67,6 +67,8 @@ internal sealed class MapPins : IMapPinState
     /// </summary>
     private static bool TryParsePin(
         ReadOnlySpan<char> args,
+        ReadOnlySpan<char> verb,
+        string sourceLog,
         out double x, out double z,
         out string label, out int shape, out int color)
     {
@@ -88,7 +90,7 @@ internal sealed class MapPins : IMapPinState
             prefix = prefix[..^1];
 
         // Parse A, shape, color from the prefix via comma split
-        var prefixTok = new ArgTokenizer(prefix);
+        var prefixTok = new ArgTokenizer(prefix, verb, sourceLog);
         prefixTok.Skip(1); // A (opaque)
 
         var shapeSpan = prefixTok.NextTokenSpan();
@@ -108,7 +110,7 @@ internal sealed class MapPins : IMapPinState
         var coords = afterOpen[..nestedClose];
 
         // Parse x, y, z from the coordinate triple
-        var coordTok = new ArgTokenizer(coords);
+        var coordTok = new ArgTokenizer(coords, verb, sourceLog);
         var xSpan = coordTok.NextTokenSpan();
         if (!double.TryParse(xSpan, NumberStyles.Float, CultureInfo.InvariantCulture, out x))
             return false;
@@ -137,13 +139,13 @@ internal sealed class MapPins : IMapPinState
 
     private sealed class AddVerb(MapPins owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnAdd(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnAdd(args, verb, sourceLog, metadata);
     }
 
     private sealed class RemoveVerb(MapPins owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnRemove(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnRemove(args, verb, sourceLog, metadata);
     }
 }

--- a/src/Arda/Arda.World.Player/Internal/Npc.cs
+++ b/src/Arda/Arda.World.Player/Internal/Npc.cs
@@ -72,7 +72,7 @@ internal sealed class Npc : INpcState
     /// Args format: <c>(entityId, arg2, favor, isNpc, "Name")</c>
     /// Example: <c>(12307, 7, 2405.813, True, "NPC_Joe")</c>
     /// </summary>
-    internal void OnStartInteraction(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnStartInteraction(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         _pendingDelete = null;
         _pendingDelta = null;
@@ -80,7 +80,7 @@ internal sealed class Npc : INpcState
         _activeVendorFavorTier = null;
         _vaultOpen = false;
 
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var entityId = tok.NextLong();
@@ -160,9 +160,9 @@ internal sealed class Npc : INpcState
     /// immediately; otherwise stash the delta as pending.
     /// Args format: <c>(entityId, "NPC_Key", delta, bool)</c>
     /// </summary>
-    internal void OnDeltaFavor(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnDeltaFavor(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         tok.NextLong(); // entityId — already tracked
@@ -200,9 +200,9 @@ internal sealed class Npc : INpcState
     /// entity ID against the active interaction to attach the NPC key.
     /// Args format: <c>(entityId, FavorTier, gold, resetCounter, cap, ...)</c>
     /// </summary>
-    internal void OnVendorScreen(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnVendorScreen(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var entityId = tok.NextLong();
@@ -226,9 +226,9 @@ internal sealed class Npc : INpcState
     /// and favor tier from the preceding <c>ProcessVendorScreen</c>.
     /// Args format: <c>(price, InternalName(instanceId), bool)</c>
     /// </summary>
-    internal void OnVendorAddItem(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnVendorAddItem(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var price = tok.NextLong();

--- a/src/Arda/Arda.World.Player/Internal/NpcDeleteItemHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/NpcDeleteItemHandler.cs
@@ -10,6 +10,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class NpcDeleteItemHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => npc.OnDeleteItem(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/NpcEndInteractionHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/NpcEndInteractionHandler.cs
@@ -11,6 +11,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class NpcEndInteractionHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => npc.OnEndInteraction(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/NpcVaultOpenedHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/NpcVaultOpenedHandler.cs
@@ -10,6 +10,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class NpcVaultOpenedHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => npc.OnVaultOpened();
 }

--- a/src/Arda/Arda.World.Player/Internal/Player.cs
+++ b/src/Arda/Arda.World.Player/Internal/Player.cs
@@ -47,11 +47,11 @@ internal sealed class Player : IPlayerState, ISkillState
     /// <summary>
     /// Args format: <c>({type=X,raw=N,bonus=N,xp=N,tnl=N,max=N}, {type=Y,...}, ...)</c>
     /// </summary>
-    private void OnLoadSkills(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnLoadSkills(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         _rawSkills.Clear();
 
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         while (tok.HasMore)
@@ -72,9 +72,9 @@ internal sealed class Player : IPlayerState, ISkillState
     /// <summary>
     /// Args format: <c>({type=X,raw=N,bonus=N,xp=N,tnl=N,max=N}, True, 25, 0, 0)</c>
     /// </summary>
-    private void OnUpdateSkill(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnUpdateSkill(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var braced = tok.NextBracedSpan();
@@ -103,11 +103,11 @@ internal sealed class Player : IPlayerState, ISkillState
     /// <summary>
     /// Args format: <c>([1,1026,1027,...,], [7,607,255,...,])</c>
     /// </summary>
-    private void OnLoadRecipes(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnLoadRecipes(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         _recipes.Clear();
 
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var idsSpan = tok.NextBracketedSpan();
@@ -126,9 +126,9 @@ internal sealed class Player : IPlayerState, ISkillState
     /// <summary>
     /// Args format: <c>(21000, 2)</c>
     /// </summary>
-    private void OnUpdateRecipe(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnUpdateRecipe(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var recipeId = tok.NextInt();
@@ -204,25 +204,25 @@ internal sealed class Player : IPlayerState, ISkillState
 
     private sealed class LoadSkillsVerb(Player owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnLoadSkills(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnLoadSkills(args, verb, sourceLog, metadata);
     }
 
     private sealed class UpdateSkillVerb(Player owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnUpdateSkill(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnUpdateSkill(args, verb, sourceLog, metadata);
     }
 
     private sealed class LoadRecipesVerb(Player owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnLoadRecipes(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnLoadRecipes(args, verb, sourceLog, metadata);
     }
 
     private sealed class UpdateRecipeVerb(Player owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnUpdateRecipe(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnUpdateRecipe(args, verb, sourceLog, metadata);
     }
 }

--- a/src/Arda/Arda.World.Player/Internal/Position.cs
+++ b/src/Arda/Arda.World.Player/Internal/Position.cs
@@ -30,7 +30,7 @@ internal sealed class Position(IDomainEventPublisher bus) : IFrameHandler, IPosi
         Source = null;
     }
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         if (args.Length >= 2 && args[0] == '(' && args[1] == '(')
             HandleNewPosition(args, metadata);

--- a/src/Arda/Arda.World.Player/Internal/ProcessBookHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/ProcessBookHandler.cs
@@ -24,10 +24,10 @@ internal sealed class ProcessBookHandler(IDomainEventPublisher bus) : IFrameHand
     private static ReadOnlySpan<char> WopEffectClose => "</size>";
     private static ReadOnlySpan<char> WopDescNewline => @"\n";
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         // Args: ("title", "body"[, ...])
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var titleSpan = tok.NextQuotedSpan();

--- a/src/Arda/Arda.World.Player/Internal/Quest.cs
+++ b/src/Arda/Arda.World.Player/Internal/Quest.cs
@@ -35,7 +35,7 @@ internal sealed class Quest : IFrameHandler, IQuestState
     /// <summary>
     /// Handles <c>ProcessBook</c> — extracts quest ID from "New Quest" prefix.
     /// </summary>
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         var inner = SpanHelpers.StripParens(args);
         if (inner.IsEmpty)
@@ -63,11 +63,11 @@ internal sealed class Quest : IFrameHandler, IQuestState
     /// <summary>
     /// <c>ProcessLoadQuests(charEntityId, TransitionalQuestState[], [workOrderIds,...], [regularIds,...])</c>
     /// </summary>
-    private void OnLoadQuests(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnLoadQuests(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         _quests.Clear();
 
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         tok.Skip(1); // charEntityId
         tok.Skip(1); // TransitionalQuestState[]
@@ -86,9 +86,9 @@ internal sealed class Quest : IFrameHandler, IQuestState
     /// <summary>
     /// <c>ProcessCompleteQuest(charEntityId, questId)</c>
     /// </summary>
-    private void OnCompleteQuest(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    private void OnCompleteQuest(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         tok.Skip(1); // charEntityId
 
@@ -110,13 +110,13 @@ internal sealed class Quest : IFrameHandler, IQuestState
 
     private sealed class LoadQuestsVerb(Quest owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnLoadQuests(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnLoadQuests(args, verb, sourceLog, metadata);
     }
 
     private sealed class CompleteQuestVerb(Quest owner) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-            => owner.OnCompleteQuest(args, sourceLog, metadata);
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => owner.OnCompleteQuest(args, verb, sourceLog, metadata);
     }
 }

--- a/src/Arda/Arda.World.Player/Internal/ScreenTextHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/ScreenTextHandler.cs
@@ -15,7 +15,7 @@ internal sealed class ScreenTextHandler(IDomainEventPublisher bus) : IFrameHandl
 {
     private static ReadOnlySpan<char> ErrorMarker => "ErrorMessage";
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         if (args.Length == 0) return;
 
@@ -24,7 +24,7 @@ internal sealed class ScreenTextHandler(IDomainEventPublisher bus) : IFrameHandl
         if (isError)
             bus.Publish(new ScreenTextErrorFrame(metadata));
 
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         var categorySpan = tok.NextTokenSpan();
         var textSpan = tok.NextQuotedSpan();

--- a/src/Arda/Arda.World.Player/Internal/Session.cs
+++ b/src/Arda/Arda.World.Player/Internal/Session.cs
@@ -25,9 +25,9 @@ internal sealed class Session : IFrameHandler, ISessionState
         LoggedInAt = null;
     }
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         tok.Skip(2); // entityId, arg2

--- a/src/Arda/Arda.World.Player/Internal/SetPetOwnerHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/SetPetOwnerHandler.cs
@@ -7,9 +7,9 @@ namespace Arda.World.Player.Internal;
 
 internal sealed class SetPetOwnerHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
         var entityId = tok.NextLong();
         bus.Publish(new SetPetOwnerFrame(entityId, metadata));

--- a/src/Arda/Arda.World.Player/Internal/StartInteractionHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/StartInteractionHandler.cs
@@ -8,6 +8,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class StartInteractionHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => npc.OnStartInteraction(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => npc.OnStartInteraction(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/StateResetHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/StateResetHandler.cs
@@ -44,7 +44,7 @@ internal sealed class StateResetHandler : IFrameHandler
         _quest = quest;
     }
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         if (args.IsEmpty || WellKnownArgs.IsNonAreaKey(args))
         {

--- a/src/Arda/Arda.World.Player/Internal/TalkScreenHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/TalkScreenHandler.cs
@@ -12,7 +12,7 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class TalkScreenHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         bus.Publish(new TalkScreenFrame(metadata));
     }

--- a/src/Arda/Arda.World.Player/Internal/UpdateDescriptionHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/UpdateDescriptionHandler.cs
@@ -12,10 +12,10 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class UpdateDescriptionHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
         // Args: (plotId, "title", "description", "action", unused, "unused(Scale=X)", count)
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var plotId = tok.NextLong();

--- a/src/Arda/Arda.World.Player/Internal/UpdateItemCodeHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/UpdateItemCodeHandler.cs
@@ -8,6 +8,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class UpdateItemCodeHandler(Inventory inventory) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => inventory.OnUpdateItemCode(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/Vault.cs
+++ b/src/Arda/Arda.World.Player/Internal/Vault.cs
@@ -44,9 +44,9 @@ internal sealed class Vault
     /// <summary>
     /// Args format: <c>(entityId, storageId, label, flavorText, slotCount, ...)</c>
     /// </summary>
-    internal void OnShowStorageVault(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnShowStorageVault(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var entityId = tok.NextLong();
@@ -121,9 +121,9 @@ internal sealed class Vault
     /// Correlates with the preceding <c>ProcessAddItem</c>, corrects inventory stack size,
     /// and emits <see cref="VaultWithdrawal"/>.
     /// </summary>
-    internal void OnRemoveFromStorageVault(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnRemoveFromStorageVault(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var entityId = tok.NextLong();
@@ -154,9 +154,9 @@ internal sealed class Vault
     /// Args format: <c>(entityId, -1, slotIndex, InternalName(instanceId))</c>
     /// Correlates with the preceding <c>ProcessDeleteItem</c> and emits <see cref="VaultDeposit"/>.
     /// </summary>
-    internal void OnAddToStorageVault(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    internal void OnAddToStorageVault(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var entityId = tok.NextLong();

--- a/src/Arda/Arda.World.Player/Internal/VaultAddItemHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VaultAddItemHandler.cs
@@ -10,6 +10,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VaultAddItemHandler(Vault vault) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => vault.OnAddItem(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/VaultDeleteItemHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VaultDeleteItemHandler.cs
@@ -10,6 +10,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VaultDeleteItemHandler(Vault vault) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         => vault.OnDeleteItem(args, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/VaultDepositHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VaultDepositHandler.cs
@@ -9,6 +9,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VaultDepositHandler(Vault vault) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => vault.OnAddToStorageVault(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => vault.OnAddToStorageVault(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/VaultShowHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VaultShowHandler.cs
@@ -8,6 +8,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VaultShowHandler(Vault vault) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => vault.OnShowStorageVault(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => vault.OnShowStorageVault(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/VaultWithdrawHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VaultWithdrawHandler.cs
@@ -9,6 +9,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VaultWithdrawHandler(Vault vault) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => vault.OnRemoveFromStorageVault(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => vault.OnRemoveFromStorageVault(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/VendorAddItemHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VendorAddItemHandler.cs
@@ -9,6 +9,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VendorAddItemHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => npc.OnVendorAddItem(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => npc.OnVendorAddItem(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/VendorGoldHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VendorGoldHandler.cs
@@ -11,9 +11,9 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VendorGoldHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var remainingGold = tok.NextLong();

--- a/src/Arda/Arda.World.Player/Internal/VendorScreenHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/VendorScreenHandler.cs
@@ -9,6 +9,6 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class VendorScreenHandler(Npc npc) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
-        => npc.OnVendorScreen(args, sourceLog, metadata);
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        => npc.OnVendorScreen(args, verb, sourceLog, metadata);
 }

--- a/src/Arda/Arda.World.Player/Internal/WaitInteractionHandler.cs
+++ b/src/Arda/Arda.World.Player/Internal/WaitInteractionHandler.cs
@@ -11,9 +11,9 @@ namespace Arda.World.Player.Internal;
 /// </summary>
 internal sealed class WaitInteractionHandler(IDomainEventPublisher bus) : IFrameHandler
 {
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var entityId = tok.NextLong();

--- a/src/Arda/Arda.World.Player/Internal/Weather.cs
+++ b/src/Arda/Arda.World.Player/Internal/Weather.cs
@@ -25,9 +25,9 @@ internal sealed class Weather : IFrameHandler, IWeatherState
         MeasuredAt = null;
     }
 
-    public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
     {
-        var tok = new ArgTokenizer(args);
+        var tok = new ArgTokenizer(args, verb, sourceLog);
         tok.SkipOpen();
 
         var conditionSpan = tok.NextQuotedSpan();

--- a/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
+++ b/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
@@ -1,5 +1,6 @@
 using Arda.Contracts;
 using Arda.Contracts.State.Health;
+using Arda.Dispatch;
 using Arda.Hosting;
 using Arda.World.Chat.Events;
 using Arda.World.Player.Events;
@@ -23,6 +24,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
 
     private readonly IDomainEventSubscriber _bus;
     private readonly IReplayProgress _replay;
+    private readonly IGrammarBreakSignal _grammarSignal;
     private readonly TimeProvider _time;
     private readonly ILogger<WorldHealthView> _logger;
 
@@ -33,6 +35,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
     private long _chatFrames;
     private bool _playerLive;
     private bool _chatLive;
+    private GrammarBreak? _break;
 
     private readonly List<IDisposable> _subscriptions = [];
     private bool _disposed;
@@ -40,11 +43,13 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
     public WorldHealthView(
         IDomainEventSubscriber bus,
         IReplayProgress replay,
+        IGrammarBreakSignal grammarSignal,
         ILogger<WorldHealthView> logger,
         TimeProvider? time = null)
     {
         _bus = bus;
         _replay = replay;
+        _grammarSignal = grammarSignal;
         _logger = logger;
         _time = time ?? TimeProvider.System;
     }
@@ -54,7 +59,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         get
         {
             lock (_gate)
-                return Snapshot(_playerTimestamp, _playerFrames, _playerLive);
+                return Snapshot(_playerTimestamp, _playerFrames, _playerLive, _break is not null);
         }
     }
 
@@ -63,13 +68,23 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         get
         {
             lock (_gate)
-                return Snapshot(_chatTimestamp, _chatFrames, _chatLive);
+                return Snapshot(_chatTimestamp, _chatFrames, _chatLive, _break is not null);
         }
     }
 
     public bool AllLive
     {
-        get { lock (_gate) return _playerLive && _chatLive; }
+        get { lock (_gate) return _playerLive && _chatLive && _break is null; }
+    }
+
+    public GrammarBreak? Break
+    {
+        get { lock (_gate) return _break; }
+    }
+
+    public bool IsHalted
+    {
+        get { lock (_gate) return _break is not null; }
     }
 
     public event EventHandler? Changed;
@@ -100,6 +115,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         _subscriptions.Add(_bus.Subscribe<ChatSessionIdentified>(OnChatSession));
 
         _replay.PropertyChanged += OnReplayProgressChanged;
+        _grammarSignal.Raised += OnGrammarBreakRaised;
 
         if (_replay.ReplayComplete.IsCompleted)
         {
@@ -110,7 +126,25 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
             }
         }
 
+        // If a break was already raised before subscription, surface it.
+        if (_grammarSignal.Current is { } existing)
+        {
+            lock (_gate) _break = existing;
+            RaiseChanged();
+        }
+
         return Task.CompletedTask;
+    }
+
+    private void OnGrammarBreakRaised(object? sender, EventArgs e)
+    {
+        var current = _grammarSignal.Current;
+        if (current is null) return;
+        lock (_gate) _break = current;
+        _logger.LogError(
+            "Arda pipeline halted on grammar drift: verb {Verb}, hint {Hint}",
+            current.Verb, current.ParserHint);
+        RaiseChanged();
     }
 
     private void OnCalendarAdvanced(CalendarTimeAdvanced evt)
@@ -187,14 +221,15 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         if (changed) RaiseChanged();
     }
 
-    private WorldHealth Snapshot(DateTimeOffset? ts, long frames, bool live)
+    private WorldHealth Snapshot(DateTimeOffset? ts, long frames, bool live, bool halted)
     {
         var drift = ts is not null
             ? _time.GetUtcNow() - ts.Value
             : TimeSpan.Zero;
         if (drift < TimeSpan.Zero) drift = TimeSpan.Zero;
 
-        return new WorldHealth(ts, frames, live ? WorldMode.Live : WorldMode.Replaying, drift);
+        var mode = halted ? WorldMode.Halted : (live ? WorldMode.Live : WorldMode.Replaying);
+        return new WorldHealth(ts, frames, mode, drift);
     }
 
     private bool DriftExceeds(DateTimeOffset? ts)
@@ -246,6 +281,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         if (_disposed) return;
         _disposed = true;
         _replay.PropertyChanged -= OnReplayProgressChanged;
+        _grammarSignal.Raised -= OnGrammarBreakRaised;
         foreach (var sub in _subscriptions) sub.Dispose();
         _subscriptions.Clear();
     }

--- a/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
+++ b/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
@@ -59,7 +59,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         get
         {
             lock (_gate)
-                return Snapshot(_playerTimestamp, _playerFrames, _playerLive, _break is not null);
+                return Snapshot(_playerTimestamp, _playerFrames, _playerLive, _grammarSignal.IsRaised);
         }
     }
 
@@ -68,13 +68,13 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         get
         {
             lock (_gate)
-                return Snapshot(_chatTimestamp, _chatFrames, _chatLive, _break is not null);
+                return Snapshot(_chatTimestamp, _chatFrames, _chatLive, _grammarSignal.IsRaised);
         }
     }
 
     public bool AllLive
     {
-        get { lock (_gate) return _playerLive && _chatLive && _break is null; }
+        get { lock (_gate) return _playerLive && _chatLive && !_grammarSignal.IsRaised; }
     }
 
     public GrammarBreak? Break
@@ -84,8 +84,15 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
 
     public bool IsHalted
     {
-        get { lock (_gate) return _break is not null; }
+        get { lock (_gate) return _grammarSignal.IsRaised; }
     }
+
+    public bool IsTolerantBreakActive
+    {
+        get { lock (_gate) return _grammarSignal.HasObservedBreak && !_grammarSignal.IsRaised; }
+    }
+
+    public int ObservedBreakCount => _grammarSignal.ObservedCount;
 
     public event EventHandler? Changed;
 
@@ -116,6 +123,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
 
         _replay.PropertyChanged += OnReplayProgressChanged;
         _grammarSignal.Raised += OnGrammarBreakRaised;
+        _grammarSignal.ObservedBreakChanged += OnGrammarBreakObserved;
 
         if (_replay.ReplayComplete.IsCompleted)
         {
@@ -144,6 +152,17 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         _logger.LogError(
             "Arda pipeline halted on grammar drift: verb {Verb}, hint {Hint}",
             current.Verb, current.ParserHint);
+        RaiseChanged();
+    }
+
+    private void OnGrammarBreakObserved(object? sender, EventArgs e)
+    {
+        // Tolerant-mode observations populate Break (first one wins) so the
+        // shell banner can render verb/hint context without going through
+        // IsRaised. RaiseChanged() then refreshes ObservedBreakCount.
+        var current = _grammarSignal.Current;
+        if (current is null) return;
+        lock (_gate) _break ??= current;
         RaiseChanged();
     }
 
@@ -282,6 +301,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         _disposed = true;
         _replay.PropertyChanged -= OnReplayProgressChanged;
         _grammarSignal.Raised -= OnGrammarBreakRaised;
+        _grammarSignal.ObservedBreakChanged -= OnGrammarBreakObserved;
         foreach (var sub in _subscriptions) sub.Dispose();
         _subscriptions.Clear();
     }

--- a/src/Mithril.Shell/ViewModels/ShellViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/ShellViewModel.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using Arda.Contracts.State.Health;
+using Arda.Dispatch;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Character;
@@ -195,14 +196,20 @@ public sealed partial class ShellViewModel : ObservableObject
     {
         var player = _health.Player;
         var chat = _health.Chat;
+        var brk = _health.Break;
 
-        PipelineModeText = _health.AllLive ? "LIVE" : "REPLAY";
+        PipelineModeText = _health.IsHalted ? "HALTED" : (_health.AllLive ? "LIVE" : "REPLAY");
         PlayerDriftText = FormatDrift(player);
         ChatDriftText = FormatDrift(chat);
         IsHealthDegraded = _health.AllLive &&
             (player.Drift > WorldHealth.DriftWarningThreshold || chat.Drift > WorldHealth.DriftWarningThreshold);
         HealthTooltip = $"Player: {player.Mode} · {player.FrameCount:N0} frames · drift {player.Drift.TotalSeconds:0.0}s\n" +
                         $"Chat: {chat.Mode} · {chat.FrameCount:N0} frames · drift {chat.Drift.TotalSeconds:0.0}s";
+
+        IsHalted = _health.IsHalted;
+        GrammarBreak = brk;
+        HaltBannerVerb = brk?.Verb ?? "";
+        HaltBannerHint = brk?.ParserHint ?? "";
     }
 
     private static string FormatDrift(WorldHealth h)
@@ -299,8 +306,19 @@ public sealed partial class ShellViewModel : ObservableObject
     [ObservableProperty] private bool _isHealthDegraded;
     [ObservableProperty] private string _healthTooltip = "";
 
+    [ObservableProperty] private bool _isHalted;
+    [ObservableProperty] private GrammarBreak? _grammarBreak;
+    [ObservableProperty] private string _haltBannerVerb = "";
+    [ObservableProperty] private string _haltBannerHint = "";
+
     [RelayCommand]
     private void DismissUpdate() => _updateStatus.Dismiss();
+
+    [RelayCommand]
+    private void CloseShell()
+    {
+        System.Windows.Application.Current?.Shutdown();
+    }
 
     [RelayCommand]
     private async Task ApplyUpdateAsync()

--- a/src/Mithril.Shell/ViewModels/ShellViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/ShellViewModel.cs
@@ -207,6 +207,8 @@ public sealed partial class ShellViewModel : ObservableObject
                         $"Chat: {chat.Mode} · {chat.FrameCount:N0} frames · drift {chat.Drift.TotalSeconds:0.0}s";
 
         IsHalted = _health.IsHalted;
+        IsTolerantBreakActive = _health.IsTolerantBreakActive;
+        ObservedBreakCount = _health.ObservedBreakCount;
         GrammarBreak = brk;
         HaltBannerVerb = brk?.Verb ?? "";
         HaltBannerHint = brk?.ParserHint ?? "";
@@ -307,6 +309,8 @@ public sealed partial class ShellViewModel : ObservableObject
     [ObservableProperty] private string _healthTooltip = "";
 
     [ObservableProperty] private bool _isHalted;
+    [ObservableProperty] private bool _isTolerantBreakActive;
+    [ObservableProperty] private int _observedBreakCount;
     [ObservableProperty] private GrammarBreak? _grammarBreak;
     [ObservableProperty] private string _haltBannerVerb = "";
     [ObservableProperty] private string _haltBannerHint = "";

--- a/src/Mithril.Shell/Views/ShellWindow.xaml
+++ b/src/Mithril.Shell/Views/ShellWindow.xaml
@@ -22,6 +22,41 @@
                          Description="{Binding AttentionTooltip}"/>
     </Window.TaskbarItemInfo>
     <DockPanel>
+        <!-- Grammar-break banner: blocks the UI when Arda halts on log-format drift.
+             Modeled after the IsUpdateAvailable banner; placed at DockPanel top so
+             it spans the whole window above the sidebar+content split. -->
+        <Border DockPanel.Dock="Top" Background="#FF5A1F1F" BorderBrush="#FFE04545" BorderThickness="0,0,0,2"
+                Padding="14,10" Visibility="{Binding IsHalted, Converter={StaticResource BoolToVis}}">
+            <DockPanel LastChildFill="True">
+                <icon:PackIconLucide DockPanel.Dock="Left" Kind="OctagonAlert" Width="22" Height="22"
+                                     VerticalAlignment="Center" Margin="0,0,12,0"
+                                     Foreground="#FFE04545"/>
+                <Button DockPanel.Dock="Right" Padding="14,4" Margin="12,0,0,0"
+                        Background="#FFE04545" Foreground="#FFF8F8F8"
+                        Command="{Binding CloseShellCommand}">
+                    <TextBlock Text="Close Mithril" FontWeight="SemiBold"/>
+                </Button>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Text="Project Gorgon was updated. Mithril can't parse the new log format."
+                               Foreground="#FFF8E8E8" FontWeight="SemiBold"
+                               FontSize="{DynamicResource AppFontSizeMedium}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                        <TextBlock Text="Broken verb:" Foreground="#AAFFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center"/>
+                        <Border Background="#33000000" CornerRadius="2" Padding="6,1" Margin="6,0,12,0"
+                                VerticalAlignment="Center">
+                            <TextBlock Text="{Binding HaltBannerVerb}" Foreground="#FFF8E8E8"
+                                       FontFamily="Cascadia Mono, Consolas, monospace"
+                                       FontSize="{DynamicResource AppFontSizeHint}"/>
+                        </Border>
+                        <TextBlock Text="{Binding HaltBannerHint}" Foreground="#CCFFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </StackPanel>
+            </DockPanel>
+        </Border>
         <tb:TaskbarIcon x:Name="Tray" DockPanel.Dock="Top" Visibility="Visible"
                         ToolTipText="Mithril">
             <tb:TaskbarIcon.ContextMenu>

--- a/src/Mithril.Shell/Views/ShellWindow.xaml
+++ b/src/Mithril.Shell/Views/ShellWindow.xaml
@@ -25,6 +25,25 @@
         <!-- Grammar-break banner: blocks the UI when Arda halts on log-format drift.
              Modeled after the IsUpdateAvailable banner; placed at DockPanel top so
              it spans the whole window above the sidebar+content split. -->
+        <Border DockPanel.Dock="Top" Background="#FF5A4321" BorderBrush="#FFE0A845" BorderThickness="0,0,0,2"
+                Padding="14,10" Visibility="{Binding IsTolerantBreakActive, Converter={StaticResource BoolToVis}}">
+            <DockPanel LastChildFill="True">
+                <icon:PackIconLucide DockPanel.Dock="Left" Kind="TriangleAlert" Width="22" Height="22"
+                                     VerticalAlignment="Center" Margin="0,0,12,0"
+                                     Foreground="#FFE0A845"/>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Foreground="#FFF8E8D8" FontWeight="SemiBold"
+                               FontSize="{DynamicResource AppFontSizeMedium}">
+                        <Run Text="Tolerant grammar mode active —"/>
+                        <Run Text="{Binding ObservedBreakCount, Mode=OneWay}"/>
+                        <Run Text="parse failures observed this session. Persisted state is gated."/>
+                    </TextBlock>
+                    <TextBlock Text="Do not ship a build with MITHRIL_GRAMMAR_TOLERANT set."
+                               Foreground="#FFE0A845" FontWeight="SemiBold" Margin="0,4,0,0"
+                               FontSize="{DynamicResource AppFontSizeHint}"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
         <Border DockPanel.Dock="Top" Background="#FF5A1F1F" BorderBrush="#FFE04545" BorderThickness="0,0,0,2"
                 Padding="14,10" Visibility="{Binding IsHalted, Converter={StaticResource BoolToVis}}">
             <DockPanel LastChildFill="True">

--- a/tests/Arda.Composition.Tests/HaltedSnapshotSkipTests.cs
+++ b/tests/Arda.Composition.Tests/HaltedSnapshotSkipTests.cs
@@ -58,6 +58,40 @@ public class HaltedSnapshotSkipTests : IDisposable
     }
 
     [Fact]
+    public void TolerantObservedBreak_GatesSnapshotWrite()
+    {
+        // Tolerant mode (MITHRIL_GRAMMAR_TOLERANT=1) does not raise the signal,
+        // it only marks the break as observed. Composer snapshots must still be
+        // gated — otherwise a developer who forgets to clear the env var
+        // silently corrupts persisted state on next launch.
+        var signal = new TestGrammarSignal();
+        var store = new PerCharacterStore<AccumulatorSnapshot>(
+            _root, "inventory-accumulator.json",
+            AccumulatorSnapshotJsonContext.Default.AccumulatorSnapshot);
+
+        var bus = new DomainEventBus(NullLogger<DomainEventBus>.Instance);
+        var composer = new InventoryComposer(bus, store, signal);
+
+        var session = new ComposedSession("Alice", "Serbule", BaseTime, TimeSpan.Zero, "alice-session");
+        bus.Publish(new SessionEstablished(session, Meta(BaseTime)));
+        bus.Publish(new InventoryItemAdded(1001, "item_sword", Meta(BaseTime.AddMilliseconds(50))));
+
+        // Tolerant observation — IsRaised stays false but HasObservedBreak flips true.
+        signal.ObserveBreak("ProcessAddItem", "boom");
+        signal.IsRaised.Should().BeFalse("tolerant mode never raises");
+        signal.HasObservedBreak.Should().BeTrue("tolerant mode marks the break as observed");
+
+        var nextSession = new ComposedSession("Bob", "Serbule", BaseTime, TimeSpan.Zero, "bob-session");
+        bus.Publish(new SessionEstablished(nextSession, Meta(BaseTime.AddSeconds(1))));
+
+        composer.Dispose();
+
+        var aliceFile = Path.Combine(_root, PerCharacterStore<AccumulatorSnapshot>.Slug("Alice", "Serbule"), "inventory-accumulator.json");
+        File.Exists(aliceFile).Should().BeFalse(
+            "tolerant mode must still gate persistence — the in-memory state is divergent and writing it to disk poisons the next launch");
+    }
+
+    [Fact]
     public void NoHalt_FlushesInventoryComposerSnapshotOnSessionSwitch()
     {
         var signal = new TestGrammarSignal();
@@ -87,15 +121,33 @@ public class HaltedSnapshotSkipTests : IDisposable
     private sealed class TestGrammarSignal : IGrammarBreakSignal
     {
         public GrammarBreak? Current { get; private set; }
-        public bool IsRaised => Current is not null;
+        public bool IsRaised { get; private set; }
+        public bool HasObservedBreak => ObservedCount > 0;
+        public int ObservedCount { get; private set; }
         public event EventHandler? Raised;
+        public event EventHandler? ObservedBreakChanged;
+
         public void Raise(GrammarBreak breakDetails)
         {
+            var first = !IsRaised;
             Current ??= breakDetails;
-            Raised?.Invoke(this, EventArgs.Empty);
+            IsRaised = true;
+            ObservedCount++;
+            ObservedBreakChanged?.Invoke(this, EventArgs.Empty);
+            if (first) Raised?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void MarkObserved(GrammarBreak breakDetails)
+        {
+            Current ??= breakDetails;
+            ObservedCount++;
+            ObservedBreakChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public void RaiseBreak(string verb, string hint) =>
             Raise(new GrammarBreak("Player", verb, "src", "tok", hint, DateTimeOffset.UtcNow));
+
+        public void ObserveBreak(string verb, string hint) =>
+            MarkObserved(new GrammarBreak("Player", verb, "src", "tok", hint, DateTimeOffset.UtcNow));
     }
 }

--- a/tests/Arda.Composition.Tests/HaltedSnapshotSkipTests.cs
+++ b/tests/Arda.Composition.Tests/HaltedSnapshotSkipTests.cs
@@ -1,0 +1,101 @@
+using Arda.Abstractions.Logs;
+using Arda.Composition.Events;
+using Arda.Composition.Internal;
+using Arda.Contracts;
+using Arda.Contracts.State.Health;
+using Arda.Dispatch;
+using Arda.World.Player.Events;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mithril.Shared.Character;
+using Xunit;
+
+namespace Arda.Composition.Tests;
+
+public class HaltedSnapshotSkipTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "arda-halt-snapshot-" + Guid.NewGuid().ToString("N"));
+
+    private static readonly DateTimeOffset BaseTime = new(2026, 5, 26, 12, 0, 0, TimeSpan.Zero);
+
+    public HaltedSnapshotSkipTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Halt_SkipsInventoryComposerSnapshotWrite()
+    {
+        var signal = new TestGrammarSignal();
+        var store = new PerCharacterStore<AccumulatorSnapshot>(
+            _root, "inventory-accumulator.json",
+            AccumulatorSnapshotJsonContext.Default.AccumulatorSnapshot);
+
+        var bus = new DomainEventBus(NullLogger<DomainEventBus>.Instance);
+        var composer = new InventoryComposer(bus, store, signal);
+
+        // Accumulate some state by triggering a session-establish + add.
+        var session = new ComposedSession("Alice", "Serbule", BaseTime, TimeSpan.Zero, "alice-session");
+        bus.Publish(new SessionEstablished(session, Meta(BaseTime)));
+        bus.Publish(new InventoryItemAdded(1001, "item_sword", Meta(BaseTime.AddMilliseconds(50))));
+
+        // Pre-halt: a session switch should flush the prior session's snapshot.
+        signal.RaiseBreak("ProcessAddItem", "boom");
+
+        // Now switching session would flush — but halt suppresses it.
+        var nextSession = new ComposedSession("Bob", "Serbule", BaseTime, TimeSpan.Zero, "bob-session");
+        bus.Publish(new SessionEstablished(nextSession, Meta(BaseTime.AddSeconds(1))));
+
+        composer.Dispose();
+
+        var aliceFile = Path.Combine(_root, PerCharacterStore<AccumulatorSnapshot>.Slug("Alice", "Serbule"), "inventory-accumulator.json");
+        File.Exists(aliceFile).Should().BeFalse(
+            "no snapshot should be written for Alice once the halt signal is raised — the prior on-disk file (if any) must remain untouched");
+    }
+
+    [Fact]
+    public void NoHalt_FlushesInventoryComposerSnapshotOnSessionSwitch()
+    {
+        var signal = new TestGrammarSignal();
+        var store = new PerCharacterStore<AccumulatorSnapshot>(
+            _root, "inventory-accumulator.json",
+            AccumulatorSnapshotJsonContext.Default.AccumulatorSnapshot);
+
+        var bus = new DomainEventBus(NullLogger<DomainEventBus>.Instance);
+        var composer = new InventoryComposer(bus, store, signal);
+
+        var session = new ComposedSession("Alice", "Serbule", BaseTime, TimeSpan.Zero, "alice-session");
+        bus.Publish(new SessionEstablished(session, Meta(BaseTime)));
+        bus.Publish(new InventoryItemAdded(1001, "item_sword", Meta(BaseTime.AddMilliseconds(50))));
+
+        var nextSession = new ComposedSession("Bob", "Serbule", BaseTime, TimeSpan.Zero, "bob-session");
+        bus.Publish(new SessionEstablished(nextSession, Meta(BaseTime.AddSeconds(1))));
+
+        composer.Dispose();
+
+        var aliceFile = Path.Combine(_root, PerCharacterStore<AccumulatorSnapshot>.Slug("Alice", "Serbule"), "inventory-accumulator.json");
+        File.Exists(aliceFile).Should().BeTrue("baseline: snapshot is written when no halt is in flight");
+    }
+
+    private static LogLineMetadata Meta(DateTimeOffset readOn) =>
+        new(Timestamp: readOn, ReadOn: readOn, IsReplay: false);
+
+    private sealed class TestGrammarSignal : IGrammarBreakSignal
+    {
+        public GrammarBreak? Current { get; private set; }
+        public bool IsRaised => Current is not null;
+        public event EventHandler? Raised;
+        public void Raise(GrammarBreak breakDetails)
+        {
+            Current ??= breakDetails;
+            Raised?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void RaiseBreak(string verb, string hint) =>
+            Raise(new GrammarBreak("Player", verb, "src", "tok", hint, DateTimeOffset.UtcNow));
+    }
+}

--- a/tests/Arda.Dispatch.Tests/ArgTokenizerTests.cs
+++ b/tests/Arda.Dispatch.Tests/ArgTokenizerTests.cs
@@ -8,7 +8,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextLong_ParsesSimpleInteger()
     {
-        var tok = new ArgTokenizer("(12345)".AsSpan());
+        var tok = new ArgTokenizer("(12345)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextLong().Should().Be(12345);
     }
@@ -16,7 +16,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextLong_MultipleValues_ParsesInOrder()
     {
-        var tok = new ArgTokenizer("(100, 200, 300)".AsSpan());
+        var tok = new ArgTokenizer("(100, 200, 300)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextLong().Should().Be(100);
         tok.NextLong().Should().Be(200);
@@ -26,7 +26,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextDouble_ParsesDecimal()
     {
-        var tok = new ArgTokenizer("(45.75)".AsSpan());
+        var tok = new ArgTokenizer("(45.75)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextDouble().Should().Be(45.75);
     }
@@ -34,7 +34,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextBool_ParsesTrueAndFalse()
     {
-        var tok = new ArgTokenizer("(True, False)".AsSpan());
+        var tok = new ArgTokenizer("(True, False)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextBool().Should().BeTrue();
         tok.NextBool().Should().BeFalse();
@@ -43,7 +43,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextQuotedSpan_ReturnsContentWithoutQuotes()
     {
-        var tok = new ArgTokenizer("(\"NPC_Marna\")".AsSpan());
+        var tok = new ArgTokenizer("(\"NPC_Marna\")".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextQuotedSpan().ToString().Should().Be("NPC_Marna");
     }
@@ -51,7 +51,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextQuotedSpan_Unquoted_FallsBackToRawToken()
     {
-        var tok = new ArgTokenizer("(Idle)".AsSpan());
+        var tok = new ArgTokenizer("(Idle)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextQuotedSpan().ToString().Should().Be("Idle");
     }
@@ -59,7 +59,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextBracedSpan_ReturnsInnerContent()
     {
-        var tok = new ArgTokenizer("({type=Toolcrafting,raw=7,bonus=0})".AsSpan());
+        var tok = new ArgTokenizer("({type=Toolcrafting,raw=7,bonus=0})".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextBracedSpan().ToString().Should().Be("type=Toolcrafting,raw=7,bonus=0");
     }
@@ -67,7 +67,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextBracedSpan_MultipleBraced_ParsesSequentially()
     {
-        var tok = new ArgTokenizer("({a=1,b=2}, {c=3,d=4})".AsSpan());
+        var tok = new ArgTokenizer("({a=1,b=2}, {c=3,d=4})".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextBracedSpan().ToString().Should().Be("a=1,b=2");
         tok.NextBracedSpan().ToString().Should().Be("c=3,d=4");
@@ -76,7 +76,7 @@ public class ArgTokenizerTests
     [Fact]
     public void NextBracketedSpan_ReturnsInnerContent()
     {
-        var tok = new ArgTokenizer("([item1,item2,item3])".AsSpan());
+        var tok = new ArgTokenizer("([item1,item2,item3])".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextBracketedSpan().ToString().Should().Be("item1,item2,item3");
     }
@@ -84,7 +84,7 @@ public class ArgTokenizerTests
     [Fact]
     public void Skip_SkipsScalars()
     {
-        var tok = new ArgTokenizer("(100, 200, 300)".AsSpan());
+        var tok = new ArgTokenizer("(100, 200, 300)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.Skip(2);
         tok.NextLong().Should().Be(300);
@@ -93,7 +93,7 @@ public class ArgTokenizerTests
     [Fact]
     public void Skip_SkipsQuotedStrings()
     {
-        var tok = new ArgTokenizer("(\"hello\", 42)".AsSpan());
+        var tok = new ArgTokenizer("(\"hello\", 42)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.Skip(1);
         tok.NextLong().Should().Be(42);
@@ -102,7 +102,7 @@ public class ArgTokenizerTests
     [Fact]
     public void Skip_SkipsBracedStructs()
     {
-        var tok = new ArgTokenizer("({type=X,raw=7}, 99)".AsSpan());
+        var tok = new ArgTokenizer("({type=X,raw=7}, 99)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.Skip(1);
         tok.NextLong().Should().Be(99);
@@ -111,7 +111,7 @@ public class ArgTokenizerTests
     [Fact]
     public void Skip_SkipsBracketedArrays()
     {
-        var tok = new ArgTokenizer("([a,b,c], 77)".AsSpan());
+        var tok = new ArgTokenizer("([a,b,c], 77)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.Skip(1);
         tok.NextLong().Should().Be(77);
@@ -121,7 +121,7 @@ public class ArgTokenizerTests
     public void MixedTypes_ParsesCorrectly()
     {
         // Simulates: ProcessStartInteraction(entityId, ?, favor, ?, "NPC_Key")
-        var tok = new ArgTokenizer("(500, 0, 45.5, Idle, \"NPC_Marna\")".AsSpan());
+        var tok = new ArgTokenizer("(500, 0, 45.5, Idle, \"NPC_Marna\")".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextLong().Should().Be(500);
         tok.Skip(1);
@@ -133,7 +133,7 @@ public class ArgTokenizerTests
     [Fact]
     public void HasMore_TrueWhileContentRemains()
     {
-        var tok = new ArgTokenizer("(1, 2)".AsSpan());
+        var tok = new ArgTokenizer("(1, 2)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.HasMore.Should().BeTrue();
         tok.NextLong();
@@ -145,7 +145,7 @@ public class ArgTokenizerTests
     [Fact]
     public void EmptyArgs_HasMoreIsFalse()
     {
-        var tok = new ArgTokenizer("()".AsSpan());
+        var tok = new ArgTokenizer("()".AsSpan(), default, "");
         tok.SkipOpen();
         tok.HasMore.Should().BeFalse();
     }
@@ -154,7 +154,7 @@ public class ArgTokenizerTests
     public void NestedParensInBraces_HandledCorrectly()
     {
         // Braces containing parens — depth tracking is for braces only
-        var tok = new ArgTokenizer("({name=Flower11(Scale=0.9)}, 0)".AsSpan());
+        var tok = new ArgTokenizer("({name=Flower11(Scale=0.9)}, 0)".AsSpan(), default, "");
         tok.SkipOpen();
         tok.NextBracedSpan().ToString().Should().Be("name=Flower11(Scale=0.9)");
         tok.NextLong().Should().Be(0);
@@ -164,7 +164,7 @@ public class ArgTokenizerTests
     public void RealWorldAddItem_ParsesCorrectly()
     {
         // ProcessAddItem(GoblinCap(84741837), -1, False)
-        var tok = new ArgTokenizer("(GoblinCap(84741837), -1, False)".AsSpan());
+        var tok = new ArgTokenizer("(GoblinCap(84741837), -1, False)".AsSpan(), default, "");
         tok.SkipOpen();
         // First token includes the parens since NextRawToken stops at ',' or ')'
         // but inner parens aren't balanced by NextRawToken — this is a known limitation

--- a/tests/Arda.Dispatch.Tests/DispatchTableHaltTests.cs
+++ b/tests/Arda.Dispatch.Tests/DispatchTableHaltTests.cs
@@ -1,0 +1,74 @@
+using Arda.Abstractions.Logs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Arda.Dispatch.Tests;
+
+public class DispatchTableHaltTests
+{
+    private static LogLineMetadata Meta => new(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, IsReplay: false);
+
+    [Fact]
+    public void GrammarException_PropagatesOutOfDispatch()
+    {
+        var table = new DispatchTable(
+            new Dictionary<string, List<IFrameHandler>>
+            {
+                ["ProcessAddItem"] = [new ThrowingHandler(() => throw new GrammarException(
+                    "ProcessAddItem", "source", "NOT_A_NUMBER", "expected long"))]
+            },
+            NullLogger<DispatchTable>.Instance);
+
+        const string line = "LocalPlayer: ProcessAddItem(NOT_A_NUMBER)";
+        var act = () => table.Dispatch(VerbExtractor.Parse(line.AsSpan()), line, Meta);
+
+        act.Should().Throw<GrammarException>()
+            .Which.Verb.Should().Be("ProcessAddItem");
+    }
+
+    [Fact]
+    public void GenericException_IsSwallowedAndLogged()
+    {
+        var table = new DispatchTable(
+            new Dictionary<string, List<IFrameHandler>>
+            {
+                ["ProcessAddItem"] = [new ThrowingHandler(() => throw new InvalidOperationException("boom"))]
+            },
+            NullLogger<DispatchTable>.Instance);
+
+        const string line = "LocalPlayer: ProcessAddItem(123)";
+        var act = () => table.Dispatch(VerbExtractor.Parse(line.AsSpan()), line, Meta);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GrammarException_AbortsRemainingHandlersForSameVerb()
+    {
+        var secondInvoked = false;
+        var table = new DispatchTable(
+            new Dictionary<string, List<IFrameHandler>>
+            {
+                ["ProcessAddItem"] =
+                [
+                    new ThrowingHandler(() => throw new GrammarException(
+                        "ProcessAddItem", "source", "NOT_A_NUMBER", "expected long")),
+                    new ThrowingHandler(() => secondInvoked = true)
+                ]
+            },
+            NullLogger<DispatchTable>.Instance);
+
+        const string line = "LocalPlayer: ProcessAddItem(NOT_A_NUMBER)";
+        var act = () => table.Dispatch(VerbExtractor.Parse(line.AsSpan()), line, Meta);
+
+        act.Should().Throw<GrammarException>();
+        secondInvoked.Should().BeFalse("the GrammarException aborts the foreach over handlers");
+    }
+
+    private sealed class ThrowingHandler(Action onHandle) : IFrameHandler
+    {
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => onHandle();
+    }
+}

--- a/tests/Arda.Dispatch.Tests/DispatchTableTests.cs
+++ b/tests/Arda.Dispatch.Tests/DispatchTableTests.cs
@@ -125,7 +125,7 @@ public class DispatchTableTests
 
     private sealed class TestHandler(Action<ReadOnlySpan<char>> onHandle) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
             => onHandle(args);
     }
 }

--- a/tests/Arda.Dispatch.Tests/DomainEventBusIntegrationTests.cs
+++ b/tests/Arda.Dispatch.Tests/DomainEventBusIntegrationTests.cs
@@ -13,7 +13,7 @@ public class DomainEventBusIntegrationTests
 
     private sealed class PublishingHandler(IDomainEventPublisher bus) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         {
             bus.Publish(new TestEventA(42, "from-handler"));
         }

--- a/tests/Arda.Dispatch.Tests/GrammarBreakSignalTests.cs
+++ b/tests/Arda.Dispatch.Tests/GrammarBreakSignalTests.cs
@@ -1,0 +1,106 @@
+using Arda.Contracts.State.Health;
+using FluentAssertions;
+using Xunit;
+
+namespace Arda.Dispatch.Tests;
+
+public class GrammarBreakSignalTests
+{
+    private static GrammarBreak MakeBreak(string verb = "ProcessAddItem", string hint = "expected long") =>
+        new("Player", verb, "LocalPlayer: ProcessAddItem(NOT_A_NUMBER)", "NOT_A_NUMBER", hint, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void Raise_SetsBothChannelsAndFiresBothEvents()
+    {
+        var signal = new GrammarBreakSignal();
+        var raisedFired = 0;
+        var observedFired = 0;
+        signal.Raised += (_, _) => raisedFired++;
+        signal.ObservedBreakChanged += (_, _) => observedFired++;
+
+        signal.Raise(MakeBreak());
+
+        signal.IsRaised.Should().BeTrue();
+        signal.HasObservedBreak.Should().BeTrue("Raise is a superset of MarkObserved");
+        signal.ObservedCount.Should().Be(1);
+        signal.Current.Should().NotBeNull();
+        raisedFired.Should().Be(1);
+        observedFired.Should().Be(1);
+    }
+
+    [Fact]
+    public void MarkObserved_SetsObservationChannelOnly()
+    {
+        var signal = new GrammarBreakSignal();
+        var raisedFired = 0;
+        var observedFired = 0;
+        signal.Raised += (_, _) => raisedFired++;
+        signal.ObservedBreakChanged += (_, _) => observedFired++;
+
+        signal.MarkObserved(MakeBreak());
+
+        signal.IsRaised.Should().BeFalse("tolerant-mode observations must not trigger halt");
+        signal.HasObservedBreak.Should().BeTrue();
+        signal.ObservedCount.Should().Be(1);
+        signal.Current.Should().NotBeNull();
+        raisedFired.Should().Be(0);
+        observedFired.Should().Be(1);
+    }
+
+    [Fact]
+    public void Raise_TwiceFiresRaisedOnce_ObservedTwice()
+    {
+        var signal = new GrammarBreakSignal();
+        var raisedFired = 0;
+        var observedFired = 0;
+        signal.Raised += (_, _) => raisedFired++;
+        signal.ObservedBreakChanged += (_, _) => observedFired++;
+
+        signal.Raise(MakeBreak("ProcessFirst"));
+        signal.Raise(MakeBreak("ProcessSecond"));
+
+        signal.IsRaised.Should().BeTrue();
+        signal.ObservedCount.Should().Be(2);
+        signal.Current!.Verb.Should().Be("ProcessFirst", "first break captured wins");
+        raisedFired.Should().Be(1, "Raised is a transition event, fires once");
+        observedFired.Should().Be(2, "every break increments the observation channel");
+    }
+
+    [Fact]
+    public void MarkObserved_ThenRaise_FlipsHaltWithoutLosingObservedCount()
+    {
+        var signal = new GrammarBreakSignal();
+
+        signal.MarkObserved(MakeBreak("ProcessFirst"));
+        signal.MarkObserved(MakeBreak("ProcessSecond"));
+        signal.Raise(MakeBreak("ProcessThird"));
+
+        signal.IsRaised.Should().BeTrue();
+        signal.HasObservedBreak.Should().BeTrue();
+        signal.ObservedCount.Should().Be(3);
+        signal.Current!.Verb.Should().Be("ProcessFirst", "first-call wins for Current");
+    }
+
+    [Fact]
+    public void Raise_ThenMarkObserved_KeepsRaisedTrue()
+    {
+        var signal = new GrammarBreakSignal();
+
+        signal.Raise(MakeBreak("ProcessFirst"));
+        signal.MarkObserved(MakeBreak("ProcessSecond"));
+
+        signal.IsRaised.Should().BeTrue("Raise sticks");
+        signal.ObservedCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void NoBreaks_BothChannelsClean()
+    {
+        var signal = new GrammarBreakSignal();
+
+        signal.IsRaised.Should().BeFalse();
+        signal.HasObservedBreak.Should().BeFalse();
+        signal.ObservedCount.Should().Be(0);
+        signal.Current.Should().BeNull();
+    }
+}

--- a/tests/Arda.Dispatch.Tests/WorldDriverHaltTests.cs
+++ b/tests/Arda.Dispatch.Tests/WorldDriverHaltTests.cs
@@ -1,0 +1,151 @@
+using System.Runtime.CompilerServices;
+using Arda.Abstractions.Logs;
+using Arda.Contracts.State.Health;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Arda.Dispatch.Tests;
+
+public class WorldDriverHaltTests
+{
+    [Fact]
+    public async Task GrammarException_RaisesSignalAndExitsLoop()
+    {
+        var signal = new GrammarBreakSignal();
+        var liveFired = false;
+
+        var table = new DispatchTable(
+            new Dictionary<string, List<IFrameHandler>>
+            {
+                ["ProcessAddItem"] = [new ThrowOnce(() => throw new GrammarException(
+                    "ProcessAddItem", "source", "NOT_A_NUMBER", "expected long"))]
+            },
+            NullLogger<DispatchTable>.Instance);
+
+        var lines = new[]
+        {
+            MakeLine("LocalPlayer: ProcessAddItem(NOT_A_NUMBER)", isReplay: true),
+            MakeLine("LocalPlayer: ProcessAddItem(123)", isReplay: true)
+        };
+
+        var driver = new WorldDriver(
+            new InMemorySource(lines),
+            table,
+            onLiveTransition: () => liveFired = true,
+            sourceFamily: "Player",
+            grammarSignal: signal);
+
+        await driver.RunAsync(CancellationToken.None);
+
+        signal.IsRaised.Should().BeTrue();
+        signal.Current!.Verb.Should().Be("ProcessAddItem");
+        signal.Current.SourceFamily.Should().Be("Player");
+        liveFired.Should().BeFalse(
+            "halt during replay must not force the end-of-stream live transition, " +
+            "which would resolve replay-complete latches and trigger snapshot writes against divergent state");
+    }
+
+    [Fact]
+    public async Task CompanionDriverHalt_StopsThisDriverAtNextLoopIteration()
+    {
+        var signal = new GrammarBreakSignal();
+        signal.Raise(new GrammarBreak("Other", "ProcessFoo", "src", "x", "hint", DateTimeOffset.UtcNow));
+
+        var processed = 0;
+        var table = new DispatchTable(
+            new Dictionary<string, List<IFrameHandler>>
+            {
+                ["ProcessAddItem"] = [new CountingHandler(() => processed++)]
+            },
+            NullLogger<DispatchTable>.Instance);
+
+        var lines = new[]
+        {
+            MakeLine("LocalPlayer: ProcessAddItem(1)"),
+            MakeLine("LocalPlayer: ProcessAddItem(2)")
+        };
+
+        var driver = new WorldDriver(
+            new InMemorySource(lines),
+            table,
+            sourceFamily: "Chat",
+            grammarSignal: signal);
+
+        await driver.RunAsync(CancellationToken.None);
+
+        processed.Should().Be(0, "driver halts before processing any line when companion already raised the signal");
+    }
+
+    [Fact]
+    public async Task TolerantMode_LogsAndContinuesPastGrammarBreak()
+    {
+        var signal = new GrammarBreakSignal();
+        var processed = 0;
+
+        var table = new DispatchTable(
+            new Dictionary<string, List<IFrameHandler>>
+            {
+                ["ProcessAddItem"] = [new ConditionalThrow(
+                    shouldThrow: args => args.Contains("NOT_A_NUMBER"),
+                    onSuccess: () => processed++)]
+            },
+            NullLogger<DispatchTable>.Instance);
+
+        var lines = new[]
+        {
+            MakeLine("LocalPlayer: ProcessAddItem(NOT_A_NUMBER)"),
+            MakeLine("LocalPlayer: ProcessAddItem(123)")
+        };
+
+        var driver = new WorldDriver(
+            new InMemorySource(lines),
+            table,
+            sourceFamily: "Player",
+            grammarSignal: signal,
+            tolerantGrammar: true);
+
+        await driver.RunAsync(CancellationToken.None);
+
+        signal.IsRaised.Should().BeFalse("tolerant mode suppresses the halt signal");
+        processed.Should().Be(1, "the second (well-formed) line still runs through the handler");
+    }
+
+    private static LogLine MakeLine(string log, bool isReplay = false) =>
+        new(log, new LogLineMetadata(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, IsReplay: isReplay));
+
+    private sealed class InMemorySource(IEnumerable<LogLine> lines) : ILogLineSource
+    {
+        public async IAsyncEnumerable<LogLine> Lines([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var line in lines)
+            {
+                if (ct.IsCancellationRequested) yield break;
+                yield return line;
+                await Task.Yield();
+            }
+        }
+    }
+
+    private sealed class ThrowOnce(Action onHandle) : IFrameHandler
+    {
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => onHandle();
+    }
+
+    private sealed class CountingHandler(Action onHandle) : IFrameHandler
+    {
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+            => onHandle();
+    }
+
+    private sealed class ConditionalThrow(Func<string, bool> shouldThrow, Action onSuccess) : IFrameHandler
+    {
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+        {
+            if (shouldThrow(args.ToString()))
+                throw new GrammarException(verb.ToString(), sourceLog, "NOT_A_NUMBER", "expected long");
+            onSuccess();
+        }
+    }
+}

--- a/tests/Arda.Dispatch.Tests/WorldDriverHaltTests.cs
+++ b/tests/Arda.Dispatch.Tests/WorldDriverHaltTests.cs
@@ -105,9 +105,17 @@ public class WorldDriverHaltTests
             grammarSignal: signal,
             tolerantGrammar: true);
 
+        var observed = 0;
+        signal.ObservedBreakChanged += (_, _) => observed++;
+
         await driver.RunAsync(CancellationToken.None);
 
         signal.IsRaised.Should().BeFalse("tolerant mode suppresses the halt signal");
+        signal.HasObservedBreak.Should().BeTrue(
+            "tolerant mode still marks breaks as observed so composer snapshots stay gated");
+        signal.ObservedCount.Should().Be(1, "one malformed line in this run");
+        signal.Current!.Verb.Should().Be("ProcessAddItem");
+        observed.Should().Be(1, "ObservedBreakChanged fires once per tolerant observation");
         processed.Should().Be(1, "the second (well-formed) line still runs through the handler");
     }
 

--- a/tests/Arda.Dispatch.Tests/WorldDriverTests.cs
+++ b/tests/Arda.Dispatch.Tests/WorldDriverTests.cs
@@ -157,7 +157,7 @@ public class WorldDriverTests
 
     private sealed class RecordingHandler(List<string> log) : IFrameHandler
     {
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
             => log.Add(sourceLog);
     }
 }

--- a/tests/Arda.Hosting.Tests/ReplayDeterminismTests.cs
+++ b/tests/Arda.Hosting.Tests/ReplayDeterminismTests.cs
@@ -131,10 +131,9 @@ public class ReplayDeterminismTests : IDisposable
     {
         public List<(string Verb, string Args, string Source)> Dispatches { get; } = [];
 
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         {
-            var parsed = VerbExtractor.Parse(sourceLog.AsSpan());
-            Dispatches.Add((parsed.Verb.ToString(), args.ToString(), sourceLog));
+            Dispatches.Add((verb.ToString(), args.ToString(), sourceLog));
         }
     }
 
@@ -142,10 +141,9 @@ public class ReplayDeterminismTests : IDisposable
     {
         public List<(string Verb, string Args, bool IsReplay)> Dispatches { get; } = [];
 
-        public void Handle(ReadOnlySpan<char> args, string sourceLog, LogLineMetadata metadata)
+        public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
         {
-            var parsed = VerbExtractor.Parse(sourceLog.AsSpan());
-            Dispatches.Add((parsed.Verb.ToString(), args.ToString(), metadata.IsReplay));
+            Dispatches.Add((verb.ToString(), args.ToString(), metadata.IsReplay));
         }
     }
 }

--- a/tests/Arda.World.Chat.Tests/ChatInventoryTests.cs
+++ b/tests/Arda.World.Chat.Tests/ChatInventoryTests.cs
@@ -25,7 +25,7 @@ public class ChatInventoryTests
     public void ParsesSingleItem()
     {
         var line = "[Status] Apple added to inventory.";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<ChatInventoryObserved>().Should().ContainSingle().Which;
         evt.DisplayName.Should().Be("Apple");
@@ -36,7 +36,7 @@ public class ChatInventoryTests
     public void ParsesItemWithCount()
     {
         var line = "[Status] Iron Ore x3 added to inventory.";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<ChatInventoryObserved>().Should().ContainSingle().Which;
         evt.DisplayName.Should().Be("Iron Ore");
@@ -47,7 +47,7 @@ public class ChatInventoryTests
     public void ParsesItemWithLargeCount()
     {
         var line = "[Status] Arrow x250 added to inventory.";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<ChatInventoryObserved>().Should().ContainSingle().Which;
         evt.DisplayName.Should().Be("Arrow");
@@ -58,7 +58,7 @@ public class ChatInventoryTests
     public void ItemNameWithSpaces_NoCount()
     {
         var line = "[Status] Goblin Cap added to inventory.";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<ChatInventoryObserved>().Should().ContainSingle().Which;
         evt.DisplayName.Should().Be("Goblin Cap");
@@ -69,7 +69,7 @@ public class ChatInventoryTests
     public void NonInventoryStatusLine_IsIgnored()
     {
         var line = "[Status] The Iron Vein is 25m east and 30m north";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         _bus.Published<ChatInventoryObserved>().Should().BeEmpty();
     }
@@ -78,7 +78,7 @@ public class ChatInventoryTests
     public void EmptyMiddle_IsIgnored()
     {
         var line = "[Status]  added to inventory.";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         _bus.Published<ChatInventoryObserved>().Should().BeEmpty();
     }

--- a/tests/Arda.World.Chat.Tests/ChatLineTests.cs
+++ b/tests/Arda.World.Chat.Tests/ChatLineTests.cs
@@ -25,7 +25,7 @@ public class ChatLineTests
     public void ParsesStandardChatLine()
     {
         var line = "[Trade] Emraell: WTS something";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<PlayerChatLine>().Should().ContainSingle().Which;
         evt.Channel.Should().Be("Trade");
@@ -37,7 +37,7 @@ public class ChatLineTests
     public void ParsesGlobalChannel()
     {
         var line = "[Global] SomePlayer: hi everyone";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<PlayerChatLine>().Should().ContainSingle().Which;
         evt.Channel.Should().Be("Global");
@@ -49,7 +49,7 @@ public class ChatLineTests
     public void TextWithColons_PreservesFullText()
     {
         var line = "[Guild] Leader: Meetup at 8:00 PM: bring food";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         var evt = _bus.Published<PlayerChatLine>().Should().ContainSingle().Which;
         evt.Speaker.Should().Be("Leader");
@@ -60,7 +60,7 @@ public class ChatLineTests
     public void NoSpeakerSeparator_IsIgnored()
     {
         var line = "[Status] Some status message without colon-space";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         _bus.Published<PlayerChatLine>().Should().BeEmpty();
     }
@@ -69,7 +69,7 @@ public class ChatLineTests
     public void EmptyChannel_IsIgnored()
     {
         var line = "[] Someone: text";
-        _handler.Handle(line.AsSpan(), line, Meta());
+        _handler.Handle(line.AsSpan(), default, line, Meta());
 
         _bus.Published<PlayerChatLine>().Should().BeEmpty();
     }

--- a/tests/Arda.World.Chat.Tests/ChatSessionTests.cs
+++ b/tests/Arda.World.Chat.Tests/ChatSessionTests.cs
@@ -25,7 +25,7 @@ public class ChatSessionTests
     public void ParsesBanner_WithStandardFormat()
     {
         var line = "**************************************** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00.";
-        _session.Handle(line.AsSpan(), line, Meta());
+        _session.Handle(line.AsSpan(), default, line, Meta());
 
         _session.Character.Should().Be("Emraell");
         _session.Server.Should().Be("Laeth");
@@ -41,7 +41,7 @@ public class ChatSessionTests
     public void ParsesBanner_NegativeOffset()
     {
         var line = "**** Logged In As TestChar. Server Kemel. Timezone Offset -05:00:00.";
-        _session.Handle(line.AsSpan(), line, Meta());
+        _session.Handle(line.AsSpan(), default, line, Meta());
 
         _session.Character.Should().Be("TestChar");
         _session.Server.Should().Be("Kemel");
@@ -52,7 +52,7 @@ public class ChatSessionTests
     public void ParsesBanner_ZeroOffset()
     {
         var line = "**** Logged In As Someone. Server Laeth. Timezone Offset 00:00:00.";
-        _session.Handle(line.AsSpan(), line, Meta());
+        _session.Handle(line.AsSpan(), default, line, Meta());
 
         _session.TimezoneOffset.Should().Be(TimeSpan.Zero);
     }
@@ -61,10 +61,10 @@ public class ChatSessionTests
     public void SubsequentBanner_UpdatesState()
     {
         var line1 = "**** Logged In As CharA. Server Laeth. Timezone Offset 01:00:00.";
-        _session.Handle(line1.AsSpan(), line1, Meta());
+        _session.Handle(line1.AsSpan(), default, line1, Meta());
 
         var line2 = "**** Logged In As CharB. Server Kemel. Timezone Offset -03:00:00.";
-        _session.Handle(line2.AsSpan(), line2, Meta());
+        _session.Handle(line2.AsSpan(), default, line2, Meta());
 
         _session.Character.Should().Be("CharB");
         _session.Server.Should().Be("Kemel");
@@ -75,7 +75,7 @@ public class ChatSessionTests
     public void MalformedBanner_NoLoggedIn_IsIgnored()
     {
         var line = "**** Some other starred line";
-        _session.Handle(line.AsSpan(), line, Meta());
+        _session.Handle(line.AsSpan(), default, line, Meta());
 
         _session.Character.Should().BeNull();
         _bus.Published<ChatSessionIdentified>().Should().BeEmpty();

--- a/tests/Arda.World.Player.Tests/BookPassthroughTests.cs
+++ b/tests/Arda.World.Player.Tests/BookPassthroughTests.cs
@@ -24,7 +24,7 @@ public class BookPassthroughTests
         var sourceLine = """LocalPlayer: ProcessBook("Skill Info", "Foods Consumed:\n\n  Guava: 42\n  Apple: 10", "icon", "SkillReport")""";
         var args = """("Skill Info", "Foods Consumed:\n\n  Guava: 42\n  Apple: 10", "icon", "SkillReport")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<WordOfPowerDiscovered>().Should().BeEmpty();
         _bus.Published<BookOpened>().Should().BeEmpty();
@@ -42,7 +42,7 @@ public class BookPassthroughTests
         var sourceLine = $"""LocalPlayer: ProcessBook("You discovered a word of power!", "{body}", "icon")""";
         var args = $"""("You discovered a word of power!", "{body}", "icon")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<FoodsConsumedReport>().Should().BeEmpty();
         _bus.Published<BookOpened>().Should().BeEmpty();
@@ -60,7 +60,7 @@ public class BookPassthroughTests
         var sourceLine = $"""LocalPlayer: ProcessBook("You discovered a word of power!", "{body}", "icon")""";
         var args = $"""("You discovered a word of power!", "{body}", "icon")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var e = _bus.Published<WordOfPowerDiscovered>().Should().ContainSingle().Which;
         e.Code.ToString().Should().Be("XYZZY");
@@ -77,7 +77,7 @@ public class BookPassthroughTests
         var sourceLine = """LocalPlayer: ProcessBook("Some Book Title", "Book body content here", "icon")""";
         var args = """("Some Book Title", "Book body content here", "icon")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<FoodsConsumedReport>().Should().BeEmpty();
         _bus.Published<WordOfPowerDiscovered>().Should().BeEmpty();
@@ -93,7 +93,7 @@ public class BookPassthroughTests
         var sourceLine = """LocalPlayer: ProcessBook("MyTitle", "MyBody", "icon")""";
         var args = sourceLine.AsSpan()["LocalPlayer: ProcessBook".Length..];
 
-        handler.Handle(args, sourceLine, Meta());
+        handler.Handle(args, default, sourceLine, Meta());
 
         var e = _bus.Published<BookOpened>().Should().ContainSingle().Which;
         e.Title.ToString().Should().Be("MyTitle");

--- a/tests/Arda.World.Player.Tests/CelestialTests.cs
+++ b/tests/Arda.World.Player.Tests/CelestialTests.cs
@@ -24,7 +24,7 @@ public class CelestialTests
     private void Dispatch(string phase)
     {
         var args = $"({phase})".AsSpan();
-        _celestial.Handle(args, $"LocalPlayer: ProcessSetCelestialInfo({phase})", Meta());
+        _celestial.Handle(args, default, $"LocalPlayer: ProcessSetCelestialInfo({phase})", Meta());
     }
 
     [Fact]

--- a/tests/Arda.World.Player.Tests/DeltaFavorHandlerTests.cs
+++ b/tests/Arda.World.Player.Tests/DeltaFavorHandlerTests.cs
@@ -33,16 +33,13 @@ public class DeltaFavorHandlerTests
 
     private void ArmNpcInteraction(string npcKey, long entityId = 12307)
     {
-        _npc.OnStartInteraction(
-            $"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(),
-            $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")",
-            Meta());
+        _npc.OnStartInteraction($"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(), default, $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")", Meta());
     }
 
     private void Dispatch(string args)
     {
         var line = $"LocalPlayer: ProcessDeltaFavor{args}";
-        _handler.Handle(args.AsSpan(), line, Meta());
+        _handler.Handle(args.AsSpan(), default, line, Meta());
     }
 
     [Fact]

--- a/tests/Arda.World.Player.Tests/EffectsTests.cs
+++ b/tests/Arda.World.Player.Tests/EffectsTests.cs
@@ -25,7 +25,7 @@ public class EffectsTests
     public void AddEffects_EmitsCatalogIds()
     {
         var args = "(12345, 67890, \"[302, 303]\", True)";
-        _effects.AddHandler.Handle(args.AsSpan(), "source", Meta());
+        _effects.AddHandler.Handle(args.AsSpan(), default, "source", Meta());
 
         var published = _bus.Published<EffectsAdded>();
         published.Should().ContainSingle();
@@ -37,7 +37,7 @@ public class EffectsTests
     public void AddEffects_TrailingComma_Tolerated()
     {
         var args = "(12345, 67890, \"[15361, ]\", False)";
-        _effects.AddHandler.Handle(args.AsSpan(), "source", Meta());
+        _effects.AddHandler.Handle(args.AsSpan(), default, "source", Meta());
 
         _bus.Published<EffectsAdded>().Should().ContainSingle()
             .Which.CatalogIds.Should().BeEquivalentTo([15361]);
@@ -47,7 +47,7 @@ public class EffectsTests
     public void RemoveEffects_EmitsInstanceIds()
     {
         var args = "(12345, [259278, 259279])";
-        _effects.RemoveHandler.Handle(args.AsSpan(), "source", Meta());
+        _effects.RemoveHandler.Handle(args.AsSpan(), default, "source", Meta());
 
         _bus.Published<EffectsRemoved>().Should().ContainSingle()
             .Which.InstanceIds.Should().BeEquivalentTo([259278L, 259279L]);
@@ -57,7 +57,7 @@ public class EffectsTests
     public void AddEffects_EmptyList_NoEvent()
     {
         var args = "(12345, 67890, \"[]\", True)";
-        _effects.AddHandler.Handle(args.AsSpan(), "source", Meta());
+        _effects.AddHandler.Handle(args.AsSpan(), default, "source", Meta());
 
         _bus.Published<EffectsAdded>().Should().BeEmpty();
     }
@@ -66,7 +66,7 @@ public class EffectsTests
     public void UpdateEffectName_EmitsInstanceIdAndDisplayName()
     {
         var args = "(25098977, 259320, \"Performance Appreciation, Level 0\")";
-        _effects.UpdateNameHandler.Handle(args.AsSpan(), "source", Meta());
+        _effects.UpdateNameHandler.Handle(args.AsSpan(), default, "source", Meta());
 
         var published = _bus.Published<EffectNameUpdated>();
         published.Should().ContainSingle();

--- a/tests/Arda.World.Player.Tests/GardenPassthroughTests.cs
+++ b/tests/Arda.World.Player.Tests/GardenPassthroughTests.cs
@@ -24,7 +24,7 @@ public class GardenPassthroughTests
         var sourceLine = "LocalPlayer: ProcessUpdateDescription(12345, \"My Garden\", \"A lovely plot\", \"Watering\", 0, \"unused(Scale=0.5)\", 1)";
         var args = "(12345, \"My Garden\", \"A lovely plot\", \"Watering\", 0, \"unused(Scale=0.5)\", 1)";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var frame = _bus.Published<UpdateDescriptionFrame>().Should().ContainSingle().Which;
         frame.PlotId.Should().Be(12345);
@@ -41,7 +41,7 @@ public class GardenPassthroughTests
         var sourceLine = "LocalPlayer: ProcessUpdateDescription(99, \"T\", \"D\", \"A\", 0, \"noscalehere\", 1)";
         var args = "(99, \"T\", \"D\", \"A\", 0, \"noscalehere\", 1)";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var frame = _bus.Published<UpdateDescriptionFrame>().Should().ContainSingle().Which;
         frame.PlotId.Should().Be(99);
@@ -55,7 +55,7 @@ public class GardenPassthroughTests
         var sourceLine = "LocalPlayer: ProcessUpdateDescription(1, \"\", \"\", \"\", 0, \"unused(Scale=1.0)\", 0)";
         var args = "(1, \"\", \"\", \"\", 0, \"unused(Scale=1.0)\", 0)";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var frame = _bus.Published<UpdateDescriptionFrame>().Should().ContainSingle().Which;
         frame.PlotId.Should().Be(1);
@@ -72,7 +72,7 @@ public class GardenPassthroughTests
         var sourceLine = "LocalPlayer: ProcessUpdateDescription(1, \"Herbs\", \"desc\", \"act\", 0, \"x(Scale=0.5)\", 1)";
         var args = sourceLine.AsSpan()["LocalPlayer: ProcessUpdateDescription".Length..];
 
-        handler.Handle(args, sourceLine, Meta());
+        handler.Handle(args, default, sourceLine, Meta());
 
         var frame = _bus.Published<UpdateDescriptionFrame>().Should().ContainSingle().Which;
         frame.Title.ToString().Should().Be("Herbs");
@@ -86,7 +86,7 @@ public class GardenPassthroughTests
         var handler = new SetPetOwnerHandler(_bus);
         var args = "(25237464, 7, 0)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var frame = _bus.Published<SetPetOwnerFrame>().Should().ContainSingle().Which;
         frame.EntityId.Should().Be(25237464);
@@ -98,7 +98,7 @@ public class GardenPassthroughTests
         var handler = new SetPetOwnerHandler(_bus);
         var args = "(9999999999, extra)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         _bus.Published<SetPetOwnerFrame>().Should().ContainSingle()
             .Which.EntityId.Should().Be(9999999999);
@@ -112,7 +112,7 @@ public class GardenPassthroughTests
         var handler = new ScreenTextHandler(_bus);
         var args = "(ErrorMessage, \"Something went wrong\")";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().ContainSingle();
     }
@@ -123,7 +123,7 @@ public class GardenPassthroughTests
         var handler = new ScreenTextHandler(_bus);
         var args = "(ImportantInfo, \"You discovered a point of interest!\")";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().BeEmpty();
     }
@@ -133,7 +133,7 @@ public class GardenPassthroughTests
     {
         var handler = new ScreenTextHandler(_bus);
 
-        handler.Handle(ReadOnlySpan<char>.Empty, "", Meta());
+        handler.Handle(ReadOnlySpan<char>.Empty, default, "", Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().BeEmpty();
     }
@@ -147,7 +147,7 @@ public class GardenPassthroughTests
         var sourceLine = "LocalPlayer: ProcessErrorMessage(ItemUnusable, \"Onion Seeds can't be used: You already have the maximum of that type of plant growing\")";
         var args = "(ItemUnusable, \"Onion Seeds can't be used: You already have the maximum of that type of plant growing\")";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var frame = _bus.Published<PlantingCapFrame>().Should().ContainSingle().Which;
         frame.SeedDisplayName.ToString().Should().Be("Onion Seeds");
@@ -159,7 +159,7 @@ public class GardenPassthroughTests
         var handler = new ErrorMessageHandler(_bus);
         var args = "(ItemUnusable, \"Cannot use that item here\")";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         _bus.Published<PlantingCapFrame>().Should().BeEmpty();
     }
@@ -169,7 +169,7 @@ public class GardenPassthroughTests
     {
         var handler = new ErrorMessageHandler(_bus);
 
-        handler.Handle(ReadOnlySpan<char>.Empty, "", Meta());
+        handler.Handle(ReadOnlySpan<char>.Empty, default, "", Meta());
 
         _bus.Published<PlantingCapFrame>().Should().BeEmpty();
     }
@@ -181,7 +181,7 @@ public class GardenPassthroughTests
         var sourceLine = "LocalPlayer: ProcessErrorMessage(ItemUnusable, \"Broccoli can't be used: You already have the maximum of that type of plant growing\")";
         var args = "(ItemUnusable, \"Broccoli can't be used: You already have the maximum of that type of plant growing\")";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<PlantingCapFrame>().Should().ContainSingle()
             .Which.SeedDisplayName.ToString().Should().Be("Broccoli");

--- a/tests/Arda.World.Player.Tests/GiftCorrelatorTests.cs
+++ b/tests/Arda.World.Player.Tests/GiftCorrelatorTests.cs
@@ -32,10 +32,7 @@ public class NpcGiftCorrelationTests
 
     private void ArmNpcInteraction(string npcKey, long entityId = 12307)
     {
-        _npc.OnStartInteraction(
-            $"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(),
-            $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")",
-            Meta());
+        _npc.OnStartInteraction($"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(), default, $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")", Meta());
         _bus.Clear();
     }
 
@@ -44,8 +41,7 @@ public class NpcGiftCorrelationTests
             $"LocalPlayer: ProcessDeleteItem({instanceId})", Meta());
 
     private void DeltaFavor(string npcKey, double delta) =>
-        _npc.OnDeltaFavor($"(12307, \"{npcKey}\", {delta}, True)".AsSpan(),
-            $"LocalPlayer: ProcessDeltaFavor(12307, \"{npcKey}\", {delta}, True)", Meta());
+        _npc.OnDeltaFavor($"(12307, \"{npcKey}\", {delta}, True)".AsSpan(), default, $"LocalPlayer: ProcessDeltaFavor(12307, \"{npcKey}\", {delta}, True)", Meta());
 
     // ── Delete-first correlation ─────────────────────────────────────────
 

--- a/tests/Arda.World.Player.Tests/InteractionPassthroughTests.cs
+++ b/tests/Arda.World.Player.Tests/InteractionPassthroughTests.cs
@@ -23,7 +23,7 @@ public class InteractionPassthroughTests
         var handler = new EndInteractionHandler(_bus);
         var args = "(-158)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<InteractionEnded>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(-158);
@@ -35,7 +35,7 @@ public class InteractionPassthroughTests
         var handler = new EndInteractionHandler(_bus);
         var args = "(42)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         _bus.Published<InteractionEnded>().Should().ContainSingle()
             .Which.EntityId.Should().Be(42);
@@ -50,7 +50,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessDoDelayLoop(3, Gather, "Collecting Fruit...", 0, AbortIfAttacked, IsInteractorDelayLoop)""";
         var args = """(3, Gather, "Collecting Fruit...", 0, AbortIfAttacked, IsInteractorDelayLoop)""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var e = _bus.Published<DelayLoopStarted>().Should().ContainSingle().Which;
         e.Seconds.Should().Be(3.0);
@@ -65,7 +65,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessDoDelayLoop(1.5, Eat, "Using Ranalon Salad", 5820, AbortIfAttacked)""";
         var args = """(1.5, Eat, "Using Ranalon Salad", 5820, AbortIfAttacked)""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var e = _bus.Published<DelayLoopStarted>().Should().ContainSingle().Which;
         e.Seconds.Should().BeApproximately(1.5, 0.001);
@@ -80,7 +80,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessDoDelayLoop(10, UseTeleportationCircle, "Recalling Other Places", 3713, AbortIfAttacked)""";
         var args = sourceLine.AsSpan()["LocalPlayer: ProcessDoDelayLoop".Length..];
 
-        handler.Handle(args, sourceLine, Meta());
+        handler.Handle(args, default, sourceLine, Meta());
 
         var e = _bus.Published<DelayLoopStarted>().Should().ContainSingle().Which;
         e.Verb.ToString().Should().Be("UseTeleportationCircle");
@@ -96,7 +96,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessWaitInteraction(-2, 500, "Filling Water Bottles...", "...")""";
         var args = """(-2, 500, "Filling Water Bottles...", "...")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var e = _bus.Published<InteractionWaiting>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(-2);
@@ -110,7 +110,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessWaitInteraction(-45, 500, "", "")""";
         var args = """(-45, 500, "", "")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         var e = _bus.Published<InteractionWaiting>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(-45);
@@ -126,7 +126,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessScreenText(CombatInfo, "You earned 5 Combat Wisdom: Killed Olugax")""";
         var args = """(CombatInfo, "You earned 5 Combat Wisdom: Killed Olugax")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().BeEmpty();
         var e = _bus.Published<ScreenTextObserved>().Should().ContainSingle().Which;
@@ -141,7 +141,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessScreenText(ImportantInfo, "Iron Ore x3 collected!")""";
         var args = """(ImportantInfo, "Iron Ore x3 collected!")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().BeEmpty();
         var e = _bus.Published<ScreenTextObserved>().Should().ContainSingle().Which;
@@ -156,7 +156,7 @@ public class InteractionPassthroughTests
         var sourceLine = """LocalPlayer: ProcessScreenText(GeneralInfo, "You've already looted this chest!")""";
         var args = """(GeneralInfo, "You've already looted this chest!")""";
 
-        handler.Handle(args.AsSpan(), sourceLine, Meta());
+        handler.Handle(args.AsSpan(), default, sourceLine, Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().BeEmpty();
         var e = _bus.Published<ScreenTextObserved>().Should().ContainSingle().Which;
@@ -169,7 +169,7 @@ public class InteractionPassthroughTests
         var handler = new ScreenTextHandler(_bus);
         var args = """(ErrorMessage, "Something went wrong")""";
 
-        handler.Handle(args.AsSpan(), args, Meta());
+        handler.Handle(args.AsSpan(), default, args, Meta());
 
         _bus.Published<ScreenTextErrorFrame>().Should().ContainSingle();
         _bus.Published<ScreenTextObserved>().Should().ContainSingle(

--- a/tests/Arda.World.Player.Tests/MapPinTests.cs
+++ b/tests/Arda.World.Player.Tests/MapPinTests.cs
@@ -24,13 +24,13 @@ public class MapPinTests
     private void DispatchAdd(int a, int shape, int color, double x, double y, double z, string label)
     {
         var args = $"({a}, {shape}, {color}, ({x}, {y}, {z}), \"{label}\")";
-        _mapPins.PinAddHandler.Handle(args.AsSpan(), "source", Meta());
+        _mapPins.PinAddHandler.Handle(args.AsSpan(), default, "source", Meta());
     }
 
     private void DispatchRemove(int a, int shape, int color, double x, double y, double z, string label)
     {
         var args = $"({a}, {shape}, {color}, ({x}, {y}, {z}), \"{label}\")";
-        _mapPins.PinRemoveHandler.Handle(args.AsSpan(), "source", Meta());
+        _mapPins.PinRemoveHandler.Handle(args.AsSpan(), default, "source", Meta());
     }
 
     [Fact]

--- a/tests/Arda.World.Player.Tests/MapTests.cs
+++ b/tests/Arda.World.Player.Tests/MapTests.cs
@@ -36,7 +36,7 @@ public class MapTests
         ReadOnlySpan<char> args = string.IsNullOrEmpty(areaArg)
             ? ReadOnlySpan<char>.Empty
             : areaArg.AsSpan();
-        _map.Handle(args, source, meta ?? Meta());
+        _map.Handle(args, default, source, meta ?? Meta());
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public class MapTests
         var source = $"!!! Initializing area! (502934): {areaKey}";
         // Args for InitializingArea: everything after "!!! Initializing area! "
         var args = $"(502934): {areaKey}".AsSpan();
-        _map.Handle(args, source, meta ?? Meta());
+        _map.Handle(args, default, source, meta ?? Meta());
     }
 
     [Fact]
@@ -140,21 +140,21 @@ public class MapTests
         var map = new Map(_bus, pool);
 
         var source1 = "LOADING LEVEL AreaSerbule";
-        map.Handle("AreaSerbule".AsSpan(), source1, Meta());
+        map.Handle("AreaSerbule".AsSpan(), default, source1, Meta());
         var initSource = "!!! Initializing area! (502934): AreaSerbule";
-        map.Handle("(502934): AreaSerbule".AsSpan(), initSource, Meta());
+        map.Handle("(502934): AreaSerbule".AsSpan(), default, initSource, Meta());
 
         var first = map.CurrentArea;
 
         var source2 = "LOADING LEVEL AreaCasino";
-        map.Handle("AreaCasino".AsSpan(), source2, Meta());
+        map.Handle("AreaCasino".AsSpan(), default, source2, Meta());
         var initSource2 = "!!! Initializing area! (100): AreaCasino";
-        map.Handle("(100): AreaCasino".AsSpan(), initSource2, Meta());
+        map.Handle("(100): AreaCasino".AsSpan(), default, initSource2, Meta());
 
         var source3 = "LOADING LEVEL AreaSerbule";
-        map.Handle("AreaSerbule".AsSpan(), source3, Meta());
+        map.Handle("AreaSerbule".AsSpan(), default, source3, Meta());
         var initSource3 = "!!! Initializing area! (502934): AreaSerbule";
-        map.Handle("(502934): AreaSerbule".AsSpan(), initSource3, Meta());
+        map.Handle("(502934): AreaSerbule".AsSpan(), default, initSource3, Meta());
 
         var second = map.CurrentArea;
 
@@ -221,7 +221,7 @@ public class MapTests
     [Fact]
     public void MalformedInitializingArea_NoColonSpace_IsIgnored()
     {
-        _map.Handle("(502934)AreaSerbule".AsSpan(), "malformed", Meta());
+        _map.Handle("(502934)AreaSerbule".AsSpan(), default, "malformed", Meta());
 
         _map.CurrentArea.Should().BeNull();
         _bus.Published<AreaChanged>().Should().BeEmpty();

--- a/tests/Arda.World.Player.Tests/NpcTests.cs
+++ b/tests/Arda.World.Player.Tests/NpcTests.cs
@@ -26,7 +26,7 @@ public class NpcTests
     private void DispatchInteraction(string interactionArgs)
     {
         var line = $"LocalPlayer: ProcessStartInteraction({interactionArgs})";
-        _npc.OnStartInteraction($"({interactionArgs})".AsSpan(), line, Meta());
+        _npc.OnStartInteraction($"({interactionArgs})".AsSpan(), default, line, Meta());
     }
 
     private void DispatchDeleteItem(long instanceId)
@@ -146,7 +146,7 @@ public class NpcTests
     private void DispatchDeltaFavor(string deltaFavorArgs)
     {
         var line = $"LocalPlayer: ProcessDeltaFavor({deltaFavorArgs})";
-        _npc.OnDeltaFavor($"({deltaFavorArgs})".AsSpan(), line, Meta());
+        _npc.OnDeltaFavor($"({deltaFavorArgs})".AsSpan(), default, line, Meta());
     }
 
     [Fact]

--- a/tests/Arda.World.Player.Tests/NpcVendorCorrelationTests.cs
+++ b/tests/Arda.World.Player.Tests/NpcVendorCorrelationTests.cs
@@ -31,18 +31,15 @@ public class NpcVendorCorrelationTests
 
     private void ArmNpcInteraction(string npcKey, long entityId = 12307)
     {
-        _npc.OnStartInteraction(
-            $"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(),
-            $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")",
-            Meta());
+        _npc.OnStartInteraction($"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(), default, $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")", Meta());
         _bus.Clear();
     }
 
     private void OpenVendorScreen(long entityId, string favorTier, long gold = 3926, long cap = 4000) =>
-        _npc.OnVendorScreen($"({entityId}, {favorTier}, {gold}, 1779404053485, {cap})".AsSpan(), "", Meta());
+        _npc.OnVendorScreen($"({entityId}, {favorTier}, {gold}, 1779404053485, {cap})".AsSpan(), default, "", Meta());
 
     private void SellItem(long price, string internalName, long instanceId) =>
-        _npc.OnVendorAddItem($"({price}, {internalName}({instanceId}), True)".AsSpan(), "", Meta());
+        _npc.OnVendorAddItem($"({price}, {internalName}({instanceId}), True)".AsSpan(), default, "", Meta());
 
     // ── Full flow: interaction → screen → sell ────────────────────────────
 

--- a/tests/Arda.World.Player.Tests/PlayerTests.cs
+++ b/tests/Arda.World.Player.Tests/PlayerTests.cs
@@ -26,25 +26,25 @@ public class PlayerTests
     private void DispatchLoadSkills(string skillArgs)
     {
         var line = $"LocalPlayer: ProcessLoadSkills({skillArgs})";
-        _player.LoadSkillsHandler.Handle($"({skillArgs})".AsSpan(), line, Meta());
+        _player.LoadSkillsHandler.Handle($"({skillArgs})".AsSpan(), default, line, Meta());
     }
 
     private void DispatchUpdateSkill(string skillArgs)
     {
         var line = $"LocalPlayer: ProcessUpdateSkill({skillArgs})";
-        _player.UpdateSkillHandler.Handle($"({skillArgs})".AsSpan(), line, Meta());
+        _player.UpdateSkillHandler.Handle($"({skillArgs})".AsSpan(), default, line, Meta());
     }
 
     private void DispatchLoadRecipes(string recipeArgs)
     {
         var line = $"LocalPlayer: ProcessLoadRecipes({recipeArgs})";
-        _player.LoadRecipesHandler.Handle($"({recipeArgs})".AsSpan(), line, Meta());
+        _player.LoadRecipesHandler.Handle($"({recipeArgs})".AsSpan(), default, line, Meta());
     }
 
     private void DispatchUpdateRecipe(string recipeArgs)
     {
         var line = $"LocalPlayer: ProcessUpdateRecipe({recipeArgs})";
-        _player.UpdateRecipeHandler.Handle($"({recipeArgs})".AsSpan(), line, Meta());
+        _player.UpdateRecipeHandler.Handle($"({recipeArgs})".AsSpan(), default, line, Meta());
     }
 
     // ── LoadSkills ───────────────────────────────────────────────────────

--- a/tests/Arda.World.Player.Tests/PositionTests.cs
+++ b/tests/Arda.World.Player.Tests/PositionTests.cs
@@ -23,12 +23,12 @@ public class PositionTests
 
     private void DispatchNewPosition(string args)
     {
-        _position.Handle(args.AsSpan(), $"LocalPlayer: ProcessNewPosition{args}", Meta());
+        _position.Handle(args.AsSpan(), default, $"LocalPlayer: ProcessNewPosition{args}", Meta());
     }
 
     private void DispatchAddPlayer(string args)
     {
-        _position.Handle(args.AsSpan(), $"LocalPlayer: ProcessAddPlayer{args}", Meta());
+        _position.Handle(args.AsSpan(), default, $"LocalPlayer: ProcessAddPlayer{args}", Meta());
     }
 
     // --- ProcessNewPosition: nested tuple ((x, y, z), ...) ---
@@ -183,7 +183,7 @@ public class PositionTests
     {
         var ts = new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero);
         var meta = new LogLineMetadata(ts, DateTimeOffset.UtcNow, false);
-        _position.Handle("((1, 2, 3), (0, 0, 0, 0))".AsSpan(), "source", meta);
+        _position.Handle("((1, 2, 3), (0, 0, 0, 0))".AsSpan(), default, "source", meta);
 
         _position.MeasuredAt.Should().Be(ts);
     }
@@ -193,7 +193,7 @@ public class PositionTests
     {
         var readOn = DateTimeOffset.UtcNow;
         var meta = new LogLineMetadata(null, readOn, false);
-        _position.Handle("((1, 2, 3), (0, 0, 0, 0))".AsSpan(), "source", meta);
+        _position.Handle("((1, 2, 3), (0, 0, 0, 0))".AsSpan(), default, "source", meta);
 
         _position.MeasuredAt.Should().Be(readOn);
     }
@@ -237,7 +237,7 @@ public class PositionTests
     public void Metadata_IsReplay_Preserved()
     {
         var meta = new LogLineMetadata(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, true);
-        _position.Handle("((1, 2, 3), (0, 0, 0, 0))".AsSpan(), "source", meta);
+        _position.Handle("((1, 2, 3), (0, 0, 0, 0))".AsSpan(), default, "source", meta);
 
         _bus.Published<PlayerPositionChanged>().Should().ContainSingle()
             .Which.Metadata.IsReplay.Should().BeTrue();

--- a/tests/Arda.World.Player.Tests/QuestTests.cs
+++ b/tests/Arda.World.Player.Tests/QuestTests.cs
@@ -25,7 +25,7 @@ public class QuestTests
     public void NewQuest_EmitsQuestId()
     {
         var args = "(\"New Quest: <<<quest_12345_Name>>>\", \"body\")".AsSpan();
-        _quest.Handle(args, "source", Meta());
+        _quest.Handle(args, default, "source", Meta());
 
         _bus.Published<QuestOffered>().Should().ContainSingle()
             .Which.QuestId.Should().Be(12345);
@@ -35,7 +35,7 @@ public class QuestTests
     public void NonQuestBook_DoesNotEmit()
     {
         var args = "(\"Some Lore Book Title\", \"body\")".AsSpan();
-        _quest.Handle(args, "source", Meta());
+        _quest.Handle(args, default, "source", Meta());
 
         _bus.Published<QuestOffered>().Should().BeEmpty();
     }
@@ -44,7 +44,7 @@ public class QuestTests
     public void MalformedQuestId_DoesNotEmit()
     {
         var args = "(\"New Quest: <<<quest_abc_Name>>>\", \"body\")".AsSpan();
-        _quest.Handle(args, "source", Meta());
+        _quest.Handle(args, default, "source", Meta());
 
         _bus.Published<QuestOffered>().Should().BeEmpty();
     }

--- a/tests/Arda.World.Player.Tests/SessionTests.cs
+++ b/tests/Arda.World.Player.Tests/SessionTests.cs
@@ -28,7 +28,7 @@ public class SessionTests
     private void Dispatch(string charName, long entityId = 99, string charId = "12345")
     {
         var args = $"({entityId}, 7, \"{charId}\", \"{charName}\", 100.0, 0.0, 200.0, 1.5)".AsSpan();
-        _session.Handle(args, "source", Meta());
+        _session.Handle(args, default, "source", Meta());
     }
 
     [Fact]

--- a/tests/Arda.World.Player.Tests/VaultTests.cs
+++ b/tests/Arda.World.Player.Tests/VaultTests.cs
@@ -40,7 +40,7 @@ public class VaultTests
         _bus.Clear();
 
         // ProcessRemoveFromStorageVault corrects to 93
-        _vault.OnRemoveFromStorageVault("(30346037, -1, 54162830, 93)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(30346037, -1, 54162830, 93)".AsSpan(), default, "", Meta());
 
         _inventory.Items[54162830].StackSize.Should().Be(93);
     }
@@ -52,7 +52,7 @@ public class VaultTests
         _vault.OnAddItem("(Diamond(87037617), -1, False)".AsSpan(), "", Meta());
         _bus.Clear();
 
-        _vault.OnRemoveFromStorageVault("(30346037, -1, 87037617, 5)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(30346037, -1, 87037617, 5)".AsSpan(), default, "", Meta());
 
         _bus.Published<InventoryItemUpdated>().Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new
@@ -70,7 +70,7 @@ public class VaultTests
         _vault.OnAddItem("(Amethyst(54162830), 132, True)".AsSpan(), "", Meta());
         _bus.Clear();
 
-        _vault.OnRemoveFromStorageVault("(30346037, -1, 54162830, 93)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(30346037, -1, 54162830, 93)".AsSpan(), default, "", Meta());
 
         _bus.Published<VaultWithdrawal>().Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new
@@ -90,7 +90,7 @@ public class VaultTests
         _bus.Clear();
 
         // Stack count = 1, same as what ProcessAddItem already set
-        _vault.OnRemoveFromStorageVault("(999, -1, 111, 1)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(999, -1, 111, 1)".AsSpan(), default, "", Meta());
 
         _bus.Published<InventoryItemUpdated>().Should().BeEmpty();
         _bus.Published<VaultWithdrawal>().Should().ContainSingle();
@@ -103,7 +103,7 @@ public class VaultTests
         _inventory.OnAddItem("(Gem(222), -1, False)".AsSpan(), "", Meta());
         _bus.Clear();
 
-        _vault.OnRemoveFromStorageVault("(999, -1, 222, 10)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(999, -1, 222, 10)".AsSpan(), default, "", Meta());
 
         // Stack size still corrected via Inventory.CorrectStackSize
         _inventory.Items[222].StackSize.Should().Be(10);
@@ -116,7 +116,7 @@ public class VaultTests
     public void Withdrawal_UnknownInstanceId_NoStackCorrection()
     {
         // No ProcessAddItem — instance not in inventory
-        _vault.OnRemoveFromStorageVault("(999, -1, 999999, 50)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(999, -1, 999999, 50)".AsSpan(), default, "", Meta());
 
         _bus.Published<InventoryItemUpdated>().Should().BeEmpty();
         _bus.Published<VaultWithdrawal>().Should().ContainSingle();
@@ -135,7 +135,7 @@ public class VaultTests
         _bus.Clear();
 
         // ProcessAddToStorageVault correlates with the pending delete
-        _vault.OnAddToStorageVault("(30346037, -1, 5, Moonstone(333))".AsSpan(), "", Meta());
+        _vault.OnAddToStorageVault("(30346037, -1, 5, Moonstone(333))".AsSpan(), default, "", Meta());
 
         _bus.Published<VaultDeposit>().Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new
@@ -151,7 +151,7 @@ public class VaultTests
     public void Deposit_WithoutPrecedingDeleteItem_StillEmits()
     {
         // No ProcessDeleteItem seen by Vault — but ProcessAddToStorageVault still fires
-        _vault.OnAddToStorageVault("(30346037, -1, 2, Ruby(444))".AsSpan(), "", Meta());
+        _vault.OnAddToStorageVault("(30346037, -1, 2, Ruby(444))".AsSpan(), default, "", Meta());
 
         _bus.Published<VaultDeposit>().Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new
@@ -168,9 +168,7 @@ public class VaultTests
     [Fact]
     public void ShowStorageVault_EmitsVaultOpenedEvent()
     {
-        _vault.OnShowStorageVault(
-            "(30346037, 100, \"My Vault\", \"A storage vault.\", 30, System.Collections.Generic.List`1[Item], , , , , 0)".AsSpan(),
-            "", Meta());
+        _vault.OnShowStorageVault("(30346037, 100, \"My Vault\", \"A storage vault.\", 30, System.Collections.Generic.List`1[Item], , , , , 0)".AsSpan(), default, "", Meta());
 
         _bus.Published<VaultOpened>().Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new
@@ -185,15 +183,13 @@ public class VaultTests
     [Fact]
     public void ShowStorageVault_SetsVaultEntityForSubsequentEvents()
     {
-        _vault.OnShowStorageVault(
-            "(12345, 200, \"Saddlebag\", \"Your saddlebag.\", 16, System.Collections.Generic.List`1[Item], , , , , 0)".AsSpan(),
-            "", Meta());
+        _vault.OnShowStorageVault("(12345, 200, \"Saddlebag\", \"Your saddlebag.\", 16, System.Collections.Generic.List`1[Item], , , , , 0)".AsSpan(), default, "", Meta());
 
         _inventory.OnAddItem("(Gold(555), -1, False)".AsSpan(), "", Meta());
         _vault.OnAddItem("(Gold(555), -1, False)".AsSpan(), "", Meta());
         _bus.Clear();
 
-        _vault.OnRemoveFromStorageVault("(99999, -1, 555, 100)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(99999, -1, 555, 100)".AsSpan(), default, "", Meta());
 
         // VaultEntityId comes from the ProcessShowStorageVault session, not the verb arg
         _bus.Published<VaultWithdrawal>().Should().ContainSingle()
@@ -213,7 +209,7 @@ public class VaultTests
 
         // After reset, the pending add should be gone — withdrawal still corrects
         // via direct inventory lookup, but pending name resolution is cleared
-        _vault.OnRemoveFromStorageVault("(999, -1, 666, 20)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(999, -1, 666, 20)".AsSpan(), default, "", Meta());
 
         _inventory.Items[666].StackSize.Should().Be(20);
         // Name resolved from inventory state (not pending)
@@ -224,9 +220,7 @@ public class VaultTests
     [Fact]
     public void Reset_ClearsVaultSession()
     {
-        _vault.OnShowStorageVault(
-            "(12345, 200, \"Vault\", \"desc\", 16, System.Collections.Generic.List`1[Item], , , , , 0)".AsSpan(),
-            "", Meta());
+        _vault.OnShowStorageVault("(12345, 200, \"Vault\", \"desc\", 16, System.Collections.Generic.List`1[Item], , , , , 0)".AsSpan(), default, "", Meta());
 
         _vault.Reset();
 
@@ -234,7 +228,7 @@ public class VaultTests
         _vault.OnAddItem("(Item(777), -1, False)".AsSpan(), "", Meta());
         _bus.Clear();
 
-        _vault.OnRemoveFromStorageVault("(99999, -1, 777, 3)".AsSpan(), "", Meta());
+        _vault.OnRemoveFromStorageVault("(99999, -1, 777, 3)".AsSpan(), default, "", Meta());
 
         // After reset, vault entity falls back to the arg from ProcessRemoveFromStorageVault
         _bus.Published<VaultWithdrawal>().Should().ContainSingle()

--- a/tests/Arda.World.Player.Tests/VendorPassthroughTests.cs
+++ b/tests/Arda.World.Player.Tests/VendorPassthroughTests.cs
@@ -25,10 +25,7 @@ public class VendorPassthroughTests
 
     private void ArmNpcInteraction(string npcKey, long entityId = 12307)
     {
-        _npc.OnStartInteraction(
-            $"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(),
-            $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")",
-            Meta());
+        _npc.OnStartInteraction($"({entityId}, 7, 2405.813, True, \"{npcKey}\")".AsSpan(), default, $"LocalPlayer: ProcessStartInteraction({entityId}, 7, 2405.813, True, \"{npcKey}\")", Meta());
         _bus.Clear();
     }
 
@@ -40,7 +37,7 @@ public class VendorPassthroughTests
         var handler = new VendorScreenHandler(_npc);
         var args = "(-162, Comfortable, 5000, 1779404053485, 10000, \"desc\", [], stuff)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorScreenOpened>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(-162);
@@ -57,7 +54,7 @@ public class VendorPassthroughTests
         ArmNpcInteraction("NPC_Therese", entityId: 14564);
 
         var handler = new VendorScreenHandler(_npc);
-        handler.Handle("(14564, Neutral, 3926, 1779404053485, 4000)".AsSpan(), "", Meta());
+        handler.Handle("(14564, Neutral, 3926, 1779404053485, 4000)".AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorScreenOpened>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(14564);
@@ -71,7 +68,7 @@ public class VendorPassthroughTests
         ArmNpcInteraction("NPC_Therese", entityId: 14564);
 
         var handler = new VendorScreenHandler(_npc);
-        handler.Handle("(99999, Neutral, 3926, 1779404053485, 4000)".AsSpan(), "", Meta());
+        handler.Handle("(99999, Neutral, 3926, 1779404053485, 4000)".AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorScreenOpened>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(99999);
@@ -84,7 +81,7 @@ public class VendorPassthroughTests
         var handler = new VendorScreenHandler(_npc);
         var args = "(-999, Neutral, 0, 1779404053485, 5000)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorScreenOpened>().Should().ContainSingle().Which;
         e.EntityId.Should().Be(-999);
@@ -101,7 +98,7 @@ public class VendorPassthroughTests
         var handler = new VendorAddItemHandler(_npc);
         var args = "(250, SwordNovice(12345), True)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorItemSold>().Should().ContainSingle().Which;
         e.Price.Should().Be(250);
@@ -115,11 +112,11 @@ public class VendorPassthroughTests
     public void VendorAddItem_WithVendorSession_EnrichesNpcKeyAndFavorTier()
     {
         ArmNpcInteraction("NPC_Johen", entityId: 9999);
-        _npc.OnVendorScreen("(9999, Friendly, 5000, 1779404053485, 8000)".AsSpan(), "", Meta());
+        _npc.OnVendorScreen("(9999, Friendly, 5000, 1779404053485, 8000)".AsSpan(), default, "", Meta());
         _bus.Clear();
 
         var handler = new VendorAddItemHandler(_npc);
-        handler.Handle("(250, SwordNovice(12345), True)".AsSpan(), "", Meta());
+        handler.Handle("(250, SwordNovice(12345), True)".AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorItemSold>().Should().ContainSingle().Which;
         e.Price.Should().Be(250);
@@ -135,7 +132,7 @@ public class VendorPassthroughTests
         var handler = new VendorAddItemHandler(_npc);
         var args = "(999999, RareItem(8888), False)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorItemSold>().Should().ContainSingle().Which;
         e.Price.Should().Be(999999);
@@ -149,7 +146,7 @@ public class VendorPassthroughTests
         var handler = new VendorAddItemHandler(_npc);
         var args = "(250, NoParenthesis, True)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         _bus.Published<VendorItemSold>().Should().BeEmpty();
     }
@@ -162,7 +159,7 @@ public class VendorPassthroughTests
         var handler = new VendorGoldHandler(_bus);
         var args = "(4500, 1779404053485, 10000)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorGoldUpdated>().Should().ContainSingle().Which;
         e.RemainingGold.Should().Be(4500);
@@ -176,7 +173,7 @@ public class VendorPassthroughTests
         var handler = new VendorGoldHandler(_bus);
         var args = "(0, 0, 0)";
 
-        handler.Handle(args.AsSpan(), "", Meta());
+        handler.Handle(args.AsSpan(), default, "", Meta());
 
         var e = _bus.Published<VendorGoldUpdated>().Should().ContainSingle().Which;
         e.RemainingGold.Should().Be(0);

--- a/tests/Arda.World.Player.Tests/WeatherTests.cs
+++ b/tests/Arda.World.Player.Tests/WeatherTests.cs
@@ -24,7 +24,7 @@ public class WeatherTests
     private void Dispatch(string condition, bool flag = true)
     {
         var args = $"(\"{condition}\", {(flag ? "True" : "False")})".AsSpan();
-        _weather.Handle(args, $"LocalPlayer: ProcessSetWeather(\"{condition}\", {(flag ? "True" : "False")})", Meta());
+        _weather.Handle(args, default, $"LocalPlayer: ProcessSetWeather(\"{condition}\", {(flag ? "True" : "False")})", Meta());
     }
 
     [Fact]

--- a/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
+++ b/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
@@ -29,12 +29,27 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     private sealed class FakeGrammarBreakSignal : IGrammarBreakSignal
     {
         public GrammarBreak? Current { get; private set; }
-        public bool IsRaised => Current is not null;
+        public bool IsRaised { get; private set; }
+        public bool HasObservedBreak => ObservedCount > 0;
+        public int ObservedCount { get; private set; }
         public event EventHandler? Raised;
+        public event EventHandler? ObservedBreakChanged;
+
         public void Raise(GrammarBreak breakDetails)
         {
+            var first = !IsRaised;
             Current ??= breakDetails;
-            Raised?.Invoke(this, EventArgs.Empty);
+            IsRaised = true;
+            ObservedCount++;
+            ObservedBreakChanged?.Invoke(this, EventArgs.Empty);
+            if (first) Raised?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void MarkObserved(GrammarBreak breakDetails)
+        {
+            Current ??= breakDetails;
+            ObservedCount++;
+            ObservedBreakChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 

--- a/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
+++ b/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
@@ -18,11 +18,24 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     private readonly TestBus _bus = new();
     private readonly FakeReplayProgress _replay = new();
     private readonly FakeTimeProvider _time = new();
+    private readonly FakeGrammarBreakSignal _grammarSignal = new();
     private readonly WorldHealthView _view;
 
     public WorldHealthViewTests()
     {
-        _view = new WorldHealthView(_bus, _replay, NullLogger<WorldHealthView>.Instance, _time);
+        _view = new WorldHealthView(_bus, _replay, _grammarSignal, NullLogger<WorldHealthView>.Instance, _time);
+    }
+
+    private sealed class FakeGrammarBreakSignal : IGrammarBreakSignal
+    {
+        public GrammarBreak? Current { get; private set; }
+        public bool IsRaised => Current is not null;
+        public event EventHandler? Raised;
+        public void Raise(GrammarBreak breakDetails)
+        {
+            Current ??= breakDetails;
+            Raised?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     public Task InitializeAsync() => _view.StartAsync(CancellationToken.None);


### PR DESCRIPTION
## Why

`ArgTokenizer.NextLong/NextInt/NextDouble` currently `long.Parse` positional args directly. One malformed token throws `FormatException`; `DispatchTable.Dispatch` swallows it per-handler with a one-line *"Handler X threw on verb dispatch"* — the handler's `_bus.Publish(...)` (always last) never fires and the entire domain event is lost.

In a deterministic world simulation that's catastrophic. One lost `InventoryItemAdded` means the instance ID is never registered, so the later `InventoryItemRemoved` can't be correlated; `Vault._pendingDelete` never matches; the `Npc` gift correlator desynchronises; and the `PerCharacterStore` snapshot persisted on replay completion encodes the divergent state — so next launch starts wrong, with the only signal in the log being *"Handler Inventory threw on verb dispatch"*.

The fix is **fail-fast**: throw a typed `GrammarException`, halt both Arda drivers, surface the break to the user, and preserve the last-known-good persisted snapshot for the next launch. Soft-log-and-continue would preserve the cascade.

## Components

One commit per layer. Numbering matches the design spec.

| # | Commit | Layer |
|---|---|---|
| 1 | `feat(arda): add GrammarException + IGrammarBreakSignal scaffolding` | `Arda.Dispatch` types + DI registration |
| 2 | `refactor(arda): ArgTokenizer throws GrammarException + adds Try* siblings` | Tokenizer rewires throw; `TryNext*` siblings for legitimately-optional fields |
| 3 | `refactor(arda): plumb verb through IFrameHandler.Handle (mechanical)` | `Handle` gains `ReadOnlySpan<char> verb`; ~50 handler files touched |
| 4 | `feat(arda): DispatchTable propagates GrammarException, enriches handler-bug log` | `GrammarException` escapes; generic handler bugs still swallowed (with verb + excerpt) |
| 5 | `feat(arda): halt both world drivers on GrammarException; MITHRIL_GRAMMAR_TOLERANT escape hatch` | `WorldDriver` raises signal, exits without firing live-transition; companion driver halts cooperatively; env-var downgrades to throttled Warn + continue |
| 6 | `feat(arda): IWorldHealthView surfaces grammar-break state` | `WorldMode.Halted`, `Break`, `IsHalted`; `WorldHealthView` subscribes to `IGrammarBreakSignal.Raised` |
| 7 | `feat(arda): composers skip snapshot writes when grammar break in flight` | `InventoryComposer` / `NpcStateComposer` / `PlayerProgressionComposer` gate `FlushToDisk` |
| 9 | `feat(shell): blocking grammar-break banner + CloseShell command` | Top-of-window banner above sidebar+content; *Close Mithril* button |

(Commit 8 — env-var plumbing — was folded into commit 5 since the BackgroundService DI plumbing needed `ArdaRuntimeOptions` to be registered for `WorldDriver` to be constructable.)

## User-confirmed design choices

Settled during planning, not relitigated:

- **Halt scope**: both drivers halt on any grammar drift (composers depend on both worlds).
- **User surface**: blocking banner at the top of the shell. Module tabs continue to render whatever they captured pre-halt; no events arrive after halt so they're effectively read-only.
- **Persistence at halt**: composers do NOT flush their in-memory snapshots; the prior on-disk JSON is preserved for next launch.
- **Developer escape hatch**: `MITHRIL_GRAMMAR_TOLERANT=1` env var (read once in `AddArda`) downgrades halt → `ThrottledWarn` + continue. Never exposed in shell settings.

## Tests

- `tests/Arda.Dispatch.Tests/DispatchTableHaltTests.cs` — `GrammarException` propagates out of `Dispatch`; generic `Exception` is swallowed; `GrammarException` aborts remaining handlers for the same verb.
- `tests/Arda.Dispatch.Tests/WorldDriverHaltTests.cs` — `GrammarException` raises the signal and suppresses live-transition; companion-driver halt stops this driver at next iteration; tolerant mode skips the bad line and continues.
- `tests/Arda.Composition.Tests/HaltedSnapshotSkipTests.cs` — halted session-switch skips snapshot write; baseline session-switch writes as before.
- Full suite: **27 projects, ~3,580 tests, 0 failures.**

No isolated `ShellViewModel` test in this PR — the VM has ~15 DI dependencies and the wiring (`Changed` event → `RefreshHealthState` → `[ObservableProperty]`) is mechanical. The `IWorldHealthView` side is covered by `WorldHealthViewTests`.

## Out of scope (follow-ups worth filing)

- Auto-update affordance from the banner (today says only *Close Mithril*; future iteration could wire a GitHub-releases check + one-click update).
- Per-handler `TryNext*` audit. The throw is intentional behaviour; migrate specific fields only when a future PG patch makes one legitimately tolerant.
- Persisted *"halted in this session"* tombstone file. The in-process banner is enough today.

## Verification owed (manual smoke, not in CI)

1. Launch Mithril against real Player.log. `IWorldHealthView.Break is null`, modules functional.
2. Copy a real Player.log, change one `ProcessAddItem(...)` arg to `NOT_A_NUMBER`. Launch shell. Banner appears within one batch; both drivers stop; quit and confirm `%LocalAppData%/Mithril/` JSON snapshots are unchanged from pre-launch.
3. `set MITHRIL_GRAMMAR_TOLERANT=1` and re-run #2. No banner; throttled Warn entries name the verb; driver keeps tailing past the malformed line.

## Background

The original code review framed the `ArgTokenizer` Parse-throws issue as a low-severity honorable-mention. That framing was wrong for a deterministic world simulation — see the *Why* section above. This PR addresses the underlying class of bug, not just the specific tokenizer entry points.

— drafted by Claude (Opus 4.7), posted by @arthur-conde

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>