### PR TITLE
feat(telemetry): TrustEndpoint toggle + exporter EventSource health (#834, #840)

### DIFF
--- a/src/Mithril.Shared.Telemetry/Export/ExporterHealthMonitor.cs
+++ b/src/Mithril.Shared.Telemetry/Export/ExporterHealthMonitor.cs
@@ -4,8 +4,8 @@ namespace Mithril.Shared.Telemetry.Export;
 
 /// <summary>
 /// Owns the live <see cref="ExporterHealth"/> snapshot consumed by the
-/// settings status-line UI. Receives success/failure pulses from the
-/// OTel-event-source listener (a future enhancement — see remarks) and from
+/// settings status-line UI. Receives success/failure pulses from the OTel-
+/// event-source listener (<see cref="OtlpExporterEventListener"/>) and from
 /// health-check probes invoked by the exporter wrapper.
 ///
 /// Exposed as <see cref="IObservable{T}"/> via a <see cref="BehaviorSubject{T}"/>
@@ -13,11 +13,27 @@ namespace Mithril.Shared.Telemetry.Export;
 /// settings UI binds via the standard Rx-to-WPF pattern and shouldn't have to
 /// wait for the next health pulse to render an initial value.
 ///
-/// Thread safety: concurrent <see cref="RecordSuccess"/> / <see cref="RecordFailure"/>
-/// calls are safe — both serialise through an internal lock so the read-modify-write
-/// of the snapshot is atomic. Required because the success/failure pulses come from
-/// at least two sources (the exporter wrapper and the OTel SDK EventSource listener)
-/// which run on different threads.
+/// <para><strong>Thread safety.</strong> Concurrent <see cref="RecordSuccess"/> /
+/// <see cref="RecordFailure"/> calls are safe — both serialise through an
+/// internal lock so the read-modify-write of the snapshot is atomic. Required
+/// because the success/failure pulses come from at least two sources (the
+/// exporter wrapper and the OTel SDK EventSource listener) which run on
+/// different threads.</para>
+///
+/// <para><strong>Subscriber dispatch contract.</strong>
+/// <see cref="BehaviorSubject{T}.OnNext"/> fans out to subscribers
+/// <em>synchronously</em>, and the fan-out happens while this monitor holds
+/// its internal write lock. That means a subscriber's <c>OnNext</c> handler
+/// runs on the producer thread — typically the OTel batch-processor thread or
+/// the EventSource listener's callback thread — under the lock that serialises
+/// future <see cref="RecordSuccess"/> / <see cref="RecordFailure"/> calls.
+/// <strong>Subscribers must do their own scheduling</strong> (e.g. Rx
+/// <c>ObserveOn</c>, a fire-and-forget WPF <c>Dispatcher.Post</c>) and must
+/// not block: a blocking handler stalls the OTel exporter thread and delays
+/// batch flushes for subsequent spans. The in-tree consumer
+/// (<c>TelemetrySettingsViewModel.OnHealth</c>) already uses
+/// <c>SynchronizationContext.Post</c> to fire-and-forget marshal back to
+/// the UI thread; future subscribers must follow the same pattern.</para>
 /// </summary>
 public sealed class ExporterHealthMonitor : IDisposable, IObservable<ExporterHealth>
 {

--- a/src/Mithril.Shared.Telemetry/Export/OtlpExporterEventListener.cs
+++ b/src/Mithril.Shared.Telemetry/Export/OtlpExporterEventListener.cs
@@ -1,0 +1,207 @@
+using System.Diagnostics.Tracing;
+using System.Globalization;
+
+namespace Mithril.Shared.Telemetry.Export;
+
+/// <summary>
+/// Subscribes to the OpenTelemetry OTLP exporter's internal
+/// <see cref="EventSource"/> (<c>OpenTelemetry-Exporter-OpenTelemetryProtocol</c>)
+/// and feeds Warning/Error/Critical events into
+/// <see cref="ExporterHealthMonitor.RecordFailure(string)"/> so the settings
+/// status line shows real OTLP transport failures rather than a perpetual
+/// "no activity yet".
+///
+/// <para>The OTel SDK exposes no public success callback, so success is
+/// synthesised by an absence-of-failure heuristic: a <see cref="Timer"/>
+/// ticks once per <see cref="DefaultSuccessTickInterval"/> and, when the
+/// most-recent failure is older than the tick window, calls
+/// <see cref="ExporterHealthMonitor.RecordSuccess"/>. Tooltip wording in the
+/// settings UI is "last successful export attempt" — not "last successful
+/// delivery" — to reflect this: a collector that ACKs and then silently drops
+/// data downstream of OTLP still presents as healthy from this listener's
+/// vantage point. Tradeoff per mithril#834.</para>
+///
+/// <para><strong>Pin: validated against
+/// <c>OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.x</c>.</strong>
+/// The exporter's event-source <em>name</em> is the stable surface; specific
+/// event ids and message templates are internal SDK detail and shift across
+/// minor versions. This listener intentionally maps by <see cref="EventLevel"/>
+/// rather than event id, so a renovate bump that renumbers events does not
+/// silently regress the health monitor. A bump that renames the event source
+/// itself, or moves failures off Warning/Error/Critical levels, must
+/// re-validate against the new SDK source.</para>
+///
+/// <para>Hosted-service ordering: the listener self-subscribes in its
+/// constructor via the base <see cref="EventListener"/> registry, so callers
+/// only need to ensure it is constructed before any export attempt. The
+/// telemetry host extension resolves the singleton eagerly at host build
+/// time to guarantee this — startup-time failures (corrupted endpoint, DNS,
+/// TLS) are then captured the first time the exporter probes the
+/// connection.</para>
+///
+/// <para><strong>Construction race.</strong>
+/// <see cref="EventListener.OnEventSourceCreated(EventSource)"/> may fire for
+/// already-existing sources before this listener's constructor body runs —
+/// the base <see cref="EventListener"/> constructor walks the active source
+/// list. The implementation defers <see cref="EventListener.EnableEvents(EventSource, EventLevel)"/>
+/// until <see cref="Initialize"/> has stored the monitor reference, queueing
+/// any sources discovered during the race.</para>
+/// </summary>
+public sealed class OtlpExporterEventListener : EventListener
+{
+    /// <summary>
+    /// The internal OTel SDK event source emitted by the OTLP exporter.
+    /// Stable across the 1.15.x line; see class-level remarks.
+    /// </summary>
+    public const string OtlpExporterEventSourceName = "OpenTelemetry-Exporter-OpenTelemetryProtocol";
+
+    /// <summary>
+    /// Default cadence at which absence-of-failure is converted into a
+    /// success pulse. Chosen to be slow enough not to mask transient failures
+    /// (which the exporter retries internally) and fast enough to flip the
+    /// status line back to green within a few minutes of a collector recovery.
+    /// </summary>
+    public static readonly TimeSpan DefaultSuccessTickInterval = TimeSpan.FromSeconds(30);
+
+    private readonly object _initLock = new();
+    private readonly List<EventSource> _pendingSources = new();
+    private ExporterHealthMonitor? _health;
+    private TimeSpan _successInterval;
+    private Timer? _successTimer;
+    private bool _initialized;
+    private long _lastFailureUtcTicks; // 0 ⇒ no failure yet
+
+    /// <summary>
+    /// Production constructor. Subscribes immediately; success ticks use
+    /// <see cref="DefaultSuccessTickInterval"/>.
+    /// </summary>
+    public OtlpExporterEventListener(ExporterHealthMonitor health)
+        : this(health, DefaultSuccessTickInterval, startTimer: true)
+    {
+    }
+
+    /// <summary>
+    /// Test-friendly constructor. When <paramref name="startTimer"/> is
+    /// <c>false</c>, the background <see cref="Timer"/> is not created and
+    /// tests drive success synthesis by calling
+    /// <see cref="TickSuccessForTests"/> directly.
+    /// </summary>
+    internal OtlpExporterEventListener(
+        ExporterHealthMonitor health,
+        TimeSpan successInterval,
+        bool startTimer)
+    {
+        Initialize(health, successInterval, startTimer);
+    }
+
+    private void Initialize(ExporterHealthMonitor health, TimeSpan successInterval, bool startTimer)
+    {
+        EventSource[] toEnable;
+        lock (_initLock)
+        {
+            _health = health;
+            _successInterval = successInterval;
+            _initialized = true;
+            toEnable = _pendingSources.ToArray();
+            _pendingSources.Clear();
+        }
+        foreach (var src in toEnable)
+        {
+            EnableEvents(src, EventLevel.Warning);
+        }
+        if (startTimer)
+        {
+            _successTimer = new Timer(_ => SafeTickSuccess(), state: null, successInterval, successInterval);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource is null) return;
+        if (eventSource.Name != OtlpExporterEventSourceName) return;
+
+        lock (_initLock)
+        {
+            if (!_initialized)
+            {
+                // Construction race: the base EventListener constructor walks
+                // the existing source list before our ctor body assigns _health.
+                // Queue and enable in Initialize.
+                _pendingSources.Add(eventSource);
+                return;
+            }
+        }
+        EnableEvents(eventSource, EventLevel.Warning);
+    }
+
+    /// <inheritdoc />
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData is null) return;
+        if (eventData.EventSource?.Name != OtlpExporterEventSourceName) return;
+        // Warning is numerically larger than Error/Critical in EventLevel —
+        // smaller value ⇒ more severe. Anything at or more severe than
+        // Warning is a failure signal we surface.
+        if (eventData.Level > EventLevel.Warning) return;
+
+        var health = Volatile.Read(ref _health);
+        if (health is null) return;
+
+        Interlocked.Exchange(ref _lastFailureUtcTicks, DateTimeOffset.UtcNow.UtcTicks);
+        health.RecordFailure(FormatReason(eventData));
+    }
+
+    /// <summary>
+    /// Format a Warning/Error/Critical event as a short human-readable reason
+    /// string suitable for the settings status line. Falls back to a generic
+    /// <c>"OTLP exporter event N"</c> when the SDK omits an event name —
+    /// better noise than silence.
+    /// </summary>
+    private static string FormatReason(EventWrittenEventArgs e)
+    {
+        var name = string.IsNullOrEmpty(e.EventName) ? "OTLP exporter event" : e.EventName!;
+        if (e.Payload is null || e.Payload.Count == 0)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0} (id={1})", name, e.EventId);
+        }
+        // Stringify each payload value defensively — payload entries can be
+        // null, boxed primitives, or object references; ToString() copes.
+        var payload = string.Join(" ", e.Payload.Select(p => p?.ToString() ?? "<null>"));
+        return string.Format(CultureInfo.InvariantCulture, "{0} (id={1}): {2}", name, e.EventId, payload);
+    }
+
+    /// <summary>
+    /// Test-only entrypoint to drive the success-synthesis tick deterministically.
+    /// Returns the same decision the background timer would have made.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the tick decided no failure had been recorded within
+    /// the current success window and called
+    /// <see cref="ExporterHealthMonitor.RecordSuccess"/>;
+    /// <c>false</c> when a recent failure suppressed the success pulse.
+    /// </returns>
+    internal bool TickSuccessForTests() => SafeTickSuccess();
+
+    private bool SafeTickSuccess()
+    {
+        var health = Volatile.Read(ref _health);
+        if (health is null) return false;
+
+        var lastFailureTicks = Interlocked.Read(ref _lastFailureUtcTicks);
+        if (lastFailureTicks != 0
+            && DateTimeOffset.UtcNow.UtcTicks - lastFailureTicks <= _successInterval.Ticks)
+        {
+            return false;
+        }
+        health.RecordSuccess();
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _successTimer?.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Mithril.Shared.Telemetry/Export/OtlpExporterEventListener.cs
+++ b/src/Mithril.Shared.Telemetry/Export/OtlpExporterEventListener.cs
@@ -136,6 +136,15 @@ public sealed class OtlpExporterEventListener : EventListener
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Runs on the OTel SDK's EventSource callback thread (whichever thread
+    /// originally raised the exporter event). The
+    /// <see cref="ExporterHealthMonitor.RecordFailure(string)"/> call below
+    /// fans out to subscribers <em>synchronously</em> under the monitor's
+    /// internal lock — a blocking subscriber would stall the OTel exporter
+    /// path. See the subscriber-dispatch contract on
+    /// <see cref="ExporterHealthMonitor"/>.
+    /// </remarks>
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
         if (eventData is null) return;

--- a/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
+++ b/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
@@ -145,6 +145,7 @@ public static class TelemetryHostExtensions
             return new ValueRedactor(GetActiveCharacter, userProfile, localAppData);
         });
         services.AddSingleton<AllowlistAndRedactionProcessor>();
