### PR TITLE
fix(legolas): pivot survey attribution to ScreenText counts (#824)

### DIFF
--- a/src/Legolas.Module/Services/ItemCollectionTracker.cs
+++ b/src/Legolas.Module/Services/ItemCollectionTracker.cs
@@ -4,6 +4,7 @@ using Arda.World.Player.Events;
 using Legolas.Domain;
 using Legolas.ViewModels;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Legolas.Services;
 
@@ -28,13 +29,18 @@ public sealed class ItemCollectionTracker : BackgroundService
 {
     private readonly IDomainEventSubscriber _bus;
     private readonly SessionState _session;
+    private readonly ILogger? _logger;
 
     private IDisposable? _screenTextSub;
 
-    public ItemCollectionTracker(IDomainEventSubscriber bus, SessionState session)
+    public ItemCollectionTracker(
+        IDomainEventSubscriber bus,
+        SessionState session,
+        ILogger? logger = null)
     {
         _bus = bus;
         _session = session;
+        _logger = logger;
     }
 
     public override Task StartAsync(CancellationToken cancellationToken)
@@ -101,9 +107,16 @@ public sealed class ItemCollectionTracker : BackgroundService
             return;
         }
 
-        _session.LastLogEvent = _session.Surveys.Count == 0
-            ? $"Collected: {name} → no surveys tracked"
-            : $"Collected: {name} → no name match (have {string.Join(", ", _session.Surveys.Where(s => !s.Collected).Select(s => s.Name).Take(3))})";
+        if (_session.Surveys.Count == 0)
+        {
+            _session.LastLogEvent = $"Collected: {name} → no surveys tracked";
+            _logger?.LogTrace("Collected {Name} (count {Count}) with no surveys tracked", name, count);
+        }
+        else
+        {
+            _session.LastLogEvent = $"Collected: {name} → no name match (have {string.Join(", ", _session.Surveys.Where(s => !s.Collected).Select(s => s.Name).Take(3))})";
+            _logger?.LogTrace("Collected {Name} (count {Count}) did not match any uncollected survey slot", name, count);
+        }
     }
 
     private void AccumulateCollected(string name, int count)

--- a/src/Legolas.Module/Services/ItemCollectionTracker.cs
+++ b/src/Legolas.Module/Services/ItemCollectionTracker.cs
@@ -2,81 +2,44 @@ using System.Windows;
 using Arda.Contracts;
 using Arda.World.Player.Events;
 using Legolas.Domain;
-using Legolas.Flow;
 using Legolas.ViewModels;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Reference;
 
 namespace Legolas.Services;
 
 /// <summary>
-/// Arda-driven inventory-add ↔ Player.log-collect attribution. Subscribes to
-/// <see cref="InventoryItemAdded"/> (replaces former <c>IPlayerWorld.Bus</c>
-/// <c>PlayerInventoryAdded</c> subscription) and <see cref="ScreenTextObserved"/>
-/// (replaces the L1 driver <c>ProcessScreenText</c> parsing) via
-/// <see cref="IDomainEventSubscriber"/>.
+/// Survey-mode item-attribution tracker. Treats <see cref="ScreenTextObserved"/>
+/// "<c>&lt;item&gt; collected!</c>" lines as the sole source of truth for both
+/// primary drops and speed-bonus drops — the chat text carries the explicit
+/// <c>xN</c> count and fires for both fresh-instance and stack-onto-existing
+/// inventory mutations, while <c>InventoryItemAdded</c> only fires on the
+/// fresh-instance path and always carries <c>StackSize = 1</c>. See #824 for
+/// the corpus evidence behind this pivot (Player-2026-05-20-0400.log) and
+/// #543 / #809 for the prior attribution attempts this replaces.
 ///
-/// <list type="bullet">
-///   <item><b>Add channel</b> — <see cref="InventoryItemAdded"/> (instance-id +
-///   InternalName). Resolved to a display-name via
-///   <see cref="IReferenceDataService.ItemsByInternalName"/> and enqueued under
-///   that key.</item>
-///   <item><b>Collect channel</b> — <see cref="ScreenTextObserved"/> with
-///   category <c>ImportantInfo</c> matching the "<c>&lt;Mineral&gt; collected!</c>"
-///   pattern (parsed by <see cref="PlayerLogParser.TryParseItemCollected"/>).
-///   Dequeues the head of the matching display-name FIFO and credits one to
-///   <see cref="SessionState.CollectedItems"/>.</item>
-/// </list>
-///
-/// <para><b>Replay gating.</b> Both channels check
-/// <see cref="Arda.Abstractions.Logs.LogLineMetadata.IsReplay"/> — replay events
-/// are dropped. Replaces the former <c>LiveOnly</c> replay mode.</para>
+/// <para><b>Replay gating.</b> <see cref="Arda.Abstractions.Logs.LogLineMetadata.IsReplay"/>
+/// events are dropped — survey state is live-session only.</para>
 ///
 /// <para><b>Threading.</b> The Arda bus fires synchronously on the driver
