### PR TITLE
feat(tools): WPF map-calibration workspace (Phase 1)

### DIFF
--- a/tools/MapCalibrationWpf/App.xaml
+++ b/tools/MapCalibrationWpf/App.xaml
@@ -1,0 +1,4 @@
+<Application x:Class="Mithril.Tools.MapCalibrationWpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml" />

--- a/tools/MapCalibrationWpf/App.xaml.cs
+++ b/tools/MapCalibrationWpf/App.xaml.cs
@@ -1,0 +1,5 @@
+namespace Mithril.Tools.MapCalibrationWpf;
+
+public partial class App : System.Windows.Application
+{
+}

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -50,7 +50,20 @@
       </ContentControl>
     </Border>
     <Border Grid.Row="1" Grid.Column="2" BorderBrush="#888" BorderThickness="1,0,0,0">
-      <TextBlock Text="(ref table + solver readout)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
+      <ContentControl Content="{Binding Workspace}">
+        <ContentControl.ContentTemplate>
+          <DataTemplate>
+            <Grid>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+              </Grid.RowDefinitions>
+              <views:RefTable Grid.Row="0" />
+              <!-- SolverReadout slot — Task 9 inserts the readout view here. -->
+            </Grid>
+          </DataTemplate>
+        </ContentControl.ContentTemplate>
+      </ContentControl>
     </Border>
   </Grid>
 </Window>

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -59,7 +59,13 @@
                 <RowDefinition Height="Auto" />
               </Grid.RowDefinitions>
               <views:RefTable Grid.Row="0" />
-              <!-- SolverReadout slot — Task 9 inserts the readout view here. -->
+              <ContentControl Grid.Row="1" Content="{Binding SolverReadout}">
+                <ContentControl.ContentTemplate>
+                  <DataTemplate>
+                    <views:SolverReadout />
+                  </DataTemplate>
+                </ContentControl.ContentTemplate>
+              </ContentControl>
             </Grid>
           </DataTemplate>
         </ContentControl.ContentTemplate>

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -18,7 +18,8 @@
       <ComboBox Width="240" Margin="4,4,4,4"
                 ItemsSource="{Binding Areas}"
                 SelectedItem="{Binding SelectedArea}" />
-      <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4" IsEnabled="False" />
+      <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4"
+              Command="{Binding Workspace.CommitCommand}" />
     </DockPanel>
     <Border Grid.Row="1" Grid.Column="0" BorderBrush="#888" BorderThickness="0,0,1,0">
       <ContentControl Content="{Binding Workspace.Picker}">

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -1,0 +1,30 @@
+<Window x:Class="Mithril.Tools.MapCalibrationWpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Mithril Map Calibration" Height="800" Width="1400">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="260" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="340" />
+    </Grid.ColumnDefinitions>
+    <DockPanel Grid.Row="0" Grid.ColumnSpan="3" LastChildFill="False">
+      <TextBlock Text="Area: " VerticalAlignment="Center" Margin="8,0,0,0" />
+      <ComboBox Width="240" Margin="4,4,4,4" />
+      <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4" IsEnabled="False" />
+    </DockPanel>
+    <Border Grid.Row="1" Grid.Column="0" BorderBrush="#888" BorderThickness="0,0,1,0">
+      <TextBlock Text="(landmark picker)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
+    </Border>
+    <Border Grid.Row="1" Grid.Column="1">
+      <TextBlock Text="(source-map canvas)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
+    </Border>
+    <Border Grid.Row="1" Grid.Column="2" BorderBrush="#888" BorderThickness="1,0,0,0">
+      <TextBlock Text="(ref table + solver readout)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
+    </Border>
+  </Grid>
+</Window>

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -2,7 +2,17 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Mithril.Tools.MapCalibrationWpf.Views"
+        xmlns:vm="clr-namespace:Mithril.Tools.MapCalibrationWpf.ViewModels"
         Title="Mithril Map Calibration" Height="800" Width="1400">
+  <!--
+    DataType-keyed templates per docs/wpf-gotchas.md §"ContentControl.ContentTemplate
+    instantiates even when Content is null": each pane uses a DataType-only
+    DataTemplate in ContentControl.Resources (NO x:Key, NO explicit
+    ContentTemplate=). WPF resolves the template by the Content's runtime
+    type, so null Content matches no DataType and renders nothing — the
+    chrome (overlay canvas with click-capture, DataGrid headers, solver
+    labels) stays suppressed until an area is picked.
+  -->
   <Window.Resources>
     <BooleanToVisibilityConverter x:Key="BoolToVis" />
   </Window.Resources>
@@ -22,7 +32,8 @@
                 ItemsSource="{Binding Areas}"
                 SelectedItem="{Binding SelectedArea}" />
       <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4"
-              Command="{Binding Workspace.CommitCommand}" />
+              Command="{Binding Workspace.CommitCommand}"
+              ToolTip="Place at least 2 refs and ensure the solved calibration differs from what's already in map-calibration-baseline.json for this area." />
       <Button Content="Extract icon templates from PG assets"
               DockPanel.Dock="Right" Margin="4,4,4,4" Padding="8,4"
               Command="{Binding ExtractIconTemplatesCommand}"
@@ -30,23 +41,17 @@
     </DockPanel>
     <Border Grid.Row="1" Grid.Column="0" BorderBrush="#888" BorderThickness="0,0,1,0">
       <ContentControl Content="{Binding Workspace.Picker}">
-        <ContentControl.ContentTemplate>
-          <DataTemplate>
+        <ContentControl.Resources>
+          <DataTemplate DataType="{x:Type vm:LandmarkPickerViewModel}">
             <views:LandmarkPicker />
           </DataTemplate>
-        </ContentControl.ContentTemplate>
+        </ContentControl.Resources>
       </ContentControl>
     </Border>
     <Border Grid.Row="1" Grid.Column="1">
-      <!--
-        DataContext walks down to Workspace so SourceMapCanvas + its inner
-        bindings (SourceMapImage, Refs, Projections) resolve. When Workspace
-        is null (no area picked), the inner control just renders empty —
-        the bindings degrade silently rather than throwing.
-      -->
       <ContentControl Content="{Binding Workspace}">
-        <ContentControl.ContentTemplate>
-          <DataTemplate>
+        <ContentControl.Resources>
+          <DataTemplate DataType="{x:Type vm:AreaWorkspaceViewModel}">
             <Grid>
               <views:SourceMapCanvas />
               <TextBlock Text="{Binding LoadError}"
@@ -54,29 +59,35 @@
                          Foreground="#C44" TextWrapping="Wrap" Margin="16" />
             </Grid>
           </DataTemplate>
-        </ContentControl.ContentTemplate>
+        </ContentControl.Resources>
       </ContentControl>
     </Border>
     <Border Grid.Row="1" Grid.Column="2" BorderBrush="#888" BorderThickness="1,0,0,0">
       <ContentControl Content="{Binding Workspace}">
-        <ContentControl.ContentTemplate>
-          <DataTemplate>
+        <ContentControl.Resources>
+          <DataTemplate DataType="{x:Type vm:AreaWorkspaceViewModel}">
             <Grid>
               <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
               </Grid.RowDefinitions>
               <views:RefTable Grid.Row="0" />
+              <!--
+                Inner ContentControl for the SolverReadout child: also
+                DataType-keyed so it stays suppressed if the workspace's
+                SolverReadout property is ever null (shouldn't be in current
+                code, but the keying makes the pattern uniform + null-safe).
+              -->
               <ContentControl Grid.Row="1" Content="{Binding SolverReadout}">
-                <ContentControl.ContentTemplate>
-                  <DataTemplate>
+                <ContentControl.Resources>
+                  <DataTemplate DataType="{x:Type vm:SolverReadoutViewModel}">
                     <views:SolverReadout />
                   </DataTemplate>
-                </ContentControl.ContentTemplate>
+                </ContentControl.Resources>
               </ContentControl>
             </Grid>
           </DataTemplate>
-        </ContentControl.ContentTemplate>
+        </ContentControl.Resources>
       </ContentControl>
     </Border>
   </Grid>

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -21,7 +21,13 @@
       <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4" IsEnabled="False" />
     </DockPanel>
     <Border Grid.Row="1" Grid.Column="0" BorderBrush="#888" BorderThickness="0,0,1,0">
-      <TextBlock Text="(landmark picker)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
+      <ContentControl Content="{Binding Workspace.Picker}">
+        <ContentControl.ContentTemplate>
+          <DataTemplate>
+            <views:LandmarkPicker />
+          </DataTemplate>
+        </ContentControl.ContentTemplate>
+      </ContentControl>
     </Border>
     <Border Grid.Row="1" Grid.Column="1">
       <!--

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -14,7 +14,9 @@
     </Grid.ColumnDefinitions>
     <DockPanel Grid.Row="0" Grid.ColumnSpan="3" LastChildFill="False">
       <TextBlock Text="Area: " VerticalAlignment="Center" Margin="8,0,0,0" />
-      <ComboBox Width="240" Margin="4,4,4,4" />
+      <ComboBox Width="240" Margin="4,4,4,4"
+                ItemsSource="{Binding Areas}"
+                SelectedItem="{Binding SelectedArea}" />
       <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4" IsEnabled="False" />
     </DockPanel>
     <Border Grid.Row="1" Grid.Column="0" BorderBrush="#888" BorderThickness="0,0,1,0">

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="Mithril.Tools.MapCalibrationWpf.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:Mithril.Tools.MapCalibrationWpf.Views"
         Title="Mithril Map Calibration" Height="800" Width="1400">
   <Grid>
     <Grid.RowDefinitions>
@@ -23,7 +24,24 @@
       <TextBlock Text="(landmark picker)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
     </Border>
     <Border Grid.Row="1" Grid.Column="1">
-      <TextBlock Text="(source-map canvas)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />
+      <!--
+        DataContext walks down to Workspace so SourceMapCanvas + its inner
+        bindings (SourceMapImage, Refs, Projections) resolve. When Workspace
+        is null (no area picked), the inner control just renders empty —
+        the bindings degrade silently rather than throwing.
+      -->
+      <ContentControl Content="{Binding Workspace}">
+        <ContentControl.ContentTemplate>
+          <DataTemplate>
+            <Grid>
+              <views:SourceMapCanvas />
+              <TextBlock Text="{Binding LoadError}"
+                         HorizontalAlignment="Center" VerticalAlignment="Center"
+                         Foreground="#C44" TextWrapping="Wrap" Margin="16" />
+            </Grid>
+          </DataTemplate>
+        </ContentControl.ContentTemplate>
+      </ContentControl>
     </Border>
     <Border Grid.Row="1" Grid.Column="2" BorderBrush="#888" BorderThickness="1,0,0,0">
       <TextBlock Text="(ref table + solver readout)" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#888" />

--- a/tools/MapCalibrationWpf/MainWindow.xaml
+++ b/tools/MapCalibrationWpf/MainWindow.xaml
@@ -3,6 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Mithril.Tools.MapCalibrationWpf.Views"
         Title="Mithril Map Calibration" Height="800" Width="1400">
+  <Window.Resources>
+    <BooleanToVisibilityConverter x:Key="BoolToVis" />
+  </Window.Resources>
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
@@ -20,6 +23,10 @@
                 SelectedItem="{Binding SelectedArea}" />
       <Button Content="Commit anchor" DockPanel.Dock="Right" Margin="4,4,8,4" Padding="8,4"
               Command="{Binding Workspace.CommitCommand}" />
+      <Button Content="Extract icon templates from PG assets"
+              DockPanel.Dock="Right" Margin="4,4,4,4" Padding="8,4"
+              Command="{Binding ExtractIconTemplatesCommand}"
+              Visibility="{Binding IconTemplatesMissing, Converter={StaticResource BoolToVis}}" />
     </DockPanel>
     <Border Grid.Row="1" Grid.Column="0" BorderBrush="#888" BorderThickness="0,0,1,0">
       <ContentControl Content="{Binding Workspace.Picker}">