+        services.AddSingleton<ValueRedactionOnlyProcessor>();
 
         // Resource attributes shared across traces, metrics, logs.
         var serviceInstanceId = Guid.NewGuid().ToString("D");
@@ -168,9 +169,20 @@ public static class TelemetryHostExtensions
             .WithTracing(tb =>
             {
                 tb.AddSource(MithrilSourcePrefix)
-                  .AddHttpClientInstrumentation()
-                  .AddProcessor<AllowlistAndRedactionProcessor>()
-                  .AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString));
+                  .AddHttpClientInstrumentation();
+                // TrustEndpoint chooses which processor runs on the tracing pipeline:
+                // off (default) → full allowlist + redactor; on → redactor only.
+                // The choice is restart-required because it's captured here at
+                // AddProcessor registration time. See mithril#840.
+                if (settings.TrustEndpoint)
+                {
+                    tb.AddProcessor<ValueRedactionOnlyProcessor>();
+                }
+                else
+                {
+                    tb.AddProcessor<AllowlistAndRedactionProcessor>();
+                }
+                tb.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString));
             })
             .WithMetrics(mb =>
             {

--- a/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
+++ b/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
@@ -306,8 +306,17 @@ public static class TelemetryHostExtensions
     /// hosted services — but EventListener subscription is process-global and
     /// completes synchronously in the constructor, so order here only needs to
     /// be "before the first batch flush", which is satisfied at host start.
-    /// <see cref="StopAsync"/> disposes the listener so the success-tick
-    /// <see cref="System.Threading.Timer"/> is released cleanly on shutdown.
+    /// <para>The starter <em>does not</em> dispose the listener in
+    /// <see cref="StopAsync"/>. The listener is registered as a DI singleton
+    /// (<see cref="ServiceLifetime.Singleton"/>) so the host's
+    /// <see cref="IServiceProvider"/> disposes it during host teardown.
+    /// Disposing here too would invoke
+    /// <see cref="OtlpExporterEventListener.Dispose"/> twice — benign today
+    /// (BCL <see cref="System.Threading.Timer"/> and
+    /// <see cref="System.Diagnostics.Tracing.EventListener"/> are idempotent)
+    /// but the contract isn't guaranteed by either API, and a subclass that
+    /// adds state in <see cref="OtlpExporterEventListener.Dispose"/> would
+    /// break it silently. Let DI own the lifecycle.</para>
     /// </summary>
     private sealed class OtlpExporterEventListenerStarter(OtlpExporterEventListener listener)
         : Microsoft.Extensions.Hosting.IHostedService
@@ -319,11 +328,7 @@ public static class TelemetryHostExtensions
             return Task.CompletedTask;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            listener.Dispose();
-            return Task.CompletedTask;
-        }
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
+++ b/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
@@ -52,13 +52,15 @@ namespace Mithril.Shared.Telemetry.Hosting;
 /// through the exporter wrapper is non-trivial. Filed as a follow-up
 /// enhancement.</para>
 ///
-/// <para><strong>EventSource listener deferred (v1).</strong> The
-/// <see cref="ExporterHealthMonitor"/> is registered in DI so the settings UI
-/// can bind to it, but the
-/// <see cref="ExporterHealthMonitor.RecordFailure(string)"/> plumbing fed by
-/// the OTel SDK's internal EventSource is left for a follow-up — v1 users can
-/// read OTLP errors from the on-disk diagnostics .json log. The status line
-/// will show "no activity yet" until then, which is honest.</para>
+/// <para><strong>Exporter health.</strong> An
+/// <see cref="OtlpExporterEventListener"/> singleton is constructed eagerly so
+/// the OTel SDK's internal exporter <see cref="System.Diagnostics.Tracing.EventSource"/>
+/// is wired to <see cref="ExporterHealthMonitor.RecordFailure(string)"/>
+/// before the first export attempt. The OTel SDK exposes no public success
+/// callback, so the listener also runs a 30-second timer that calls
+/// <see cref="ExporterHealthMonitor.RecordSuccess"/> whenever no failure has
+/// been observed in the previous tick window — the v1 absence-of-failure
+/// compromise documented on the listener type. mithril#834.</para>
 /// </summary>
 public static class TelemetryHostExtensions
 {
@@ -121,6 +123,13 @@ public static class TelemetryHostExtensions
         services.AddSingleton<NewlySeenTagsObserver>();
         services.AddSingleton<HeaderValueProtection>(); // Consumed by Task 13 settings UI.
         services.AddSingleton<ExporterHealthMonitor>();
+        services.AddSingleton<OtlpExporterEventListener>();
+        // Eager start: the listener subscribes to the OTel exporter EventSource
+        // in its constructor, and we need it alive before the first export
+        // attempt so startup-time failures (DNS, TLS, corrupted endpoint) are
+        // captured. Hosted-service ordering is too coarse; resolve on host
+        // start via IHostedService bridged below.
+        services.AddHostedService<OtlpExporterEventListenerStarter>();
         services.AddSingleton(sp =>
         {
             // Active character read lazily on each scrub call so character
@@ -286,6 +295,35 @@ public static class TelemetryHostExtensions
         return asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
             ?? asm.GetName().Version?.ToString()
             ?? "0.0.0";
+    }
+
+    /// <summary>
+    /// Hosted-service shim that resolves the <see cref="OtlpExporterEventListener"/>
+    /// singleton on host start so the listener subscribes to the OTel exporter
+    /// EventSource <em>before</em> the first export attempt. The host's hosted-
+    /// service collection is started in registration order, and this entry is
+    /// registered after the OTel <see cref="OpenTelemetry.Trace.TracerProvider"/>
+    /// hosted services — but EventListener subscription is process-global and
+    /// completes synchronously in the constructor, so order here only needs to
+    /// be "before the first batch flush", which is satisfied at host start.
+    /// <see cref="StopAsync"/> disposes the listener so the success-tick
+    /// <see cref="System.Threading.Timer"/> is released cleanly on shutdown.
+    /// </summary>
+    private sealed class OtlpExporterEventListenerStarter(OtlpExporterEventListener listener)
+        : Microsoft.Extensions.Hosting.IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Touch the listener so DI builds the singleton (the ctor self-subscribes).
+            _ = listener;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            listener.Dispose();
+            return Task.CompletedTask;
+        }
     }
 
     /// <summary>

--- a/src/Mithril.Shared.Telemetry/Mithril.Shared.Telemetry.csproj
+++ b/src/Mithril.Shared.Telemetry/Mithril.Shared.Telemetry.csproj
@@ -8,6 +8,9 @@
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Mithril.Shared.Telemetry.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/src/Mithril.Shared.Telemetry/Processing/ValueRedactionOnlyProcessor.cs
+++ b/src/Mithril.Shared.Telemetry/Processing/ValueRedactionOnlyProcessor.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry;
+
+namespace Mithril.Shared.Telemetry.Processing;
+
+/// <summary>
+/// OpenTelemetry <see cref="BaseProcessor{T}"/> registered in place of
+/// <see cref="AllowlistAndRedactionProcessor"/> when
+/// <see cref="Settings.TelemetrySettings.TrustEndpoint"/> is <c>true</c>.
+///
+/// Skips the catalog / allowlist / user-override gate entirely — every producer
+/// tag flows to the OTLP destination — but still runs <see cref="ValueRedactor"/>
+/// across string tag values as belt-and-suspenders against accidental path-prefix
+/// or active-character-name leaks. The redactor is cheap, and prevents the dumbest
+/// accidental-screenshot-paste leak class without breaking the
+/// "I want to see what's actually being emitted" intent that motivates trust mode.
+///
+/// See mithril#840.
+/// </summary>
+public sealed class ValueRedactionOnlyProcessor : BaseProcessor<Activity>
+{
+    private readonly ValueRedactor _redactor;
+
+    public ValueRedactionOnlyProcessor(ValueRedactor redactor)
+    {
+        _redactor = redactor;
+    }
+
+    /// <inheritdoc />
+    public override void OnEnd(Activity activity)
+    {
+        var keys = activity.TagObjects.Select(kv => kv.Key).ToList();
+        foreach (var key in keys)
+        {
+            var original = activity.GetTagItem(key);
+            if (original is string s)
+            {
+                var redacted = _redactor.Redact(s);
+                if (!ReferenceEquals(redacted, s))
+                {
+                    activity.SetTag(key, redacted);
+                }
+            }
+        }
+    }
+}

--- a/src/Mithril.Shared.Telemetry/Settings/TelemetrySettings.cs
+++ b/src/Mithril.Shared.Telemetry/Settings/TelemetrySettings.cs
@@ -50,6 +50,18 @@ public sealed class TelemetrySettings : INotifyPropertyChanged, IVersionedState<
     private string _serviceName = "mithril";
     public string ServiceName { get => _serviceName; set => Set(ref _serviceName, value); }
 
+    private bool _trustEndpoint;
+    /// <summary>
+    /// When <c>true</c>, span exports skip the allowlist gate (<see cref="Catalog.TagCatalog"/>
+    /// membership + <see cref="TagExports"/> overrides + Sensitive-by-default drops) so
+    /// every producer tag flows to the OTLP destination. Use only for fully-trusted local
+    /// destinations (e.g. a Seq container the user runs themselves). The
+    /// <c>ValueRedactor</c> still runs as belt-and-suspenders against accidental paths /
+    /// character-name leaks in string tag values. Restart-required: the processor choice
+    /// is captured once in <c>AddMithrilOtlpExport</c>. Off by default. mithril#840.
+    /// </summary>
+    public bool TrustEndpoint { get => _trustEndpoint; set => Set(ref _trustEndpoint, value); }
+
     /// <summary>Header NAME → wrapped value. Wrap on set via UI VM; unwrap when binding to OTel options.</summary>
     public Dictionary<string, string> Headers { get; set; } = new();
 

--- a/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
+++ b/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
@@ -57,7 +57,9 @@
 
             <!-- Restart-required banner. v1: always visible whenever the master toggle
                  is on, because the host captures EnableOtlpExport + endpoint/headers/
-                 protocol/service-name fields once at AddMithrilOtlpExport time. -->
+                 protocol/service-name + trust-endpoint fields once at AddMithrilOtlpExport
+                 time. Banner text must enumerate every restart-required field — users read
+                 it as the source of truth for "what applies live vs after restart". -->
             <Border Background="#332C2010" BorderBrush="#FFD4A847" BorderThickness="0,0,0,2"
                     Padding="8,6" Margin="0,0,0,12"
                     Visibility="{Binding Settings.EnableOtlpExport, Converter={StaticResource BoolToVis}}">
@@ -65,7 +67,7 @@
                     <icon:PackIconLucide Kind="Info" Width="14" Height="14"
                                          VerticalAlignment="Center" Margin="0,0,8,0"
                                          Foreground="#FFD4A847"/>
-                    <TextBlock Text="Restart Mithril to apply endpoint, headers, protocol, and service-name changes. Tag-export toggles apply live."
+                    <TextBlock Text="Restart Mithril to apply endpoint, headers, protocol, service-name, and trust-endpoint changes. Tag-export toggles apply live."
                                TextWrapping="Wrap" Foreground="#FFE8E8E8"
                                FontSize="{DynamicResource AppFontSizeHint}"/>
                 </StackPanel>

--- a/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
+++ b/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
@@ -47,6 +47,14 @@
                       IsChecked="{Binding Settings.EnableOtlpExport, Mode=TwoWay}"
                       Foreground="#FFE8E8E8" Margin="0,0,0,4"/>
 
+            <!-- Trust endpoint (mithril#840). Skips the allowlist gate for fully-trusted
+                 local destinations (e.g. a self-hosted Seq) while keeping the value
+                 redactor running. Restart-required like the other top-level fields. -->
+            <CheckBox Content="Trust endpoint (skip allowlist for trusted local destinations)"
+                      IsChecked="{Binding Settings.TrustEndpoint, Mode=TwoWay}"
+                      Foreground="#FFE8E8E8" Margin="0,0,0,4"
+                      ToolTip="Use only for local sinks you fully control (e.g. self-hosted Seq). The value redactor still runs to scrub paths and character names from string tags."/>
+
             <!-- Restart-required banner. v1: always visible whenever the master toggle
                  is on, because the host captures EnableOtlpExport + endpoint/headers/
                  protocol/service-name fields once at AddMithrilOtlpExport time. -->

--- a/tests/Mithril.Shared.Telemetry.Tests/Export/OtlpExporterEventListenerTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Export/OtlpExporterEventListenerTests.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics.Tracing;
+using FluentAssertions;
+using Mithril.Shared.Telemetry.Export;
+using Xunit;
+
+namespace Mithril.Shared.Telemetry.Tests.Export;
+
+/// <summary>
+/// Contract for mithril#834: the listener subscribes to the OTel SDK's
+/// internal exporter <see cref="EventSource"/> and routes Warning+ events
+/// into <see cref="ExporterHealthMonitor.RecordFailure(string)"/>. Success
+/// is synthesised by an absence-of-failure tick (driven directly by tests
+/// via the internal <c>TickSuccessForTests</c> hook).
+/// </summary>
+public class OtlpExporterEventListenerTests
+{
+    /// <summary>
+    /// In-process stand-in for the OTel exporter's internal EventSource.
+    /// Constructed with the same name (<see cref="OtlpExporterEventListener.OtlpExporterEventSourceName"/>)
+    /// so the listener's <c>OnEventSourceCreated</c> filter matches. Subscribers
+    /// to one EventSource instance under that name see events from any other
+    /// instance under the same name in the same process — the listener's filter
+    /// is name-based.
+    /// </summary>
+    private sealed class FakeOtlpEventSource() : EventSource(OtlpExporterEventListener.OtlpExporterEventSourceName)
+    {
+        [Event(1, Level = EventLevel.Error)]
+        public void ExportFailed(string reason) => WriteEvent(1, reason);
+
+        [Event(2, Level = EventLevel.Warning)]
+        public void TransientHttpError(string status) => WriteEvent(2, status);
+
+        [Event(3, Level = EventLevel.Informational)]
+        public void HousekeepingInfo(string note) => WriteEvent(3, note);
+    }
+
+    [Fact]
+    public void Error_level_event_from_otlp_source_records_failure()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var src = new FakeOtlpEventSource();
+        // Build the listener AFTER the source so OnEventSourceCreated fires for
+        // an already-existing source — this exercises the initialization race
+        // path (queued source enabled via Initialize, not OnEventSourceCreated).
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+
+        src.ExportFailed("Connection refused");
+
+        health.Current.LastError.Should().NotBeNull();
+        health.Current.LastError.Should().Contain("ExportFailed");
+        health.Current.LastError.Should().Contain("Connection refused");
+        health.Current.LastFailureUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Warning_level_event_from_otlp_source_records_failure()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var src = new FakeOtlpEventSource();
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+
+        src.TransientHttpError("503 ServiceUnavailable");
+
+        health.Current.LastError.Should().NotBeNull();
+        health.Current.LastError.Should().Contain("503 ServiceUnavailable");
+    }
+
+    [Fact]
+    public void Informational_level_event_does_not_record_failure()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var src = new FakeOtlpEventSource();
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+
+        src.HousekeepingInfo("opened persistent retry directory");
+
+        // Informational events live below the Warning threshold the listener
+        // monitors — they must not turn the status line red.
+        health.Current.LastError.Should().BeNull();
+        health.Current.LastFailureUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public void Tick_with_no_prior_failure_records_success()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+
+        var recorded = listener.TickSuccessForTests();
+
+        recorded.Should().BeTrue();
+        health.Current.LastSuccessUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Tick_immediately_after_failure_suppresses_success()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var src = new FakeOtlpEventSource();
+        // Long window so a within-window tick is suppressed.
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromHours(1), startTimer: false);
+
+        src.ExportFailed("DNS resolution failed");
+        var recorded = listener.TickSuccessForTests();
+
+        recorded.Should().BeFalse(
+            "absence-of-failure must respect the window — a tick immediately after a recorded " +
+            "failure should not flip the status line back to green.");
+        health.Current.LastError.Should().Be(health.Current.LastError);
+        // Verify the failure remained the latest signal.
+        health.Current.LastError.Should().Contain("DNS resolution failed");
+    }
+
+    [Fact]
+    public void Tick_after_window_elapses_following_failure_records_success()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var src = new FakeOtlpEventSource();
+        // Zero-length window: any tick is "after the window" for the prior failure.
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.Zero, startTimer: false);
+
+        src.ExportFailed("transient");
+        var recorded = listener.TickSuccessForTests();
+
+        recorded.Should().BeTrue();
+        // Both timestamps are populated — failure history is preserved alongside the new success.
+        health.Current.LastFailureUtc.Should().NotBeNull();
+        health.Current.LastSuccessUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Events_from_unrelated_event_sources_are_ignored()
+    {
+        using var health = new ExporterHealthMonitor();
+        using var unrelated = new UnrelatedErrorEventSource();
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+
+        unrelated.SomethingBroke("unrelated subsystem");
+
+        health.Current.LastError.Should().BeNull(
+            "the listener must filter by EventSource name — only failures from the OTel exporter " +
+            "source itself should drive the status line.");
+    }
+
+    private sealed class UnrelatedErrorEventSource() : EventSource("Mithril-Unrelated-Test-Source")
+    {
+        [Event(1, Level = EventLevel.Error)]
+        public void SomethingBroke(string detail) => WriteEvent(1, detail);
+    }
+
+    [Fact]
+    public void Listener_self_subscribes_when_constructed_after_source_already_exists()
+    {
+        // Exercises the "source exists before listener" path: the listener's
+        // base ctor sees the source in its initial walk, defers EnableEvents
+        // until Initialize sets _health, then enables. The first event after
+        // that point must be recorded.
+        using var src = new FakeOtlpEventSource();
+        using var health = new ExporterHealthMonitor();
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+
+        src.ExportFailed("post-construction failure");
+        health.Current.LastError.Should().Contain("post-construction failure");
+    }
+
+    [Fact]
+    public void Listener_picks_up_source_constructed_after_listener()
+    {
+        // Exercises the "listener exists before source" path: OnEventSourceCreated
+        // fires after Initialize, so the source is enabled inline.
+        using var health = new ExporterHealthMonitor();
+        using var listener = new OtlpExporterEventListener(health, TimeSpan.FromSeconds(30), startTimer: false);
+        using var src = new FakeOtlpEventSource();
+
+        src.ExportFailed("late-bound source failure");
+        health.Current.LastError.Should().Contain("late-bound source failure");
+    }
+}