-/// thread. Handlers marshal to the UI thread via the WPF dispatcher so
+/// thread. The handler marshals to the UI thread via the WPF dispatcher so
 /// overlay-bound state mutations stay single-threaded.</para>
 /// </summary>
 public sealed class ItemCollectionTracker : BackgroundService
 {
     private readonly IDomainEventSubscriber _bus;
     private readonly SessionState _session;
-    private readonly SurveyFlowController _flow;
-    private readonly IReferenceDataService? _refData;
-    private readonly ILogger? _logger;
-    private readonly ThrottledWarn _warn;
 
-    private readonly Dictionary<string, Queue<long>> _pendingAdds
-        = new(StringComparer.OrdinalIgnoreCase);
-    private readonly object _pendingLock = new();
-
-    private IDisposable? _invAddedSub;
     private IDisposable? _screenTextSub;
 
-    public ItemCollectionTracker(
-        IDomainEventSubscriber bus,
-        SessionState session,
-        SurveyFlowController flow,
-        IReferenceDataService? refData = null,
-        ILogger? logger = null,
-        TimeProvider? time = null)
+    public ItemCollectionTracker(IDomainEventSubscriber bus, SessionState session)
     {
         _bus = bus;
         _session = session;
-        _flow = flow;
-        _refData = refData;
-        _logger = logger;
-        _warn = new ThrottledWarn(logger, "Legolas.Ingestion", time: time ?? TimeProvider.System);
-
-        _flow.Transitioned += OnFlowTransitioned;
     }
 
     public override Task StartAsync(CancellationToken cancellationToken)
     {
-        _invAddedSub ??= _bus.Subscribe<InventoryItemAdded>(OnInventoryItemAdded);
         _screenTextSub ??= _bus.Subscribe<ScreenTextObserved>(OnScreenTextObserved);
-
         return base.StartAsync(cancellationToken);
     }
 
@@ -88,36 +51,16 @@ public sealed class ItemCollectionTracker : BackgroundService
 
     public override Task StopAsync(CancellationToken cancellationToken)
     {
-        _invAddedSub?.Dispose();
-        _invAddedSub = null;
         _screenTextSub?.Dispose();
         _screenTextSub = null;
-        _flow.Transitioned -= OnFlowTransitioned;
         return base.StopAsync(cancellationToken);
     }
 
     public override void Dispose()
     {
-        _invAddedSub?.Dispose();
-        _invAddedSub = null;
         _screenTextSub?.Dispose();
         _screenTextSub = null;
-        _flow.Transitioned -= OnFlowTransitioned;
         base.Dispose();
-    }
-
-    private void OnInventoryItemAdded(InventoryItemAdded evt)
-    {
-        if (evt.Metadata.IsReplay) return;
-
-        var displayName = ResolveDisplayName(evt.InternalName);
-        if (string.IsNullOrEmpty(displayName)) return;
-        lock (_pendingLock)
-        {
-            if (!_pendingAdds.TryGetValue(displayName, out var q))
-                _pendingAdds[displayName] = q = new Queue<long>();
-            q.Enqueue(evt.InstanceId);
-        }
     }
 
     private void OnScreenTextObserved(ScreenTextObserved evt)
@@ -125,29 +68,17 @@ public sealed class ItemCollectionTracker : BackgroundService
         if (evt.Metadata.IsReplay) return;
         if (!evt.Category.Span.SequenceEqual("ImportantInfo".AsSpan())) return;
 
-        var text = evt.Text.ToString();
-        if (PlayerLogParser.TryParseItemCollected(text) is not var (name, bonus)) return;
+        if (PlayerLogParser.TryParseItemCollected(evt.Text.Span) is not var (name, count, bonusName, bonusCount))
+            return;
 
-        MarshalToUi(() => HandleItemCollected(name, bonus));
+        MarshalToUi(() => HandleItemCollected(name, count, bonusName, bonusCount));
     }
 