--- a/tools/MapCalibrationWpf/MainWindow.xaml.cs
+++ b/tools/MapCalibrationWpf/MainWindow.xaml.cs
@@ -1,0 +1,9 @@
+namespace Mithril.Tools.MapCalibrationWpf;
+
+public partial class MainWindow : System.Windows.Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/tools/MapCalibrationWpf/MainWindow.xaml.cs
+++ b/tools/MapCalibrationWpf/MainWindow.xaml.cs
@@ -5,5 +5,8 @@ public partial class MainWindow : System.Windows.Window
     public MainWindow()
     {
         InitializeComponent();
+        DataContext = new ViewModels.MainViewModel(
+            new Services.AreaCatalog(),
+            new Services.PgInstallResolver());
     }
 }

--- a/tools/MapCalibrationWpf/MapCalibrationWpf.csproj
+++ b/tools/MapCalibrationWpf/MapCalibrationWpf.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>Mithril.Tools.MapCalibrationWpf</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+      Same isolation pattern as MapCalibrationFromScreenshot: tool-local package
+      versions, no repo-wide GitVersioning analyzer / Directory.Build.targets.
+      Keeps AssetsTools.NET (pulled in transitively via the shared Tools.Common
+      lib) out of the main Mithril.slnx build/test loop.
+    -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <!-- Registry reads (PG install) + System.Drawing (PNG IO via the common
+         lib's pipeline) are Windows-only. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+    <ProjectReference Include="..\Mithril.MapCalibration.Tools.Common\Mithril.MapCalibration.Tools.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/MapCalibrationWpf/Services/AreaCatalog.cs
+++ b/tools/MapCalibrationWpf/Services/AreaCatalog.cs
@@ -1,0 +1,33 @@
+namespace Mithril.Tools.MapCalibrationWpf.Services;
+
+using System.IO;
+using System.Text.Json;
+
+/// <summary>
+/// Lists area names known to <c>landmarks.json</c>. The tool only offers
+/// areas the data files actually mention; an area with no landmarks AND no
+/// NPCs can't be calibrated.
+///
+/// <para>v1 reads landmarks alone — every populated PG area has at least one
+/// landmark, and NPC-only areas would need separate UX (no anchor type to
+/// click) which is out of scope for Phase 1.</para>
+/// </summary>
+public sealed class AreaCatalog
+{
+    public IReadOnlyList<string> ListAreasWithData(string landmarksJsonPath)
+    {
+        using var stream = File.OpenRead(landmarksJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+        var areas = new List<string>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+        {
+            if (prop.Value.ValueKind == JsonValueKind.Array
+                && prop.Value.GetArrayLength() > 0)
+            {
+                areas.Add(prop.Name);
+            }
+        }
+        areas.Sort(StringComparer.Ordinal);
+        return areas;
+    }
+}

--- a/tools/MapCalibrationWpf/Services/AssetBootstrapService.cs
+++ b/tools/MapCalibrationWpf/Services/AssetBootstrapService.cs
@@ -1,0 +1,79 @@
+namespace Mithril.Tools.MapCalibrationWpf.Services;
+
+using System.IO;
+using Mithril.Tools.MapCalibration.Common;
+
+/// <summary>
+/// Glues the common-lib asset extractors (<see cref="MapTextureExtractor"/>,
+/// <see cref="IconTemplateExtractor"/>) onto a background <c>Task.Run</c> with
+/// <see cref="IProgress{T}"/> updates so the UI dispatcher can show a modal
+/// progress dialog without freezing.
+///
+/// <para>Both extractors are no-ops when their output is already cached
+/// (<c>MapTextureExtractor.EnsureExtracted</c> checks bundle mtime;
+/// <c>IconTemplateExtractor.EnsureExtracted</c> checks the cache version on
+/// disk), so calling these on every area open is cheap once the first
+/// extraction lands.</para>
+/// </summary>
+public sealed class AssetBootstrapService
+{
+    private readonly PgInstallResolver _installResolver;
+
+    public AssetBootstrapService(PgInstallResolver installResolver)
+    {
+        _installResolver = installResolver;
+    }
+
+    public async Task<string> EnsureSourcePngAsync(string area, IProgress<string> progress)
+    {
+        var installPath = _installResolver.Resolve()
+            ?? throw new UserFacingException(
+                "PG install path not found; pick it from the dialog and retry.");
+        var mapDir = RepoPaths.DefaultMapsCacheDir();
+        progress.Report($"Locating Map_{area} bundle…");
+        return await Task.Run(() =>
+        {
+            progress.Report($"Extracting Map_{area} from sharedassets bundle…");
+            var pngPath = MapTextureExtractor.EnsureExtracted(installPath, mapDir, area);
+            progress.Report($"Loaded {Path.GetFileName(pngPath)}");
+            return pngPath;
+        }).ConfigureAwait(false);
+    }
+
+    public async Task EnsureIconTemplatesAsync(IProgress<string> progress)
+    {
+        var installPath = _installResolver.Resolve()
+            ?? throw new UserFacingException(
+                "PG install path not found; pick it from the dialog and retry.");
+        var iconsDir = RepoPaths.DefaultIconsCacheDir();
+        var tpkPath = RepoPaths.DefaultTpkPath();
+        progress.Report("Loading classdata.tpk…");
+        await Task.Run(() =>
+        {
+            progress.Report("Decoding sharedassets0.assets via AssetsTools.NET…");
+            IconTemplateExtractor.EnsureExtracted(installPath, iconsDir, tpkPath);
+            progress.Report("Icon templates ready.");
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// True when no <c>index.json</c> exists in the icon cache directory — the
+    /// signal that <see cref="IconTemplateExtractor.EnsureExtracted"/> has
+    /// never successfully completed. Used to show/hide the header "Extract
+    /// icon templates" action in <see cref="ViewModels.MainViewModel"/>.
+    /// </summary>
+    public static bool AreIconTemplatesMissing()
+    {
+        try
+        {
+            var iconsDir = RepoPaths.DefaultIconsCacheDir();
+            return !File.Exists(Path.Combine(iconsDir, "index.json"));
+        }
+        catch (UserFacingException)
+        {
+            // Can't resolve the repo root → treat as missing so the user has a
+            // visible affordance to retry.
+            return true;
+        }
+    }
+}

--- a/tools/MapCalibrationWpf/Services/PgInstallResolver.cs
+++ b/tools/MapCalibrationWpf/Services/PgInstallResolver.cs
@@ -1,0 +1,43 @@
+namespace Mithril.Tools.MapCalibrationWpf.Services;
+
+using System.IO;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibrationWpf.Settings;
+
+/// <summary>
+/// Resolves the Project Gorgon install path for the in-process asset extractors.
+/// Tries (1) the persisted user override (typed in via
+/// <c>PgInstallPickerDialog</c>) and (2) <see cref="SteamInstall.FindPgInstall"/>
+/// — the same auto-detect path the CLI uses. Returns null when neither yields
+/// an existing directory, so callers can prompt the user to point at it once.
+///
+/// <para><see cref="SteamInstall.FindPgInstall"/> throws <c>UserFacingException</c>
+/// when it can't locate PG; we trap that here and convert to a nullable so the
+/// dialog flow can react to "no install found" the same way as "user hasn't
+/// configured one yet".</para>
+/// </summary>
+public sealed class PgInstallResolver
+{
+    public string? Resolve()
+    {
+        var persisted = PersistedSettings.Load();
+        if (!string.IsNullOrEmpty(persisted.PgInstallPathOverride)
+            && Directory.Exists(persisted.PgInstallPathOverride))
+        {
+            return persisted.PgInstallPathOverride;
+        }
+        try
+        {
+            return SteamInstall.FindPgInstall();
+        }
+        catch (UserFacingException)
+        {
+            return null;
+        }
+    }
+
+    public void PersistOverride(string path)
+    {
+        new PersistedSettings(path).Save();
+    }
+}

--- a/tools/MapCalibrationWpf/Services/WorkspaceCommitService.cs
+++ b/tools/MapCalibrationWpf/Services/WorkspaceCommitService.cs
@@ -1,0 +1,47 @@
+namespace Mithril.Tools.MapCalibrationWpf.Services;
+
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+
+/// <summary>
+/// Stamps the solved <see cref="AreaCalibration"/> with the BundledBaseline
+/// metadata and writes it to <c>src/Mithril.MapCalibration/BundledData/
+/// map-calibration-baseline.json</c> via <see cref="BaselineFile.UpsertAnchor"/>.
+///
+/// <para>The same path the CLI writes to (resolved via <see cref="RepoPaths"/>)
+/// so the WPF tool's commit lands exactly where the existing baseline test
+/// suite reads from.</para>
+/// </summary>
+public sealed class WorkspaceCommitService
+{
+    public void Commit(string area, AreaCalibration calibration)
+    {
+        var stamped = calibration with
+        {
+            Source = CalibrationSource.BundledBaseline,
+            CalibrationZoom = 1.0,
+            SchemaVersion = 1,
+        };
+        BaselineFile.UpsertAnchor(RepoPaths.BaselineJsonPath(), area, stamped);
+    }
+
+    /// <summary>
+    /// Reads the currently-stored anchor for <paramref name="area"/>. Returns
+    /// null when no anchor exists yet — the workspace treats that as "dirty"
+    /// (commit-enabled).
+    /// </summary>
+    public AreaCalibration? ReadStored(string area)
+    {
+        try
+        {
+            return BaselineFile.TryReadAnchor(RepoPaths.BaselineJsonPath(), area);
+        }
+        catch (UserFacingException)
+        {
+            // Baseline file missing (running outside the repo); pretend "no
+            // stored anchor" so the commit button surfaces a useful error
+            // when the user clicks it.
+            return null;
+        }
+    }
+}

--- a/tools/MapCalibrationWpf/Services/WorkspaceCommitService.cs
+++ b/tools/MapCalibrationWpf/Services/WorkspaceCommitService.cs
@@ -38,9 +38,13 @@ public sealed class WorkspaceCommitService
         }
         catch (UserFacingException)
         {
-            // Baseline file missing (running outside the repo); pretend "no
-            // stored anchor" so the commit button surfaces a useful error
-            // when the user clicks it.
+            // Either the baseline path doesn't resolve (running outside the
+            // repo — RepoPaths throws), or the JSON is malformed / has a
+            // required field missing for this area (TryReadAnchor throws).
+            // Either way pretend "no stored anchor" so the workspace treats
+            // the in-progress calibration as dirty and the commit button
+            // stays available — the user can see the underlying issue when
+            // they try to commit (UpsertAnchor will re-surface the error).
             return null;
         }
     }

--- a/tools/MapCalibrationWpf/Settings/PersistedSettings.cs
+++ b/tools/MapCalibrationWpf/Settings/PersistedSettings.cs
@@ -1,0 +1,57 @@
+namespace Mithril.Tools.MapCalibrationWpf.Settings;
+
+using System.IO;
+using System.Text.Json;
+
+/// <summary>
+/// Tool-local persistence for the WPF map-calibration workspace. Backed by a
+/// small JSON file at <c>%LocalAppData%/Mithril/MapCalibrationWpf/settings.json</c>.
+///
+/// <para>Phase 1 carries one field — an override for the Project Gorgon install
+/// path used when <c>SteamInstall.FindPgInstall()</c> can't locate the install
+/// automatically (custom Steam libraries, non-Steam manual installs). The
+/// "5-line JSON write" choice over <c>Properties.Settings</c> is intentional
+/// — no designer-tooling dependency, file lives in the same well-known
+/// location as the rest of Mithril's settings.</para>
+/// </summary>
+public sealed record PersistedSettings(string? PgInstallPathOverride)
+{
+    private static readonly string DefaultPath =
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Mithril", "MapCalibrationWpf", "settings.json");
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public static PersistedSettings Load() => Load(DefaultPath);
+
+    public static PersistedSettings Load(string path)
+    {
+        if (!File.Exists(path)) return new PersistedSettings((string?)null);
+        try
+        {
+            var text = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<PersistedSettings>(text, JsonOpts)
+                ?? new PersistedSettings((string?)null);
+        }
+        catch
+        {
+            // Malformed settings shouldn't brick the tool — fall back to defaults
+            // and let the next Save() overwrite the bad file.
+            return new PersistedSettings((string?)null);
+        }
+    }
+
+    public void Save() => Save(DefaultPath);
+
+    public void Save(string path)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        File.WriteAllText(path, JsonSerializer.Serialize(this, JsonOpts));
+    }
+}

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -28,6 +28,8 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     [ObservableProperty]
     private string? _loadError;
 
+    public LandmarkPickerViewModel Picker { get; }
+
     /// <summary>
     /// Click handler hook from <see cref="Views.SourceMapCanvas"/>. Task 8
     /// fills this in to materialise a <c>RefViewModel</c> at the click pixel.
@@ -42,6 +44,10 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     {
         Area = area;
         _installResolver = installResolver;
+        Picker = new LandmarkPickerViewModel(
+            area,
+            RepoPaths.LandmarksJsonPath(),
+            RepoPaths.NpcsJsonPath());
         // Fire-and-forget: the dialog runs modally on the UI thread; the bg work
         // updates UI properties when complete. Caller (MainViewModel) doesn't
         // await — area-switch responsiveness wins over linearised completion.

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -37,6 +37,8 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
 
     public ObservableCollection<RefViewModel> Refs { get; } = new();
 
+    public ObservableCollection<ProjectionMarkerViewModel> Projections { get; } = new();
+
     [ObservableProperty]
     private AreaCalibration? _calibration;
 
@@ -71,6 +73,7 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
             Calibration = null;
             SolverReadout.Calibration = null;
             foreach (var r in Refs) r.ResidualPx = null;
+            Projections.Clear();
             return;
         }
 
@@ -84,6 +87,7 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
         if (cal is null)
         {
             foreach (var r in Refs) r.ResidualPx = null;
+            Projections.Clear();
             return;
         }
 
@@ -94,7 +98,25 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
             var dy = projected.Y - r.TexturePixel.Y;
             r.ResidualPx = Math.Sqrt(dx * dx + dy * dy);
         }
+
+        RefreshProjections(cal);
     }