--- a/tests/Mithril.Shared.Telemetry.Tests/Export/OtlpExporterEventListenerTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Export/OtlpExporterEventListenerTests.cs
@@ -101,14 +101,22 @@ public class OtlpExporterEventListenerTests
         using var listener = new OtlpExporterEventListener(health, TimeSpan.FromHours(1), startTimer: false);
 
         src.ExportFailed("DNS resolution failed");
+        var errorBeforeTick = health.Current.LastError;
+        var failureUtcBeforeTick = health.Current.LastFailureUtc;
+        var successUtcBeforeTick = health.Current.LastSuccessUtc;
+
         var recorded = listener.TickSuccessForTests();
 
         recorded.Should().BeFalse(
             "absence-of-failure must respect the window — a tick immediately after a recorded " +
             "failure should not flip the status line back to green.");
-        health.Current.LastError.Should().Be(health.Current.LastError);
-        // Verify the failure remained the latest signal.
+        // A suppressed tick must not mutate the health snapshot — neither the
+        // failure reason nor the timestamps move. This is what makes the status
+        // line stay red across the window.
+        health.Current.LastError.Should().Be(errorBeforeTick);
         health.Current.LastError.Should().Contain("DNS resolution failed");
+        health.Current.LastFailureUtc.Should().Be(failureUtcBeforeTick);
+        health.Current.LastSuccessUtc.Should().Be(successUtcBeforeTick);
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Telemetry.Tests/Hosting/TelemetryHostExtensionsTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Hosting/TelemetryHostExtensionsTests.cs
@@ -8,6 +8,7 @@ using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics.Telemetry;
 using Mithril.Shared.Telemetry.Abstractions;
 using Mithril.Shared.Telemetry.Hosting;
