### PR TITLE
refactor(tools): factor MapCalibrationFromScreenshot primitives into shared common lib

### DIFF
--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Mithril.Tools.MapCalibration.Common;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot;
 

--- a/tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj
+++ b/tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj
@@ -32,5 +32,6 @@
       independent of this csproj's local opt-out.
     -->
     <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+    <ProjectReference Include="..\Mithril.MapCalibration.Tools.Common\Mithril.MapCalibration.Tools.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/tools/MapCalibrationFromScreenshot/Pipeline.cs
+++ b/tools/MapCalibrationFromScreenshot/Pipeline.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot;
 

--- a/tools/MapCalibrationFromScreenshot/Program.cs
+++ b/tools/MapCalibrationFromScreenshot/Program.cs
@@ -15,6 +15,8 @@
 //
 // See README.md next to this file for usage and the synthetic test harness.
 
+using Mithril.Tools.MapCalibration.Common;
+
 namespace Mithril.Tools.MapCalibrationFromScreenshot;
 
 internal static class Program
@@ -47,6 +49,3 @@ internal static class Program
         }
     }
 }
-
-/// <summary>Marker exception for clean exit-with-message paths. Stack trace suppressed.</summary>
-internal sealed class UserFacingException(string message) : Exception(message);

--- a/tools/MapCalibrationFromScreenshot/ScreenshotCalibrator.cs
+++ b/tools/MapCalibrationFromScreenshot/ScreenshotCalibrator.cs
@@ -1,4 +1,5 @@
 using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot;
 

--- a/tools/MapCalibrationFromScreenshot/SelfTest.cs
+++ b/tools/MapCalibrationFromScreenshot/SelfTest.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot;
 

--- a/tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Mithril.MapCalibration;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Reads and writes <c>src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json</c>.
@@ -14,7 +14,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// <para>Writes JSON in the exact shape <c>BundledBaselineLoader</c> reads:
 /// camelCase property names, indented, default values omitted.</para>
 /// </summary>