+
+    private void RefreshProjections(AreaCalibration cal)
+    {
+        Projections.Clear();
+        foreach (var item in Picker.AllItems)
+        {
+            var px = cal.WorldToWindow(item.World);
+            var refMatch = RefForLandmark(item);
+            Projections.Add(new ProjectionMarkerViewModel(item.Name, px, refMatch?.ResidualPx));
+        }
+    }
+
+    private RefViewModel? RefForLandmark(LandmarkPickerItem item) =>
+        Refs.FirstOrDefault(r =>
+            Math.Abs(r.World.X - item.World.X) < 1e-6
+            && Math.Abs(r.World.Z - item.World.Z) < 1e-6);
 
     public AreaWorkspaceViewModel(string area, PgInstallResolver installResolver)
     {

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -1,20 +1,81 @@
 namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
 
+using System.Windows;
+using System.Windows.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Tools.MapCalibration.Common;
 using Mithril.Tools.MapCalibrationWpf.Services;
+using Mithril.Tools.MapCalibrationWpf.Views;
 
 /// <summary>
-/// Per-area state machine. Task 4 fills in just the <see cref="Area"/> handle
-/// so the area picker can spin one up; the asset bootstrap + landmark picker +
-/// solver wiring land in Tasks 5–10.
+/// Per-area state machine. On construction it kicks off
+/// <see cref="AssetBootstrapService.EnsureSourcePngAsync"/> behind a modal
+/// progress dialog; success populates <see cref="SourceMapImage"/>, failure
+/// populates <see cref="LoadError"/>.
+///
+/// <para>Tasks 7–10 layer the landmark picker, ref collection, solver, and
+/// projection overlay on top.</para>
 /// </summary>
 public sealed partial class AreaWorkspaceViewModel : ObservableObject
 {
+    private readonly PgInstallResolver _installResolver;
+
     public string Area { get; }
+
+    [ObservableProperty]
+    private BitmapImage? _sourceMapImage;
+
+    [ObservableProperty]
+    private string? _loadError;
 
     public AreaWorkspaceViewModel(string area, PgInstallResolver installResolver)
     {
         Area = area;
-        _ = installResolver; // wired in Task 5
+        _installResolver = installResolver;
+        // Fire-and-forget: the dialog runs modally on the UI thread; the bg work
+        // updates UI properties when complete. Caller (MainViewModel) doesn't
+        // await — area-switch responsiveness wins over linearised completion.
+        _ = LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        ExtractionProgressDialog? dialog = null;
+        try
+        {
+            var bootstrap = new AssetBootstrapService(_installResolver);
+
+            // Surface the dialog only when extraction will actually take time —
+            // EnsureExtracted is a fast file-stat when the cache is fresh.
+            dialog = new ExtractionProgressDialog($"Loading map for {Area}…")
+            {
+                Owner = Application.Current?.MainWindow,
+            };
+            // Show non-modally; the await keeps the UI dispatcher pumping.
+            // Show() returns immediately; the dialog stays on screen until
+            // the explicit CompleteAndClose() / Close() below.
+            dialog.Show();
+
+            var progress = new Progress<string>(msg => dialog?.UpdateStatus(msg));
+            var pngPath = await bootstrap.EnsureSourcePngAsync(Area, progress).ConfigureAwait(true);
+
+            // Load with CacheOption.OnLoad so the PNG file doesn't stay
+            // locked — the same file may be re-extracted on the next PG patch.
+            var bmp = new BitmapImage();
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad;
+            bmp.UriSource = new Uri(pngPath);
+            bmp.EndInit();
+            bmp.Freeze();
+            SourceMapImage = bmp;
+        }
+        catch (Exception ex)
+        {
+            LoadError = ex.Message;
+        }
+        finally
+        {
+            try { dialog?.Close(); } catch { /* dialog may have been closed already */ }
+        }
     }
 }

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -1,8 +1,11 @@
 namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
 
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.MapCalibration;
 using Mithril.Tools.MapCalibration.Common;
 using Mithril.Tools.MapCalibrationWpf.Services;
 using Mithril.Tools.MapCalibrationWpf.Views;
@@ -11,10 +14,12 @@ using Mithril.Tools.MapCalibrationWpf.Views;
 /// Per-area state machine. On construction it kicks off
 /// <see cref="AssetBootstrapService.EnsureSourcePngAsync"/> behind a modal
 /// progress dialog; success populates <see cref="SourceMapImage"/>, failure
-/// populates <see cref="LoadError"/>.
+/// populates <see cref="LoadError"/>. The picker is instantiated synchronously
+/// from the bundled landmarks/NPCs JSON (cheap; no IO except a JSON parse).
 ///
-/// <para>Tasks 7–10 layer the landmark picker, ref collection, solver, and
-/// projection overlay on top.</para>
+/// <para><see cref="Refs"/> is the user's committed reference clicks. The
+/// solver wiring (Task 9) subscribes to <see cref="ObservableCollection{T}.CollectionChanged"/>
+/// and re-solves on every change.</para>
 /// </summary>
 public sealed partial class AreaWorkspaceViewModel : ObservableObject
 {
@@ -30,14 +35,31 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
 
     public LandmarkPickerViewModel Picker { get; }
 
+    public ObservableCollection<RefViewModel> Refs { get; } = new();
+
+    [ObservableProperty]
+    private AreaCalibration? _calibration;
+
     /// <summary>
-    /// Click handler hook from <see cref="Views.SourceMapCanvas"/>. Task 8
-    /// fills this in to materialise a <c>RefViewModel</c> at the click pixel.
+    /// True when the user has placed refs that haven't been committed to the
+    /// baseline JSON yet. Wired in Task 11 — for now it just tracks the
+    /// presence of refs so the area-switch guard has a signal to gate on.
+    /// </summary>
+    public bool HasUncommittedRefs => Refs.Count > 0;
+
+    /// <summary>
+    /// Click handler hook from <see cref="Views.SourceMapCanvas"/>. Materialises
+    /// a <see cref="RefViewModel"/> from the picker's <see cref="LandmarkPickerViewModel.Selected"/>
+    /// + the click pixel, then clears the picker selection. No-op when nothing
+    /// is selected (so stray clicks don't pollute the ref table).
     /// </summary>
     public void PlaceRefAt(double x, double y)
     {
-        // Task 8 implements this.
-        _ = (x, y);
+        if (Picker.Selected is not LandmarkPickerItem sel) return;
+        var refVm = new RefViewModel(sel.Name, sel.Kind, sel.World, new PixelPoint(x, y));
+        Refs.Add(refVm);
+        Picker.Selected = null;
+        // Task 9 hooks the solver here via Refs.CollectionChanged.
     }
 
     public AreaWorkspaceViewModel(string area, PgInstallResolver installResolver)
@@ -48,10 +70,17 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
             area,
             RepoPaths.LandmarksJsonPath(),
             RepoPaths.NpcsJsonPath());
+        Refs.CollectionChanged += OnRefsChanged;
         // Fire-and-forget: the dialog runs modally on the UI thread; the bg work
         // updates UI properties when complete. Caller (MainViewModel) doesn't
         // await — area-switch responsiveness wins over linearised completion.
         _ = LoadAsync();
+    }
+
+    private void OnRefsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasUncommittedRefs));
+        // Task 9 will call ReSolve() here.
     }
 
     private async Task LoadAsync()
@@ -61,22 +90,17 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
         {
             var bootstrap = new AssetBootstrapService(_installResolver);
 
-            // Surface the dialog only when extraction will actually take time —
-            // EnsureExtracted is a fast file-stat when the cache is fresh.
             dialog = new ExtractionProgressDialog($"Loading map for {Area}…")
             {
                 Owner = Application.Current?.MainWindow,
             };
-            // Show non-modally; the await keeps the UI dispatcher pumping.
-            // Show() returns immediately; the dialog stays on screen until
-            // the explicit CompleteAndClose() / Close() below.
             dialog.Show();
 
             var progress = new Progress<string>(msg => dialog?.UpdateStatus(msg));
             var pngPath = await bootstrap.EnsureSourcePngAsync(Area, progress).ConfigureAwait(true);
 
-            // Load with CacheOption.OnLoad so the PNG file doesn't stay
-            // locked — the same file may be re-extracted on the next PG patch.
+            // CacheOption.OnLoad so the PNG file isn't held locked across
+            // re-extracts; Freeze so the bound Image can render cross-thread.
             var bmp = new BitmapImage();
             bmp.BeginInit();
             bmp.CacheOption = BitmapCacheOption.OnLoad;

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -188,10 +188,14 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
             SolverReadout.Calibration = stored;
             RefreshProjections(stored);
         }
-        // Fire-and-forget: the dialog runs modally on the UI thread; the bg work
+        // Fire-and-forget: the dialog runs on the UI thread; the bg work
         // updates UI properties when complete. Caller (MainViewModel) doesn't
         // await — area-switch responsiveness wins over linearised completion.
-        _ = LoadAsync();
+        // try/catch around the assignment so any sync throw that escapes
+        // before the first await inside LoadAsync (e.g. the dialog ctor) gets
+        // funnelled into LoadError rather than silently lost.
+        try { _ = LoadAsync(); }
+        catch (Exception ex) { LoadError = ex.Message; }
     }
 
     private void OnRefsChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -63,6 +63,20 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     {
         if (Calibration is not { } cal) return;
         _commitService.Commit(Area, cal);
+        // LandmarkCalibrationSolver.Solve always emits Source=UserRefinement
+        // (record default) but the service stamps Source=BundledBaseline
+        // (+ Zoom=1.0 + SchemaVersion=1) into the JSON. Stamp the in-memory
+        // copy to match what's now on disk — otherwise ApproximatelyEqual
+        // would never report a match after commit and the button would
+        // stay enabled forever (round-2 review blocker). Mirror exactly what
+        // WorkspaceCommitService.Commit writes.
+        Calibration = cal with
+        {
+            Source = CalibrationSource.BundledBaseline,
+            CalibrationZoom = 1.0,
+            SchemaVersion = 1,
+        };
+        SolverReadout.Calibration = Calibration;
         // Refresh the stored cache so HasUncommittedRefs flips to false (and
         // the button greys out) until the user changes a ref again.
         _storedCalibration = _commitService.ReadStored(Area);
@@ -191,11 +205,10 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
         // Fire-and-forget: the dialog runs on the UI thread; the bg work
         // updates UI properties when complete. Caller (MainViewModel) doesn't
         // await — area-switch responsiveness wins over linearised completion.
-        // try/catch around the assignment so any sync throw that escapes
-        // before the first await inside LoadAsync (e.g. the dialog ctor) gets
-        // funnelled into LoadError rather than silently lost.
-        try { _ = LoadAsync(); }
-        catch (Exception ex) { LoadError = ex.Message; }
+        // The async state machine captures pre-first-await throws into the
+        // returned Task, so an outer try/catch here would be dead code —
+        // LoadAsync's own try/catch funnels every failure path into LoadError.
+        _ = LoadAsync();
     }
 
     private void OnRefsChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Mithril.MapCalibration;
 using Mithril.Tools.MapCalibration.Common;
 using Mithril.Tools.MapCalibrationWpf.Services;