+using Mithril.Shared.Telemetry.Processing;
 using Mithril.Shared.Telemetry.Settings;
 using OpenTelemetry.Trace;
 using Xunit;
@@ -131,5 +132,68 @@ public class TelemetryHostExtensionsTests
         {
             try { Directory.Delete(settingsDir, recursive: true); } catch { /* best-effort */ }
         }
+    }
+
+    [Fact]
+    public void TrustEndpoint_false_registers_full_scrubber_processor_as_singleton()
+    {
+        var settings = new TelemetrySettings
+        {
+            EnableOtlpExport = true,
+            Endpoint = "http://localhost:65535/",
+            TrustEndpoint = false,
+        };
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(settings);
+                services.AddSingleton<ITagDescriptorProvider, MithrilSharedTagDescriptors>();
+                services.AddMithrilOtlpExport(settings);
+            })
+            .Build();
+
+        // Both processors are registered as singletons (the choice of which one
+        // is added to the tracing pipeline is captured at registration time);
+        // the full scrubber must be resolvable so AddProcessor<T> can wire it.
+        host.Services.GetService<AllowlistAndRedactionProcessor>().Should().NotBeNull(
+            "TrustEndpoint = false must keep the catalog + allowlist + redactor processor on the tracing pipeline.");
+    }
+
+    [Fact]
+    public void TrustEndpoint_true_registers_redaction_only_processor_singleton()
+    {
+        var settings = new TelemetrySettings
+        {
+            EnableOtlpExport = true,
+            Endpoint = "http://localhost:65535/",
+            TrustEndpoint = true,
+        };
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(settings);
+                services.AddSingleton<ITagDescriptorProvider, MithrilSharedTagDescriptors>();
+                services.AddMithrilOtlpExport(settings);
+            })
+            .Build();
+
+        host.Services.GetService<ValueRedactionOnlyProcessor>().Should().NotBeNull(
+            "TrustEndpoint = true swaps the allowlist gate out for the redactor-only processor " +
+            "(see mithril#840); the singleton must be resolvable so AddProcessor<T> can wire it.");
+        host.Services.GetService<TracerProvider>().Should().NotBeNull(
+            "Toggling TrustEndpoint must not break the tracer provider wiring.");
+    }
+
+    [Fact]
+    public void TrustEndpoint_default_is_false_so_existing_configs_keep_scrubbing()
+    {
+        // Restart-required behaviour-preservation check: loading a v1 telemetry.json
+        // that pre-dates the TrustEndpoint field must default to the safe (scrubbed)
+        // path, not the bypass. STJ tolerates the missing field; the default value
+        // of `false` carries the contract.
+        var settings = new TelemetrySettings();
+        settings.TrustEndpoint.Should().BeFalse();
     }
 }

