### PR TITLE
Fix: register DiagnosticsLoggerProvider after ClearProviders so MEL logs surface

### DIFF
--- a/src/Mithril.Shared/DependencyInjection/DiagnosticsLoggingExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/DiagnosticsLoggingExtensions.cs
@@ -16,14 +16,18 @@ public static class DiagnosticsLoggingExtensions
     {
         services.AddSingleton<DiagnosticsLoggerProvider>(_ => new DiagnosticsLoggerProvider(logDirectory));
         services.AddSingleton<IDiagnosticsLog>(sp => sp.GetRequiredService<DiagnosticsLoggerProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, DiagnosticsLoggerProvider>(sp =>
-            sp.GetRequiredService<DiagnosticsLoggerProvider>()));
 
         services.AddLogging(builder =>
         {
+            // ClearProviders calls Services.RemoveAll<ILoggerProvider>(), so it MUST run
+            // before we register DiagnosticsLoggerProvider as ILoggerProvider — otherwise
+            // ILoggerFactory ends up with zero providers and every MEL log call is a no-op.
             builder.ClearProviders();
             builder.SetMinimumLevel(MelLogLevel.Trace);
         });
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, DiagnosticsLoggerProvider>(sp =>
+            sp.GetRequiredService<DiagnosticsLoggerProvider>()));
 
         return services;
     }

--- a/tests/Mithril.Shared.Tests/Diagnostics/DiagnosticsLoggingDiPipelineTests.cs
+++ b/tests/Mithril.Shared.Tests/Diagnostics/DiagnosticsLoggingDiPipelineTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Diagnostics;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Diagnostics;
+
+/// <summary>
+/// Regression test for the bug where AddMithrilLogging registered DiagnosticsLoggerProvider
+/// as ILoggerProvider BEFORE calling builder.ClearProviders(), which silently wiped the
+/// registration. Production MEL loggers were no-ops, and the diagnostics view showed nothing.
+/// </summary>
+public sealed class DiagnosticsLoggingDiPipelineTests
+{
+    [Fact]
+    public void Mel_logger_resolved_from_DI_surfaces_in_IDiagnosticsLog()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mithril-di-{Guid.NewGuid():N}");
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddMithrilLogging(dir);
+            using var sp = services.BuildServiceProvider();
+
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("CategoryX");
+            logger.LogInformation("hello pipeline");
+
+            var diag = sp.GetRequiredService<IDiagnosticsLog>();
+            diag.Snapshot().Should().ContainSingle(e =>
+                e.Category == "CategoryX"
+                && e.Message == "hello pipeline"
+                && e.Level == DiagnosticLevel.Info);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Reorder `AddMithrilLogging` so `builder.ClearProviders()` runs *before* `TryAddEnumerable<ILoggerProvider>` — otherwise `ClearProviders` (which calls `Services.RemoveAll<ILoggerProvider>()`) silently wipes the `DiagnosticsLoggerProvider` registration. `ILoggerFactory` ends up with zero providers, every MEL `ILogger<T>` is a no-op, and the Diagnostics view, ring buffer, Rx live stream, and Serilog compact-JSON file all stay empty.
- Add `DiagnosticsLoggingDiPipelineTests` exercising the full DI/MEL pipeline. Confirmed it fails on the broken ordering (snapshot empty) and passes on the fix. The existing `DiagnosticsLoggerProviderGoldenLineTests` missed this because it constructs `DiagnosticsLoggerProvider` directly and bypasses MEL.

## Test plan

- [x] `dotnet test tests/Mithril.Shared.Tests --filter "FullyQualifiedName~DiagnosticsLoggingDiPipelineTests"` — passes on fix, fails on revert
- [x] `dotnet test tests/Mithril.Shared.Tests` — 1150 / 1150 pass
- [ ] Launch shell, open Diagnostics tab, confirm live + buffered entries surface (manual verification owed once Arda is merged into `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