-    private string? ResolveDisplayName(string internalName)
+    private void HandleItemCollected(string name, int count, string? bonusName, int bonusCount)
     {
-        if (string.IsNullOrEmpty(internalName)) return null;
-        if (_refData is null) return internalName;
-        if (_refData.ItemsByInternalName.TryGetValue(internalName, out var item)
-            && !string.IsNullOrEmpty(item.Name))
-        {
-            return item.Name;
-        }
-        return internalName;
-    }
-
-    private void HandleItemCollected(string name, string? speedBonusItem)
-    {
-        CreditCollect(name);
-        if (!string.IsNullOrEmpty(speedBonusItem))
-            CreditCollect(speedBonusItem!);
+        AccumulateCollected(name, count);
+        if (!string.IsNullOrEmpty(bonusName))
+            AccumulateCollected(bonusName, bonusCount);
 
         SurveyItemViewModel? best = null;
         var bestOrder = int.MaxValue;
@@ -175,58 +106,10 @@ public sealed class ItemCollectionTracker : BackgroundService
             : $"Collected: {name} → no name match (have {string.Join(", ", _session.Surveys.Where(s => !s.Collected).Select(s => s.Name).Take(3))})";
     }
 
-    private void CreditCollect(string name)
-    {
-        bool hadAny;
-        lock (_pendingLock)
-        {
-            hadAny = _pendingAdds.TryGetValue(name, out var q) && q.Count > 0;
-            if (hadAny)
-            {
-                _pendingAdds[name].Dequeue();
-                if (_pendingAdds[name].Count == 0)
-                    _pendingAdds.Remove(name);
-            }
-        }
-
-        if (hadAny)
-        {
-            AccumulateCollected(name, 1);
-            return;
-        }
-        _warn.Warn(
-            $"Collect for '{name}' had no pending inventory add; crediting 0.");
-    }
-
     private void AccumulateCollected(string name, int count)
     {
         _session.CollectedItems.TryGetValue(name, out var existing);
         _session.CollectedItems[name] = existing + count;
-    }
-
-    private void OnFlowTransitioned(SurveyTransition t)
-    {
-        var shouldClear = t.To == SurveyFlowState.Done
-            || string.Equals(t.Trigger, nameof(SurveyFlowController.Reset), StringComparison.Ordinal);
-        if (!shouldClear) return;
-
-        Dictionary<string, int>? unmatched = null;
-        lock (_pendingLock)
-        {
-            if (_pendingAdds.Count > 0)
-            {
-                unmatched = new Dictionary<string, int>(_pendingAdds.Count, StringComparer.OrdinalIgnoreCase);
-                foreach (var (name, q) in _pendingAdds) unmatched[name] = q.Count;
-                _pendingAdds.Clear();
-            }
-        }
-        if (unmatched is { Count: > 0 })
-        {
-            var summary = string.Join(", ",
-                unmatched.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
-                    .Select(kv => $"{kv.Key} x{kv.Value}"));
-            _logger?.LogTrace($"survey ended ({t.Trigger}); unmatched pending Adds dropped: {summary}");
-        }
     }
 
     private static void MarshalToUi(Action action)

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -39,13 +39,6 @@ public static partial class PlayerLogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
     private static partial Regex MotherlodeDistanceTextRx();
 