--- a/tests/Mithril.Shared.Telemetry.Tests/Processing/ValueRedactionOnlyProcessorTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Processing/ValueRedactionOnlyProcessorTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Diagnostics;
+using FluentAssertions;
+using Mithril.Shared.Telemetry.Processing;
+using Xunit;
+
+namespace Mithril.Shared.Telemetry.Tests.Processing;
+
+/// <summary>
+/// Behavioural contract for the TrustEndpoint = true processor (mithril#840):
+/// unknown tag keys survive (no catalog gate, no allowlist), Sensitive-classified
+/// tags survive (no default-off), user-disabled overrides are ignored — but the
+/// <see cref="ValueRedactor"/> still scrubs path prefixes and the active
+/// character name from string tag values.
+///
+/// Tests bypass the process-global <see cref="ActivityListener"/> registry by
+/// calling <see cref="ValueRedactionOnlyProcessor.OnEnd"/> directly on a
+/// hand-built <see cref="Activity"/>. Routing through
+/// <see cref="ActivitySource.StartActivity"/> would let any other test class's
+/// listener (running in parallel) observe and mutate the same Activity — and
+/// the existing <c>AllowlistAndRedactionProcessorTests</c> registers listeners
+/// with <c>ShouldListenTo = _ =&gt; true</c>, which would drop our unknown-tag
+/// assertions out from under us.
+/// </summary>
+public class ValueRedactionOnlyProcessorTests
+{
+    private static ValueRedactionOnlyProcessor Build(
+        Func<string?>? activeChar = null,
+        string userProfile = @"C:\Users\u",
+        string localAppData = @"C:\Users\u\AppData\Local")
+    {
+        var redactor = new ValueRedactor(activeChar ?? (() => null), userProfile, localAppData);
+        return new ValueRedactionOnlyProcessor(redactor);
+    }
+
+    [Fact]
+    public void Keeps_tag_whose_key_is_unknown_to_the_catalog()
+    {
+        var p = Build();
+        using var act = new Activity("op").Start();
+        act.SetTag("brand.new.unknown.tag", "value");
+
+        p.OnEnd(act);
+
+        act.GetTagItem("brand.new.unknown.tag").Should().Be("value",
+            "TrustEndpoint = true skips the allowlist entirely so producer-emitted tags " +
+            "flow to the destination without catalog membership.");
+    }
+
+    [Fact]
+    public void Keeps_sensitive_classified_tag_that_the_default_processor_would_drop()
+    {
+        // The full AllowlistAndRedactionProcessor drops Sensitive-classified tags unless
+        // explicitly opt-in via user override. The redactor-only processor has no
+        // classification awareness at all.
+        var p = Build();
+        using var act = new Activity("op").Start();
+        act.SetTag("character.name", "Thorgrim");
+
+        p.OnEnd(act);
+
+        act.GetTagItem("character.name").Should().Be("Thorgrim");
+    }
+
+    [Fact]
+    public void Redacts_userprofile_path_prefix_from_string_tag_value()
+    {
+        var p = Build();
+        using var act = new Activity("op").Start();
+        act.SetTag("unknown.path.tag", @"C:\Users\u\Documents\save.log");
+
+        p.OnEnd(act);
+
+        // Belt-and-suspenders: the redactor still rewrites %USERPROFILE%-rooted
+        // paths even when the allowlist is bypassed. The screenshot-leak threat
+        // is independent of whether the destination is "trusted".
+        act.GetTagItem("unknown.path.tag").Should().Be(@"$USER\Documents\save.log");
+    }
+
+    [Fact]
+    public void Redacts_localappdata_prefix_before_userprofile_so_longer_prefix_wins()
+    {
+        var p = Build();
+        using var act = new Activity("op").Start();
+        act.SetTag("unknown.path.tag", @"C:\Users\u\AppData\Local\Mithril\boot.log");
+
+        p.OnEnd(act);
+
+        // ValueRedactor applies $LOCALAPPDATA before $USER so the longer prefix
+        // wins; we keep that invariant in trust-mode as well.
+        act.GetTagItem("unknown.path.tag").Should().Be(@"$LOCALAPPDATA\Mithril\boot.log");
+    }
+
+    [Fact]
+    public void Redacts_active_character_name_from_string_tag_value()
+    {
+        var p = Build(activeChar: () => "Thorgrim");
+        using var act = new Activity("op").Start();
+        act.SetTag("error.message", "Thorgrim died");
+
+        p.OnEnd(act);
+
+        act.GetTagItem("error.message").Should().Be("$CHARACTER died");
+    }
+
+    [Fact]
+    public void Leaves_non_string_tag_values_alone()
+    {
+        var p = Build();
+        using var act = new Activity("op").Start();
+        act.SetTag("count", 42);
+        act.SetTag("ratio", 0.5);
+
+        p.OnEnd(act);
+
+        act.GetTagItem("count").Should().Be(42);
+        act.GetTagItem("ratio").Should().Be(0.5);
+    }
+}