-internal static class BaselineFile
+public static class BaselineFile
 {
     public static void UpsertAnchor(string baselinePath, string area, AreaCalibration cal)
     {

--- a/tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs
@@ -16,10 +16,10 @@ namespace Mithril.Tools.MapCalibration.Common;
 ///
 /// <para>The pivot is load-bearing: PG's landmark icons are teardrop-shaped and
 /// anchored at the bottom tip (pivot ≈ (0.5, 0)), not the centre. Template-match
-/// returns the icon centre; the world-anchor pixel is centre + (w*(pivot.x-0.5),
-/// h*(0.5-pivot.y)) — see <c>ScreenshotCalibrator</c> in the CLI. Without this
-/// correction every landmark drifts by ~icon-height/2, blowing the 12 px residual
-/// threshold systematically (issue #852 comment).</para>
+/// returns the icon centre; the consumer recovers the world-anchor pixel as
+/// centre + (w*(pivot.x-0.5), h*(0.5-pivot.y)). Without this correction every
+/// landmark drifts by ~icon-height/2, blowing the 12 px residual threshold
+/// systematically (issue #852 comment).</para>
 ///
 /// <para>sharedassets0.assets is type-tree-stripped, so AssetsTools.NET can't
 /// decode <c>m_Pivot</c> without a Unity 6000.3 <c>classdata.tpk</c> loaded via
@@ -254,7 +254,7 @@ public static class IconTemplateExtractor
         // icon. NCC against a screenshot is shape-matching — if templates are
         // upside-down vs rendered icons, scores collapse and detection fails.
         // The Sprite.m_Pivot we cache alongside is in Unity Y-up coords; the
-        // formula in ScreenshotCalibrator (`h * (0.5 - pivotY)`) is written
+        // downstream pivot-correction formula (`h * (0.5 - pivotY)`) is written
         // against right-side-up rendered icons + Unity-Y-up pivot, so flipping
         // here keeps the pivot interpretation correct.
         int rowBytes = width * 4;

--- a/tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs
@@ -6,7 +6,7 @@ using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using AssetsTools.NET.Texture;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Extracts the named landmark + player-pin icon Texture2Ds from
@@ -17,7 +17,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// <para>The pivot is load-bearing: PG's landmark icons are teardrop-shaped and
 /// anchored at the bottom tip (pivot ≈ (0.5, 0)), not the centre. Template-match
 /// returns the icon centre; the world-anchor pixel is centre + (w*(pivot.x-0.5),
-/// h*(0.5-pivot.y)) — see <see cref="ScreenshotCalibrator"/>. Without this
+/// h*(0.5-pivot.y)) — see <c>ScreenshotCalibrator</c> in the CLI. Without this
 /// correction every landmark drifts by ~icon-height/2, blowing the 12 px residual
 /// threshold systematically (issue #852 comment).</para>
 ///
@@ -26,7 +26,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// <see cref="AssetsManager.LoadClassPackage"/>. The user supplies that — the
 /// tool errors with the download URL if missing.</para>
 /// </summary>
-internal static class IconTemplateExtractor
+public static class IconTemplateExtractor
 {
     // Bump when the extracted PNG bytes or sidecar shape change in a way that
     // requires re-extracting from sharedassets0.assets (e.g., the vertical-flip
@@ -326,9 +326,9 @@ internal static class IconTemplateExtractor
     }
 }
 
-internal sealed record IconIndex(int Version, List<IconMeta> Icons);
+public sealed record IconIndex(int Version, List<IconMeta> Icons);
 
-internal sealed record IconMeta(
+public sealed record IconMeta(
     string Name,
     string File,
     int Width,

--- a/tools/Mithril.MapCalibration.Tools.Common/ImageIo.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/ImageIo.cs
@@ -2,7 +2,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Loads PNGs into <see cref="GrayImage"/> form for NCC consumption.
@@ -10,7 +10,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// <see cref="MapTextureExtractor"/> and <see cref="IconTemplateExtractor"/>;
 /// pure Windows desktop tool, no cross-platform concern.
 /// </summary>
-internal static class ImageIo
+public static class ImageIo
 {
     /// <summary>Loads a PNG as a grayscale image (ITU-R BT.601 luma).</summary>
     public static GrayImage LoadGray(string path)

--- a/tools/Mithril.MapCalibration.Tools.Common/LandmarksReader.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/LandmarksReader.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Mithril.MapCalibration;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Reads the subset of <c>landmarks.json</c> we need: per-area list of
@@ -10,7 +10,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// the solver — no point in dragging the whole reference-data project graph
 /// into this tool's build.
 /// </summary>
-internal static class LandmarksReader
+public static class LandmarksReader
 {
     public static IReadOnlyList<LandmarkRef> LoadForArea(string landmarksJsonPath, string area)
     {
@@ -41,4 +41,4 @@ internal static class LandmarksReader
     }
 }
 
-internal sealed record LandmarkRef(string Type, string Name, WorldCoord World);
+public sealed record LandmarkRef(string Type, string Name, WorldCoord World);

--- a/tools/Mithril.MapCalibration.Tools.Common/MapRectLocator.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/MapRectLocator.cs
@@ -1,4 +1,4 @@
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Finds where the area map's rendered window sits inside a screenshot.
@@ -13,7 +13,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// <c>--map-rect</c>. Zoomed-in screenshots (where the visible map is only a
 /// pan window) defeat this v1 approach — the user must zoom out first.</para>
 /// </summary>
-internal static class MapRectLocator
+public static class MapRectLocator
 {
     /// <summary>
     /// Tries NCC across a coarse scale ladder. Returns null on weak/no match.
@@ -103,7 +103,7 @@ internal static class MapRectLocator
 /// Visible map's bounding box in the screenshot, plus the source texture's
 /// native dimensions. Combined these give the screenshot↔texture transform.
 /// </summary>
-internal sealed record MapRect(
+public sealed record MapRect(
     int OriginX,
     int OriginY,
     int Width,

--- a/tools/Mithril.MapCalibration.Tools.Common/MapTextureExtractor.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/MapTextureExtractor.cs
@@ -5,7 +5,7 @@ using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using AssetsTools.NET.Texture;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Pulls the <c>Map_&lt;Area&gt;</c> Texture2D out of its per-area Addressables
@@ -20,7 +20,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// is what downstream consumers expect to see, so the rotation belongs in
 /// the cache write rather than as a post-load step.</para>
 /// </summary>
-internal static class MapTextureExtractor
+public static class MapTextureExtractor
 {
     // Bump when the extracted PNG bytes change in a way that requires
     // re-extracting (e.g. the orientation fix). Stored as a suffix on the

--- a/tools/Mithril.MapCalibration.Tools.Common/Mithril.MapCalibration.Tools.Common.csproj
+++ b/tools/Mithril.MapCalibration.Tools.Common/Mithril.MapCalibration.Tools.Common.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Tools.MapCalibration.Common</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Shared by sibling tools (CLI + WPF workspace). Same isolation pattern
+         as the CLI: keep AssetsTools.NET out of central package management,
+         skip the repo's Directory.Build.targets (versionless analyzer adds
+         that clash with non-central versioning). -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <!-- Registry reads + System.Drawing — Windows-only. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AssetsTools.NET" Version="3.0.4" />
+    <PackageReference Include="AssetsTools.NET.Texture" Version="3.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Mithril.MapCalibration.Tools.Common/NccTemplateMatch.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/NccTemplateMatch.cs
@@ -1,4 +1,4 @@
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Hand-rolled normalised cross-correlation (NCC) for template matching against
@@ -15,7 +15,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// teardrop pin doesn't get scored against the empty corners of its bounding
 /// rectangle.</para>
 /// </summary>
-internal static class NccTemplateMatch
+public static class NccTemplateMatch
 {
     /// <summary>
     /// Slides <paramref name="template"/> over <paramref name="image"/> and
@@ -218,7 +218,7 @@ internal static class NccTemplateMatch
 /// Downstream consumers should prefer <see cref="Centre"/> which uses the
 /// sub-pixel values automatically.
 /// </summary>
-internal readonly record struct Detection(int X, int Y, double Score, double SubX, double SubY)
+public readonly record struct Detection(int X, int Y, double Score, double SubX, double SubY)
 {
     public Detection(int x, int y, double score) : this(x, y, score, x, y) { }
 
@@ -230,7 +230,7 @@ internal readonly record struct Detection(int X, int Y, double Score, double Sub
 /// Single-channel byte image (grayscale, or alpha-only when used as a mask).
 /// Row-major, top-down. Constructed by <see cref="ImageIo"/>.
 /// </summary>
-internal sealed class GrayImage
+public sealed class GrayImage
 {
     public int Width { get; }
     public int Height { get; }

--- a/tools/Mithril.MapCalibration.Tools.Common/NpcsReader.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/NpcsReader.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Mithril.MapCalibration;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Reads the subset of <c>npcs.json</c> we need: per-area list of NPCs with
@@ -15,7 +15,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// gives the solver an order of magnitude more reference points than
 /// landmarks alone.</para>
 /// </summary>
-internal static class NpcsReader
+public static class NpcsReader
 {
     public static IReadOnlyList<LandmarkRef> LoadForArea(string npcsJsonPath, string area)
     {

--- a/tools/Mithril.MapCalibration.Tools.Common/PlayerLogScanner.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/PlayerLogScanner.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Mithril.MapCalibration;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Reads <c>Player.log</c> backwards looking for the most recent <c>[Status]</c>
@@ -17,7 +17,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot;
 /// becomes the most reliable reference point for the solver via the player-pin
 /// template match.</para>
 /// </summary>
-internal static class PlayerLogScanner
+public static class PlayerLogScanner
 {
     // [Status] lines vary across PG versions. The robust subset to extract:
     //   - the area name (often "Area: <Area...>" or embedded in a longer status)

--- a/tools/Mithril.MapCalibration.Tools.Common/SteamInstall.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/SteamInstall.cs
@@ -1,14 +1,14 @@
 using System.Text;
 using Microsoft.Win32;
 
-namespace Mithril.Tools.MapCalibrationFromScreenshot;
+namespace Mithril.Tools.MapCalibration.Common;
 
 /// <summary>
 /// Locates the user's Steam install and the Project Gorgon application directory.
 /// Lifted from <c>tools/MapAssetSpike/Program.cs</c>; PG ships as Steam AppID 342940.
 /// Verified once at startup so subsequent code can assume the paths exist.
 /// </summary>
-internal static class SteamInstall
+public static class SteamInstall
 {
     private const int PgAppId = 342940;
 

--- a/tools/Mithril.MapCalibration.Tools.Common/UserFacingException.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/UserFacingException.cs
@@ -1,0 +1,9 @@
+namespace Mithril.Tools.MapCalibration.Common;
+
+/// <summary>
+/// Thrown when the tool encounters a user-input or environment problem that
+/// should be reported as a clean error message rather than an uncaught
+/// stack trace. <c>Program.Main</c> in the CLI catches these and prints them
+/// without the trace; WPF consumers surface them in dialogs.
+/// </summary>
+public sealed class UserFacingException(string message) : Exception(message);

--- a/tools/Mithril.MapCalibration.Tools.slnx
+++ b/tools/Mithril.MapCalibration.Tools.slnx
@@ -1,0 +1,21 @@
+<Solution>
+  <!--
+    Focused solution for the offline map-calibration tool family, kept separate
+    from Mithril.slnx on purpose: the tool projects opt out of the repo's central
+    package management + Directory.Build.targets so their AssetsTools.NET /
+    System.Drawing deps stay out of the main build/test/CI loop. Open this to
+    work on the CLI + shared lib (and, later, the WPF workspace) together.
+
+    src/Mithril.MapCalibration (the solver lib both tools ProjectReference) is
+    listed so a solution-level Release build maps it to Release too — a P2P
+    reference to a project outside the solution would otherwise build Debug.
+    It also lives in Mithril.slnx; multi-solution membership is fine.
+  -->
+  <Folder Name="/src/">
+    <Project Path="../src/Mithril.MapCalibration/Mithril.MapCalibration.csproj" />
+  </Folder>
+  <Folder Name="/tools/">
+    <Project Path="Mithril.MapCalibration.Tools.Common/Mithril.MapCalibration.Tools.Common.csproj" />
+    <Project Path="MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj" />
+  </Folder>
+</Solution>


### PR DESCRIPTION
Closes #859.

Pure refactor — no behavioural change. Moves the screenshot-calibration CLI's primitive types into a new shared lib `tools/Mithril.MapCalibration.Tools.Common/` so the upcoming WPF workspace tool (Phase 1) can `ProjectReference` them without source duplication.

## What moved

10 primitive files `git mv`'d (history preserved as renames) from `tools/MapCalibrationFromScreenshot/` into `tools/Mithril.MapCalibration.Tools.Common/`:

`BaselineFile.cs`, `IconTemplateExtractor.cs`, `ImageIo.cs`, `LandmarksReader.cs`, `MapRectLocator.cs`, `MapTextureExtractor.cs`, `NccTemplateMatch.cs`, `NpcsReader.cs`, `PlayerLogScanner.cs`, `SteamInstall.cs`

Plus `UserFacingException` extracted out of `Program.cs` into its own file in the new lib.

## Changes

- **New csproj** `Mithril.MapCalibration.Tools.Common.csproj` (RootNamespace `Mithril.Tools.MapCalibration.Common`), mirroring the CLI's isolation pattern: opts out of central package management + `Directory.Build.targets`, suppresses CA1416 for the Windows-only `System.Drawing` / registry deps. References the `src/Mithril.MapCalibration` solver lib.
- All moved top-level types promoted `internal` → `public` (the supporting records `IconIndex`/`IconMeta`/`LandmarkRef`/`MapRect`/`Detection`/`GrayImage` cross the lib boundary, so they're public too).
- Namespace on the 10 moved files + UFE switched to `Mithril.Tools.MapCalibration.Common`.
- CLI gains a `ProjectReference` to the new lib and a `using Mithril.Tools.MapCalibration.Common;` in the 5 files that referenced moved types (`CliArgs`, `Pipeline`, `Program`, `ScreenshotCalibrator`, `SelfTest`).
- One dangling doc-comment `<see cref="ScreenshotCalibrator"/>` in the moved `IconTemplateExtractor.cs` changed to `<c>ScreenshotCalibrator</c>` (that type stays in the CLI, unreferenceable from Common).

No change to `src/Mithril.MapCalibration/` or the bundled baseline JSON (verified byte-identical — no upsert ran).

## Verification

- ✅ Common lib builds clean (Release, 0 warnings).
- ✅ CLI builds clean (Release, 0 warnings) against the new ProjectReference.
- ✅ `--phase self-test` **PASS** — synthetic round-trip recovered scale 1.2001 (truth 1.2000), rot 0.354 rad (truth 0.350), **residualPixels = 0.09** (well under the 0.5 px criterion).
- ⚠️ AreaSerbule real-screenshot regression skipped — no screenshot in the local workspace. Per the issue's documented fallback, this PR relies on the green self-test + the diff being a mechanical move (renames + namespace + visibility only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
