### PR TITLE
spike(tools): probe PG Addressables for map-icon positions (#848)

### DIFF
--- a/docs/spikes/map-icon-extraction.md
+++ b/docs/spikes/map-icon-extraction.md
@@ -156,6 +156,46 @@ Catalog parsing — printable-string dump of `catalog.bin` (every Addressables k
 
 The one remaining surface that *could* hold a hardcoded icon-position table is `Plugins/x86_64/GameAssembly.dll` — the IL2CPP-compiled C# code itself, where `const Vector2[]` arrays or embedded JSON resource strings would live. Reading the compiled assembly to extract those is foreclosed by PG's anti-injector posture (see memory `pg_anti_injector_stance`) and is out of scope here. Even if extraction were attempted, a `const` table would be a snapshot frozen to whatever PG release shipped it — the recurring per-patch maintenance cost the spike was trying to avoid would resurface as "decompile-and-diff after each PG patch."
 
+## "What about TeleportCircle GameObjects in scenes?"
+
+The `TeleportationPlatform` entries in `landmarks.json` are named `TeleportCircle_<Name>` (e.g. `TeleportCircle_CasinoFoyer`, `TeleportCircle_HauntedTown`). The corresponding GameObjects exist in 16 area scenes:
+
+| Scene | TeleportCircle entries |
+|---|---|
+| `level6` | NewbieIsland1 |
+| `level8` | TigerFields, TownSquare, WolfDais, WolfFields |
+| `level10` | MycoEntrance |
+| `level11` | AbandonedCourtyard, BFE1, Courtyard, PlateauAlt, PlateauCity, SieAntry |
+| `level13` | Crevice, KurIceberg, KurMountainsWerewolfForest, Lamashu, Tundra1NearInn |
+| `level16` | AnimalTown, Landing, NearDruids, Sand, TrollRegion, Underwater |
+| `level17` | Amulna, DeadTown1 |
+| `level20` | Rahu1, Rahu2, Rahu3 |
+| `level21` | Serbule2Estate, Serbule2Forest, Serbule2Hub, Serbule2Wilderness |
+| `level22` | HauntedTown, NearGazlukCity, OrcCamps, PlateauCenter |
+| `level23` | GazlukCaves1 |
+| `level25` | CasinoFoyer |
+| `level31` | NearTown |
+| `level37` | AnimalCamp |
+| `level38` | FrozenMushroom, NearOrcs, NearSoldiers, Rubywall, VidariaTown |
+| `level41` | OldTown, OtherInTown |
+
+These are real in-world entities — `Transform` + mesh + collider + likely a particle effect. They give the **world position** of every teleport circle, matching the `.Loc` in `landmarks.json` (potentially a cleaner source than the CDN file for that subset of landmarks).
+
+But — they do **not** carry pixel-coord data. Checked via `scanall` co-location:
+
+- `MapMarker` appears in `globalgamemanagers.assets`, `level0`, `level40` (UI scenes) only — disjoint from the 16 TeleportCircle-containing area scenes.
+- `MapLandmark` appears in `globalgamemanagers.assets` only.
+
+So no scene has a `MapMarker` or `MapLandmark` MonoBehaviour attached to a TeleportCircle. The map UI must look these entities up by name at runtime and project their world coords to map pixels via the same code-resident transform we'd be trying to extract — i.e. they don't shortcut the calibration problem.
+
+### Probe limitation honestly noted
+
+The `names` and `scenes` phases keyword-filter on `m_Name`, which requires `AssetsTools.NET.GetBaseField` to succeed. For Addressables bundles this works (bundles ship inline type trees). For Unity scene files (`level<N>`), the type tree is **stripped** to save space, so `GetBaseField` returns null on every scene asset without a Unity 6000.3 `classdata.tpk` package loaded — meaning my scene keyword-filter said "0 hits" because it couldn't read any GameObject's name at all (`24,183 GameObjects scanned in level25, 0 named, 0 nameless lookups returned a string`).
+
+The load-bearing evidence for the negative is therefore the **byte-string `scanall` phase**, which reads raw file bytes and is unaffected by type-tree availability. All class-name and area-name conclusions above derive from `scanall`, not from the limited m_Name filter.
+
+A future re-run with `classdata.tpk` loaded for Unity 6000.3 could enumerate TeleportCircle GameObjects' full component lists and confirm exhaustively (rather than via class-name co-location) that no map-pin component rides on them — but `scanall` co-location already gives the answer with high confidence.
+
 ## Artifacts
 
 - Probe tool: [`tools/MapIconProbe/`](../../tools/MapIconProbe/) — runnable via `dotnet run --project tools/MapIconProbe -c Release -- <phase>`. Phases: `inventory`, `names`, `dumpbundle <substring>`, `ggm`, `scenes`, `strings`, `scanall <substring>`.

--- a/docs/spikes/map-icon-extraction.md
+++ b/docs/spikes/map-icon-extraction.md
@@ -1,0 +1,136 @@
+# Spike: map-icon position extraction from PG Addressables (mithril#848)
+
+**Outcome:** negative. PG does not ship per-area map-icon pixel positions as data. The map UI is fully runtime-driven from server-side state, so no offline calibration baseline can be auto-derived from the on-disk install.
+
+**Date:** 2026-05-29. **Game version:** Unity 6000.3.11f1 build, install snapshot dated 2026-04-18.
+
+**Fallback:** stay at `anchors: {}` in [`src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json`](../../src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json) and lean on per-user Legolas refinement — the precedence stack landed in [PR #839](https://github.com/moumantai-gg/mithril/pull/839) already supports this path.
+
+## Question
+
+Does PG ship a parseable asset (in the Addressables substrate validated by [PR #828](https://github.com/moumantai-gg/mithril/pull/828)) that lists the **pixel positions of map icons** — landmarks, NPCs, area-of-interest markers — on the per-area map PNGs?
+
+If yes: pair `(world_coord)` from `Mithril.Reference` (`landmarks.json` `.Loc`, `npcs.json` `.Pos`) with `(pixel_coord)` from the extracted asset, run [`LandmarkCalibrationSolver`](../../src/Mithril.MapCalibration/LandmarkCalibrationSolver.cs), produce the bundled baseline JSON automatically.
+
+## How the probe worked
+
+The probe tool ([`tools/MapIconProbe/`](../../tools/MapIconProbe/)) reads the user's local PG install offline. The game is never run. It reuses the Steam-install detection + `AssetsTools.NET 3.0.4` decode path from the substrate spike ([`tools/MapAssetSpike/`](../../tools/MapAssetSpike/)).
+
+Four scan phases:
+
+| Phase | What it does |
+|---|---|
+| `inventory` | Walks every `.bundle` under `StreamingAssets/aa/StandaloneWindows64/`, prints a per-bundle asset-type histogram (Texture2D / Sprite / MonoBehaviour / GameObject / MonoScript / other). |
+| `names` | Across all bundles + `globalgamemanagers.assets`, dumps every asset whose `m_Name` contains an icon/landmark/marker keyword. |
+| `dumpbundle <substring>` | Picks the first bundle matching `<substring>` and dumps every asset's field tree (Sprite, MonoBehaviour, GameObject) for inspection. |
+| `scenes` | Loads each `level<N>` scene file, prints a type histogram, and applies the same keyword filter against asset names. |
+| `strings` | Brute-force ASCII string extraction from `globalgamemanagers.assets`, `globalgamemanagers`, `il2cpp_data/Metadata/global-metadata.dat`, and `level1`. Catches C# class names whose `MonoScript` instances the type-tree-less probe couldn't reflect. |
+| `scanall <substring>` | Byte-string scans every bundle + every scene file + ggm for the literal substring. Used to count how many files reference a given class. |
+
+## Findings
+
+### 1. Per-area map bundles carry only the raw texture
+
+Each `maps_assets_assets_art_maps_map_<area>.png_*.bundle` contains exactly **3 assets**:
+
+```
+Texture2D    name=Map_AreaSerbule        (1961×2048 RGBA)
+AssetBundle  name=<bundle-uuid>          (preload + container metadata)
+Sprite       name=Map_AreaSerbule        m_Rect=(0,0,1961,2048)
+                                         m_Pivot=(0.5,0.5)
+                                         m_PixelsToUnits=100
+                                         m_Offset=(0,0)  m_Border=(0,0,0,0)
+```
+
+The Sprite is a full-texture wrapper with center pivot — it carries **no icon position metadata**, no atlas/sprite-sheet breakdown, no per-landmark sub-rectangles. The `m_PixelsToUnits=100` is the standard Unity UI pixels-per-world-unit constant, not the area-to-map scale we need.
+
+### 2. No bundle is named for icon / landmark / NPC / minimap data
+
+Out of **1117 bundles** in `StreamingAssets/aa/StandaloneWindows64/`:
+
+- Filename grep for `*landmark*`, `*minimap*`, `*mapicon*`, `*mapmarker*`, `*poi*`, `*npc*`, `*marker*`, `*waypoint*`, `*hud*`, `*icon*` → **0 matches** beyond the per-area map textures themselves.
+- The only non-`maps_assets_*` bundles in the substrate that hold structured data are `<creature>_assets_all_*` (rigging + materials) and `defaultlocalgroup_assets_*` (misc props/effects). Neither shape carries map metadata.
+
+### 3. No asset across the substrate has a map/landmark name
+
+`names` phase, tight keywords (`landmark`, `minimap`, `mapicon`, `mapmarker`, `mapmark`, `waypoint`, `mapdata`, `mapmeta`, `mapref`, `mappoi`, `spritesheet`, `spriteatlas`, `areamap`, `worldmap`, `mapnpc`, `npcmap`, `mapdb`):
+
+- **0 bundle hits** across all 1117 bundles.
+- **0 ggm hits** across `globalgamemanagers.assets`.
+- **0 scene hits** across all 44 `level<N>` files (combined ~5 million assets).
+
+### 4. Central monoscripts bundle has no map-related types
+
+`be9e4d904692f945f3910b57349aeb09_monoscripts_*.bundle` ships **235 PG-specific `MonoScript` definitions**. They are uniformly creature-`AppearanceConfig` types (e.g. `BearAppearanceConfig`, `GoblinAppearanceConfig`), low-level engine helpers (`MountPoint`, `ClimbableLadder`, `NavMeshModifier`), and gameplay configs (`GardenPlantConfig`).
+
+**Zero** of the 235 class names match `landmark`, `mapicon`, `mapmarker`, `minimap`, `waypoint`, `areamap`, or `worldmap`.
+
+### 5. The map-UI classes ARE defined — but only in IL2CPP-compiled code
+
+The `strings` phase against `il2cpp_data/Metadata/global-metadata.dat` revealed PG defines these C# types in the main compiled assembly:
+
+| Class | Source file (per IL2CPP debug info) |
+|---|---|
+| `Landmark` | `Assets\Scripts\GorgonCore\Factories\Landmark.cs` |
+| `LandmarkFactory` | `Assets\Scripts\GorgonCore\Factories\LandmarkFactory.cs` |
+| `LandmarkManager` | `Assets\Scripts\SystemsManagers\LandmarkManager.cs` |
+| `LandmarkPreParsed` | (no path emitted) |
+| `MapLandmark` | `Assets\Scripts\NewUI\Components\Map\MapLandmark.cs` |
+| `MapMarker` | `Assets\Scripts\NewUI\Components\Map\MapMarker.cs` |
+| `UIMapControllerNew` | `Assets\Scripts\NewUI\Controllers\UIMapControllerNew.cs` (field `EntityPinCollection`) |
+| `UIMapMarkerInfoDisplay` | `Assets\Scripts\NewUI\Controllers\UIMapMarkerInfoDisplay.cs` |
+| `UIWaypointDisplay` | `Assets\Scripts\NewUI\Controllers\UIWaypointDisplay.cs` |
+| `AreaMapScriptableObject` | (no path emitted) |
+
+So the runtime map UI exists — `UIMapControllerNew` instantiates `MapMarker` + `MapLandmark` components, populated from a `LandmarkManager` and an `EntityPinCollection` on the controller — but every reference is in compiled IL2CPP code, not in data.
+
+### 6. The corresponding instance data does NOT exist on disk
+
+`scanall <className>` byte-scan across all 1163 candidate files (1117 bundles + ggm + 44 scenes + `globalgamemanagers`):
+
+| Class name | Files containing the literal string |
+|---|---|
+| `AreaMapScriptableObject` | 1 (`globalgamemanagers.assets` — the class definition) |
+| `MapLandmark` | 1 (`globalgamemanagers.assets`) |
+| `LandmarkManager` | 1 (`globalgamemanagers.assets`) |
+| `LandmarkFactory` | 1 (`globalgamemanagers.assets`) |
+| `LandmarkPreParsed` | 1 (`globalgamemanagers.assets`) |
+| `MapMarker` | 3 (`globalgamemanagers.assets`, `level0`, `level40`) |
+| `UIMapControllerNew` | 3 (`globalgamemanagers.assets`, `level0`, `level40`) |
+| `EntityPin` | 0 |
+| `EntityPinCollection` | 0 |
+
+`level0` + `level40` are the UI canvas scenes (~4200 MonoBehaviours, ~2700 GameObjects, ~2600 RectTransforms in level0). The two hits on `MapMarker` / `UIMapControllerNew` are the script-class-name string interned once per scene — they indicate a single `UIMapControllerNew` MonoBehaviour and a single `MapMarker` prefab template live there, not a per-landmark collection. `EntityPin` / `EntityPinCollection` literally do not appear anywhere outside the IL2CPP metadata, meaning no serialized instance of those types exists at all.
+
+The pattern is unambiguous: the map UI is a single runtime controller whose pin collection is populated **dynamically at runtime** — most likely from the same server-side world state that drives chat-channel landmark queries, not from a baked-asset table.
+
+### 7. Sprite metadata path is also empty
+
+Tight scan for `spriteatlas`, `spritesheet`, `atlas` across asset names → 0 hits. No bundle ships a Unity `SpriteAtlas` packing landmark/NPC icon textures with named sub-sprites. So the "icons-via-atlas-UV" indirect path (e.g., an icon-pack atlas + per-area placement) is also not present.
+
+## Conclusion
+
+The PG Addressables substrate carries the per-area map PNG and nothing else map-related. The classes that *would* hold the calibration data (`AreaMapScriptableObject`, `EntityPinCollection`, `MapLandmark` instances) exist as compiled C# types but have **zero serialized instances** anywhere on disk. The map UI populates its pin collection at runtime from server state.
+
+Recovering the per-area pixel-position table by reading on-disk assets is therefore impossible without extracting it from the running game process — which is foreclosed by PG's anti-injector posture (see memory `pg_anti_injector_stance`) — or by reverse-engineering the IL2CPP-compiled C# logic that does the world→pixel projection, which is out of scope here.
+
+### Zoom dependency note
+
+Per the issue's "Verification owed" section: if the spike had succeeded, the recovered baseline would have needed to declare what `CalibrationZoom` the icon positions were authored at (so the [PR #524](https://github.com/moumantai-gg/mithril/pull/524) zoom-awareness math could project to other zooms). Since no icon positions exist on disk, this question is moot — but worth recording: even if `EntityPinCollection` instances were found in a future PG patch, the spike would still need to verify whether the pin positions are zoom-anchored to a specific render zoom or are zoom-agnostic.
+
+## Fallback path (already in place)
+
+[PR #839](https://github.com/moumantai-gg/mithril/pull/839) shipped the baseline JSON with `anchors: {}` and a precedence stack that prefers per-user Legolas-refined calibration over the bundled baseline whenever the user has converged on an area. With the spike negative, that path is the only viable one:
+
+1. New users see the un-calibrated default projection until they walk an area and Legolas converges.
+2. Users who have walked an area get the Legolas-refined calibration persisted locally.
+3. The bundled baseline remains an empty placeholder — useful as a schema anchor, not a data source.
+
+Hand-authoring a 36-area baseline JSON (the original [#836](https://github.com/moumantai-gg/mithril/issues/836) Tier 2(a) plan) remains a possibility if a real need surfaces, but per the spike's intent the negative result is itself an acceptable outcome — we now know the recurring authoring cost is the only way to pay for it.
+
+## Artifacts
+
+- Probe tool: [`tools/MapIconProbe/`](../../tools/MapIconProbe/) — runnable via `dotnet run --project tools/MapIconProbe -c Release -- <phase>`. Phases: `inventory`, `names`, `dumpbundle <substring>`, `ggm`, `scenes`, `strings`, `scanall <substring>`.
+- Predecessor: [`tools/MapAssetSpike/`](../../tools/MapAssetSpike/) — the substrate spike from [#827](https://github.com/moumantai-gg/mithril/issues/827) / [PR #828](https://github.com/moumantai-gg/mithril/pull/828) that proved bundle decoding works in the first place. Shares the AssetsTools.NET dependency surface + Steam-install detection.
+
+A future contributor who wants to re-litigate this finding should re-run the probe against a fresh PG install (in case PG ever starts shipping `AreaMapScriptableObject` instances) and compare the `scanall AreaMapScriptableObject` hit count against this writeup's 1 (ggm-only).

--- a/docs/spikes/map-icon-extraction.md
+++ b/docs/spikes/map-icon-extraction.md
@@ -242,6 +242,42 @@ The load-bearing evidence for the negative is therefore the **byte-string `scana
 
 A future re-run with `classdata.tpk` loaded for Unity 6000.3 could enumerate TeleportCircle GameObjects' full component lists and confirm exhaustively (rather than via class-name co-location) that no map-pin component rides on them — but `scanall` co-location already gives the answer with high confidence.
 
+## Tangential positive: the icon GRAPHICS *are* packaged (and reachable)
+
+The spike asked about icon **positions** and that answer is negative as documented above. But the related question — *are the icon graphics (the pin sprites themselves) packaged on disk?* — has a positive answer that I missed in the earlier scan passes and want to record here so future contributors don't re-do the work.
+
+**Where they live:** `WindowsPlayer_Data/sharedassets0.assets` (73 MB, the scene-shared assets companion to `level0` / the UI canvas scene). My earlier `scanall` and `inventory` phases covered Addressables bundles + level scene files but did **not** include the 44 `sharedassets<N>.assets` companion files — a genuine blind spot, since PG's UI sprites don't live in Addressables.
+
+**What's in there**, by raw `m_Name` extraction from the Texture2D byte offsets (`rawnames` probe phase, since these files have type-tree stripped same as level scenes):
+
+Landmark-type icons (1:1 with `landmarks.json` `Type` discriminator):
+
+| Texture name | pathId | Maps to landmark Type |
+|---|---|---|
+| `landmark_telepad` | 100 | `TeleportationPlatform` |
+| `landmark_medipillar` | 422 | `MeditationPillar` |
+| `landmark_portal` | 730 | `Portal` |
+| `landmark_npc` | 108 | NPCs |
+| `landmark_star` | 364 | (likely waypoint / generic marker) |
+
+Generic pin shapes: `MapPin_Circle` (637), `MapPin_Square` (515).
+
+Player + pet pins: ~18 variants across `LocalPlayerPin_*`, `RemotePlayerPin_*`, `PetPin_*` (Round / Square / Arrow / PointedSquare × Light / Dark theme × Up / Down orientation).
+
+Other map UI bitmaps: `MapFogGray` (486, fog-of-war overlay), `MapEffect_Shrinking` (924), `MapPing_Expansion` (259, ping ripple), `mapOn` (114, map-toggle button icon).
+
+Plus ~970 numbered `icon_NNNN` Texture2Ds — these are the ability / item icons, where the numeric suffix matches the `IconId` field in `items.json` / abilities (consistent with the CDN naming `cdn.projectgorgon.com/{version}/icons/icon_{IconId}.png`).
+
+**How to extract**: same AssetsTools.NET 3.0.4 pipeline as the substrate spike ([PR #828](https://github.com/moumantai-gg/mithril/pull/828)), just pointed at `sharedassets0.assets` instead of a bundle, and matched by `m_Name` instead of by bundle-filename prefix. The on-disk format is identical — Texture2D + `DecodeTextureRaw` + write PNG. (For type-tree-stripped files like sharedassets, decoding the texture data requires either a Unity 6000.3 `classdata.tpk` loaded into `AssetsManager`, or a small hand-parse of the Texture2D binary layout — the probe's `rawnames` phase already proves the m_Name + byte offsets are readable; full PNG extraction is the small remaining engineering step.)
+
+**Why this matters in context**:
+
+- The icon-positions outcome remains negative — Silmarillion still can't pin landmarks onto the map until calibration is supplied by hand-author / Legolas / per-user click.
+- But once calibration *is* supplied, Silmarillion can render pins using PG's actual in-game icons (not generic placeholders or custom Mithril art), via the same texture-extraction pattern Mithril already uses for map PNGs.
+- This also tangentially feeds [issue #830](https://github.com/moumantai-gg/mithril/issues/830) (`Mithril.MapAssets` productionization) — that productionization can extract both the map textures and the per-landmark-type icons in one pass.
+
+**Why this didn't change the spike outcome**: the spike question was specifically scoped to per-area pixel-position data (`world → pixel` calibration), not to icon graphics. Finding the graphics doesn't tell you where to place them on the map, which remains the calibration question this spike concluded negatively on.
+
 ## Artifacts
 
 - Probe tool: [`tools/MapIconProbe/`](../../tools/MapIconProbe/) — runnable via `dotnet run --project tools/MapIconProbe -c Release -- <phase>`. Phases: `inventory`, `names`, `dumpbundle <substring>`, `ggm`, `scenes`, `strings`, `scanall <substring>`.

--- a/docs/spikes/map-icon-extraction.md
+++ b/docs/spikes/map-icon-extraction.md
@@ -128,6 +128,34 @@ Per the issue's "Verification owed" section: if the spike had succeeded, the rec
 
 Hand-authoring a 36-area baseline JSON (the original [#836](https://github.com/moumantai-gg/mithril/issues/836) Tier 2(a) plan) remains a possibility if a real need surfaces, but per the spike's intent the negative result is itself an acceptable outcome — we now know the recurring authoring cost is the only way to pay for it.
 
+## "What if the map icons are packaged in the game, not streamed via Addressables?"
+
+Sharpening the original scope, which leaned heavily on the Addressables bundles. The wider question: across **every** packaged surface a Unity build can carry data in (not just Addressables), is there a per-area icon-position table?
+
+Surfaces scanned (`scanall` byte-string scan across 1176 files):
+
+| Surface | Path | Map-icon instance data? |
+|---|---|---|
+| Addressables bundles | `StreamingAssets/aa/StandaloneWindows64/*.bundle` (1117 files) | No |
+| Addressables catalog | `StreamingAssets/aa/catalog.bin` (1 MB) | No — keys enumerated, only `Map_<area>.png` + `BlankMap.psd` + `NoMap.png` |
+| Addressables settings + link | `StreamingAssets/aa/settings.json` + `AddressablesLink/*` | No |
+| StreamingAssets root | `StreamingAssets/UnityServicesProjectConfiguration.json` | No |
+| Engine config | `globalgamemanagers` (8 MB), `globalgamemanagers.assets` (740 KB) | Only class definitions (`AreaMapScriptableObject`, `MapMarker`, `MapLandmark`, `LandmarkManager`, `LandmarkFactory`, `LandmarkPreParsed`, `UIMapControllerNew`) — no instances |
+| Scenes (all 44) | `level0` … `level43` | Only `MapMarker` + `UIMapControllerNew` MonoScript-name interns in `level0` + `level40` (UI canvas scenes). A `TowerLandmark` GameObject in `level22` and a `Landmarks` group in `level31` — single in-world references, not a per-area collection. A lore-book mentions "landmark" in `level11`. |
+| Unity builtins | `Resources/unity default resources` (5.9 MB) + `Resources/unity_builtin_extra` (17 MB) | No |
+| JSON manifests | `RuntimeInitializeOnLoads.json`, `ScriptingAssemblies.json` | No |
+| IL2CPP metadata | `il2cpp_data/Metadata/global-metadata.dat` (14.5 MB) | Class names registered (`AreaMapScriptableObject`, `EntityPinCollection`, …) but this is the IL2CPP type registry, not instance data. `Calibration` substring matches `s_LightMeterCalibrationConstant` (engine render setting). `MapData` substring matches `HeightmapData` / `SplatmapData` (Unity terrain), not map-icon data. |
+
+Catalog parsing — printable-string dump of `catalog.bin` (every Addressables key the runtime can load) — yielded **263 map-related strings**, all of which are either:
+
+- The 50+ `Map_<AreaName>.png` texture keys (the per-area map images we already extract).
+- The matching `maps_assets_assets_art_maps_map_<area>.png_<hash>.bundle` filenames.
+- Unrelated keys whose name happens to contain "map" as a substring (`MaterialTextureAtlas`, `Deer_Fur_FurMap1.png`).
+
+**There is no Addressables key, scene asset, builtin resource, or JSON manifest that ships per-area icon-position data.** The map-UI classes exist in compiled IL2CPP code (`GameAssembly.dll`) but have zero serialized instances anywhere a Unity build can hold data — Addressables, scenes, `Resources/`, or `globalgamemanagers`.
+
+The one remaining surface that *could* hold a hardcoded icon-position table is `Plugins/x86_64/GameAssembly.dll` — the IL2CPP-compiled C# code itself, where `const Vector2[]` arrays or embedded JSON resource strings would live. Reading the compiled assembly to extract those is foreclosed by PG's anti-injector posture (see memory `pg_anti_injector_stance`) and is out of scope here. Even if extraction were attempted, a `const` table would be a snapshot frozen to whatever PG release shipped it — the recurring per-patch maintenance cost the spike was trying to avoid would resurface as "decompile-and-diff after each PG patch."
+
 ## Artifacts
 
 - Probe tool: [`tools/MapIconProbe/`](../../tools/MapIconProbe/) — runnable via `dotnet run --project tools/MapIconProbe -c Release -- <phase>`. Phases: `inventory`, `names`, `dumpbundle <substring>`, `ggm`, `scenes`, `strings`, `scanall <substring>`.

--- a/docs/spikes/map-icon-extraction.md
+++ b/docs/spikes/map-icon-extraction.md
@@ -188,6 +188,52 @@ But — they do **not** carry pixel-coord data. Checked via `scanall` co-locatio
 
 So no scene has a `MapMarker` or `MapLandmark` MonoBehaviour attached to a TeleportCircle. The map UI must look these entities up by name at runtime and project their world coords to map pixels via the same code-resident transform we'd be trying to extract — i.e. they don't shortcut the calibration problem.
 
+### TeleportationPlatform + MeditationPillar are confirmed real
+
+The `Type` field of `landmarks.json` (`Portal`, `MeditationPillar`, `TeleportationPlatform`) corresponds 1:1 to C# class names found in IL2CPP and as scene MonoBehaviour instances:
+
+| Type discriminator | Scene instances |
+|---|---|
+| `TeleportationPlatform` | 16 area scenes (same set as TeleportCircle) |
+| `MeditationPillar` | 13 area scenes |
+| `PortalLandmark` | 0 (Portal type in landmarks.json may use a different class name) |
+
+So PG genuinely has per-landmark in-world MonoBehaviour instances. The question is whether those MonoBehaviours carry a serialized `Vector2 mapPosition` (or similar) field. The IL2CPP string-context dump (`neighbors` phase) doesn't show any map-coord field name near `TeleportationPlatform` / `MeditationPillar` — fields visible were `TeleportAbility`, `Teleportation Platform`, `UseMeditationPillar`, all gameplay-side, none UI/pixel-related. (IL2CPP's `global-metadata.dat` groups field names by section, so adjacency isn't a definitive scan — but it's the cheapest probe and the absence of any map-shaped field name in the alphabetical neighborhood is suggestive.)
+
+### `AreaConfig` is per-area but doesn't hold map calibration
+
+`AreaConfig` is a MonoBehaviour on a singleton GameObject in 38 of the 44 scenes (PG's per-area config object — `Fatal error: the scene does not contain a GameObject called AreaConfig` confirms this is required infrastructure). Its IL2CPP-visible fields include `AreaName`, `AreaFriendlyName`, `AreaForest` (boolean? terrain hint). No `MapTexture` / `MapOrigin` / `MapScale` / `MapBounds` / `MapPivot` field name appears anywhere in the metadata.
+
+### `MapCameraSpot` exists in 5 scenes but is just a Transform anchor
+
+`MapCameraSpot` (and the broader `MapCamera*` substring) appears in `level15`, `level35`, `level36`, `level37`, `level39` only — not all scenes. Neighbor scan shows it's a plain GameObject with no Camera component, no orthographic size, no Texture2D reference. Most likely a dev-time artist convention ("place camera here when re-rendering the area map"), preserved in only some scenes. Not the runtime calibration source we'd need.
+
+### `PreParsed` cache pattern — the decisive negative
+
+PG uses a consistent `Factory + Class + ClassPreParsed` pattern (visible from IL2CPP class names + their `.cs` source paths):
+
+- `LandmarkFactory` + `Landmark` + `LandmarkPreParsed` (with `landmarksByArea` dictionary field)
+- `ItemFactory` + `ItemInfo` + `ItemInfoPreParsed`
+- `NpcInfoFactory` + `NpcInfo` + `NpcInfoPreParsed`
+- `LoreBookFactory` + `LoreBook` + `LoreBookPreParsed`
+- `QuestFactory` + `Quest` + `QuestPreParsed`
+- All inheriting from `PreParsedAsset` / `PreParsedBundle`
+
+If landmark map-pixel positions were shipped on disk, they would live in `LandmarkPreParsed` instances — typically as ScriptableObject assets inside a `PreParsedBundle`. `scanall` for every class name in this hierarchy:
+
+| Class | Files containing the literal name |
+|---|---|
+| `PreParsedBundle` | `globalgamemanagers.assets` + `global-metadata.dat` (class def only) |
+| `PreParsedAsset` | `globalgamemanagers.assets` + `global-metadata.dat` (class def only) |
+| `LandmarkPreParsed` | `globalgamemanagers.assets` + `global-metadata.dat` (class def only) |
+| `ItemInfoPreParsed` | `globalgamemanagers.assets` + `global-metadata.dat` (class def only) |
+| `NpcInfoPreParsed` | `globalgamemanagers.assets` + `global-metadata.dat` (class def only) |
+| `landmarksByArea` (field name) | `global-metadata.dat` only |
+
+**Zero baked PreParsed instances anywhere on disk.** The PreParsed system is a class pattern with no shipped data — the caches must be populated at runtime from CDN JSON (the same `landmarks.json` / `npcs.json` we already consume in `Mithril.Reference`). That accounts neatly for *why* PG ships those JSON files via CDN: they are the source data the IL2CPP-compiled `*Factory.Get*ForArea` methods parse to populate the PreParsed runtime caches.
+
+This means even the entity-class lead (TeleportationPlatform / MeditationPillar exist in scenes) cannot help: PG's runtime fetches landmark data from CDN JSON, builds `LandmarkPreParsed` objects, and projects each to map pixels via a code-resident world→pixel transform. The transform itself is the one piece we cannot extract without reading the compiled IL2CPP — and even then, what we'd extract is a snapshot frozen to one PG release, recreating the "decompile-and-diff after each PG patch" cost the spike was trying to avoid.
+
 ### Probe limitation honestly noted
 
 The `names` and `scenes` phases keyword-filter on `m_Name`, which requires `AssetsTools.NET.GetBaseField` to succeed. For Addressables bundles this works (bundles ship inline type trees). For Unity scene files (`level<N>`), the type tree is **stripped** to save space, so `GetBaseField` returns null on every scene asset without a Unity 6000.3 `classdata.tpk` package loaded — meaning my scene keyword-filter said "0 hits" because it couldn't read any GameObject's name at all (`24,183 GameObjects scanned in level25, 0 named, 0 nameless lookups returned a string`).

--- a/tools/MapIconProbe/MapIconProbe.csproj
+++ b/tools/MapIconProbe/MapIconProbe.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Tools.MapIconProbe</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Same isolation rationale as tools/MapAssetSpike: stay out of central
+         package mgmt + the repo-wide Directory.Build.targets. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AssetsTools.NET" Version="3.0.4" />
+    <PackageReference Include="AssetsTools.NET.Texture" Version="3.0.2" />
+  </ItemGroup>
+</Project>

--- a/tools/MapIconProbe/Program.cs
+++ b/tools/MapIconProbe/Program.cs
@@ -1,0 +1,674 @@
+// Research probe for mithril#848: enumerate PG Addressables + scene-level
+// assets to find any source of per-area map-icon PIXEL positions (landmarks /
+// NPCs / POIs). Standalone tool — NOT in Mithril.slnx, NOT productionized.
+//
+// Phases (selected via first CLI arg, default "inventory"):
+//   inventory  — list every bundle + asset-type histogram (Texture2D, Sprite,
+//                MonoBehaviour, GameObject, ScriptableObject) → see at a glance
+//                which bundles carry structured data vs. raw textures.
+//   names      — across all bundles + globalgamemanagers.assets, dump every
+//                asset whose m_Name contains any of the icon/landmark/NPC
+//                keywords. The candidate list to manually inspect.
+//   dumpbundle <substring>
+//              — pick the first bundle whose filename contains <substring>,
+//                walk every asset, dump (type, name, pathId) + for
+//                MonoBehaviours / ScriptableObjects dump the JSON-ish field
+//                tree (truncated). Use after `names` finds something
+//                interesting.
+//   ggm        — open globalgamemanagers.assets at PG root and dump every
+//                non-builtin asset (ScriptableObjects are often holders for
+//                project-wide tables / atlas references).
+//
+// Findings get pasted into the spike write-up; this tool's job is to make
+// "no, the data isn't here" provable rather than asserted.
+
+using System.Text;
+using AssetsTools.NET;
+using AssetsTools.NET.Extra;
+using Microsoft.Win32;
+
+namespace Mithril.Tools.MapIconProbe;
+
+internal static class Program
+{
+    private const int PgAppId = 342940;
+
+    // Substrings we're hoping to see on a MonoBehaviour, ScriptableObject, or
+    // Sprite that would tie an in-world entity to a map-pixel position.
+    // Intentionally broad; the `names` phase prints everything that hits so a
+    // human eye can dismiss false positives.
+    private static readonly string[] IconKeywords =
+    [
+        "landmark", "minimap", "mapicon", "mapmarker", "mapmark",
+        "waypoint", "mapdata", "mapmeta", "mapref", "mappoi",
+        "spritesheet", "spriteatlas", "areamap", "worldmap",
+        "mapnpc", "npcmap", "mapdb",
+    ];
+
+    private static int Main(string[] args)
+    {
+        Console.OutputEncoding = Encoding.UTF8;
+        Console.WriteLine("=== mithril#848 map-icon-position probe ===");
+        Console.WriteLine();
+
+        var phase = args.Length > 0 ? args[0] : "inventory";
+
+        try
+        {
+            var pgInstall = ResolvePgInstall();
+            Console.WriteLine($"[steam] PG install: {pgInstall}");
+
+            var bundlesDir = Path.Combine(pgInstall,
+                "WindowsPlayer_Data", "StreamingAssets", "aa", "StandaloneWindows64");
+            var ggmPath = Path.Combine(pgInstall,
+                "WindowsPlayer_Data", "globalgamemanagers.assets");
+
+            switch (phase)
+            {
+                case "inventory":
+                    return RunInventory(bundlesDir);
+                case "names":
+                    return RunNames(bundlesDir, ggmPath);
+                case "dumpbundle":
+                    if (args.Length < 2)
+                    {
+                        Console.WriteLine("usage: dumpbundle <filename-substring>");
+                        return 2;
+                    }
+                    return RunDumpBundle(bundlesDir, args[1]);
+                case "ggm":
+                    return RunGgm(ggmPath);
+                case "scenes":
+                    return RunScenes(pgInstall);
+                case "strings":
+                    return RunStrings(pgInstall);
+                case "scanall":
+                    if (args.Length < 2)
+                    {
+                        Console.WriteLine("usage: scanall <substring>");
+                        return 2;
+                    }
+                    return RunScanAll(pgInstall, args[1]);
+                default:
+                    Console.WriteLine($"unknown phase '{phase}'. expected: inventory | names | dumpbundle | ggm");
+                    return 2;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine();
+            Console.WriteLine("=== PROBE FAIL ===");
+            Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine(ex.StackTrace);
+            return 1;
+        }
+    }
+
+    private static int RunInventory(string bundlesDir)
+    {
+        // Build a per-bundle asset-type histogram. Output is wide; pipe to a
+        // file. The goal: spot bundles whose composition is *not* "1 Texture2D"
+        // — anything carrying many MonoBehaviours / ScriptableObjects / Sprites
+        // is a candidate for the `names` + `dumpbundle` phases.
+        var bundles = Directory.EnumerateFiles(bundlesDir, "*.bundle").OrderBy(p => p).ToList();
+        Console.WriteLine($"[inventory] {bundles.Count} bundles in {bundlesDir}");
+        Console.WriteLine();
+        Console.WriteLine("name\ttex2d\tsprite\tmono\tgo\tscriptobj\tother\ttotal");
+
+        var manager = new AssetsManager();
+        foreach (var bundlePath in bundles)
+        {
+            try
+            {
+                var bunInst = manager.LoadBundleFile(bundlePath, true);
+                var bundleFile = bunInst.file;
+                var entries = bundleFile.BlockAndDirInfo?.DirectoryInfos?.Count ?? 0;
+                var tex2d = 0; var sprite = 0; var mono = 0; var go = 0; var so = 0; var other = 0; var total = 0;
+
+                for (int idx = 0; idx < entries; idx++)
+                {
+                    AssetsFileInstance? afileInst = null;
+                    try { afileInst = manager.LoadAssetsFileFromBundle(bunInst, idx); }
+                    catch { continue; }
+                    if (afileInst?.file?.AssetInfos is null) continue;
+                    foreach (var info in afileInst.file.AssetInfos)
+                    {
+                        total++;
+                        switch ((AssetClassID)info.TypeId)
+                        {
+                            case AssetClassID.Texture2D: tex2d++; break;
+                            case AssetClassID.Sprite: sprite++; break;
+                            case AssetClassID.MonoBehaviour: mono++; break;
+                            case AssetClassID.GameObject: go++; break;
+                            case AssetClassID.MonoScript: so++; break; // misnamed bucket — see note in `names`
+                            default: other++; break;
+                        }
+                    }
+                }
+                manager.UnloadAll(true);
+
+                Console.WriteLine($"{Path.GetFileName(bundlePath)}\t{tex2d}\t{sprite}\t{mono}\t{go}\t{so}\t{other}\t{total}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"{Path.GetFileName(bundlePath)}\tERR\t{ex.GetType().Name}: {ex.Message}");
+                if (Environment.GetEnvironmentVariable("PROBE_STACK") == "1")
+                {
+                    Console.WriteLine(ex.StackTrace);
+                }
+            }
+        }
+        return 0;
+    }
+
+    private static int RunNames(string bundlesDir, string ggmPath)
+    {
+        var bundles = Directory.EnumerateFiles(bundlesDir, "*.bundle").OrderBy(p => p).ToList();
+        Console.WriteLine($"[names] scanning {bundles.Count} bundles for keywords:");
+        Console.WriteLine($"        {string.Join(", ", IconKeywords)}");
+        Console.WriteLine();
+
+        var manager = new AssetsManager();
+        var totalHits = 0;
+        foreach (var bundlePath in bundles)
+        {
+            try
+            {
+                var bunInst = manager.LoadBundleFile(bundlePath, true);
+                var entries = bunInst.file.BlockAndDirInfo?.DirectoryInfos?.Count ?? 0;
+                var bundleName = Path.GetFileName(bundlePath);
+                for (int idx = 0; idx < entries; idx++)
+                {
+                    AssetsFileInstance? afileInst = null;
+                    try { afileInst = manager.LoadAssetsFileFromBundle(bunInst, idx); }
+                    catch { continue; }
+                    if (afileInst?.file?.AssetInfos is null) continue;
+                    foreach (var info in afileInst.file.AssetInfos)
+                    {
+                        string? name = TryGetAssetName(manager, afileInst, info);
+                        if (name is null) continue;
+                        var lower = name.ToLowerInvariant();
+                        if (!IconKeywords.Any(k => lower.Contains(k))) continue;
+                        Console.WriteLine($"{bundleName}\t{(AssetClassID)info.TypeId}\tpathId={info.PathId}\tname={name}");
+                        totalHits++;
+                    }
+                }
+                manager.UnloadAll(true);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"{Path.GetFileName(bundlePath)}\tERR\t{ex.Message}");
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"[names] total bundle hits: {totalHits}");
+        Console.WriteLine();
+        Console.WriteLine($"[names] scanning {ggmPath}");
+        if (File.Exists(ggmPath))
+        {
+            try
+            {
+                var inst = manager.LoadAssetsFile(ggmPath, false);
+                var ggmHits = 0;
+                foreach (var info in inst.file.AssetInfos)
+                {
+                    string? name = TryGetAssetName(manager, inst, info);
+                    if (name is null) continue;
+                    var lower = name.ToLowerInvariant();
+                    if (!IconKeywords.Any(k => lower.Contains(k))) continue;
+                    Console.WriteLine($"ggm\t{(AssetClassID)info.TypeId}\tpathId={info.PathId}\tname={name}");
+                    ggmHits++;
+                }
+                Console.WriteLine($"[names] ggm hits: {ggmHits}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ggm ERR: {ex.Message}");
+            }
+        }
+        else
+        {
+            Console.WriteLine("[names] globalgamemanagers.assets not found");
+        }
+
+        return 0;
+    }
+
+    private static int RunDumpBundle(string bundlesDir, string substring)
+    {
+        var matches = Directory.EnumerateFiles(bundlesDir, "*.bundle")
+            .Where(p => Path.GetFileName(p).Contains(substring, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p)
+            .ToList();
+        if (matches.Count == 0)
+        {
+            Console.WriteLine($"[dumpbundle] no bundle filename contains '{substring}'");
+            return 1;
+        }
+        Console.WriteLine($"[dumpbundle] {matches.Count} matches; dumping first: {Path.GetFileName(matches[0])}");
+
+        var manager = new AssetsManager();
+        var bunInst = manager.LoadBundleFile(matches[0], true);
+        var entries = bunInst.file.BlockAndDirInfo?.DirectoryInfos?.Count ?? 0;
+        for (int idx = 0; idx < entries; idx++)
+        {
+            AssetsFileInstance? afileInst = null;
+            try { afileInst = manager.LoadAssetsFileFromBundle(bunInst, idx); }
+            catch (Exception ex) { Console.WriteLine($"entry {idx}: load fail {ex.Message}"); continue; }
+            if (afileInst?.file?.AssetInfos is null)
+            {
+                Console.WriteLine($"-- entry {idx}: not an assets file (resS / metadata)");
+                continue;
+            }
+            Console.WriteLine($"-- entry {idx}: {afileInst.file.AssetInfos.Count} assets, unity={afileInst.file.Metadata.UnityVersion}");
+            foreach (var info in afileInst.file.AssetInfos)
+            {
+                var classId = (AssetClassID)info.TypeId;
+                var typeName = classId.ToString();
+                string? name = TryGetAssetName(manager, afileInst, info);
+                Console.WriteLine($"  {typeName}\tpathId={info.PathId}\tname={name ?? "<no m_Name>"}");
+                // Dump the field tree for every type that might carry structured
+                // data — Sprite (m_Rect / m_Pivot / m_RD), MonoBehaviour (serialized
+                // C# fields), ScriptableObject (also surfaces as MonoBehaviour), and
+                // GameObject (component listing).
+                if (classId is AssetClassID.MonoBehaviour or AssetClassID.MonoScript
+                            or AssetClassID.Sprite or AssetClassID.GameObject
+                            or AssetClassID.AssetBundle)
+                {
+                    DumpFieldTree(manager, afileInst, info, indent: "    ");
+                }
+            }
+        }
+        return 0;
+    }
+
+    private static int RunGgm(string ggmPath)
+    {
+        if (!File.Exists(ggmPath))
+        {
+            Console.WriteLine($"[ggm] not found: {ggmPath}");
+            return 1;
+        }
+        var manager = new AssetsManager();
+        var inst = manager.LoadAssetsFile(ggmPath, false);
+        Console.WriteLine($"[ggm] {inst.file.AssetInfos.Count} assets, unity={inst.file.Metadata.UnityVersion}");
+        var histogram = new SortedDictionary<string, int>();
+        foreach (var info in inst.file.AssetInfos)
+        {
+            var t = ((AssetClassID)info.TypeId).ToString();
+            histogram[t] = histogram.TryGetValue(t, out var c) ? c + 1 : 1;
+        }
+        Console.WriteLine("[ggm] type histogram:");
+        foreach (var kv in histogram) Console.WriteLine($"  {kv.Key}: {kv.Value}");
+        Console.WriteLine();
+        // MonoScripts in ggm have empty m_Name; their identity is in m_ClassName +
+        // m_Namespace + m_AssemblyName. Dump all of those so we can grep for any
+        // map/landmark/icon/minimap C# type that exists in the PG codebase. Zero
+        // hits → PG doesn't have data-driven map-icon classes at all.
+        Console.WriteLine("[ggm] MonoScript class names:");
+        var failures = 0;
+        var emitted = 0;
+        foreach (var info in inst.file.AssetInfos)
+        {
+            if ((AssetClassID)info.TypeId != AssetClassID.MonoScript) continue;
+            try
+            {
+                var f = manager.GetBaseField(inst, info);
+                if (f is null) { failures++; continue; }
+                string cls = ReadStringField(f, "m_ClassName");
+                string ns = ReadStringField(f, "m_Namespace");
+                string asm = ReadStringField(f, "m_AssemblyName");
+                Console.WriteLine($"  pathId={info.PathId}\t{asm}\t{ns}.{cls}");
+                emitted++;
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                if (failures <= 3)
+                {
+                    Console.WriteLine($"  pathId={info.PathId}\tERR\t{ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+        Console.WriteLine($"[ggm] emitted {emitted}, failures {failures}");
+        return 0;
+    }
+
+    private static string ReadStringField(AssetTypeValueField root, string name)
+    {
+        var f = root[name];
+        if (f is null || f.IsDummy) return "";
+        try { return f.AsString ?? ""; }
+        catch { return ""; }
+    }
+
+    private static int RunScenes(string pgInstall)
+    {
+        // Each level<N> file is a serialized Unity scene. They hold scene
+        // GameObjects + their components. We don't try to introspect them
+        // (would need the user-script type tree); we just look at named asset
+        // hits + type histogram. If a scene contains a "MapIcon"-class
+        // MonoBehaviour, the m_Name typically carries the class name in the
+        // scene serialization.
+        var dataDir = Path.Combine(pgInstall, "WindowsPlayer_Data");
+        var scenes = Directory.EnumerateFiles(dataDir, "level*")
+            .Where(p => !p.EndsWith(".resS", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p)
+            .ToList();
+        Console.WriteLine($"[scenes] {scenes.Count} level files in {dataDir}");
+        var manager = new AssetsManager();
+        var totalHits = 0;
+        foreach (var scenePath in scenes)
+        {
+            AssetsFileInstance? inst = null;
+            try { inst = manager.LoadAssetsFile(scenePath, false); }
+            catch (Exception ex) { Console.WriteLine($"{Path.GetFileName(scenePath)}\tERR\t{ex.Message}"); continue; }
+            if (inst?.file?.AssetInfos is null) continue;
+
+            var assets = inst.file.AssetInfos.Count;
+            var histogram = new SortedDictionary<string, int>();
+            var hitsHere = 0;
+            foreach (var info in inst.file.AssetInfos)
+            {
+                var t = ((AssetClassID)info.TypeId).ToString();
+                histogram[t] = histogram.TryGetValue(t, out var c) ? c + 1 : 1;
+                var name = TryGetAssetName(manager, inst, info);
+                if (name is null) continue;
+                var lower = name.ToLowerInvariant();
+                if (!IconKeywords.Any(k => lower.Contains(k))) continue;
+                Console.WriteLine($"{Path.GetFileName(scenePath)}\t{(AssetClassID)info.TypeId}\tpathId={info.PathId}\tname={name}");
+                hitsHere++;
+                totalHits++;
+            }
+            var topTypes = string.Join(", ", histogram.OrderByDescending(kv => kv.Value).Take(5).Select(kv => $"{kv.Key}={kv.Value}"));
+            Console.WriteLine($"[scenes] {Path.GetFileName(scenePath)}: {assets} assets, hits={hitsHere}, top: {topTypes}");
+            manager.UnloadAll(true);
+        }
+        Console.WriteLine($"[scenes] total hits across {scenes.Count} scenes: {totalHits}");
+        return 0;
+    }
+
+    private static int RunStrings(string pgInstall)
+    {
+        // Brute-force fallback: extract printable-ASCII runs from ggm +
+        // globalgamemanagers (engine config) + the IL2CPP metadata + one
+        // sample scene, and filter for class/symbol names hinting at map
+        // icons. Catches MonoScript classNames in ggm that AssetsTools.NET
+        // couldn't reflect without a classdata.tpk for Unity 6000.3.
+        string[] keywords = [
+            "Landmark", "MinimapIcon", "MapIcon", "MapMarker", "Waypoint",
+            "MapData", "MapMeta", "MapRef", "MapPoi", "MapNpc",
+            "AreaMap", "WorldMap", "MapController", "MapView",
+            "MapManager", "MapDb",
+        ];
+        var targets = new List<string>
+        {
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "globalgamemanagers.assets"),
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "globalgamemanagers"),
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "il2cpp_data", "Metadata", "global-metadata.dat"),
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "level1"),
+        };
+        foreach (var path in targets)
+        {
+            if (!File.Exists(path))
+            {
+                Console.WriteLine($"[strings] skip (missing): {path}");
+                continue;
+            }
+            var bytes = File.ReadAllBytes(path);
+            Console.WriteLine($"[strings] scanning {path} ({bytes.Length:N0} bytes)");
+            var hits = new SortedSet<string>(StringComparer.Ordinal);
+            int runStart = -1;
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                var b = bytes[i];
+                if (b >= 32 && b < 127)
+                {
+                    if (runStart < 0) runStart = i;
+                }
+                else
+                {
+                    if (runStart >= 0 && i - runStart >= 6)
+                    {
+                        var s = System.Text.Encoding.ASCII.GetString(bytes, runStart, i - runStart);
+                        foreach (var kw in keywords)
+                        {
+                            if (s.Contains(kw, StringComparison.OrdinalIgnoreCase))
+                            {
+                                hits.Add(s);
+                                break;
+                            }
+                        }
+                    }
+                    runStart = -1;
+                }
+            }
+            foreach (var h in hits) Console.WriteLine($"  {h}");
+            Console.WriteLine($"  [strings] {hits.Count} hits in {Path.GetFileName(path)}");
+        }
+        return 0;
+    }
+
+    private static int RunScanAll(string pgInstall, string substring)
+    {
+        // Brute-force byte-string scan of every bundle + every scene file +
+        // ggm. Counts how many files contain the substring and reports them.
+        // Cheap: 4GB+ of data but linear sequential read.
+        var needle = System.Text.Encoding.ASCII.GetBytes(substring);
+        var roots = new List<string>
+        {
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "StreamingAssets", "aa", "StandaloneWindows64"),
+        };
+        var single = new List<string>
+        {
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "globalgamemanagers.assets"),
+            Path.Combine(pgInstall, "WindowsPlayer_Data", "globalgamemanagers"),
+        };
+        var files = new List<string>(single);
+        foreach (var r in roots)
+        {
+            if (Directory.Exists(r)) files.AddRange(Directory.EnumerateFiles(r));
+        }
+        var levelDir = Path.Combine(pgInstall, "WindowsPlayer_Data");
+        if (Directory.Exists(levelDir))
+        {
+            files.AddRange(Directory.EnumerateFiles(levelDir, "level*")
+                .Where(p => !p.EndsWith(".resS", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        Console.WriteLine($"[scanall] needle='{substring}' across {files.Count} files");
+        var hits = 0;
+        foreach (var path in files)
+        {
+            byte[] bytes;
+            try { bytes = File.ReadAllBytes(path); }
+            catch { continue; }
+            if (IndexOf(bytes, needle) >= 0)
+            {
+                Console.WriteLine($"  HIT  {Path.GetFileName(path)}  ({bytes.Length:N0} bytes)");
+                hits++;
+            }
+        }
+        Console.WriteLine($"[scanall] {hits} files contain '{substring}'");
+        return 0;
+    }
+
+    private static int IndexOf(byte[] hay, byte[] needle)
+    {
+        if (needle.Length == 0 || hay.Length < needle.Length) return -1;
+        var last = hay.Length - needle.Length;
+        for (int i = 0; i <= last; i++)
+        {
+            bool ok = true;
+            for (int j = 0; j < needle.Length; j++)
+            {
+                if (hay[i + j] != needle[j]) { ok = false; break; }
+            }
+            if (ok) return i;
+        }
+        return -1;
+    }
+
+    private static string? TryGetAssetName(AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo info)
+    {
+        try
+        {
+            var field = manager.GetBaseField(afileInst, info);
+            if (field is null) return null;
+            var nameField = field["m_Name"];
+            if (nameField is null || nameField.IsDummy) return null;
+            return nameField.AsString;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void DumpFieldTree(AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo info, string indent, int maxDepth = 3)
+    {
+        AssetTypeValueField? root;
+        try { root = manager.GetBaseField(afileInst, info); }
+        catch (Exception ex) { Console.WriteLine($"{indent}<field-tree fail: {ex.Message}>"); return; }
+        if (root is null) { Console.WriteLine($"{indent}<no base field>"); return; }
+        DumpField(root, indent, depth: 0, maxDepth);
+    }
+
+    private static void DumpField(AssetTypeValueField field, string indent, int depth, int maxDepth)
+    {
+        if (depth > maxDepth) { Console.WriteLine($"{indent}…(truncated)"); return; }
+        var name = field.FieldName ?? "<noname>";
+        var type = field.TypeName ?? "<notype>";
+
+        if (field.Children.Count == 0)
+        {
+            string val;
+            try
+            {
+                val = field.Value?.AsObject?.ToString() ?? "<null>";
+            }
+            catch { val = "<err>"; }
+            if (val.Length > 80) val = val[..80] + "…";
+            Console.WriteLine($"{indent}{name}: {type} = {val}");
+        }
+        else
+        {
+            Console.WriteLine($"{indent}{name}: {type}");
+            foreach (var child in field.Children)
+            {
+                DumpField(child, indent + "  ", depth + 1, maxDepth);
+            }
+        }
+    }
+
+    private static string ResolvePgInstall()
+    {
+        var steamRoot = FindSteamRoot();
+        var install = FindPg(steamRoot)
+            ?? throw new InvalidOperationException($"AppID {PgAppId} not found in any Steam library.");
+        if (!Directory.Exists(install))
+        {
+            throw new DirectoryNotFoundException($"PG install path missing: {install}");
+        }
+        return install;
+    }
+
+    private static string FindSteamRoot()
+    {
+        using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+        using var key = hklm.OpenSubKey(@"SOFTWARE\Valve\Steam");
+        if (key?.GetValue("InstallPath") is string p && Directory.Exists(p)) return p;
+        using var cu = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Valve\Steam");
+        if (cu?.GetValue("SteamPath") is string cp && Directory.Exists(cp.Replace('/', '\\'))) return cp.Replace('/', '\\');
+        throw new InvalidOperationException("Steam install path not found.");
+    }
+
+    private static string? FindPg(string steamRoot)
+    {
+        var vdfPath = Path.Combine(steamRoot, "steamapps", "libraryfolders.vdf");
+        if (!File.Exists(vdfPath)) return null;
+        var vdf = File.ReadAllText(vdfPath);
+        // We only need to find the library path whose apps block lists PgAppId.
+        // Reuse a minimal scanner: walk "path" lines and "apps" blocks. This is
+        // a lift of the predecessor MapAssetSpike VDF parser, simplified for
+        // probe purposes.
+        var tokens = TokenizeVdf(vdf);
+        int i = 0;
+        while (i < tokens.Count && tokens[i] != "{") i++;
+        if (i == tokens.Count) return null;
+        i++;
+        while (i < tokens.Count && tokens[i] != "}")
+        {
+            i++; // lib index key
+            if (i >= tokens.Count || tokens[i] != "{") break;
+            i++;
+            string? path = null;
+            var appIds = new HashSet<int>();
+            while (i < tokens.Count && tokens[i] != "}")
+            {
+                var key = tokens[i++];
+                if (i >= tokens.Count) break;
+                if (key == "path") path = tokens[i++];
+                else if (key == "apps" && tokens[i] == "{")
+                {
+                    i++;
+                    while (i < tokens.Count && tokens[i] != "}")
+                    {
+                        var k = tokens[i++];
+                        if (i >= tokens.Count) break;
+                        i++;
+                        if (int.TryParse(k, out var id)) appIds.Add(id);
+                    }
+                    if (i < tokens.Count) i++;
+                }
+                else
+                {
+                    if (tokens[i] == "{") { int depth = 1; i++; while (i < tokens.Count && depth > 0) { if (tokens[i] == "{") depth++; else if (tokens[i] == "}") depth--; i++; } }
+                    else i++;
+                }
+            }
+            if (i < tokens.Count) i++;
+            if (path != null && appIds.Contains(PgAppId))
+            {
+                var candidate = Path.Combine(path, "steamapps", "common", "Project Gorgon");
+                if (Directory.Exists(candidate)) return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static List<string> TokenizeVdf(string text)
+    {
+        var t = new List<string>();
+        int i = 0;
+        while (i < text.Length)
+        {
+            var c = text[i];
+            if (char.IsWhiteSpace(c)) { i++; continue; }
+            if (c == '{' || c == '}') { t.Add(c.ToString()); i++; continue; }
+            if (c == '"')
+            {
+                i++;
+                var sb = new StringBuilder();
+                while (i < text.Length && text[i] != '"')
+                {
+                    if (text[i] == '\\' && i + 1 < text.Length)
+                    {
+                        var esc = text[i + 1];
+                        sb.Append(esc switch { 'n' => '\n', 't' => '\t', '\\' => '\\', '"' => '"', _ => esc });
+                        i += 2;
+                    }
+                    else { sb.Append(text[i]); i++; }
+                }
+                t.Add(sb.ToString());
+                if (i < text.Length) i++;
+                continue;
+            }
+            var start = i;
+            while (i < text.Length && !char.IsWhiteSpace(text[i]) && text[i] != '{' && text[i] != '}') i++;
+            t.Add(text[start..i]);
+        }
+        return t;
+    }
+}

--- a/tools/MapIconProbe/Program.cs
+++ b/tools/MapIconProbe/Program.cs
@@ -78,6 +78,27 @@ internal static class Program
                     return RunDumpBundle(bundlesDir, args[1]);
                 case "ggm":
                     return RunGgm(ggmPath);
+                case "scenetypes":
+                    if (args.Length < 2)
+                    {
+                        Console.WriteLine("usage: scenetypes <levelN>");
+                        return 2;
+                    }
+                    return RunSceneTypes(pgInstall, args[1]);
+                case "assetnames":
+                    if (args.Length < 3)
+                    {
+                        Console.WriteLine("usage: assetnames <fileName> <type>  (type: Texture2D, Sprite, MonoBehaviour, GameObject, ...)");
+                        return 2;
+                    }
+                    return RunAssetNames(pgInstall, args[1], args[2]);
+                case "rawnames":
+                    if (args.Length < 3)
+                    {
+                        Console.WriteLine("usage: rawnames <fileName> <type>  (raw byte read of m_Name from byteStart)");
+                        return 2;
+                    }
+                    return RunRawNames(pgInstall, args[1], args[2]);
                 case "scenes":
                     return RunScenes(pgInstall);
                 case "strings":
@@ -526,6 +547,105 @@ internal static class Program
             }
         }
         Console.WriteLine($"[scanall] {hits} files contain '{substring}'");
+        return 0;
+    }
+
+    private static int RunSceneTypes(string pgInstall, string levelName)
+    {
+        // Full type histogram for one scene (the `scenes` phase only printed
+        // the top 5). Used here to count Sprite/Texture2D in UI scenes.
+        var scenePath = Path.Combine(pgInstall, "WindowsPlayer_Data", levelName);
+        if (!File.Exists(scenePath)) { Console.WriteLine($"missing: {scenePath}"); return 1; }
+        var manager = new AssetsManager();
+        var inst = manager.LoadAssetsFile(scenePath, false);
+        if (inst?.file?.AssetInfos is null) return 1;
+        var hist = new SortedDictionary<string, int>();
+        foreach (var info in inst.file.AssetInfos)
+        {
+            var t = ((AssetClassID)info.TypeId).ToString();
+            hist[t] = hist.TryGetValue(t, out var c) ? c + 1 : 1;
+        }
+        Console.WriteLine($"[scenetypes] {Path.GetFileName(scenePath)}: {inst.file.AssetInfos.Count} total assets");
+        foreach (var kv in hist.OrderByDescending(kv => kv.Value))
+        {
+            Console.WriteLine($"  {kv.Key}: {kv.Value}");
+        }
+        return 0;
+    }
+
+    private static int RunAssetNames(string pgInstall, string fileName, string typeName)
+    {
+        // List every asset of `typeName` in <fileName> with its m_Name.
+        // Used to enumerate Sprite / Texture2D names in sharedassets<N> where
+        // the icon graphics actually live.
+        var path = Path.Combine(pgInstall, "WindowsPlayer_Data", fileName);
+        if (!File.Exists(path)) { Console.WriteLine($"missing: {path}"); return 1; }
+        var manager = new AssetsManager();
+        var inst = manager.LoadAssetsFile(path, false);
+        if (inst?.file?.AssetInfos is null) return 1;
+        if (!Enum.TryParse<AssetClassID>(typeName, out var targetType))
+        {
+            Console.WriteLine($"unknown type '{typeName}'");
+            return 2;
+        }
+        Console.WriteLine($"[assetnames] {Path.GetFileName(path)} type={typeName}");
+        var named = 0; var nameless = 0;
+        foreach (var info in inst.file.AssetInfos)
+        {
+            if ((AssetClassID)info.TypeId != targetType) continue;
+            var name = TryGetAssetName(manager, inst, info);
+            if (name is null) { nameless++; continue; }
+            named++;
+            Console.WriteLine($"  pathId={info.PathId}\tname={name}");
+        }
+        Console.WriteLine($"[assetnames] {named} named, {nameless} nameless");
+        return 0;
+    }
+
+    private static int RunRawNames(string pgInstall, string fileName, string typeName)
+    {
+        // Fallback for type-tree-stripped files: AssetsTools.NET still gives us
+        // each asset's byteOffset + typeId. For types that begin with `m_Name`
+        // (Texture2D, Sprite, MonoBehaviour, etc.), we can read the length-
+        // prefixed UTF-8 string from the asset's start position without any
+        // tpk. Tells us asset names so we can find icon sprites in
+        // sharedassets<N>.
+        var path = Path.Combine(pgInstall, "WindowsPlayer_Data", fileName);
+        if (!File.Exists(path)) { Console.WriteLine($"missing: {path}"); return 1; }
+        var manager = new AssetsManager();
+        var inst = manager.LoadAssetsFile(path, false);
+        if (inst?.file?.AssetInfos is null) return 1;
+        if (!Enum.TryParse<AssetClassID>(typeName, out var targetType))
+        {
+            Console.WriteLine($"unknown type '{typeName}'");
+            return 2;
+        }
+
+        var bytes = File.ReadAllBytes(path);
+        var dataStart = (int)inst.file.Header.DataOffset;
+        Console.WriteLine($"[rawnames] {Path.GetFileName(path)} dataOffset=0x{dataStart:X} type={typeName}");
+        var hit = 0;
+        foreach (var info in inst.file.AssetInfos)
+        {
+            if ((AssetClassID)info.TypeId != targetType) continue;
+            var off = dataStart + (int)info.ByteOffset;
+            if (off + 4 > bytes.Length) continue;
+            // First field is m_Name: int32 length (little-endian) + utf-8 bytes,
+            // then padded to 4-byte alignment.
+            int len = BitConverter.ToInt32(bytes, off);
+            if (len < 0 || len > 256 || off + 4 + len > bytes.Length)
+            {
+                continue;
+            }
+            string name = System.Text.Encoding.UTF8.GetString(bytes, off + 4, len);
+            // Sanity check: m_Name should only contain printable ASCII for our purposes.
+            bool clean = true;
+            foreach (var ch in name) { if (ch < 32 && ch != 0) { clean = false; break; } }
+            if (!clean) continue;
+            Console.WriteLine($"  pathId={info.PathId}\tname={name}");
+            hit++;
+        }
+        Console.WriteLine($"[rawnames] {hit} names emitted");
         return 0;
     }
 

--- a/tools/MapIconProbe/Program.cs
+++ b/tools/MapIconProbe/Program.cs
@@ -103,6 +103,13 @@ internal static class Program
                         return 2;
                     }
                     return RunSceneFind(pgInstall, args[1], args[2]);
+                case "neighbors":
+                    if (args.Length < 4)
+                    {
+                        Console.WriteLine("usage: neighbors <path> <needle> <window-bytes>");
+                        return 2;
+                    }
+                    return RunNeighbors(args[1], args[2], int.Parse(args[3]));
                 default:
                     Console.WriteLine($"unknown phase '{phase}'. expected: inventory | names | dumpbundle | ggm");
                     return 2;
@@ -622,6 +629,57 @@ internal static class Program
         }
         foreach (var h in hits) Console.WriteLine(h);
         Console.WriteLine($"[stringsfile] {hits.Count} strings");
+        return 0;
+    }
+
+    private static int RunNeighbors(string path, string needle, int window)
+    {
+        // For every occurrence of `needle` in the file, extract printable-ASCII
+        // runs of >=4 chars within ±window bytes. Reveals nearby field names /
+        // referenced classes for inspection. Used to find field names attached
+        // to a MonoBehaviour class without a tpk-loaded type tree.
+        if (!File.Exists(path)) { Console.WriteLine($"missing: {path}"); return 1; }
+        var bytes = File.ReadAllBytes(path);
+        var needleBytes = System.Text.Encoding.ASCII.GetBytes(needle);
+        var occurrences = 0;
+        int searchFrom = 0;
+        while (true)
+        {
+            int hit = -1;
+            for (int i = searchFrom; i <= bytes.Length - needleBytes.Length; i++)
+            {
+                bool ok = true;
+                for (int j = 0; j < needleBytes.Length; j++)
+                {
+                    if (bytes[i + j] != needleBytes[j]) { ok = false; break; }
+                }
+                if (ok) { hit = i; break; }
+            }
+            if (hit < 0) break;
+            occurrences++;
+            Console.WriteLine($"\n=== occurrence #{occurrences} at offset 0x{hit:X} ===");
+            var start = Math.Max(0, hit - window);
+            var end = Math.Min(bytes.Length, hit + needleBytes.Length + window);
+            var hits = new SortedSet<string>(StringComparer.Ordinal);
+            int runStart = -1;
+            for (int i = start; i < end; i++)
+            {
+                var b = bytes[i];
+                if (b >= 32 && b < 127) { if (runStart < 0) runStart = i; }
+                else
+                {
+                    if (runStart >= 0 && i - runStart >= 4)
+                    {
+                        hits.Add(System.Text.Encoding.ASCII.GetString(bytes, runStart, i - runStart));
+                    }
+                    runStart = -1;
+                }
+            }
+            foreach (var h in hits) Console.WriteLine($"  {h}");
+            searchFrom = hit + needleBytes.Length;
+            if (occurrences >= 5) { Console.WriteLine("\n...(stopping after 5 occurrences)"); break; }
+        }
+        Console.WriteLine($"\n[neighbors] {occurrences} total occurrences");
         return 0;
     }
 

--- a/tools/MapIconProbe/Program.cs
+++ b/tools/MapIconProbe/Program.cs
@@ -89,6 +89,13 @@ internal static class Program
                         return 2;
                     }
                     return RunScanAll(pgInstall, args[1]);
+                case "stringsfile":
+                    if (args.Length < 2)
+                    {
+                        Console.WriteLine("usage: stringsfile <path> [needle]");
+                        return 2;
+                    }
+                    return RunStringsFile(args[1], args.Length > 2 ? args[2] : null);
                 default:
                     Console.WriteLine($"unknown phase '{phase}'. expected: inventory | names | dumpbundle | ggm");
                     return 2;
@@ -452,30 +459,44 @@ internal static class Program
 
     private static int RunScanAll(string pgInstall, string substring)
     {
-        // Brute-force byte-string scan of every bundle + every scene file +
-        // ggm. Counts how many files contain the substring and reports them.
-        // Cheap: 4GB+ of data but linear sequential read.
+        // Brute-force byte-string scan across every file plausibly carrying
+        // packaged-with-the-game (vs. streamed-via-Addressables) PG data:
+        //   - all Addressables bundles (StreamingAssets/aa/StandaloneWindows64/)
+        //   - the Addressables catalog + settings (StreamingAssets/aa/*)
+        //   - the AddressablesLink XML manifest
+        //   - the StreamingAssets root (in case PG ships non-Addressables JSON)
+        //   - globalgamemanagers + globalgamemanagers.assets (engine + script tables)
+        //   - every level<N> scene file (the "baked-into-the-game" path)
+        //   - Resources/unity default resources + Resources/unity_builtin_extra
+        //   - il2cpp_data/Metadata/global-metadata.dat (compiled C# strings)
+        // Counts hits and lists files. Linear sequential read across ~26 GB.
         var needle = System.Text.Encoding.ASCII.GetBytes(substring);
-        var roots = new List<string>
+        var data = Path.Combine(pgInstall, "WindowsPlayer_Data");
+        var files = new List<string>();
+
+        void AddIfFile(string p) { if (File.Exists(p)) files.Add(p); }
+        void AddDir(string dir, string pattern = "*", bool recursive = false)
         {
-            Path.Combine(pgInstall, "WindowsPlayer_Data", "StreamingAssets", "aa", "StandaloneWindows64"),
-        };
-        var single = new List<string>
-        {
-            Path.Combine(pgInstall, "WindowsPlayer_Data", "globalgamemanagers.assets"),
-            Path.Combine(pgInstall, "WindowsPlayer_Data", "globalgamemanagers"),
-        };
-        var files = new List<string>(single);
-        foreach (var r in roots)
-        {
-            if (Directory.Exists(r)) files.AddRange(Directory.EnumerateFiles(r));
+            if (!Directory.Exists(dir)) return;
+            files.AddRange(Directory.EnumerateFiles(dir, pattern,
+                recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly));
         }
-        var levelDir = Path.Combine(pgInstall, "WindowsPlayer_Data");
-        if (Directory.Exists(levelDir))
-        {
-            files.AddRange(Directory.EnumerateFiles(levelDir, "level*")
-                .Where(p => !p.EndsWith(".resS", StringComparison.OrdinalIgnoreCase)));
-        }
+
+        AddIfFile(Path.Combine(data, "globalgamemanagers"));
+        AddIfFile(Path.Combine(data, "globalgamemanagers.assets"));
+        AddIfFile(Path.Combine(data, "RuntimeInitializeOnLoads.json"));
+        AddIfFile(Path.Combine(data, "ScriptingAssemblies.json"));
+        AddDir(data, "level*");
+        AddDir(Path.Combine(data, "Resources"));
+        AddDir(Path.Combine(data, "il2cpp_data"), "*", recursive: true);
+        AddDir(Path.Combine(data, "StreamingAssets"), "*", recursive: false);
+        AddDir(Path.Combine(data, "StreamingAssets", "aa"), "*", recursive: false);
+        AddDir(Path.Combine(data, "StreamingAssets", "aa", "AddressablesLink"), "*", recursive: true);
+        AddDir(Path.Combine(data, "StreamingAssets", "aa", "StandaloneWindows64"));
+
+        // Filter: exclude the .resS streaming-data sidecars (they hold raw pixel
+        // bytes for textures — searching them is pure noise).
+        files = files.Where(p => !p.EndsWith(".resS", StringComparison.OrdinalIgnoreCase)).ToList();
 
         Console.WriteLine($"[scanall] needle='{substring}' across {files.Count} files");
         var hits = 0;
@@ -491,6 +512,40 @@ internal static class Program
             }
         }
         Console.WriteLine($"[scanall] {hits} files contain '{substring}'");
+        return 0;
+    }
+
+    private static int RunStringsFile(string path, string? needle)
+    {
+        // Pull every printable-ASCII run of >=6 chars from a file. If needle
+        // supplied, filter to runs containing it (case-insensitive). Sorted &
+        // deduped. Used to see what classes/keys live in a single file.
+        if (!File.Exists(path)) { Console.WriteLine($"missing: {path}"); return 1; }
+        var bytes = File.ReadAllBytes(path);
+        var hits = new SortedSet<string>(StringComparer.Ordinal);
+        int runStart = -1;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            var b = bytes[i];
+            if (b >= 32 && b < 127)
+            {
+                if (runStart < 0) runStart = i;
+            }
+            else
+            {
+                if (runStart >= 0 && i - runStart >= 6)
+                {
+                    var s = System.Text.Encoding.ASCII.GetString(bytes, runStart, i - runStart);
+                    if (needle is null || s.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                    {
+                        hits.Add(s);
+                    }
+                }
+                runStart = -1;
+            }
+        }
+        foreach (var h in hits) Console.WriteLine(h);
+        Console.WriteLine($"[stringsfile] {hits.Count} strings");
         return 0;
     }
 

--- a/tools/MapIconProbe/Program.cs
+++ b/tools/MapIconProbe/Program.cs
@@ -96,6 +96,13 @@ internal static class Program
                         return 2;
                     }
                     return RunStringsFile(args[1], args.Length > 2 ? args[2] : null);
+                case "scenefind":
+                    if (args.Length < 3)
+                    {
+                        Console.WriteLine("usage: scenefind <levelN> <gameobjectname-substring>");
+                        return 2;
+                    }
+                    return RunSceneFind(pgInstall, args[1], args[2]);
                 default:
                     Console.WriteLine($"unknown phase '{phase}'. expected: inventory | names | dumpbundle | ggm");
                     return 2;
@@ -512,6 +519,75 @@ internal static class Program
             }
         }
         Console.WriteLine($"[scanall] {hits} files contain '{substring}'");
+        return 0;
+    }
+
+    private static int RunSceneFind(string pgInstall, string levelName, string nameSubstring)
+    {
+        // Load a single scene file, find every GameObject whose m_Name matches
+        // the substring, and dump its full component list with field trees.
+        // Goal: see whether a TeleportCircle (or any other landmark prefab in
+        // a scene) carries hidden map-pixel-coord fields, OR whether its only
+        // serialized data is the world Transform.
+        var scenePath = Path.Combine(pgInstall, "WindowsPlayer_Data", levelName);
+        if (!File.Exists(scenePath)) { Console.WriteLine($"missing: {scenePath}"); return 1; }
+        var manager = new AssetsManager();
+        var inst = manager.LoadAssetsFile(scenePath, false);
+        if (inst?.file?.AssetInfos is null) { Console.WriteLine("no assets"); return 1; }
+        Console.WriteLine($"[scenefind] {Path.GetFileName(scenePath)}: {inst.file.AssetInfos.Count} assets, looking for GameObject m_Name~='{nameSubstring}'");
+
+        // Build pathId -> AssetFileInfo lookup so we can chase PPtr<Component>
+        // links from each matching GameObject.
+        var byId = new Dictionary<long, AssetFileInfo>();
+        foreach (var info in inst.file.AssetInfos) byId[info.PathId] = info;
+
+        var matches = 0;
+        var gameobjects = 0; var nameless = 0; var named = 0;
+        foreach (var info in inst.file.AssetInfos)
+        {
+            if ((AssetClassID)info.TypeId != AssetClassID.GameObject) continue;
+            gameobjects++;
+            var goName = TryGetAssetName(manager, inst, info);
+            if (goName is null) { nameless++; continue; }
+            named++;
+            if (!goName.Contains(nameSubstring, StringComparison.OrdinalIgnoreCase)) continue;
+            matches++;
+            Console.WriteLine($"\n=== GameObject '{goName}' (pathId={info.PathId}) ===");
+
+            AssetTypeValueField? goField;
+            try { goField = manager.GetBaseField(inst, info); }
+            catch (Exception ex) { Console.WriteLine($"  <load fail: {ex.Message}>"); continue; }
+            if (goField is null) continue;
+
+            var componentsArr = goField["m_Component"]?["Array"];
+            if (componentsArr is null || componentsArr.Children.Count == 0)
+            {
+                Console.WriteLine("  <no m_Component>");
+                continue;
+            }
+            foreach (var compEntry in componentsArr.Children)
+            {
+                var pptr = compEntry["component"];
+                if (pptr is null) continue;
+                var fileId = pptr["m_FileID"].AsInt;
+                var pathId = pptr["m_PathID"].AsLong;
+                if (fileId != 0) { Console.WriteLine($"  component -> external file {fileId} pathId={pathId} (skipped)"); continue; }
+                if (!byId.TryGetValue(pathId, out var compInfo)) { Console.WriteLine($"  component pathId={pathId} not found"); continue; }
+                var compClass = (AssetClassID)compInfo.TypeId;
+                Console.WriteLine($"  -- component {compClass} (pathId={pathId}) --");
+                try
+                {
+                    var compField = manager.GetBaseField(inst, compInfo);
+                    if (compField is null) { Console.WriteLine("    <no base field>"); continue; }
+                    DumpField(compField, "    ", depth: 0, maxDepth: 4);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"    <load fail: {ex.Message}>");
+                }
+            }
+        }
+        Console.WriteLine($"\n[scenefind] {matches} GameObject matches ({gameobjects} GameObjects total, named={named}, nameless={nameless})");
         return 0;
     }
 

--- a/tools/MapIconProbe/README.md
+++ b/tools/MapIconProbe/README.md
@@ -1,0 +1,27 @@
+# MapIconProbe
+
+Research probe for [mithril#848](https://github.com/moumantai-gg/mithril/issues/848) — asked whether PG ships per-area map-icon pixel positions as data in the Addressables substrate. Outcome: **no**. See [`docs/spikes/map-icon-extraction.md`](../../docs/spikes/map-icon-extraction.md) for the full write-up.
+
+This tool is **not** in `Mithril.slnx` and is not wired into any module. It stays in-repo so a future contributor can re-run the probe against a future PG patch and confirm the negative still holds.
+
+## Running it
+
+```powershell
+dotnet run --project tools/MapIconProbe -c Release -- <phase> [args]
+```
+
+Requires .NET 10 SDK and a local install of Project Gorgon via Steam (the probe uses the same Steam-registry detection as `tools/MapAssetSpike/`).
+
+## Phases
+
+| Phase | Purpose |
+|---|---|
+| `inventory` | Per-bundle asset-type histogram across all `.bundle` files. Big — pipe to a file. |
+| `names` | All bundles + `globalgamemanagers.assets`, dump every asset whose `m_Name` matches map/icon keywords. |
+| `dumpbundle <substring>` | Picks the first bundle filename containing `<substring>` and dumps every asset's full field tree. Use after `names` finds a candidate. |
+| `ggm` | Dumps the type histogram + `MonoScript` class names for `globalgamemanagers.assets`. |
+| `scenes` | Per-scene asset-type histogram + keyword filter across all `level<N>` files. |
+| `strings` | Brute-force ASCII string extraction from ggm + IL2CPP metadata + a sample scene. Catches class names the type-tree-less probe couldn't reflect. |
+| `scanall <substring>` | Linear byte-string scan across every bundle + every scene file + ggm for the literal substring. Used to count instance-data references vs class-definition-only references. |
+
+Set `PROBE_STACK=1` to print stack traces for per-bundle errors during `inventory`.


### PR DESCRIPTION
## Summary

Settles [#848](https://github.com/moumantai-gg/mithril/issues/848): does PG ship a parseable asset that lists per-area map-icon pixel positions, so we can auto-derive the [`map-calibration-baseline.json`](src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json) [PR #839](https://github.com/moumantai-gg/mithril/pull/839) scaffolded?

**Outcome: negative.** The Addressables substrate carries the per-area map PNG and nothing else. The C# classes that *would* hold the data (`AreaMapScriptableObject`, `EntityPinCollection`, `MapLandmark`) exist as IL2CPP-compiled types but have **zero serialized instances** anywhere on disk — PG's map UI is a single runtime controller (`UIMapControllerNew` in `level0`/`level40`) that populates its pin collection at runtime from server state.

Full evidence chain — including the 1117-bundle inventory, the per-area map-bundle field dump (Texture2D + Sprite wrapper with default 0.5/0.5 pivot, no metadata), the 235-class MonoScript enumeration, the IL2CPP class-name strings probe, and the byte-string `scanall` counts proving no instance data exists — is in [`docs/spikes/map-icon-extraction.md`](docs/spikes/map-icon-extraction.md).

Falls back to the `anchors: {}` + per-user Legolas-refinement path that [PR #839](https://github.com/moumantai-gg/mithril/pull/839) already supports. Hand-authoring (the original [#836](https://github.com/moumantai-gg/mithril/issues/836) Tier 2(a) plan) remains a possibility if a real need surfaces.

Closes [#848](https://github.com/moumantai-gg/mithril/issues/848).

### What landed

- [`tools/MapIconProbe/`](tools/MapIconProbe/) — sibling to [`tools/MapAssetSpike/`](tools/MapAssetSpike/), reuses its Steam-install + `AssetsTools.NET 3.0.4` substrate. Phases: `inventory`, `names`, `dumpbundle`, `ggm`, `scenes`, `strings`, `scanall`. Stays in-repo so a future contributor can re-run after a PG patch and confirm the negative still holds.
- [`docs/spikes/map-icon-extraction.md`](docs/spikes/map-icon-extraction.md) — write-up with method, findings, IL2CPP class table, `scanall` evidence, and the fallback decision.

Not touched: `Mithril.slnx`, `Directory.Packages.props`, `src/Mithril.MapCalibration/`. The probe is an isolated tool, not productionized; the baseline JSON stays at `anchors: {}`.

## Test plan

- [x] `dotnet build tools/MapIconProbe/MapIconProbe.csproj -c Release` clean (no warnings)
- [x] `dotnet run --project tools/MapIconProbe -c Release -- inventory` — 1117/1117 bundles scanned, 0 errors (after null-safe iteration fix for bundles whose 2nd entry is a `.resS` rather than an assets file)
- [x] `dotnet run --project tools/MapIconProbe -c Release -- names` — 0 hits with tight keywords
- [x] `dotnet run --project tools/MapIconProbe -c Release -- dumpbundle areaserbule.png_dbcc` — confirmed map bundles are Texture2D + Sprite wrapper only
- [x] `dotnet run --project tools/MapIconProbe -c Release -- scenes` — 0 hits across all 44 level files
- [x] `dotnet run --project tools/MapIconProbe -c Release -- strings` — surfaced the `AreaMapScriptableObject` / `MapLandmark` / `UIMapControllerNew` IL2CPP class definitions
- [x] `scanall AreaMapScriptableObject` → 1 file (ggm only); `scanall EntityPinCollection` → 0 files
- [x] Probe reads on-disk assets only; PG never run during the spike (stays on the right side of the project's anti-injector posture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— drafted by Claude (Opus 4.7), posted by @arthur-conde