### PR DESCRIPTION
v1-polish follow-ups to the merged mithril#815 BYOB OTLP exporter (PR #838, commit 1211c780). Two cohesive sections; one PR because the new surfaces wire into the same `AddMithrilOtlpExport` and don't conflict.

## Part A — `TrustEndpoint` toggle (closes #840)

Off-by-default checkbox in telemetry settings that swaps `AllowlistAndRedactionProcessor` for the new `ValueRedactionOnlyProcessor` on the tracing pipeline. Producer tags bypass the catalog + allowlist + Sensitive-default-off gate so every span attribute reaches the destination (matching what the in-process diagnostics view shows), while `ValueRedactor` keeps running — belt-and-suspenders against accidental path / character-name leaks in string tag values.

- `TelemetrySettings.TrustEndpoint: bool = false` — no schema bump (STJ tolerates the missing field on v1 configs).
- New `ValueRedactionOnlyProcessor` next to the existing processor; the host extension picks one at `AddProcessor<T>` time.
- Restart-required (captured once at registration), surfaced via the existing restart banner.
- New checkbox under the master "Enable OTLP export" toggle with tooltip explaining the trade-off.
- 9 new tests (5 behavioural for the redactor-only processor, 3 host-wiring, 1 default-value).

## Part B — exporter health pulses (closes #834)