-    // Survey collect readout — the bare text inside ScreenTextObserved
-    // (ImportantInfo category). Primary mineral + optional speed-bonus tail.
-    [GeneratedRegex(
-        """^(?<name>.+?)(?:\s+x\d+)?\s+collected!(?:\s+Also found\s+(?<bonus>.+?)(?:\s+x\d+)?\s+\(speed bonus!\))?\.?$""",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
-    private static partial Regex ItemCollectedTextRx();
-
     /// <summary>
     /// Extract the relative-offset readout embedded in a <c>MapFxObserved</c>
     /// message string ("The X is Nm DIR and Mm DIR."). Returns null when
@@ -82,16 +75,66 @@ public static partial class PlayerLogParser
 
     /// <summary>
     /// Try to parse an item-collected readout from a ScreenTextObserved
-    /// text field. Returns the item name and optional speed-bonus item,
-    /// or null if no match.
+    /// text field. Returns the primary item (name + count) and optional
+    /// speed-bonus item (name + count), or null if the text isn't a
+    /// collect line. Implicit count is 1 when the <c>xN</c> tail is absent.
+    /// Span-based; allocates only on the match path (one or two
+    /// <c>.ToString()</c> calls on the matched name slices).
     /// </summary>
-    public static (string Name, string? SpeedBonusItem)? TryParseItemCollected(string text)
+    public static (string Name, int Count, string? BonusName, int BonusCount)? TryParseItemCollected(
+        ReadOnlySpan<char> text)
     {
-        if (string.IsNullOrEmpty(text)) return null;
-        var m = ItemCollectedTextRx().Match(text);
-        if (!m.Success) return null;
-        string? bonus = m.Groups["bonus"].Success ? m.Groups["bonus"].Value.Trim() : null;
-        return (m.Groups["name"].Value.Trim(), bonus);
+        if (text.IsEmpty) return null;
+
+        // Trim an optional trailing '.' (e.g. some clients append a period).
+        if (text[^1] == '.') text = text[..^1];
+
+        const string CollectedMarker = " collected!";
+        var collectedIdx = text.IndexOf(CollectedMarker.AsSpan());
+        if (collectedIdx <= 0) return null;
+
+        var primaryName = StripTrailingXn(text[..collectedIdx], out var primaryCount);
+        if (primaryName.IsEmpty) return null;
+
+        var tail = text[(collectedIdx + CollectedMarker.Length)..];
+        if (tail.IsEmpty)
+        {
+            return (primaryName.ToString(), primaryCount, null, 0);
+        }
+
+        const string BonusPrefix = " Also found ";
+        const string BonusSuffix = " (speed bonus!)";
+        if (!tail.StartsWith(BonusPrefix.AsSpan()) || !tail.EndsWith(BonusSuffix.AsSpan()))
+            return null;
+
+        var bonusName = StripTrailingXn(tail[BonusPrefix.Length..^BonusSuffix.Length], out var bonusCount);
+        if (bonusName.IsEmpty) return null;
+
+        return (primaryName.ToString(), primaryCount, bonusName.ToString(), bonusCount);
+    }
+
+    // Strips a trailing " xN" suffix (where N is a positive integer) and
+    // returns the leading name slice plus the count via out (defaulting
+    // to 1 when absent). Same shape as ChatInventory's [Status] parser.
+    // Item names containing an internal 'x' (e.g. "Wax Sculpture") are
+    // unaffected because the check requires the literal " x" + digits
+    // pattern at the end of the slice.
+    private static ReadOnlySpan<char> StripTrailingXn(ReadOnlySpan<char> middle, out int count)
+    {
+        var lastSpace = middle.LastIndexOf(' ');
+        if (lastSpace > 0)
+        {
+            var candidate = middle[(lastSpace + 1)..];
+            if (candidate.Length > 1
+                && candidate[0] == 'x'
+                && int.TryParse(candidate[1..], NumberStyles.None, CultureInfo.InvariantCulture, out var parsed))
+            {
+                count = parsed;
+                return middle[..lastSpace];
+            }
+        }
+        count = 1;
+        return middle;
     }
 
     /// <summary>

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -245,22 +245,6 @@
         { "name": "desc", "group": "desc", "type": "string" }
       ]
     },
-    "legolas.PlayerLogParser.ItemCollectedRx": {
-      "pattern": "^(?<name>.+?)(?:\\s+x\\d+)?\\s+collected!(?:\\s+Also found\\s+(?<bonus>.+?)(?:\\s+x\\d+)?\\s+\\(speed bonus!\\))?\\.?$",
-      "source": "player",
-      "module": "legolas",
-      "csharp": {
-        "type": "Legolas.Services.PlayerLogParser",
-        "method": "ItemCollectedTextRx",
-        "options": ["Compiled", "CultureInvariant"]
-      },
-      "eventType": "legolas.ItemCollected",
-      "notes": "Post-Arda: operates on the already-extracted ScreenTextObserved.Text (ImportantInfo category) rather than the full log line. Matches the inner text body only.",
-      "fields": [
-        { "name": "name", "group": "name", "type": "string" },
-        { "name": "bonus", "group": "bonus", "type": "string" }
-      ]
-    },
     "legolas.PlayerLogParser.MapFxRelativeOffsetRx": {
       "pattern": "The (?<name>.+?) is (?<a>\\d+)m (?<aDir>north|south|east|west) and (?<b>\\d+)m (?<bDir>north|south|east|west)\\b",
       "source": "player",

--- a/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
@@ -48,33 +48,62 @@ public class PlayerLogParserTests
     }
 
     // ---- TryParseItemCollected (ScreenTextObserved.Text) -----------------
+    //
+    // Post-#824: the parser carries both the primary item count and the
+    // speed-bonus count (extracted from the literal "xN" tail emitted by the
+    // game). Implicit count is 1 when "xN" is absent. ScreenText is the
+    // single source of truth for survey-mode attribution — the inventory
+    // bus drops counts on stack-onto-existing and always emits StackSize = 1
+    // on fresh-instance adds.
 
     [Theory]
