### PR TITLE
Split shepherd command into inline + spawning variants

### DIFF
--- a/.claude/commands/create-shepherd.md
+++ b/.claude/commands/create-shepherd.md
@@ -1,0 +1,14 @@
+---
+description: Spawn a detached session that shepherds an issue end-to-end through an engineer/reviewer agent team
+argument-hint: <issue-id> [max-iterations]
+---
+
+Arguments: `$ARGUMENTS`
+
+Parse the arguments above as `<issue-id> [max-iterations]`. The first token is the issue ID and is required. The second token is the iteration cap; if it is missing or empty, treat it as `3`. Use the resolved values everywhere `<issue-id>` and `<max-iterations>` appear below.
+
+Then `spawn_task` a new session whose sole job is to shepherd delivery of issue `<issue-id>`. The spawned session's standing instructions are:
+
+> Run the `/shepherd <issue-id> <max-iterations>` command and follow it to completion. That command makes you the shepherd: you own this issue end-to-end, orchestrating an engineer/reviewer agent team and committing the merge yourself. Do not spawn a further shepherd session — `/shepherd` runs the playbook inline, which is correct here.
+
+Title the spawned task so it is identifiable as the shepherd for issue `<issue-id>`.

--- a/.claude/commands/shepherd.md
+++ b/.claude/commands/shepherd.md
@@ -1,5 +1,5 @@
 ---
-description: Shepherd an issue end-to-end through an engineer/reviewer agent team
+description: Assume the shepherd role here and drive an issue end-to-end through an engineer/reviewer agent team
 argument-hint: <issue-id> [max-iterations]
 ---
 
@@ -7,9 +7,9 @@ Arguments: `$ARGUMENTS`
 
 Parse the arguments above as `<issue-id> [max-iterations]`. The first token is the issue ID and is required. The second token is the iteration cap; if it is missing or empty, treat it as `3`. Use the resolved values everywhere `<issue-id>` and `<max-iterations>` appear below.
 
-Then `spawn_task` a session to shepherd delivery of issue `<issue-id>` using agent teams. The spawned session's standing instructions are:
+You are the shepherd for issue `<issue-id>` and you own it end-to-end **in this session** — assume the role directly, do not spawn a separate shepherd session. (To kick a shepherd off in its own detached session instead, use `/create-shepherd`.)
 
-**Team setup.** You are the shepherd and you own the issue end-to-end. Create a senior engineer agent to implement the work, and (when needed) a reviewer agent to review the resulting PR. You do not implement or review yourself — you orchestrate.
+**Team setup.** Create a senior engineer agent to implement the work, and (when needed) a reviewer agent to review the resulting PR. You do not implement or review yourself — you orchestrate.
 
 **Engineer constraints.** The engineer commits only to its own worktree and is explicitly forbidden to merge. After opening the PR, the engineer idles until you either deliver reviewer feedback to action or tell it to wind down.
 


### PR DESCRIPTION
## What

Splits the `/shepherd` slash command into two commands so the spawn-vs-inline decision is made explicitly at the call site:

- **`/shepherd <issue> [max-iterations]`** — assumes the shepherd role **inline** in the current session.
- **`/create-shepherd <issue> [max-iterations]`** — `spawn_task`s a detached session whose first action is to run `/shepherd`.

## Why

`/shepherd` previously *always* spawned a fresh session before running the playbook. When an orchestrator had already created the session via `spawn_task`, invoking `/shepherd` inside it produced a redundant extra session layer (orchestrator → spawned session → another spawned shepherd).

A single command with a mode argument would still have one default that one of the two callers must remember to override — relocating the same silent-failure bug. Two commands make the choice unmissable: the command name *is* the switch.

The playbook stays DRY — `create-shepherd` delegates to `/shepherd` rather than duplicating the standing instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