`OtlpExporterEventListener` subclasses `EventListener`, subscribes to the OTel SDK's internal `OpenTelemetry-Exporter-OpenTelemetryProtocol` event source, and routes Warning+ events into `ExporterHealthMonitor.RecordFailure`. Validated against `OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.x` — the listener filters by `EventLevel` rather than event id so a renovate bump that renumbers events doesn't silently regress the status line.

Because OTel SDK exposes no public success callback, success is synthesised via a 30-second timer that calls `RecordSuccess` whenever no failure has been observed in the previous tick window. Tooltip in the settings UI already reads "last successful export attempt" (not "delivery"), reflecting this absence-of-failure heuristic.

Registered as a singleton + started eagerly via a tiny `IHostedService` so the EventSource subscription is in place before the first export attempt — startup-time failures (DNS, TLS, corrupted endpoint) reach the status line on the first probe.

- New `OtlpExporterEventListener` with handles for both construction-race paths (listener-before-source and source-before-listener).
- 9 new tests including a fake `EventSource` matching the OTel exporter source name, level-filter verification, success-suppression-after-failure, and unrelated-source filtering.
- Existing `ExporterHealthMonitor` tests (concurrency lock + observable surface) continue to pass.
- XML doc on `AddMithrilOtlpExport` updated: the "EventSource listener deferred" paragraph is replaced with a short note pointing at the listener type.

## Test results

```
Mithril.Shared.Telemetry.Tests: 61/61 passed (was 43; +18 new)
Full solution suite: all green
```

## Verification owed

Manual Seq smoke test before closing the two issues:

- [ ] Start a local Seq container (`docker compose up -d seq`), enable OTLP export, send a few spans, confirm they reach Seq's *Traces* view with scrubbed attributes.
- [ ] Tick `TrustEndpoint`, restart Mithril, send the same spans, confirm previously-scrubbed attributes (e.g. unknown producer tags, Sensitive-classified `character.name`) now flow through.
- [ ] Stop Seq mid-session and confirm the status line transitions to a failure state with a concrete reason from the exporter EventSource within ~5s.
- [ ] Restart Seq and confirm the status line returns to a success state within ~30s (one success-tick interval).

---

Closes #834.
Closes #840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— drafted by Claude (Opus 4.7), posted by @arthur-conde