@@ -24,6 +25,8 @@ using Mithril.Tools.MapCalibrationWpf.Views;
 public sealed partial class AreaWorkspaceViewModel : ObservableObject
 {
     private readonly PgInstallResolver _installResolver;
+    private readonly WorkspaceCommitService _commitService;
+    private AreaCalibration? _storedCalibration;
 
     public string Area { get; }
 
@@ -45,11 +48,59 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     public SolverReadoutViewModel SolverReadout { get; } = new();
 
     /// <summary>
-    /// True when the user has placed refs that haven't been committed to the
-    /// baseline JSON yet. Wired in Task 11 — for now it just tracks the
-    /// presence of refs so the area-switch guard has a signal to gate on.
+    /// True when the user has placed refs whose solved calibration differs
+    /// from what's stored in <c>map-calibration-baseline.json</c> for this
+    /// area. Used by both the commit-button CanExecute and the area-switch
+    /// guard dialog in <see cref="MainViewModel"/>.
     /// </summary>
-    public bool HasUncommittedRefs => Refs.Count > 0;
+    public bool HasUncommittedRefs =>
+        Refs.Count >= 2
+        && Calibration is { } current
+        && !ApproximatelyEqual(current, _storedCalibration);
+
+    [RelayCommand(CanExecute = nameof(CanCommit))]
+    private void Commit()
+    {
+        if (Calibration is not { } cal) return;
+        _commitService.Commit(Area, cal);
+        // Refresh the stored cache so HasUncommittedRefs flips to false (and
+        // the button greys out) until the user changes a ref again.
+        _storedCalibration = _commitService.ReadStored(Area);
+        OnPropertyChanged(nameof(HasUncommittedRefs));
+        CommitCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanCommit() =>
+        Calibration is not null && Refs.Count >= 2 && HasUncommittedRefs;
+
+    /// <summary>
+    /// ULP-tolerant comparison: two calibrations are "the same" if every
+    /// numeric field matches within a tight epsilon AND the bool/enum fields
+    /// match exactly. Threshold chosen to be tighter than any visible-pixel
+    /// effect (Scale + Origin float-rounds round-trip via JSON well below
+    /// 1e-9 on values in the px-per-unit / origin-pixel range we see).
+    /// </summary>
+    private static bool ApproximatelyEqual(AreaCalibration a, AreaCalibration? b)
+    {
+        if (b is null) return false;
+        const double eps = 1e-9;
+        return Math.Abs(a.Scale - b.Scale) < eps
+            && Math.Abs(a.RotationRadians - b.RotationRadians) < eps
+            && Math.Abs(a.OriginX - b.OriginX) < eps
+            && Math.Abs(a.OriginY - b.OriginY) < eps
+            && Math.Abs(a.ResidualPixels - b.ResidualPixels) < eps
+            && a.ReferenceCount == b.ReferenceCount
+            && a.MirrorNorth == b.MirrorNorth
+            && Math.Abs(a.CalibrationZoom - b.CalibrationZoom) < eps
+            && a.Source == b.Source
+            && a.SchemaVersion == b.SchemaVersion;
+    }
+
+    partial void OnCalibrationChanged(AreaCalibration? value)
+    {
+        OnPropertyChanged(nameof(HasUncommittedRefs));
+        CommitCommand.NotifyCanExecuteChanged();
+    }
 
     /// <summary>
     /// Click handler hook from <see cref="Views.SourceMapCanvas"/>. Materialises
@@ -122,11 +173,21 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     {
         Area = area;
         _installResolver = installResolver;
+        _commitService = new WorkspaceCommitService();
         Picker = new LandmarkPickerViewModel(
             area,
             RepoPaths.LandmarksJsonPath(),
             RepoPaths.NpcsJsonPath());
         Refs.CollectionChanged += OnRefsChanged;
+        _storedCalibration = _commitService.ReadStored(area);
+        // If a stored anchor exists, render its projections immediately so the
+        // user sees the existing baseline overlay before they place any refs.
+        if (_storedCalibration is { } stored)
+        {
+            Calibration = stored;
+            SolverReadout.Calibration = stored;
+            RefreshProjections(stored);
+        }
         // Fire-and-forget: the dialog runs modally on the UI thread; the bg work
         // updates UI properties when complete. Caller (MainViewModel) doesn't
         // await — area-switch responsiveness wins over linearised completion.

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -28,6 +28,16 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     [ObservableProperty]
     private string? _loadError;
 
+    /// <summary>
+    /// Click handler hook from <see cref="Views.SourceMapCanvas"/>. Task 8
+    /// fills this in to materialise a <c>RefViewModel</c> at the click pixel.
+    /// </summary>
+    public void PlaceRefAt(double x, double y)
+    {
+        // Task 8 implements this.
+        _ = (x, y);
+    }
+
     public AreaWorkspaceViewModel(string area, PgInstallResolver installResolver)
     {
         Area = area;

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -1,0 +1,20 @@
+namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Tools.MapCalibrationWpf.Services;
+
+/// <summary>
+/// Per-area state machine. Task 4 fills in just the <see cref="Area"/> handle
+/// so the area picker can spin one up; the asset bootstrap + landmark picker +
+/// solver wiring land in Tasks 5–10.
+/// </summary>
+public sealed partial class AreaWorkspaceViewModel : ObservableObject
+{
+    public string Area { get; }
+
+    public AreaWorkspaceViewModel(string area, PgInstallResolver installResolver)
+    {
+        Area = area;
+        _ = installResolver; // wired in Task 5
+    }
+}

--- a/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/AreaWorkspaceViewModel.cs
@@ -40,6 +40,8 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     [ObservableProperty]
     private AreaCalibration? _calibration;
 
+    public SolverReadoutViewModel SolverReadout { get; } = new();
+
     /// <summary>
     /// True when the user has placed refs that haven't been committed to the
     /// baseline JSON yet. Wired in Task 11 — for now it just tracks the
@@ -59,7 +61,39 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
         var refVm = new RefViewModel(sel.Name, sel.Kind, sel.World, new PixelPoint(x, y));
         Refs.Add(refVm);
         Picker.Selected = null;
-        // Task 9 hooks the solver here via Refs.CollectionChanged.
+        // Solver re-runs via the OnRefsChanged hook below.
+    }
+
+    private void ReSolve()
+    {
+        if (Refs.Count < 2)
+        {
+            Calibration = null;
+            SolverReadout.Calibration = null;
+            foreach (var r in Refs) r.ResidualPx = null;
+            return;
+        }
+
+        var solverRefs = Refs.Select(r =>
+            new LandmarkCalibrationSolver.Reference(r.World.X, r.World.Z, r.TexturePixel))
+            .ToList();
+        var cal = LandmarkCalibrationSolver.Solve(solverRefs);
+        Calibration = cal;
+        SolverReadout.Calibration = cal;
+
+        if (cal is null)
+        {
+            foreach (var r in Refs) r.ResidualPx = null;
+            return;
+        }
+
+        foreach (var r in Refs)
+        {
+            var projected = cal.WorldToWindow(r.World);
+            var dx = projected.X - r.TexturePixel.X;
+            var dy = projected.Y - r.TexturePixel.Y;
+            r.ResidualPx = Math.Sqrt(dx * dx + dy * dy);
+        }
     }
 
     public AreaWorkspaceViewModel(string area, PgInstallResolver installResolver)
@@ -80,7 +114,7 @@ public sealed partial class AreaWorkspaceViewModel : ObservableObject
     private void OnRefsChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         OnPropertyChanged(nameof(HasUncommittedRefs));
-        // Task 9 will call ReSolve() here.
+        ReSolve();
     }
 
     private async Task LoadAsync()

--- a/tools/MapCalibrationWpf/ViewModels/LandmarkPickerViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/LandmarkPickerViewModel.cs
@@ -1,0 +1,65 @@
+namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+
+/// <summary>
+/// Searchable list of all landmarks + NPCs in the current area. Selection
+/// drives "click the source map to place a ref at the highlighted entry's
+/// world coord" — set by the user, cleared by
+/// <see cref="AreaWorkspaceViewModel.PlaceRefAt"/> after the click.
+///
+/// <para>NPCs and landmarks both come through <c>LandmarksReader</c> /
+/// <c>NpcsReader</c> as <see cref="LandmarkRef"/> records — the picker only
+/// needs name + world coord, plus a kind chip ("Npc" vs landmark Type) for
+/// disambiguation when names clash.</para>
+/// </summary>
+public sealed partial class LandmarkPickerViewModel : ObservableObject
+{
+    private readonly List<LandmarkPickerItem> _all;
+
+    public IReadOnlyList<LandmarkPickerItem> AllItems => _all;
+
+    [ObservableProperty]
+    private string _searchText = "";
+
+    [ObservableProperty]
+    private LandmarkPickerItem? _selected;
+
+    public ObservableCollection<LandmarkPickerItem> Filtered { get; } = new();
+
+    public LandmarkPickerViewModel(string area, string landmarksJsonPath, string npcsJsonPath)
+    {
+        var landmarks = LandmarksReader.LoadForArea(landmarksJsonPath, area);
+        var npcs = NpcsReader.LoadForArea(npcsJsonPath, area);
+        _all = [
+            .. landmarks.Select(l => new LandmarkPickerItem(l.Name, l.Type, l.World)),
+            .. npcs.Select(n => new LandmarkPickerItem(n.Name, n.Type, n.World)),
+        ];
+        _all.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        Refilter();
+    }
+
+    partial void OnSearchTextChanged(string value) => Refilter();
+
+    private void Refilter()
+    {
+        Filtered.Clear();
+        var q = SearchText.Trim();
+        foreach (var item in _all)
+        {
+            if (q.Length == 0 || item.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+            {
+                Filtered.Add(item);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// One row in the picker: display name, the source kind (landmark Type or
+/// "Npc"), and the world coord that gets paired with the user's click pixel.
+/// </summary>
+public sealed record LandmarkPickerItem(string Name, string Kind, WorldCoord World);

--- a/tools/MapCalibrationWpf/ViewModels/MainViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/MainViewModel.cs
@@ -1,0 +1,53 @@
+namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibrationWpf.Services;
+
+/// <summary>
+/// Top-level workspace VM: holds the area picker, instantiates a per-area
+/// <see cref="AreaWorkspaceViewModel"/> on selection. The dirty-state guard
+/// for area switches lands in Task 11.
+/// </summary>
+public sealed partial class MainViewModel : ObservableObject
+{
+    private readonly AreaCatalog _catalog;
+    private readonly PgInstallResolver _installResolver;
+
+    public MainViewModel(AreaCatalog catalog, PgInstallResolver installResolver)
+    {
+        _catalog = catalog;
+        _installResolver = installResolver;
+        Areas = LoadAreas();
+    }
+
+    public IReadOnlyList<string> Areas { get; }
+
+    [ObservableProperty]
+    private string? _selectedArea;
+
+    [ObservableProperty]
+    private AreaWorkspaceViewModel? _workspace;
+
+    partial void OnSelectedAreaChanged(string? value)
+    {
+        Workspace = value is null
+            ? null
+            : new AreaWorkspaceViewModel(value, _installResolver);
+    }
+
+    private IReadOnlyList<string> LoadAreas()
+    {
+        try
+        {
+            return _catalog.ListAreasWithData(RepoPaths.LandmarksJsonPath());
+        }
+        catch (UserFacingException)
+        {
+            // Repo-relative resolution failed (running from outside the repo
+            // tree). Surface an empty list — the picker will show no items
+            // and the user can investigate via the console output.
+            return [];
+        }
+    }
+}

--- a/tools/MapCalibrationWpf/ViewModels/MainViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/MainViewModel.cs
@@ -2,8 +2,10 @@ namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
 
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Mithril.Tools.MapCalibration.Common;
 using Mithril.Tools.MapCalibrationWpf.Services;
+using Mithril.Tools.MapCalibrationWpf.Views;
 
 /// <summary>
 /// Top-level workspace VM: holds the area picker, instantiates a per-area
@@ -35,10 +37,43 @@ public sealed partial class MainViewModel : ObservableObject
 
     /// <summary>
     /// True when the icon-templates cache is missing (no <c>index.json</c>
-    /// in the icons cache dir). Drives the Task 12 header-button visibility.
+    /// in the icons cache dir). Drives the header-button visibility.
+    /// Phase 1 surfaces this button so a user can prime the cache before
+    /// future phases (NCC live overlay, screenshot-bbox modality) need it.
     /// </summary>
     [ObservableProperty]
     private bool _iconTemplatesMissing;
+
+    [RelayCommand]
+    private async Task ExtractIconTemplatesAsync()
+    {
+        ExtractionProgressDialog? dialog = null;
+        try
+        {
+            dialog = new ExtractionProgressDialog("Preparing icon-template extraction…")
+            {
+                Owner = Application.Current?.MainWindow,
+            };
+            dialog.Show();
+
+            var bootstrap = new AssetBootstrapService(_installResolver);
+            var progress = new Progress<string>(msg => dialog?.UpdateStatus(msg));
+            await bootstrap.EnsureIconTemplatesAsync(progress).ConfigureAwait(true);
+            IconTemplatesMissing = AssetBootstrapService.AreIconTemplatesMissing();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(
+                ex.Message,
+                "Icon-template extraction failed",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+        finally
+        {
+            try { dialog?.Close(); } catch { /* dialog may have been closed already */ }
+        }
+    }
 
     partial void OnSelectedAreaChanged(string? value)
     {

--- a/tools/MapCalibrationWpf/ViewModels/MainViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/MainViewModel.cs
@@ -1,24 +1,28 @@
 namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
 
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Mithril.Tools.MapCalibration.Common;
 using Mithril.Tools.MapCalibrationWpf.Services;
 
 /// <summary>
 /// Top-level workspace VM: holds the area picker, instantiates a per-area
-/// <see cref="AreaWorkspaceViewModel"/> on selection. The dirty-state guard
-/// for area switches lands in Task 11.
+/// <see cref="AreaWorkspaceViewModel"/> on selection. Guards the
+/// <see cref="SelectedArea"/> change against uncommitted refs in the
+/// outgoing workspace with a confirm-discard <c>MessageBox</c>.
 /// </summary>
 public sealed partial class MainViewModel : ObservableObject
 {
     private readonly AreaCatalog _catalog;
     private readonly PgInstallResolver _installResolver;
+    private bool _suppressGuard;
 
     public MainViewModel(AreaCatalog catalog, PgInstallResolver installResolver)
     {
         _catalog = catalog;
         _installResolver = installResolver;
         Areas = LoadAreas();
+        IconTemplatesMissing = AssetBootstrapService.AreIconTemplatesMissing();
     }
 
     public IReadOnlyList<string> Areas { get; }
@@ -29,8 +33,32 @@ public sealed partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private AreaWorkspaceViewModel? _workspace;
 
+    /// <summary>
+    /// True when the icon-templates cache is missing (no <c>index.json</c>
+    /// in the icons cache dir). Drives the Task 12 header-button visibility.
+    /// </summary>
+    [ObservableProperty]
+    private bool _iconTemplatesMissing;
+
     partial void OnSelectedAreaChanged(string? value)
     {
+        if (_suppressGuard) return;
+        if (Workspace is { HasUncommittedRefs: true } outgoing)
+        {
+            var ok = MessageBox.Show(
+                $"Discard uncommitted refs on {outgoing.Area} and switch to {value ?? "no area"}?",
+                "Uncommitted refs",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning);
+            if (ok != MessageBoxResult.Yes)
+            {
+                // Revert SelectedArea without re-triggering this partial.
+                _suppressGuard = true;
+                try { SelectedArea = outgoing.Area; }
+                finally { _suppressGuard = false; }
+                return;
+            }
+        }
         Workspace = value is null
             ? null
             : new AreaWorkspaceViewModel(value, _installResolver);

--- a/tools/MapCalibrationWpf/ViewModels/ProjectionMarkerViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/ProjectionMarkerViewModel.cs
@@ -1,0 +1,21 @@
+namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+using System.Windows.Media;
+using Mithril.MapCalibration;
+
+/// <summary>
+/// One dot on the projection overlay: every known landmark/NPC's world coord
+/// projected through the current <see cref="AreaCalibration"/>. Colour-keyed
+/// on per-ref residual when this marker corresponds to a committed ref, else
+/// neutral grey.
+/// </summary>
+public sealed record ProjectionMarkerViewModel(string Name, PixelPoint TexturePixel, double? ResidualPx)
+{
+    public Brush MarkerBrush => ResidualPx switch
+    {
+        null => Brushes.Gray,
+        <= SolverReadoutViewModel.GoodResidualPx => Brushes.LimeGreen,
+        <= SolverReadoutViewModel.AcceptableResidualPx => Brushes.Goldenrod,
+        _ => Brushes.IndianRed,
+    };
+}

--- a/tools/MapCalibrationWpf/ViewModels/RefViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/RefViewModel.cs
@@ -1,0 +1,28 @@
+namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.MapCalibration;
+
+/// <summary>
+/// One committed reference: a landmark/NPC's world coordinate paired with the
+/// texture-pixel the user clicked. Residual is filled in by the solver after
+/// each Refs change (Task 9).
+/// </summary>
+public sealed partial class RefViewModel : ObservableObject
+{
+    public string Name { get; }
+    public string Kind { get; }
+    public WorldCoord World { get; }
+    public PixelPoint TexturePixel { get; }
+
+    [ObservableProperty]
+    private double? _residualPx;
+
+    public RefViewModel(string name, string kind, WorldCoord world, PixelPoint texturePixel)
+    {
+        Name = name;
+        Kind = kind;
+        World = world;
+        TexturePixel = texturePixel;
+    }
+}

--- a/tools/MapCalibrationWpf/ViewModels/SolverReadoutViewModel.cs
+++ b/tools/MapCalibrationWpf/ViewModels/SolverReadoutViewModel.cs
@@ -1,0 +1,62 @@
+namespace Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+using System.Windows.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.MapCalibration;
+
+/// <summary>
+/// Observable wrapper around the workspace's current <see cref="AreaCalibration"/>.
+/// Exposes display-friendly fields + a coloured badge brush keyed on the
+/// 3 / 12 px residual thresholds defined in Mithril's LegolasSettings
+/// (CalibrationGoodResidualPx = 12.0). The thresholds are inlined here rather
+/// than referenced from Legolas — this is a dev-only tool and the constant
+/// hasn't churned in months. Reference: src/Legolas.Module/Domain/LegolasSettings.cs.
+/// </summary>
+public sealed partial class SolverReadoutViewModel : ObservableObject
+{
+    /// <summary>RMS residual at which the calibration is "ship-quality".</summary>
+    public const double GoodResidualPx = 3.0;
+
+    /// <summary>RMS residual ceiling for an "acceptable" fit.</summary>
+    public const double AcceptableResidualPx = 12.0;
+
+    [ObservableProperty]
+    private AreaCalibration? _calibration;
+
+    partial void OnCalibrationChanged(AreaCalibration? value)
+    {
+        OnPropertyChanged(nameof(Scale));
+        OnPropertyChanged(nameof(RotationDegrees));
+        OnPropertyChanged(nameof(MirrorNorth));
+        OnPropertyChanged(nameof(OriginX));
+        OnPropertyChanged(nameof(OriginY));
+        OnPropertyChanged(nameof(ResidualPixels));
+        OnPropertyChanged(nameof(ReferenceCount));
+        OnPropertyChanged(nameof(ResidualBadgeBrush));
+        OnPropertyChanged(nameof(StatusLabel));
+    }
+
+    public double? Scale => Calibration?.Scale;
+    public double? RotationDegrees => Calibration is { } c ? c.RotationRadians * 180.0 / Math.PI : null;
+    public bool MirrorNorth => Calibration?.MirrorNorth ?? false;
+    public double? OriginX => Calibration?.OriginX;
+    public double? OriginY => Calibration?.OriginY;
+    public double? ResidualPixels => Calibration?.ResidualPixels;
+    public int ReferenceCount => Calibration?.ReferenceCount ?? 0;
+
+    public Brush ResidualBadgeBrush => Calibration?.ResidualPixels switch
+    {
+        null => Brushes.Gray,
+        <= GoodResidualPx => Brushes.LimeGreen,
+        <= AcceptableResidualPx => Brushes.Goldenrod,
+        _ => Brushes.IndianRed,
+    };
+
+    public string StatusLabel => Calibration?.ResidualPixels switch
+    {
+        null => "no solve",
+        <= GoodResidualPx => "ship-quality",
+        <= AcceptableResidualPx => "acceptable",
+        _ => "below shipping bar",
+    };
+}

--- a/tools/MapCalibrationWpf/Views/ExtractionProgressDialog.xaml
+++ b/tools/MapCalibrationWpf/Views/ExtractionProgressDialog.xaml
@@ -1,0 +1,13 @@
+<Window x:Class="Mithril.Tools.MapCalibrationWpf.Views.ExtractionProgressDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Extracting…"
+        Width="480" Height="140"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False">
+  <StackPanel Margin="12" VerticalAlignment="Center">
+    <TextBlock x:Name="StatusText" Text="Starting…" Margin="0,0,0,8" />
+    <ProgressBar IsIndeterminate="True" Height="14" />
+  </StackPanel>
+</Window>

--- a/tools/MapCalibrationWpf/Views/ExtractionProgressDialog.xaml.cs
+++ b/tools/MapCalibrationWpf/Views/ExtractionProgressDialog.xaml.cs
@@ -1,0 +1,39 @@
+namespace Mithril.Tools.MapCalibrationWpf.Views;
+
+using System.Windows;
+
+/// <summary>
+/// Modal progress indicator for the in-process asset extractors. The owning
+/// VM forwards <see cref="IProgress{T}"/> ticks to <see cref="UpdateStatus"/>.
+/// <see cref="CompleteAndClose"/> dismisses the dialog on success; on failure
+/// the caller surfaces the error separately and calls <see cref="Close"/>.
+/// </summary>
+public partial class ExtractionProgressDialog : Window
+{
+    public ExtractionProgressDialog(string initialStatus)
+    {
+        InitializeComponent();
+        StatusText.Text = initialStatus;
+    }
+
+    public void UpdateStatus(string status)
+    {
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.Invoke(() => StatusText.Text = status);
+            return;
+        }
+        StatusText.Text = status;
+    }
+
+    public void CompleteAndClose()
+    {
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.Invoke(CompleteAndClose);
+            return;
+        }
+        DialogResult = true;
+        Close();
+    }
+}

--- a/tools/MapCalibrationWpf/Views/LandmarkPicker.xaml
+++ b/tools/MapCalibrationWpf/Views/LandmarkPicker.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="Mithril.Tools.MapCalibrationWpf.Views.LandmarkPicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <DockPanel>
+    <TextBox DockPanel.Dock="Top" Margin="4"
+             Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+    <ListBox ItemsSource="{Binding Filtered}"
+             SelectedItem="{Binding Selected}">
+      <ListBox.ItemTemplate>
+        <DataTemplate>
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Text="{Binding Name}" />
+            <TextBlock Text="{Binding Kind, StringFormat=' ({0})'}"
+                       Foreground="#888" />
+          </StackPanel>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+  </DockPanel>
+</UserControl>

--- a/tools/MapCalibrationWpf/Views/LandmarkPicker.xaml.cs
+++ b/tools/MapCalibrationWpf/Views/LandmarkPicker.xaml.cs
@@ -1,0 +1,11 @@
+namespace Mithril.Tools.MapCalibrationWpf.Views;
+
+using System.Windows.Controls;
+
+public partial class LandmarkPicker : UserControl
+{
+    public LandmarkPicker()
+    {
+        InitializeComponent();
+    }
+}

--- a/tools/MapCalibrationWpf/Views/PgInstallPickerDialog.xaml
+++ b/tools/MapCalibrationWpf/Views/PgInstallPickerDialog.xaml
@@ -1,0 +1,32 @@
+<Window x:Class="Mithril.Tools.MapCalibrationWpf.Views.PgInstallPickerDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Locate Project Gorgon install"
+        Width="640" Height="200"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False">
+  <Grid Margin="12">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <TextBlock Grid.Row="0" Margin="0,0,0,8" TextWrapping="Wrap">
+      Steam auto-detect couldn't find the Project Gorgon install. Pick the install folder
+      (the one that contains <Run FontFamily="Consolas">WindowsPlayer_Data\</Run>).
+    </TextBlock>
+    <DockPanel Grid.Row="1">
+      <Button x:Name="BrowseButton" Content="Browse…" DockPanel.Dock="Right"
+              Margin="4,0,0,0" Padding="8,2" Click="OnBrowseClick" />
+      <TextBox x:Name="PathTextBox" />
+    </DockPanel>
+    <TextBlock x:Name="ErrorText" Grid.Row="2" Foreground="#C44"
+               Margin="0,8,0,0" TextWrapping="Wrap" />
+    <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Content="OK" Width="80" Margin="4,0,0,0" Padding="0,4" IsDefault="True" Click="OnOkClick" />
+      <Button Content="Cancel" Width="80" Margin="4,0,0,0" Padding="0,4" IsCancel="True" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/tools/MapCalibrationWpf/Views/PgInstallPickerDialog.xaml.cs
+++ b/tools/MapCalibrationWpf/Views/PgInstallPickerDialog.xaml.cs
@@ -1,0 +1,62 @@
+namespace Mithril.Tools.MapCalibrationWpf.Views;
+
+using System.IO;
+using System.Windows;
+using Microsoft.Win32;
+
+/// <summary>
+/// Modal that prompts the user to point at the Project Gorgon install folder
+/// when <see cref="Services.PgInstallResolver"/> can't auto-detect it.
+/// Validates that the chosen folder contains <c>WindowsPlayer_Data</c> before
+/// accepting — the asset extractors will fail later with a less-helpful message
+/// if we let through a wrong folder here.
+/// </summary>
+public partial class PgInstallPickerDialog : Window
+{
+    public string? SelectedPath { get; private set; }
+
+    public PgInstallPickerDialog(string? initialPath = null)
+    {
+        InitializeComponent();
+        if (!string.IsNullOrEmpty(initialPath))
+        {
+            PathTextBox.Text = initialPath;
+        }
+    }
+
+    private void OnBrowseClick(object sender, RoutedEventArgs e)
+    {
+        // .NET 8+ ships OpenFolderDialog in System.Windows; no need for the
+        // legacy WinForms FolderBrowserDialog interop.
+        var dlg = new OpenFolderDialog
+        {
+            Title = "Select the Project Gorgon install folder",
+            InitialDirectory = PathTextBox.Text,
+        };
+        if (dlg.ShowDialog(this) == true)
+        {
+            PathTextBox.Text = dlg.FolderName;
+        }
+    }
+
+    private void OnOkClick(object sender, RoutedEventArgs e)
+    {
+        var path = PathTextBox.Text?.Trim() ?? "";
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+        {
+            ErrorText.Text = "Path does not exist.";
+            return;
+        }
+        // Light sanity check — the canonical PG layout has WindowsPlayer_Data
+        // immediately under the install root. If that's missing the downstream
+        // asset extractors will fail with a less informative message.
+        if (!Directory.Exists(Path.Combine(path, "WindowsPlayer_Data")))
+        {
+            ErrorText.Text = "That folder doesn't look like a PG install (no WindowsPlayer_Data subfolder).";
+            return;
+        }
+        SelectedPath = path;
+        DialogResult = true;
+        Close();
+    }
+}

--- a/tools/MapCalibrationWpf/Views/RefTable.xaml
+++ b/tools/MapCalibrationWpf/Views/RefTable.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="Mithril.Tools.MapCalibrationWpf.Views.RefTable"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <DataGrid ItemsSource="{Binding Refs}"
+            AutoGenerateColumns="False"
+            CanUserAddRows="False"
+            CanUserDeleteRows="True"
+            HeadersVisibility="Column"
+            GridLinesVisibility="Horizontal"
+            SelectionMode="Single">
+    <DataGrid.Columns>
+      <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" IsReadOnly="True" />
+      <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="60" IsReadOnly="True" />
+      <DataGridTextColumn Header="TX" Binding="{Binding TexturePixel.X, StringFormat={}{0:F0}}" Width="46" IsReadOnly="True" />
+      <DataGridTextColumn Header="TY" Binding="{Binding TexturePixel.Y, StringFormat={}{0:F0}}" Width="46" IsReadOnly="True" />
+      <DataGridTextColumn Header="Residual" Binding="{Binding ResidualPx, StringFormat={}{0:F2} px}" Width="72" IsReadOnly="True" />
+    </DataGrid.Columns>
+  </DataGrid>
+</UserControl>

--- a/tools/MapCalibrationWpf/Views/RefTable.xaml.cs
+++ b/tools/MapCalibrationWpf/Views/RefTable.xaml.cs
@@ -1,0 +1,11 @@
+namespace Mithril.Tools.MapCalibrationWpf.Views;
+
+using System.Windows.Controls;
+
+public partial class RefTable : UserControl
+{
+    public RefTable()
+    {
+        InitializeComponent();
+    }
+}

--- a/tools/MapCalibrationWpf/Views/SolverReadout.xaml
+++ b/tools/MapCalibrationWpf/Views/SolverReadout.xaml
@@ -1,0 +1,49 @@
+<UserControl x:Class="Mithril.Tools.MapCalibrationWpf.Views.SolverReadout"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Border BorderBrush="#888" BorderThickness="0,1,0,0" Padding="8">
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+
+      <TextBlock Grid.Row="0" Grid.Column="0" Text="Refs " Foreground="#888" />
+      <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ReferenceCount}" />
+
+      <TextBlock Grid.Row="1" Grid.Column="0" Text="Residual " Foreground="#888" />
+      <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal">
+        <TextBlock Text="{Binding ResidualPixels, StringFormat={}{0:F2} px, TargetNullValue=—}" />
+        <Border Margin="6,0,0,0" Padding="6,1" CornerRadius="3"
+                Background="{Binding ResidualBadgeBrush}">
+          <TextBlock Text="{Binding StatusLabel}" Foreground="White" FontSize="10" />
+        </Border>
+      </StackPanel>
+
+      <TextBlock Grid.Row="2" Grid.Column="0" Text="Scale " Foreground="#888" />
+      <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Scale, StringFormat={}{0:F4} px/unit, TargetNullValue=—}" />
+
+      <TextBlock Grid.Row="3" Grid.Column="0" Text="Rotation " Foreground="#888" />
+      <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding RotationDegrees, StringFormat={}{0:F2}°, TargetNullValue=—}" />
+
+      <TextBlock Grid.Row="4" Grid.Column="0" Text="Mirror N " Foreground="#888" />
+      <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding MirrorNorth}" />
+
+      <TextBlock Grid.Row="5" Grid.Column="0" Text="Origin X " Foreground="#888" />
+      <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding OriginX, StringFormat={}{0:F1}, TargetNullValue=—}" />
+
+      <TextBlock Grid.Row="6" Grid.Column="0" Text="Origin Y " Foreground="#888" />
+      <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding OriginY, StringFormat={}{0:F1}, TargetNullValue=—}" />
+    </Grid>
+  </Border>
+</UserControl>

--- a/tools/MapCalibrationWpf/Views/SolverReadout.xaml.cs
+++ b/tools/MapCalibrationWpf/Views/SolverReadout.xaml.cs
@@ -1,0 +1,11 @@
+namespace Mithril.Tools.MapCalibrationWpf.Views;
+
+using System.Windows.Controls;
+
+public partial class SolverReadout : UserControl
+{
+    public SolverReadout()
+    {
+        InitializeComponent();
+    }
+}

--- a/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml
+++ b/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml
@@ -6,11 +6,26 @@
       OverlayCanvas needs Background="Transparent" to receive clicks. A null
       Background means clicks fall through to the Image underneath.
 
+    ItemContainerStyle gotcha (docs/wpf-gotchas.md §"ItemContainerStyle"):
+      Canvas.Left/Top is set on the ContentPresenter (= the generated item
+      container), NOT on the DataTemplate root. Set via ItemContainerStyle.
+
     Coordinate model (issue #860 §Decisions):
       Image is shown 1:1 via Stretch="None" so the canvas pixel directly equals
       the texture pixel. ScrollViewer handles the case where the texture
       exceeds the viewport.
   -->
+  <UserControl.Resources>
+    <!--
+      Marker offsets: each marker template renders centred on (0,0) in its
+      own coord space, so the ContentPresenter pulls Canvas.Left/Top from
+      TexturePixel.X / TexturePixel.Y directly.
+    -->
+    <Style x:Key="RefMarkerContainerStyle" TargetType="ContentPresenter">
+      <Setter Property="Canvas.Left" Value="{Binding TexturePixel.X}" />
+      <Setter Property="Canvas.Top" Value="{Binding TexturePixel.Y}" />
+    </Style>
+  </UserControl.Resources>
   <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
     <Grid>
       <Image x:Name="MapImage"
@@ -21,15 +36,31 @@
               Height="{Binding ActualHeight, ElementName=MapImage}"
               Background="Transparent"
               MouseLeftButtonDown="OnCanvasLeftClick">
-        <ItemsControl x:Name="RefsLayer">
+        <ItemsControl x:Name="RefsLayer"
+                      ItemsSource="{Binding Refs}"
+                      ItemContainerStyle="{StaticResource RefMarkerContainerStyle}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
-              <!-- IsItemsHost on a Canvas is the correct host for Canvas.Left/Top
-                   positioning (per WPF gotchas: a StackPanel here would silently
-                   ignore Canvas.Left/Top). -->
+              <!-- IsItemsHost on a Canvas — required for Canvas.Left/Top
+                   to take effect on the generated containers. A StackPanel
+                   here would silently ignore the positioning Setters. -->
               <Canvas IsItemsHost="True" />
             </ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <!--
+                ✕ marker: two crossed lines centred on (0,0). The container's
+                Canvas.Left/Top puts that (0,0) at the texture pixel; the
+                lines extend ±6 px so the cross visually sits on the click.
+                Path Tag carries the name as a tooltip.
+              -->
+              <Grid Width="14" Height="14" Margin="-7,-7,0,0" ToolTip="{Binding Name}">
+                <Path Stroke="#E33" StrokeThickness="2"
+                      Data="M 1,1 L 13,13 M 13,1 L 1,13" />
+              </Grid>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
         </ItemsControl>
         <ItemsControl x:Name="ProjectionsLayer">
           <ItemsControl.ItemsPanel>

--- a/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml
+++ b/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml
@@ -25,6 +25,10 @@
       <Setter Property="Canvas.Left" Value="{Binding TexturePixel.X}" />
       <Setter Property="Canvas.Top" Value="{Binding TexturePixel.Y}" />
     </Style>
+    <Style x:Key="ProjectionMarkerContainerStyle" TargetType="ContentPresenter">
+      <Setter Property="Canvas.Left" Value="{Binding TexturePixel.X}" />
+      <Setter Property="Canvas.Top" Value="{Binding TexturePixel.Y}" />
+    </Style>
   </UserControl.Resources>
   <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
     <Grid>
@@ -38,7 +42,8 @@
               MouseLeftButtonDown="OnCanvasLeftClick">
         <ItemsControl x:Name="RefsLayer"
                       ItemsSource="{Binding Refs}"
-                      ItemContainerStyle="{StaticResource RefMarkerContainerStyle}">
+                      ItemContainerStyle="{StaticResource RefMarkerContainerStyle}"
+                      IsHitTestVisible="False">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <!-- IsItemsHost on a Canvas — required for Canvas.Left/Top
@@ -62,12 +67,24 @@
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>
-        <ItemsControl x:Name="ProjectionsLayer">
+        <ItemsControl x:Name="ProjectionsLayer"
+                      ItemsSource="{Binding Projections}"
+                      ItemContainerStyle="{StaticResource ProjectionMarkerContainerStyle}"
+                      IsHitTestVisible="False">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <Canvas IsItemsHost="True" />
             </ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <!-- 8-px filled ellipse centred on (0,0); the container's
+                   Canvas.Left/Top puts that centre at the projected pixel. -->
+              <Ellipse Width="8" Height="8" Margin="-4,-4,0,0"
+                       Fill="{Binding MarkerBrush}" Opacity="0.8"
+                       ToolTip="{Binding Name}" />
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
         </ItemsControl>
       </Canvas>
     </Grid>

--- a/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml
+++ b/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml
@@ -1,0 +1,44 @@
+<UserControl x:Class="Mithril.Tools.MapCalibrationWpf.Views.SourceMapCanvas"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <!--
+    Canvas hit-testing gotcha (docs/wpf-gotchas.md §"Click capture & hit-testing"):
+      OverlayCanvas needs Background="Transparent" to receive clicks. A null
+      Background means clicks fall through to the Image underneath.
+
+    Coordinate model (issue #860 §Decisions):
+      Image is shown 1:1 via Stretch="None" so the canvas pixel directly equals
+      the texture pixel. ScrollViewer handles the case where the texture
+      exceeds the viewport.
+  -->
+  <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+    <Grid>
+      <Image x:Name="MapImage"
+             Source="{Binding SourceMapImage}"
+             Stretch="None" />
+      <Canvas x:Name="OverlayCanvas"
+              Width="{Binding ActualWidth, ElementName=MapImage}"
+              Height="{Binding ActualHeight, ElementName=MapImage}"
+              Background="Transparent"
+              MouseLeftButtonDown="OnCanvasLeftClick">
+        <ItemsControl x:Name="RefsLayer">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <!-- IsItemsHost on a Canvas is the correct host for Canvas.Left/Top
+                   positioning (per WPF gotchas: a StackPanel here would silently
+                   ignore Canvas.Left/Top). -->
+              <Canvas IsItemsHost="True" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+        </ItemsControl>
+        <ItemsControl x:Name="ProjectionsLayer">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <Canvas IsItemsHost="True" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+        </ItemsControl>
+      </Canvas>
+    </Grid>
+  </ScrollViewer>
+</UserControl>

--- a/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml.cs
+++ b/tools/MapCalibrationWpf/Views/SourceMapCanvas.xaml.cs
@@ -1,0 +1,26 @@
+namespace Mithril.Tools.MapCalibrationWpf.Views;
+
+using System.Windows.Controls;
+using System.Windows.Input;
+using Mithril.Tools.MapCalibrationWpf.ViewModels;
+
+/// <summary>
+/// Source-map canvas. Renders the per-area PNG and overlays committed-ref +
+/// projection-dot ItemsControls. Click handler converts the click position to
+/// a texture pixel (1:1 mapping per the Stretch="None" decision) and forwards
+/// to <see cref="AreaWorkspaceViewModel.PlaceRefAt"/>.
+/// </summary>
+public partial class SourceMapCanvas : UserControl
+{
+    public SourceMapCanvas()
+    {
+        InitializeComponent();
+    }
+
+    private void OnCanvasLeftClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is not AreaWorkspaceViewModel vm) return;
+        var p = e.GetPosition(OverlayCanvas);
+        vm.PlaceRefAt(p.X, p.Y);
+    }
+}

--- a/tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs
@@ -16,6 +16,28 @@ namespace Mithril.Tools.MapCalibration.Common;
 /// </summary>
 public static class BaselineFile
 {
+    /// <summary>
+    /// Reads the currently-stored anchor for <paramref name="area"/> from
+    /// <paramref name="baselinePath"/>, or null if the file/anchor isn't
+    /// present. Used by the WPF workspace's dirty-state check to decide
+    /// whether the Commit button should enable.
+    ///
+    /// <para>Mirrors <see cref="UpsertAnchor"/>'s JsonNode-based reader so the
+    /// tool doesn't need to take a dependency on
+    /// <c>Mithril.MapCalibration.Internal.BundledBaselineLoader</c> (internal).
+    /// Field defaults match <c>AreaCalibration</c>: MirrorNorth=false,
+    /// CalibrationZoom=1.0, Source=UserRefinement, SchemaVersion=1.</para>
+    /// </summary>
+    public static AreaCalibration? TryReadAnchor(string baselinePath, string area)
+    {
+        if (!File.Exists(baselinePath)) return null;
+        var text = File.ReadAllText(baselinePath);
+        if (JsonNode.Parse(text) is not JsonObject root) return null;
+        if (root["anchors"] is not JsonObject anchors) return null;
+        if (anchors[area] is not JsonObject obj) return null;
+        return DeserializeAreaCalibration(obj);
+    }
+
     public static void UpsertAnchor(string baselinePath, string area, AreaCalibration cal)
     {
         if (!File.Exists(baselinePath))
@@ -42,6 +64,31 @@ public static class BaselineFile
             // custom comparer; the bundled-loader doesn't care about order.
         });
         File.WriteAllText(baselinePath, json + Environment.NewLine);
+    }
+
+    private static AreaCalibration DeserializeAreaCalibration(JsonObject obj)
+    {
+        // Required fields — UpsertAnchor always writes these; treat missing as
+        // a default of 0 / 0 rather than throwing so an externally-edited
+        // baseline with omissions still loads.
+        var scale = obj["scale"]?.GetValue<double>() ?? 0.0;
+        var rotation = obj["rotationRadians"]?.GetValue<double>() ?? 0.0;
+        var originX = obj["originX"]?.GetValue<double>() ?? 0.0;
+        var originY = obj["originY"]?.GetValue<double>() ?? 0.0;
+        var refCount = obj["referenceCount"]?.GetValue<int>() ?? 0;
+        var residual = obj["residualPixels"]?.GetValue<double>() ?? 0.0;
+
+        var cal = new AreaCalibration(scale, rotation, originX, originY, refCount, residual);
+
+        if (obj["mirrorNorth"]?.GetValue<bool>() is bool mirror) cal = cal with { MirrorNorth = mirror };
+        if (obj["calibrationZoom"]?.GetValue<double>() is double zoom) cal = cal with { CalibrationZoom = zoom };
+        if (obj["source"]?.GetValue<string>() is string srcStr
+            && Enum.TryParse<CalibrationSource>(srcStr, out var src))
+        {
+            cal = cal with { Source = src };
+        }
+        if (obj["schemaVersion"]?.GetValue<int>() is int sv) cal = cal with { SchemaVersion = sv };
+        return cal;
     }
 
     private static JsonObject SerializeAreaCalibration(AreaCalibration cal)

--- a/tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs
@@ -32,10 +32,22 @@ public static class BaselineFile
     {
         if (!File.Exists(baselinePath)) return null;
         var text = File.ReadAllText(baselinePath);
-        if (JsonNode.Parse(text) is not JsonObject root) return null;
+        JsonNode? rootNode;
+        try
+        {
+            rootNode = JsonNode.Parse(text);
+        }
+        catch (JsonException ex)
+        {
+            // Wrap parse failures as UserFacingException so the caller's
+            // existing catch surface (and the WPF tool's error dialogs) handle
+            // a corrupt baseline the same way they handle a missing one.
+            throw new UserFacingException($"baseline JSON at {baselinePath} is malformed: {ex.Message}");
+        }
+        if (rootNode is not JsonObject root) return null;
         if (root["anchors"] is not JsonObject anchors) return null;
         if (anchors[area] is not JsonObject obj) return null;
-        return DeserializeAreaCalibration(obj);
+        return DeserializeAreaCalibration(obj, baselinePath, area);
     }
 
     public static void UpsertAnchor(string baselinePath, string area, AreaCalibration cal)
@@ -66,17 +78,18 @@ public static class BaselineFile
         File.WriteAllText(baselinePath, json + Environment.NewLine);
     }
 
-    private static AreaCalibration DeserializeAreaCalibration(JsonObject obj)
+    private static AreaCalibration DeserializeAreaCalibration(JsonObject obj, string baselinePath, string area)
     {
-        // Required fields — UpsertAnchor always writes these; treat missing as
-        // a default of 0 / 0 rather than throwing so an externally-edited
-        // baseline with omissions still loads.
-        var scale = obj["scale"]?.GetValue<double>() ?? 0.0;
-        var rotation = obj["rotationRadians"]?.GetValue<double>() ?? 0.0;
-        var originX = obj["originX"]?.GetValue<double>() ?? 0.0;
-        var originY = obj["originY"]?.GetValue<double>() ?? 0.0;
-        var refCount = obj["referenceCount"]?.GetValue<int>() ?? 0;
-        var residual = obj["residualPixels"]?.GetValue<double>() ?? 0.0;
+        // Required fields — UpsertAnchor always writes all six, so a missing
+        // one means the JSON was hand-edited badly or truncated. Throw rather
+        // than coercing to 0.0 (which would silently yield an all-zeros
+        // "calibration" the dirty-check compares against — round-2 review nit).
+        var scale = RequireDouble(obj, "scale", baselinePath, area);
+        var rotation = RequireDouble(obj, "rotationRadians", baselinePath, area);
+        var originX = RequireDouble(obj, "originX", baselinePath, area);
+        var originY = RequireDouble(obj, "originY", baselinePath, area);
+        var refCount = RequireInt(obj, "referenceCount", baselinePath, area);
+        var residual = RequireDouble(obj, "residualPixels", baselinePath, area);
 
         var cal = new AreaCalibration(scale, rotation, originX, originY, refCount, residual);
 
@@ -89,6 +102,36 @@ public static class BaselineFile
         }
         if (obj["schemaVersion"]?.GetValue<int>() is int sv) cal = cal with { SchemaVersion = sv };
         return cal;
+    }
+
+    private static double RequireDouble(JsonObject obj, string key, string baselinePath, string area)
+    {
+        if (obj[key] is not JsonNode node)
+        {
+            throw new UserFacingException(
+                $"baseline JSON at {baselinePath} is missing required field anchors[{area}].{key}");
+        }
+        try { return node.GetValue<double>(); }
+        catch (Exception ex) when (ex is InvalidOperationException or FormatException)
+        {
+            throw new UserFacingException(
+                $"baseline JSON at {baselinePath} field anchors[{area}].{key} is not a number");
+        }
+    }
+
+    private static int RequireInt(JsonObject obj, string key, string baselinePath, string area)
+    {
+        if (obj[key] is not JsonNode node)
+        {
+            throw new UserFacingException(
+                $"baseline JSON at {baselinePath} is missing required field anchors[{area}].{key}");
+        }
+        try { return node.GetValue<int>(); }
+        catch (Exception ex) when (ex is InvalidOperationException or FormatException)
+        {
+            throw new UserFacingException(
+                $"baseline JSON at {baselinePath} field anchors[{area}].{key} is not an integer");
+        }
     }
 
     private static JsonObject SerializeAreaCalibration(AreaCalibration cal)

--- a/tools/Mithril.MapCalibration.Tools.Common/RepoPaths.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/RepoPaths.cs
@@ -1,0 +1,96 @@
+namespace Mithril.Tools.MapCalibration.Common;
+
+/// <summary>
+/// Resolves canonical in-repo asset paths the map-calibration tools share —
+/// bundled landmarks/NPCs reference data, the calibration baseline JSON, the
+/// per-tool scratch directories for extracted map textures + icon templates.
+///
+/// <para>Both the CLI (<c>MapCalibrationFromScreenshot</c>) and the WPF
+/// workspace (<c>MapCalibrationWpf</c>) need to find these files identically
+/// — the tools have to agree on paths because they read/write the same on-disk
+/// artifacts (extracted PNGs are cached, baseline JSON is the persistence
+/// surface). Centralising the resolution here keeps the two callers in sync.</para>
+///
+/// <para>The repo-relative paths are resolved by walking up from
+/// <see cref="AppContext.BaseDirectory"/> until a folder containing
+/// <c>Mithril.slnx</c> is found — same approach <c>Pipeline.cs</c> used before
+/// this helper landed. Throws <see cref="UserFacingException"/> when the walk
+/// fails so the caller can surface a useful error.</para>
+/// </summary>
+public static class RepoPaths
+{
+    /// <summary>
+    /// Absolute path to <c>src/Mithril.Shared/Reference/BundledData/landmarks.json</c>.
+    /// </summary>
+    public static string LandmarksJsonPath() =>
+        EnsureExists(Path.Combine(RepoRoot(), "src", "Mithril.Shared", "Reference", "BundledData", "landmarks.json"));
+
+    /// <summary>
+    /// Absolute path to <c>src/Mithril.Shared/Reference/BundledData/npcs.json</c>.
+    /// </summary>
+    public static string NpcsJsonPath() =>
+        EnsureExists(Path.Combine(RepoRoot(), "src", "Mithril.Shared", "Reference", "BundledData", "npcs.json"));
+
+    /// <summary>
+    /// Absolute path to <c>src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json</c>.
+    /// </summary>
+    public static string BaselineJsonPath() =>
+        EnsureExists(Path.Combine(RepoRoot(), "src", "Mithril.MapCalibration", "BundledData", "map-calibration-baseline.json"));
+
+    /// <summary>
+    /// Scratch directory for cached map-area PNGs (one per area). Matches the
+    /// CLI's <c>DefaultScratch("maps")</c> location so the WPF tool reuses any
+    /// extraction the CLI already performed (and vice versa).
+    /// </summary>
+    public static string DefaultMapsCacheDir() => DefaultScratch("maps");
+
+    /// <summary>
+    /// Scratch directory for icon templates extracted from sharedassets0.assets.
+    /// Matches the CLI's <c>DefaultScratch("icons")</c> location.
+    /// </summary>
+    public static string DefaultIconsCacheDir() => DefaultScratch("icons");
+
+    /// <summary>
+    /// Default classdata.tpk path the CLI uses (alongside the tool's binary).
+    /// The icon extractor errors with a friendly download URL when the file
+    /// is missing from this path.
+    /// </summary>
+    public static string DefaultTpkPath() =>
+        Path.Combine(AppContext.BaseDirectory, "classdata.tpk");
+
+    /// <summary>
+    /// Walks up from <see cref="AppContext.BaseDirectory"/> looking for the
+    /// folder that owns <c>Mithril.slnx</c>. Throws if the repo root can't be
+    /// found within 10 levels (which is more than enough — the tool bin paths
+    /// are 5 levels deep).
+    /// </summary>
+    public static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 10; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "Mithril.slnx"))) return dir;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        throw new UserFacingException(
+            $"could not locate Mithril.slnx walking up from {AppContext.BaseDirectory}");
+    }
+
+    private static string DefaultScratch(string sub)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mithril-852", sub);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string EnsureExists(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new UserFacingException($"bundled asset not found: {path}");
+        }
+        return path;
+    }
+}

