### PR TITLE
feat(legolas): MahApps ColorPicker for hex settings (#132)

### DIFF
--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -7,15 +7,29 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <!-- Issue #132: scope MahApps theme resources to this view so
-                 mah:ColorPicker renders styled. Same pattern as
-                 LegolasShareDialog.xaml — UserControl-scoped merge keeps the
-                 rest of the app's visuals untouched. App resources first so
-                 our brushes / fonts win on any key collision. -->
+                 mah:ColorPicker renders styled. UserControl-scoped merge
+                 keeps the rest of the app's visuals untouched.
+
+                 Order is load-bearing: WPF MergedDictionaries lookup is
+                 last-wins on key collision, so MahApps theme dictionaries
+                 come FIRST (they supply mah:ColorPicker's style + a
+                 baseline for any MahApps-specific keys it needs) and
+                 Mithril's Resources.xaml comes LAST so its implicit
+                 TargetType styles for the built-ins this view uses —
+                 TextBox (Resources.xaml:112), CheckBox (:123), GroupBox
+                 (:135), Button (:148), ComboBox (:287), ToolTip (:628) —
+                 override Dark.Steel's. Without this ordering, every
+                 stroke-style ComboBox / opacity Slider / "Reset to
+                 defaults" Button in this view would render in MahApps
+                 chrome, visually inconsistent with every other settings
+                 view. (LegolasShareDialog.xaml uses the inverse order
+                 deliberately to inherit MahApps' DropDownButton polish;
+                 not the same use case.) -->
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Steel.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -2,11 +2,20 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Legolas.Views.Converters"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              Background="{DynamicResource BgPrimaryBrush}">
     <UserControl.Resources>
         <ResourceDictionary>
+            <!-- Issue #132: scope MahApps theme resources to this view so
+                 mah:ColorPicker renders styled. Same pattern as
+                 LegolasShareDialog.xaml — UserControl-scoped merge keeps the
+                 rest of the app's visuals untouched. App resources first so
+                 our brushes / fonts win on any key collision. -->
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Steel.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -184,26 +193,17 @@
                         </Grid.RowDefinitions>
 
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Route line" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
-                                  Text="{Binding Colors.RouteLine, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="0" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                  Background="{Binding Brushes.RouteLine}" />
+                        <mah:ColorPicker Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding Colors.RouteLine, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Wedge fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
-                                  Text="{Binding Colors.BearingWedgeFill, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="1" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                  Background="{Binding Brushes.BearingWedgeFill}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding Colors.BearingWedgeFill, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Wedge stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
-                                  Text="{Binding Colors.BearingWedgeStroke, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="2" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                  Background="{Binding Brushes.BearingWedgeStroke}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding Colors.BearingWedgeStroke, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
-                    <TextBlock Text="ARGB hex (e.g. #FFFF0000 — opaque red, or #33FFFF80 — translucent yellow). 6-digit RGB also accepted; alpha defaults to FF."
-                               Foreground="{StaticResource TextTertiaryBrush}"
-                               TextWrapping="Wrap" Margin="0,6,0,0" />
                     <Button Content="Reset to defaults" HorizontalAlignment="Right" Margin="0,8,0,0"
                             Padding="10,4" Command="{Binding ResetColorsToDefaultsCommand}" />
                 </StackPanel>
@@ -290,16 +290,12 @@
                                    SelectedItem="{Binding Shape}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.OuterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding FillColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.OuterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding StrokeColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
@@ -337,16 +333,12 @@
                                    SelectedItem="{Binding Shape}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.CenterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding FillColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.CenterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding StrokeColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
@@ -450,16 +442,12 @@
                                    SelectedItem="{Binding Shape}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.PlayerOuterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding FillColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.PlayerOuterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding StrokeColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
@@ -503,16 +491,12 @@
                                    SelectedItem="{Binding Shape}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.PlayerCenterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding FillColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.PlayerCenterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding StrokeColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
@@ -638,10 +622,8 @@
                                    SelectedItem="{Binding Treatment}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Color" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding Color, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.ActivePin, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding Color, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Halo thickness" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <Slider    Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
@@ -752,16 +734,12 @@
                                    SelectedItem="{Binding Shape}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.CalibrationOuterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding FillColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.CalibrationOuterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding StrokeColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
@@ -805,16 +783,12 @@
                                    SelectedItem="{Binding Shape}" />
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.CalibrationCenterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding FillColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
-                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
-                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                   Background="{Binding DataContext.Brushes.CalibrationCenterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+                        <mah:ColorPicker Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                         SelectedColor="{Binding StrokeColor, Converter={StaticResource ArgbHexToColor}, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"

--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -32,9 +32,21 @@ public sealed class StringToColorConverter : IValueConverter
 /// Two-way bridge between an ARGB-hex string property (canonical
 /// <c>#AARRGGBB</c>) and a WPF <see cref="Color"/>, for binding hex-string
 /// settings to color-picker controls (e.g. <c>mah:ColorPicker.SelectedColor</c>).
-/// Malformed / null input falls back to opaque magenta — matching the existing
-/// fail-loud convention used by Legolas's settings layer so a bad value is
-/// visible everywhere rather than silently transparent.
+/// <para>
+/// <see cref="Convert"/> (hex → Color): malformed / null input falls back to
+/// opaque magenta — matching the existing fail-loud convention used by
+/// Legolas's settings layer so a bad persisted value is visible everywhere
+/// rather than silently transparent.
+/// </para>
+/// <para>
+/// <see cref="ConvertBack"/> (Color → hex): non-<see cref="Color"/> input
+/// (including <see langword="null"/>) returns <see cref="Binding.DoNothing"/>
+/// so the source property is NOT mutated. MahApps' <c>SelectedColor</c>
+/// dependency property is typed <c>Color?</c> and dispatches <see langword="null"/>
+/// on initialisation races / mid-edit hex clears / future reset paths;
+/// fabricating a literal hex on that signal would silently clobber the user's
+/// saved color with opaque magenta.
+/// </para>
 /// </summary>
 public sealed class ArgbHexToColorConverter : IValueConverter
 {
@@ -46,7 +58,7 @@ public sealed class ArgbHexToColorConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => value is Color c
             ? $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}"
-            : "#FFFF00FF";
+            : Binding.DoNothing;
 
     private static bool TryParseArgb(string input, out Color color)
     {

--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -28,6 +28,50 @@ public sealed class StringToColorConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
 }
 
+/// <summary>
+/// Two-way bridge between an ARGB-hex string property (canonical
+/// <c>#AARRGGBB</c>) and a WPF <see cref="Color"/>, for binding hex-string
+/// settings to color-picker controls (e.g. <c>mah:ColorPicker.SelectedColor</c>).
+/// Malformed / null input falls back to opaque magenta — matching the existing
+/// fail-loud convention used by Legolas's settings layer so a bad value is
+/// visible everywhere rather than silently transparent.
+/// </summary>
+public sealed class ArgbHexToColorConverter : IValueConverter
+{
+    private static readonly Color Fallback = Colors.Magenta; // #FFFF00FF
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is string s && TryParseArgb(s, out var color) ? color : Fallback;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is Color c
+            ? $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}"
+            : "#FFFF00FF";
+
+    private static bool TryParseArgb(string input, out Color color)
+    {
+        color = Fallback;
+        if (string.IsNullOrWhiteSpace(input)) return false;
+        var s = input.Trim();
+        if (s.StartsWith('#')) s = s[1..];
+        // Accept 6-digit RGB (alpha = FF) or 8-digit ARGB.
+        if (s.Length is not (6 or 8)) return false;
+        foreach (var ch in s)
+        {
+            if (!Uri.IsHexDigit(ch)) return false;
+        }
+        byte a = s.Length == 8
+            ? byte.Parse(s.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture)
+            : (byte)0xFF;
+        int rgbStart = s.Length == 8 ? 2 : 0;
+        byte r = byte.Parse(s.AsSpan(rgbStart, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        byte g = byte.Parse(s.AsSpan(rgbStart + 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        byte b = byte.Parse(s.AsSpan(rgbStart + 4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        color = Color.FromArgb(a, r, g, b);
+        return true;
+    }
+}
+
 public sealed class NullOrEmptyToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Mithril.Shared.Wpf/Converters.xaml
+++ b/src/Mithril.Shared.Wpf/Converters.xaml
@@ -4,6 +4,7 @@
     <c:BoolToVisibilityConverter x:Key="BoolToVis"/>
     <c:InverseBoolToVisibilityConverter x:Key="InverseBoolToVis"/>
     <c:StringToColorConverter x:Key="StringToColor"/>
+    <c:ArgbHexToColorConverter x:Key="ArgbHexToColor"/>
     <c:NullOrEmptyToVisibilityConverter x:Key="NullOrEmptyToVis"/>
     <c:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
     <c:PositiveIntToVisibilityConverter x:Key="PositiveIntToVis"/>

--- a/tests/Mithril.Shared.Tests/Wpf/ArgbHexToColorConverterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/ArgbHexToColorConverterTests.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using System.Windows.Media;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Coverage for the issue #132 <see cref="ArgbHexToColorConverter"/> — the two-way
+/// bridge between an ARGB-hex string property (canonical <c>#AARRGGBB</c>) and a WPF
+/// <see cref="Color"/> used to wire <c>mah:ColorPicker.SelectedColor</c> against the
+/// existing Legolas hex-string settings. Covers 8-digit ARGB round-trip, 6-digit RGB
+/// (alpha defaults to FF on parse), the fail-loud opaque-magenta fallback on malformed
+/// input, ConvertBack canonicalisation to uppercase #AARRGGBB, and alpha preservation
+/// (including translucent values — the picker's whole reason for existing).
+/// </summary>
+public sealed class ArgbHexToColorConverterTests
+{
+    private static readonly ArgbHexToColorConverter Sut = new();
+
+    private static Color Convert(object? value)
+        => (Color)Sut.Convert(value!, typeof(Color), null!, CultureInfo.InvariantCulture);
+
+    private static string ConvertBack(Color color)
+        => (string)Sut.ConvertBack(color, typeof(string), null!, CultureInfo.InvariantCulture);
+
+    [Theory]
+    [InlineData("#FFFF0000", 0xFF, 0xFF, 0x00, 0x00)] // opaque red
+    [InlineData("#33FFFF80", 0x33, 0xFF, 0xFF, 0x80)] // translucent yellow (issue example)
+    [InlineData("#80808080", 0x80, 0x80, 0x80, 0x80)] // 50% mid-grey
+    [InlineData("#00000000", 0x00, 0x00, 0x00, 0x00)] // fully transparent
+    public void Convert_parses_eight_digit_argb(string hex, byte a, byte r, byte g, byte b)
+    {
+        var color = Convert(hex);
+        color.A.Should().Be(a);
+        color.R.Should().Be(r);
+        color.G.Should().Be(g);
+        color.B.Should().Be(b);
+    }
+
+    [Theory]
+    [InlineData("#FF0000", 0xFF, 0x00, 0x00)] // bare RGB → alpha defaults to FF
+    [InlineData("#AABBCC", 0xAA, 0xBB, 0xCC)]
+    public void Convert_six_digit_rgb_defaults_alpha_to_FF(string hex, byte r, byte g, byte b)
+    {
+        var color = Convert(hex);
+        color.A.Should().Be(0xFF);
+        color.R.Should().Be(r);
+        color.G.Should().Be(g);
+        color.B.Should().Be(b);
+    }
+
+    [Theory]
+    [InlineData("ff00ff00")] // lower-case, no '#'
+    [InlineData("FF00FF00")] // upper-case, no '#'
+    public void Convert_accepts_input_without_leading_hash(string hex)
+    {
+        var color = Convert(hex);
+        color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-color")]
+    [InlineData("#GGGGGG")]     // non-hex digits
+    [InlineData("#FFF")]        // wrong length (3)
+    [InlineData("#FFFFFFFFF")]  // wrong length (9)
+    [InlineData("garbage with #FFFFFFFF inside")]
+    public void Convert_returns_opaque_magenta_on_malformed_input(string? hex)
+    {
+        var color = Convert(hex);
+        color.Should().Be(Colors.Magenta);
+        color.A.Should().Be(0xFF, "fail-loud fallback must be opaque so a bad value is visible, not silently transparent");
+    }
+
+    [Theory]
+    [InlineData(0xFF, 0xFF, 0x00, 0x00, "#FFFF0000")]
+    [InlineData(0x33, 0xFF, 0xFF, 0x80, "#33FFFF80")]
+    [InlineData(0x00, 0x12, 0x34, 0x56, "#00123456")] // pads single-digit hex components with leading zeros
+    public void ConvertBack_emits_canonical_uppercase_argb_hex(byte a, byte r, byte g, byte b, string expected)
+    {
+        ConvertBack(Color.FromArgb(a, r, g, b)).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("#33FFFF80")]
+    [InlineData("#80808080")]
+    [InlineData("#01000000")] // Legolas' near-transparent default Fill — must survive the round-trip
+    public void Round_trip_preserves_argb_components(string hex)
+    {
+        var color = Convert(hex);
+        ConvertBack(color).Should().Be(hex.ToUpperInvariant());
+    }
+
+    [Fact]
+    public void Round_trip_preserves_alpha_for_translucent_color()
+    {
+        // The whole reason #132 needs a real picker: 33-alpha is the "translucent yellow"
+        // example from the issue body. Loss of alpha here would defeat the feature.
+        var original = Color.FromArgb(0x33, 0xFF, 0xFF, 0x80);
+        var hex = ConvertBack(original);
+        var roundTripped = Convert(hex);
+        roundTripped.Should().Be(original);
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/ArgbHexToColorConverterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/ArgbHexToColorConverterTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Windows.Data;
 using System.Windows.Media;
 using FluentAssertions;
 using Mithril.Shared.Wpf;
@@ -24,6 +25,9 @@ public sealed class ArgbHexToColorConverterTests
 
     private static string ConvertBack(Color color)
         => (string)Sut.ConvertBack(color, typeof(string), null!, CultureInfo.InvariantCulture);
+
+    private static object ConvertBackRaw(object? value)
+        => Sut.ConvertBack(value!, typeof(string), null!, CultureInfo.InvariantCulture);
 
     [Theory]
     [InlineData("#FFFF0000", 0xFF, 0xFF, 0x00, 0x00)] // opaque red
@@ -104,5 +108,28 @@ public sealed class ArgbHexToColorConverterTests
         var hex = ConvertBack(original);
         var roundTripped = Convert(hex);
         roundTripped.Should().Be(original);
+    }
+
+    [Fact]
+    public void ConvertBack_returns_DoNothing_for_null()
+    {
+        // MahApps mah:ColorPicker.SelectedColor is typed Color? and dispatches null
+        // during initialisation races / mid-edit hex clears / future reset paths.
+        // Fabricating a literal hex on null would silently clobber the user's saved
+        // color with opaque magenta — the wrong shape of "fail loud" here, because
+        // null on ConvertBack is a "no value" signal, not malformed user input.
+        // Binding.DoNothing tells WPF to skip the source-property update.
+        ConvertBackRaw(null).Should().BeSameAs(Binding.DoNothing);
+    }
+
+    [Theory]
+    [InlineData("not a color")]
+    [InlineData(42)]
+    [InlineData(true)]
+    public void ConvertBack_returns_DoNothing_for_non_Color_input(object value)
+    {
+        // Defensive: any non-Color from the binding system (mis-wired template,
+        // converter applied to wrong DP) leaves the source property untouched.
+        ConvertBackRaw(value).Should().BeSameAs(Binding.DoNothing);
     }
 }


### PR DESCRIPTION
Closes #132.

## Summary

Replace every hand-edited ARGB-hex `TextBox` + 16×16 swatch `Border` pair in the Legolas settings view with `mah:ColorPicker`, wired through a new two-way string⇄`Color` converter. The underlying settings stay as ARGB-hex strings, so no schema migration is needed and existing `LegolasSettings.json` files round-trip unchanged.

## What changed

- **New converter** — [`ArgbHexToColorConverter`](src/Mithril.Shared.Wpf/Converters.cs) in `Mithril.Shared.Wpf` (next to `StringToColorConverter`), registered in [`Converters.xaml`](src/Mithril.Shared.Wpf/Converters.xaml) as `ArgbHexToColor`. `Convert` parses 8-digit `#AARRGGBB` and 6-digit `#RRGGBB` (alpha defaults to `FF`); malformed/null input falls back to opaque magenta (matches the existing fail-loud convention in `HexColor.Normalize` / `LegolasBrushes.Parse`). `ConvertBack` emits canonical uppercase `#AARRGGBB`.

- **Settings view** — [`LegolasSettingsView.xaml`](src/Legolas.Module/Views/LegolasSettingsView.xaml): added `xmlns:mah` and replaced all 16 hex `TextBox` + swatch `Border` pairs with a single `<mah:ColorPicker SelectedColor="…"/>` per row across:
  - **Map Colors** — route line, wedge fill, wedge stroke (3)
  - **Pin Appearance** — Outer fill/stroke, Centre fill/stroke (4)
  - **Player Pin** — Outer fill/stroke, Centre fill/stroke (4)
  - **Active Pin Highlight** — Color (1)
  - **Calibration Markers** — Outer fill/stroke, Centre fill/stroke (4)

  The Calibration Markers group wasn't named explicitly in #132 but uses the same `TextBox` + swatch pattern. The issue's scope says "Replace every `TextBox` + swatch pair in `LegolasSettingsView.xaml`", so it ships in the same pass. Easy to split off if undesired.

- **Theme resources** — `Controls.xaml` / `Fonts.xaml` / `Dark.Steel.xaml` are merged into the view's `UserControl.Resources`, scoped to this view, same idiom as [`LegolasShareDialog.xaml`](src/Legolas.Module/Sharing/LegolasShareDialog.xaml). Outside-the-view visuals are untouched. `mah:ColorPicker` needs these resources to render styled.

- **No package work** — `MahApps.Metro 2.4.11` is already a direct `PackageReference` on `Mithril.Shared.Wpf`, `Legolas.Module`, `Arwen.Module`, `Gandalf.Module`. The "may bloat the dependency footprint" concern in #132's Option 1 is moot — full MahApps is already paid for.

- **No state changes** — `LegolasPinShapeStyle.FillColor` / `StrokeColor`, `LegolasColors.*`, `LegolasActivePinStyle.Color`, and `HexColor.Normalize` are untouched. Reset-to-defaults commands and the `LegolasBrushes` preview pipeline keep working as-is.

## Tests

New: [`ArgbHexToColorConverterTests`](tests/Mithril.Shared.Tests/Wpf/ArgbHexToColorConverterTests.cs) — 8-digit ARGB parse, 6-digit RGB (alpha → FF), no-`#` prefix, opaque-magenta fallback on malformed input (incl. `null`, empty, whitespace, non-hex digits, wrong lengths, garbage with `#FFFFFFFF` substring), `ConvertBack` canonical uppercase output with leading-zero padding, full round-trip preservation including the explicit 0x33-alpha translucent case from #132's issue body.

`dotnet build Mithril.slnx` — **Build succeeded. 0 Warning(s), 0 Error(s).**

`dotnet test Mithril.slnx --no-build` — 1183/1183 in `Mithril.Shared.Tests` (incl. all new converter tests), 494/494 in `Legolas.Tests`, all other test DLLs green. One unrelated failure in `Samwise.Tests.GardenIngestionHighWaterTests.Restart_idempotence_byte_equivalence_under_high_water` that passes when re-run in isolation — pre-existing flake under parallel runner load, not caused by this change.

## ⚠️ Interactive verification still owed

This is a WPF-only visual change and the test suite cannot exercise it. **Not manually verified by me** — needs the user's eyes on the actual app before merge:

- `mah:ColorPicker` popup opens / closes correctly in each of the five groups.
- Alpha slider drives the on-pin / on-route preview live (the whole point of #132).
- Canonical `#AARRGGBB` hex round-trip survives a save / restart cycle (it should — the setter still funnels through `HexColor.Normalize`).
- MahApps theme merge (`Controls.xaml` + `Dark.Steel.xaml`) doesn't visibly clash with the existing settings-view chrome (TextBox / Slider / ComboBox / CheckBox in this view will inherit MahApps styles — most should look fine, but worth a once-over).
- "Reset to defaults" buttons still produce the expected pin colors.

If the MahApps merge causes visible regression within the view, the fallback is to scope-merge a tighter subset (just `Controls.xaml` without the theme), or rely on default un-styled `ColorPicker` rendering.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