-    [InlineData("Rubywall Crystal collected!", "Rubywall Crystal", null)]
-    [InlineData("Diamond collected!", "Diamond", null)]
-    [InlineData("Expert-Quality Metal Slab collected!", "Expert-Quality Metal Slab", null)]
-    [InlineData("Citrine collected!", "Citrine", null)]
-    public void TryParseItemCollected_extracts_name(string text, string expectedName, string? expectedBonus)
+    [InlineData("Rubywall Crystal collected!", "Rubywall Crystal", 1, null, 0)]
+    [InlineData("Diamond collected!", "Diamond", 1, null, 0)]
+    [InlineData("Expert-Quality Metal Slab collected!", "Expert-Quality Metal Slab", 1, null, 0)]
+    [InlineData("Citrine collected!", "Citrine", 1, null, 0)]
+    public void TryParseItemCollected_extracts_name(
+        string text, string expectedName, int expectedCount, string? expectedBonus, int expectedBonusCount)
     {
         var result = PlayerLogParser.TryParseItemCollected(text);
         result.Should().NotBeNull();
         result!.Value.Name.Should().Be(expectedName);
-        result.Value.SpeedBonusItem.Should().Be(expectedBonus);
+        result.Value.Count.Should().Be(expectedCount);
+        result.Value.BonusName.Should().Be(expectedBonus);
+        result.Value.BonusCount.Should().Be(expectedBonusCount);
     }
 
     [Theory]
-    [InlineData("Rubywall Crystal collected! Also found Azurite x2 (speed bonus!)",
-        "Rubywall Crystal", "Azurite")]
+    [InlineData("Rubywall Crystal collected! Also found Amethyst x2 (speed bonus!)",
+        "Rubywall Crystal", 1, "Amethyst", 2)]
+    [InlineData("Sapphire x3 collected! Also found Lapis Lazuli x3 (speed bonus!)",
+        "Sapphire", 3, "Lapis Lazuli", 3)]
     [InlineData("Garnet collected! Also found Fluorite (speed bonus!)",
-        "Garnet", "Fluorite")]
+        "Garnet", 1, "Fluorite", 1)]
     [InlineData("Simple Metal Slab collected! Also found Simple Metal Slab x3 (speed bonus!)",
-        "Simple Metal Slab", "Simple Metal Slab")]
-    public void TryParseItemCollected_extracts_speed_bonus(string text, string expectedName, string expectedBonus)
+        "Simple Metal Slab", 1, "Simple Metal Slab", 3)]
+    [InlineData("Piece of Green Glass x2 collected!",
+        "Piece of Green Glass", 2, null, 0)]
+    public void TryParseItemCollected_extracts_counts(
+        string text, string expectedName, int expectedCount, string? expectedBonus, int expectedBonusCount)
     {
         var result = PlayerLogParser.TryParseItemCollected(text);
         result.Should().NotBeNull();
         result!.Value.Name.Should().Be(expectedName);
-        result.Value.SpeedBonusItem.Should().Be(expectedBonus);
+        result.Value.Count.Should().Be(expectedCount);
+        result.Value.BonusName.Should().Be(expectedBonus);
+        result.Value.BonusCount.Should().Be(expectedBonusCount);
+    }
+
+    [Theory]
+    [InlineData("Wax Sculpture collected!", "Wax Sculpture", 1)]
+    [InlineData("Wax Sculpture x2 collected!", "Wax Sculpture", 2)]
+    public void TryParseItemCollected_handles_item_names_containing_x(
+        string text, string expectedName, int expectedCount)
+    {
+        var result = PlayerLogParser.TryParseItemCollected(text);
+        result.Should().NotBeNull();
+        result!.Value.Name.Should().Be(expectedName);
+        result.Value.Count.Should().Be(expectedCount);
     }
 
     [Theory]

--- a/tests/Legolas.Tests/Services/ItemCollectionTrackerTests.cs
+++ b/tests/Legolas.Tests/Services/ItemCollectionTrackerTests.cs
@@ -1,22 +1,20 @@
-using System.IO;
 using FluentAssertions;
 using Arda.Abstractions.Logs;
 using Arda.World.Player.Events;
 using Legolas.Domain;
-using Legolas.Flow;
 using Legolas.Services;
 using Legolas.Tests.TestSupport;
 using Legolas.ViewModels;
-using Mithril.Reference.Models.Items;
-using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Reference;
 
 namespace Legolas.Tests.Services;
 
 /// <summary>