--- a/tools/Mithril.MapCalibration.Tools.slnx
+++ b/tools/Mithril.MapCalibration.Tools.slnx
@@ -17,5 +17,6 @@
   <Folder Name="/tools/">
     <Project Path="Mithril.MapCalibration.Tools.Common/Mithril.MapCalibration.Tools.Common.csproj" />
     <Project Path="MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj" />
+    <Project Path="MapCalibrationWpf/MapCalibrationWpf.csproj" />
   </Folder>
 </Solution>


### PR DESCRIPTION
Closes #860. Supersedes #857.

## Summary

Phase 1 of the WPF Map Calibration Workspace per the [design spec](docs/superpowers/specs/2026-05-29-map-calibration-wpf-tool-design.md): a dev-only desktop tool (`tools/MapCalibrationWpf/`) where a developer picks an area, watches the source map PNG render from PG's bundles in-process, clicks landmarks on the source map to place reference points, watches the calibration solve live, and commits the resulting `AreaCalibration` straight into `src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json` — all without leaving the window.

12 implementation tasks landed, one commit each:

1. **Project scaffold + 3-pane placeholder window** — `MapCalibrationWpf.csproj` (WinExe, net10.0-windows, same isolation pattern as the existing CLI: `ManagePackageVersionsCentrally=false`, `ImportDirectoryBuildTargets=false`). Added to `tools/Mithril.MapCalibration.Tools.slnx`.
2. **PG install resolver + persistence** — `PersistedSettings` round-trips to `%LocalAppData%/Mithril/MapCalibrationWpf/settings.json`; `PgInstallResolver` wraps `SteamInstall.FindPgInstall()` (trapping its `UserFacingException`) with an optional user override; `PgInstallPickerDialog` modal Browse-folder picker.
3. **AreaCatalog + shared `RepoPaths` helper** — added `tools/Mithril.MapCalibration.Tools.Common/RepoPaths.cs` centralising landmarks/npcs/baseline/cache-dir path resolution that the CLI had inlined.
4. **`MainViewModel` + area picker wired up** — ComboBox bound; selecting an area spins up a workspace VM.
5. **`AssetBootstrapService` + extraction modal** — wraps `MapTextureExtractor.EnsureExtracted` + `IconTemplateExtractor.EnsureExtracted` on a background `Task.Run` with `IProgress<string>` ticks driving a non-modal `ExtractionProgressDialog`.
6. **Source-map canvas** — 1:1 image render inside a `ScrollViewer`; `Background="Transparent"` overlay for click capture (per `docs/wpf-gotchas.md` §Click capture & hit-testing).
7. **Landmark/NPC picker** — merges `LandmarksReader.LoadForArea` + `NpcsReader.LoadForArea` (both already return `LandmarkRef`) into one searchable `ObservableCollection` sorted ordinal.
8. **Click-to-add-ref + ref table** — `PlaceRefAt` materialises a `RefViewModel` from `Picker.Selected` + click pixel; `ItemContainerStyle` on `ContentPresenter` positions the ✕ marker via `Canvas.Left/Top` (per gotchas — `DataTemplate` root has no effect). `RefTable` DataGrid below.
9. **Solver wiring + readout** — `LandmarkCalibrationSolver.Solve` runs on every `Refs.CollectionChanged`; back-fills per-ref residuals. `SolverReadoutViewModel` exposes Scale / RotationDegrees / MirrorNorth / Origin XY / Residual / Refs + a coloured badge keyed on 3 / 12 px thresholds (inlined from `LegolasSettings.CalibrationGoodResidualPx`).
10. **Projection overlay** — every `Picker.AllItems` entry projected through the current calibration as a coloured dot on `ProjectionsLayer` (`IsHitTestVisible="False"` so clicks pass through).
11. **Commit to baseline + dirty-state guard** — `WorkspaceCommitService.Commit` stamps `Source=BundledBaseline` + `Zoom=1.0` + `SchemaVersion=1` and upserts via `BaselineFile.UpsertAnchor`. Stored anchor is read back on area open (renders as a live overlay before the user places any refs). Commit button gated on `Calibration != null && Refs.Count >= 2 && IsDirty` (ULP-tolerant equality). `MainViewModel.OnSelectedAreaChanged` confirm-discards uncommitted refs via `MessageBox`.
12. **Icon-template extraction action** — header button bound to `ExtractIconTemplatesCommand`, `Visibility=BooleanToVisibility(IconTemplatesMissing)` so it disappears once the cache is primed.