-/// Post-Arda migration: the tracker subscribes to <see cref="InventoryItemAdded"/>
-/// and <see cref="ScreenTextObserved"/> via <see cref="Arda.Contracts.IDomainEventSubscriber"/>.
-/// Tests publish events through a <see cref="TestDomainEventBus"/>.
+/// Post-#824 pivot to ScreenText-as-truth: the tracker subscribes only to
+/// <see cref="ScreenTextObserved"/> via <see cref="Arda.Contracts.IDomainEventSubscriber"/>
+/// and credits the counts parsed straight out of the chat banner. The
+/// <see cref="InventoryItemAdded"/> add-channel has been retired (it dropped
+/// counts on stack-onto-existing and always emitted StackSize=1 on fresh
+/// instances). Tests publish events through a <see cref="TestDomainEventBus"/>.
 /// </summary>
 public sealed class ItemCollectionTrackerTests
 {
@@ -33,24 +31,14 @@ public sealed class ItemCollectionTrackerTests
     private sealed record Harness(
         ItemCollectionTracker Service,
         TestDomainEventBus Bus,
-        SessionState Session,
-        SurveyFlowController Flow,
-        LegolasSettings Settings,
-        DiagnosticsLoggerProvider LogProvider);
+        SessionState Session);
 
     private static Harness Build()
     {
         var bus = new TestDomainEventBus();
         var session = new SessionState();
-        var settings = new LegolasSettings { AutoResetWhenAllCollected = false };
-        var flow = new SurveyFlowController(session, settings);
-        var logProvider = new DiagnosticsLoggerProvider(
-            Path.Combine(Path.GetTempPath(), "legolas-tracker-" + Guid.NewGuid()));
-        var refData = new FakeRefData();
-        var svc = new ItemCollectionTracker(
-            bus, session, flow,
-            refData: refData, logger: logProvider.CreateLogger("Legolas.Ingestion"));
-        return new Harness(svc, bus, session, flow, settings, logProvider);
+        var svc = new ItemCollectionTracker(bus, session);
+        return new Harness(svc, bus, session);
     }
 
     private static SurveyItemViewModel SeedSurvey(SessionState session, string displayName)
@@ -74,17 +62,20 @@ public sealed class ItemCollectionTrackerTests
         }
     }
 
-    // ---- basic add + collect flow ----------------------------------------
+    // ---- basic collect flow ----------------------------------------------
 
     [Fact]
-    public async Task Matched_add_then_collect_credits_one()
+    public async Task Collect_credits_text_count_without_any_add()
     {
+        // Post-#824: ScreenText is the source of truth. Even without any
+        // InventoryItemAdded firing (the stack-onto-existing case from the
+        // Player-2026-05-20-0400.log corpus), the collect line must credit
+        // the slot.
         var h = Build();
         await Run(h, async () =>
         {
             var survey = SeedSurvey(h.Session, "Iron Ore");
 
-            h.Bus.Publish(new InventoryItemAdded(100, "IronOre", LiveMeta));
             h.Bus.Publish(new ScreenTextObserved(
                 "ImportantInfo".AsMemory(),
                 "Iron Ore collected!".AsMemory(),
@@ -98,33 +89,38 @@ public sealed class ItemCollectionTrackerTests
     }
 
     [Fact]
-    public async Task Collect_without_add_credits_zero()
+    public async Task Stack_onto_existing_credits_one_with_no_inventory_event()
     {
+        // 02:02:36 in Player-2026-05-20-0400.log — "Rubywall Crystal collected!"
+        // fires with no ProcessAddItem and no ProcessUpdateItemCode-derived
+        // bus event the tracker subscribes to. ScreenText alone must credit 1.
         var h = Build();
         await Run(h, async () =>
         {
-            SeedSurvey(h.Session, "Iron Ore");
+            SeedSurvey(h.Session, "Rubywall Crystal");
 
             h.Bus.Publish(new ScreenTextObserved(
                 "ImportantInfo".AsMemory(),
-                "Iron Ore collected!".AsMemory(),
+                "Rubywall Crystal collected!".AsMemory(),
                 LiveMeta));
 
             await Task.Yield();
-            h.Session.CollectedItems.Should().NotContainKey("Iron Ore");
+            h.Session.CollectedItems.Should().ContainKey("Rubywall Crystal")
+                .WhoseValue.Should().Be(1);
         });
     }
 
     [Fact]
     public async Task Speed_bonus_is_credited_separately()
     {
+        // Post-#824: bonus count comes from the chat text's "xN" tail, NOT
+        // from inventory subscribers. The Copper Ore x2 banner must credit 2,
+        // not 1.
         var h = Build();
         await Run(h, async () =>
         {
             SeedSurvey(h.Session, "Iron Ore");
 
-            h.Bus.Publish(new InventoryItemAdded(100, "IronOre", LiveMeta));
-            h.Bus.Publish(new InventoryItemAdded(101, "CopperOre", LiveMeta));
             h.Bus.Publish(new ScreenTextObserved(
                 "ImportantInfo".AsMemory(),
                 "Iron Ore collected! Also found Copper Ore x2 (speed bonus!)".AsMemory(),
@@ -132,7 +128,7 @@ public sealed class ItemCollectionTrackerTests
 
             await Task.Yield();
             h.Session.CollectedItems.Should().ContainKey("Iron Ore").WhoseValue.Should().Be(1);
-            h.Session.CollectedItems.Should().ContainKey("Copper Ore").WhoseValue.Should().Be(1);
+            h.Session.CollectedItems.Should().ContainKey("Copper Ore").WhoseValue.Should().Be(2);
         });
     }
 
@@ -144,7 +140,6 @@ public sealed class ItemCollectionTrackerTests
         {
             SeedSurvey(h.Session, "Iron Ore");
 
-            h.Bus.Publish(new InventoryItemAdded(100, "IronOre", ReplayMeta));
             h.Bus.Publish(new ScreenTextObserved(
                 "ImportantInfo".AsMemory(),
                 "Iron Ore collected!".AsMemory(),
@@ -162,7 +157,6 @@ public sealed class ItemCollectionTrackerTests
         await Run(h, async () =>
         {
             SeedSurvey(h.Session, "Iron Ore");
-            h.Bus.Publish(new InventoryItemAdded(100, "IronOre", LiveMeta));
 
             h.Bus.Publish(new ScreenTextObserved(
                 "GeneralInfo".AsMemory(),
@@ -173,83 +167,4 @@ public sealed class ItemCollectionTrackerTests
             h.Session.CollectedItems.Should().BeEmpty();
         });
     }
-
-    // ---- survey-session lifecycle ----------------------------------------
-
-    [Fact]
-    public async Task Reset_clears_pending_adds()
-    {
-        var h = Build();
-        await Run(h, async () =>
-        {
-            h.Bus.Publish(new InventoryItemAdded(100, "IronOre", LiveMeta));
-            h.Flow.Reset();
-
-            h.Bus.Publish(new ScreenTextObserved(
-                "ImportantInfo".AsMemory(),
-                "Iron Ore collected!".AsMemory(),
-                LiveMeta));
-
-            await Task.Yield();
-            h.Session.CollectedItems.Should().NotContainKey("Iron Ore",
-                "pending Adds should be cleared by Reset");
-        });
-    }
-
-    // ---- helpers ----------------------------------------------------------
-
-    private sealed class FakeRefData : IReferenceDataService
-    {
-        private static readonly Item _ironOre = new()
-        {
-            Id = 1, Name = "Iron Ore", InternalName = "IronOre",
-            MaxStackSize = 1000, IconId = 0, Keywords = [],
-        };
-        private static readonly Item _copperOre = new()
-        {
-            Id = 2, Name = "Copper Ore", InternalName = "CopperOre",
-            MaxStackSize = 1000, IconId = 0, Keywords = [],
-        };
-        private static readonly Item _garnet = new()
-        {
-            Id = 3, Name = "Garnet", InternalName = "Garnet",
-            MaxStackSize = 1000, IconId = 0, Keywords = [],
-        };
-
-        public IReadOnlyList<string> Keys { get; } = ["items"];
-        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>
-        {
-            [1L] = _ironOre, [2L] = _copperOre, [3L] = _garnet,
-        };
-        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>(StringComparer.Ordinal)
-        {
-            ["IronOre"] = _ironOre,
-            ["CopperOre"] = _copperOre,
-            ["Garnet"] = _garnet,
-        };
-        public ItemKeywordIndex KeywordIndex => new(Items);
-        public IReadOnlyDictionary<string, Mithril.Reference.Models.Recipes.Recipe> Recipes { get; }
-            = new Dictionary<string, Mithril.Reference.Models.Recipes.Recipe>();
-        public IReadOnlyDictionary<string, Mithril.Reference.Models.Recipes.Recipe> RecipesByInternalName { get; }
-            = new Dictionary<string, Mithril.Reference.Models.Recipes.Recipe>();
-        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
-        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
-        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
-        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
-        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
-        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
-        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
-        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
-        public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> Quests { get; }
-            = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
-        public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> QuestsByInternalName { get; }
-            = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
-        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
-        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
-        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
-        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public void BeginBackgroundRefresh() { }
-        public event EventHandler<string>? FileUpdated { add { } remove { } }
-    }
-
 }


### PR DESCRIPTION
## Summary

Pivots `ItemCollectionTracker` to use the `ScreenTextObserved` "`<item> collected!`" banner as the sole source of truth for survey-mode attribution, and rewrites `PlayerLogParser.TryParseItemCollected` to a span-based overload that returns explicit primary + bonus counts. The chat-tail+inventory correlation it replaces was the regression caught by issue #824: stack-onto-existing collects produced no `InventoryItemAdded`, and fresh-instance adds always emit `StackSize = 1`, so the parser's `xN` was the only place the real count was visible.

Corpus repro: [`Player-2026-05-20-0400.log`](https://github.com/moumantai-gg/mithril-logs/blob/main/sessions/2026-05/Player-2026-05-20-0400.log) (Emraell Rubywall Crystal run, 01:59:39 → 02:04:00).

Closes #543 (the original name-mangling symptom the umbrella account-correctness goal traces to) and #809 (the parser-perf direction this fix subsumes) on merge.

## What changed

- **`src/Legolas.Module/Services/PlayerLogParser.cs`** — replaces the compiled `ItemCollectedTextRx` with a span-based `TryParseItemCollected(ReadOnlySpan<char>) → (Name, Count, BonusName, BonusCount)?`. Uses `IndexOf` for the `" collected!"` and `" Also found "`/`" (speed bonus!)"` markers and a `StripTrailingXn` helper that mirrors `ChatInventory`'s `[Status]` parser. Allocates only on the match path. Retired regex declaration + the corresponding `log-patterns.json` entry (was tracked by `LogPatternCatalogParityTests`).
- **`src/Legolas.Module/Services/ItemCollectionTracker.cs`** — drops `_pendingAdds` / `_pendingLock` / `_invAddedSub`, the `_flow.Transitioned` buffer-clear path, and the `CreditCollect` / `DrainPendingForName` helpers. `HandleItemCollected` now takes `(name, count, bonusName, bonusCount)` and calls `AccumulateCollected` directly. `ScreenTextObserved` is the only subscription that remains; replay gate and survey-slot name match are unchanged. Constructor narrows to `(IDomainEventSubscriber, SessionState)` since the flow controller / reference data / logger params are no longer needed.
- **Tests** — `PlayerLogParserTests`: extends the speed-bonus theory to assert counts (Rubywall+Amethyst×2, Sapphire×3+Lapis×3, Garnet+Fluorite, `Piece of Green Glass x2 collected!` with no bonus) and adds a `Wax Sculpture` edge case covering item names that contain `x`. `ItemCollectionTrackerTests`: inverts the old `Collect_without_add_credits_zero` to `Collect_credits_text_count_without_any_add`, updates `Speed_bonus_is_credited_separately` to assert `Copper Ore = 2` for the `x2` banner, adds `Stack_onto_existing_credits_one_with_no_inventory_event` (the 02:02:36 Rubywall corpus repro), and deletes `Reset_clears_pending_adds` + the `Matched_add_then_collect_credits_one` add-required setup + the now-unused `FakeRefData` fixture.

Motherlode loot attribution (`MotherlodeMeasurementCoordinator`) is unchanged — its inventory deltas are the right model there since Motherlode dig doesn't emit `"X collected!"` banners. Per-intent subscription gating (#823) is left as a separate change.

## Test plan

- [x] `dotnet build Mithril.slnx` — Build succeeded. 0 Warning(s) 0 Error(s). 35.8s.
- [x] `dotnet test tests/Legolas.Tests --no-build --filter "FullyQualifiedName~PlayerLogParser"` — Passed: 38, Failed: 0, Skipped: 0.
- [x] `dotnet test tests/Legolas.Tests --no-build --filter "FullyQualifiedName~ItemCollectionTracker"` — Passed: 5, Failed: 0, Skipped: 0.
- [x] `dotnet test Mithril.slnx --no-build` — all suites pass except 1 pre-existing concurrency flake: `Mithril.Shared.Tests.Icons.IconCachePreloadTests.PreloadAsync_downloads_missing_ids_and_reports_progress` (passes 100% in isolation; fails sporadically when the full `Mithril.Shared.Tests` assembly runs in parallel with the larger suite, expected `3` got `2` in progress-tick count — unrelated to this change). Legolas.Tests: 497/497 pass.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