## Common-lib additions

- `tools/Mithril.MapCalibration.Tools.Common/RepoPaths.cs` — NEW. Centralises bundled-asset path resolution shared between the CLI and the WPF tool (landmarks.json, npcs.json, baseline JSON, cache directories, default tpk path).
- `tools/Mithril.MapCalibration.Tools.Common/BaselineFile.cs` — added `TryReadAnchor(baselinePath, area)` returning `AreaCalibration?`. Mirrors the existing `UpsertAnchor` JsonNode reader/writer; backs the WPF tool's dirty-state check. Field defaults match `AreaCalibration`'s init properties.

The CLI (`MapCalibrationFromScreenshot`) is not refactored to consume `RepoPaths` in this PR — that's intentional to keep the diff scoped to additive changes. A follow-up can swap `Pipeline.ResolveLandmarksPath` / `ResolveNpcsPath` / `ResolveBaselinePath` / `DefaultScratch` / `RepoRoot` over to the shared helpers.

## Spec corrections applied during implementation

The issue body's snippets carried a few names that needed verifying against the real common-lib API; the corrected mapping:

- `SteamInstall.FindPgInstall()` (throws `UserFacingException`) — not `TryFindProjectGorgon()`. `PgInstallResolver.Resolve()` wraps in try/catch to return null.
- `MapTextureExtractor.EnsureExtracted(pgInstall, mapDir, area)` — not `EnsureOrExtract`. `AssetBootstrapService` produces `mapDir` via `RepoPaths.DefaultMapsCacheDir()` (same `%TEMP%/mithril-852/maps` the CLI's `DefaultScratch` produces).
- `NpcsReader.LoadForArea` returns `IReadOnlyList<LandmarkRef>` (with `Type="Npc"`) — the picker uses the single shared shape directly.
- `IconTemplateExtractor.EnsureExtracted(pgInstall, iconsDir, tpkPath)` — the actual extract-all entry.
- `CommunityToolkit.Mvvm` 8.4.2 (matches `Directory.Packages.props`), not 8.4.0.
- The repo's existing modules use the field-based `[ObservableProperty] private T _foo;` syntax (Samwise/Smaug/etc. all do). The WPF VMs match that idiom for consistency.

## Test plan

**Build** (verified):
- [x] `dotnet build tools/MapCalibrationWpf/MapCalibrationWpf.csproj -c Release` — green.
- [x] `dotnet build tools/Mithril.MapCalibration.Tools.slnx -c Release` — all 4 projects green.
- [x] `dotnet build Mithril.slnx -c Release` — full repo green (BaselineFile change doesn't break the CLI).

**Manual validation (Tasks 13 & 14 — OWED BY A HUMAN REVIEWER WITH A LIVE PG INSTALL):**
- [ ] Launch tool, pick AreaSerbule, place 5 reference clicks on known landmarks (e.g. Kleave, Sus Cow, Meditation Pillar, Strange Gateway, etc.). Confirm `ResidualPixels` lands within a few px of the CLI's 0.30 baseline (manual clicks have human noise the CLI's sub-pixel NCC peak doesn't). Hit Commit, verify `map-calibration-baseline.json` updates.
- [ ] Reload tool, reopen AreaSerbule — confirm prior anchor reads back and projection overlay renders against it before any refs are placed.
- [ ] Pick AreaEltibule (which the CLI's NCC pipeline failed on). Place 5+ refs; confirm residual converges ≤ 12 px and the AreaEltibule anchor lands in the baseline JSON. **This is the empirical validation that motivated the project** — Eltibule failing the CLI is what proved the WPF approach was needed.

These two tasks need a running PG client + a working asset extraction (the tool will prompt for the install path and the `classdata.tpk` if not auto-detected), so they can't be done by an automated agent.

Future phases per the spec (NCC live overlay + sliders, screenshot-bbox modality, native PG-window capture, auto-bootstrap from world-bounds) layer onto this Phase 1 without restructuring the project graph.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
