### PR TITLE
feat(telemetry): fire IOptionsMonitor.OnChange on TelemetrySettings mutation (#833)

### DIFF
--- a/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
+++ b/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
@@ -60,16 +60,24 @@ namespace Mithril.Shared.Telemetry.Hosting;
 /// surfaces but <see cref="ValueRedactor"/> still scrubs paths + character
 /// name from string values and the formatted log body.</para>
 ///
-/// <para><strong>Hot-reload — partial in v1.</strong>
-/// <see cref="TelemetrySettings.TagExports"/> mutations on the singleton
-/// flow through to the scrubber live (per-span read of
-/// <c>IOptionsMonitor.CurrentValue.TagExports</c>) — the settings UI can
-/// toggle a tag and the next exported span honours it. Endpoint, headers,
-/// protocol, and service-name changes still require a process restart in
-/// v1: the OTel SDK <c>AddOtlpExporter</c> callback captures those once at
-/// registration, and threading per-field <c>OnChange</c> notifications
-/// through the exporter wrapper is non-trivial. Filed as a follow-up
-/// enhancement.</para>
+/// <para><strong>Hot-reload — partial.</strong>
+/// The <see cref="IOptionsMonitor{T}"/> registered here is a real
+/// <see cref="NotifyPropertyChangedOptionsMonitor{T}"/> that fires
+/// <c>OnChange</c> on every settings-singleton mutation (the settings UI's
+/// in-place edit + <c>Touch()</c> path). <see cref="TelemetrySettings.TagExports"/>
+/// mutations flow through to the scrubber live (per-record read of
+/// <c>IOptionsMonitor.CurrentValue.TagExports</c>) — the settings UI can toggle
+/// a tag and the next exported span honours it.
+/// Endpoint, headers, protocol, and service-name changes still require a
+/// process restart: OTel SDK 1.15.x captures them in the exporter instance at
+/// provider-build time (the <c>AddOtlpExporter(Action&lt;OtlpExporterOptions&gt;)</c>
+/// callback runs once and <c>OtlpTraceExporter</c> snapshots them into its
+/// transmission handler in its constructor — it never re-reads). A per-export
+/// <c>IServiceProvider</c> factory overload that would permit live re-reads is
+/// an open upstream request (open-telemetry/opentelemetry-dotnet#6537); until it
+/// lands, live swapping these fields would require a full
+/// <c>TracerProvider</c>/<c>MeterProvider</c>/<c>LoggerProvider</c> rebuild.
+/// Tracked as a follow-up. mithril#833.</para>
 ///
 /// <para><strong>Exporter health.</strong> An
 /// <see cref="OtlpExporterEventListener"/> singleton is constructed eagerly so
@@ -131,10 +139,14 @@ public static class TelemetryHostExtensions
         // one the host eventually builds (e.g. when the caller resolved settings
         // from a temp ServiceProvider for the EnableOtlpExport gating decision).
         // Resolve through sp instead so the scrubber always sees the live
-        // host-singleton dictionary. OnChange notifications are a v1 no-op — the
-        // scrubber polls CurrentValue, doesn't subscribe.
+        // host-singleton dictionary. The monitor subscribes to the singleton's
+        // PropertyChanged so OnChange listeners actually fire on the settings-UI
+        // save / in-place-mutation path (mithril#833). Endpoint/headers/protocol/
+        // service-name remain restart-required regardless — the OTel exporter
+        // bakes them at provider-build time and never re-reads (see the
+        // restart-required note below and NotifyPropertyChangedOptionsMonitor).
         services.AddSingleton<IOptionsMonitor<TelemetrySettings>>(sp =>
-            new SingletonOptionsMonitor<TelemetrySettings>(sp.GetRequiredService<TelemetrySettings>()));
+            new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(sp.GetRequiredService<TelemetrySettings>()));
 
         // Scrubber graph. Process-wide singletons; the processor references
         // the catalog + redactor + observer + settings monitor.
@@ -383,25 +395,5 @@ public static class TelemetryHostExtensions
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// IOptionsMonitor shim that returns the DI singleton on every CurrentValue
-    /// read so in-place mutations (TagExports add/remove) are picked up per
-    /// scrub. OnChange notification is a no-op for v1 — the scrubber polls
-    /// CurrentValue, doesn't subscribe. The full OnChange path lands with the
-    /// IOptionsMonitor hot-reload follow-up (see XML doc on AddMithrilOtlpExport).
-    /// </summary>
-    private sealed class SingletonOptionsMonitor<T>(T instance) : IOptionsMonitor<T> where T : class
-    {
-        public T CurrentValue => instance;
-        public T Get(string? name) => instance;
-        public IDisposable OnChange(Action<T, string?> listener) => NoSubscription.Instance;
-
-        private sealed class NoSubscription : IDisposable
-        {
-            public static readonly NoSubscription Instance = new();
-            public void Dispose() { }
-        }
     }
 }

--- a/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
+++ b/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
@@ -144,7 +144,7 @@ public static class TelemetryHostExtensions
         // save / in-place-mutation path (mithril#833). Endpoint/headers/protocol/
         // service-name remain restart-required regardless — the OTel exporter
         // bakes them at provider-build time and never re-reads (see the
-        // restart-required note below and NotifyPropertyChangedOptionsMonitor).
+        // hot-reload note in this type's XML doc and NotifyPropertyChangedOptionsMonitor).
         services.AddSingleton<IOptionsMonitor<TelemetrySettings>>(sp =>
             new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(sp.GetRequiredService<TelemetrySettings>()));
 

--- a/src/Mithril.Shared.Telemetry/Settings/NotifyPropertyChangedOptionsMonitor.cs
+++ b/src/Mithril.Shared.Telemetry/Settings/NotifyPropertyChangedOptionsMonitor.cs
@@ -43,6 +43,7 @@ public sealed class NotifyPropertyChangedOptionsMonitor<T> : IOptionsMonitor<T>,
     where T : class, INotifyPropertyChanged
 {
     private readonly T _instance;
+    // auto-event accessors give us thread-safe +=/-=; ?.Invoke reads the field into a temp.
     private event Action<T, string?>? _listeners;
 
     public NotifyPropertyChangedOptionsMonitor(T instance)
@@ -65,11 +66,13 @@ public sealed class NotifyPropertyChangedOptionsMonitor<T> : IOptionsMonitor<T>,
 
     private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // IOptionsMonitor.OnChange listeners receive the value + the named
-        // options instance (null for the default unnamed options). We forward
-        // the changed property name in that slot so a listener can filter on
-        // it if it wants finer granularity, while still working for listeners
-        // that ignore the name.
+        // The IOptionsMonitor.OnChange second argument is the named-options name
+        // string (Options.DefaultName == ""), not an options instance. We
+        // repurpose this slot for the changed property name: standard MEL
+        // listeners that switch on the named-options name will receive the
+        // property name instead of Options.DefaultName — a deliberate convention
+        // deviation. Currently no in-repo consumer cares (they read CurrentValue),
+        // and it gives subscribers finer-grained filtering for free.
         _listeners?.Invoke(_instance, e.PropertyName);
     }
 

--- a/src/Mithril.Shared.Telemetry/Settings/NotifyPropertyChangedOptionsMonitor.cs
+++ b/src/Mithril.Shared.Telemetry/Settings/NotifyPropertyChangedOptionsMonitor.cs
@@ -1,0 +1,95 @@
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.Options;
+
+namespace Mithril.Shared.Telemetry.Settings;
+
+/// <summary>
+/// <see cref="IOptionsMonitor{T}"/> adapter over a settings singleton that
+/// raises <see cref="INotifyPropertyChanged.PropertyChanged"/> on mutation
+/// (Mithril's <c>ISettingsStore&lt;T&gt;</c>-backed settings types — see
+/// <see cref="TelemetrySettings"/>). Two responsibilities:
+/// <list type="number">
+/// <item><see cref="CurrentValue"/> / <see cref="Get"/> always return the
+///   wrapped singleton, so existing per-record live reads
+///   (<c>CurrentValue.TagExports</c> in the scrubber processors) keep
+///   reflecting in-place dictionary edits exactly as they did under the prior
+///   <c>SingletonOptionsMonitor</c> shim.</item>
+/// <item><see cref="OnChange"/> registrations actually fire — every
+///   <c>PropertyChanged</c> on the singleton (the settings UI's in-place
+///   mutation + <c>Touch()</c> path, see <c>TelemetrySettingsViewModel</c>)
+///   invokes registered listeners. The prior shim's <c>OnChange</c> was a
+///   no-op, so subscribers silently never heard about changes (mithril#833).</item>
+/// </list>
+///
+/// <para><strong>Scope of "hot-reload" delivered (mithril#833).</strong>
+/// Firing <c>OnChange</c> lets UI / future consumers react to settings edits
+/// live. It does <em>not</em> make the OTLP exporter pick up endpoint / headers
+/// / protocol / service-name changes without a restart: OTel SDK 1.15.x bakes
+/// those into the exporter instance at provider-build time (the
+/// <c>AddOtlpExporter(Action&lt;OtlpExporterOptions&gt;)</c> callback runs once;
+/// <c>OtlpTraceExporter</c> snapshots them into its transmission handler in its
+/// constructor and never re-reads). A per-export <c>IServiceProvider</c> factory
+/// overload that would allow live re-reads is an open upstream request
+/// (open-telemetry/opentelemetry-dotnet#6537). Live endpoint/header swapping
+/// therefore requires a provider rebuild — tracked as a follow-up.</para>
+///
+/// <para>No file watching: Mithril's <c>ISettingsStore&lt;T&gt;</c> does not
+/// observe the persisted JSON, so out-of-band file edits are not surfaced here
+/// (they aren't anywhere in the settings stack). The live signal is the
+/// in-process singleton mutation, which is what the settings UI performs.</para>
+/// </summary>
+public sealed class NotifyPropertyChangedOptionsMonitor<T> : IOptionsMonitor<T>, IDisposable
+    where T : class, INotifyPropertyChanged
+{
+    private readonly T _instance;
+    private event Action<T, string?>? _listeners;
+
+    public NotifyPropertyChangedOptionsMonitor(T instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        _instance = instance;
+        _instance.PropertyChanged += OnPropertyChanged;
+    }
+
+    public T CurrentValue => _instance;
+
+    public T Get(string? name) => _instance;
+
+    public IDisposable OnChange(Action<T, string?> listener)
+    {
+        ArgumentNullException.ThrowIfNull(listener);
+        _listeners += listener;
+        return new Subscription(this, listener);
+    }
+
+    private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // IOptionsMonitor.OnChange listeners receive the value + the named
+        // options instance (null for the default unnamed options). We forward
+        // the changed property name in that slot so a listener can filter on
+        // it if it wants finer granularity, while still working for listeners
+        // that ignore the name.
+        _listeners?.Invoke(_instance, e.PropertyName);
+    }
+
+    public void Dispose()
+    {
+        _instance.PropertyChanged -= OnPropertyChanged;
+        _listeners = null;
+    }
+
+    private sealed class Subscription(NotifyPropertyChangedOptionsMonitor<T> owner, Action<T, string?> listener)
+        : IDisposable
+    {
+        private NotifyPropertyChangedOptionsMonitor<T>? _owner = owner;
+
+        public void Dispose()
+        {
+            var owner = _owner;
+            if (owner is null) return;
+            _owner = null;
+            owner._listeners -= listener;
+        }
+    }
+}

--- a/src/Mithril.Shared.Telemetry/Settings/TelemetrySettings.cs
+++ b/src/Mithril.Shared.Telemetry/Settings/TelemetrySettings.cs
@@ -11,11 +11,16 @@ namespace Mithril.Shared.Telemetry.Settings;
 public enum OtlpProtocol { Grpc, HttpProtobuf }
 
 /// <summary>
-/// Persisted opt-in OTLP export configuration. Hot-reloaded via
-/// <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/> for
-/// endpoint/headers/scrubber changes; <see cref="EnableOtlpExport"/>
-/// requires a restart so off-mode preserves zero
-/// <see cref="System.Diagnostics.ActivitySource.HasListeners"/> cost.
+/// Persisted opt-in OTLP export configuration. Mutations are surfaced via
+/// <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/>
+/// (<c>NotifyPropertyChangedOptionsMonitor</c>) which fires <c>OnChange</c> on
+/// every in-place edit. <see cref="TagExports"/> is read live per exported
+/// record so chip toggles apply without restart. <see cref="Endpoint"/>,
+/// <see cref="Headers"/>, <see cref="Protocol"/>, and <see cref="ServiceName"/>
+/// are <strong>restart-required</strong>: the OTel SDK bakes them into the
+/// exporter instance at provider-build time and never re-reads (mithril#833).
+/// <see cref="EnableOtlpExport"/> also requires a restart so off-mode preserves
+/// zero <see cref="System.Diagnostics.ActivitySource.HasListeners"/> cost.
 ///
 /// Header values are DPAPI-wrapped at rest via
 /// <see cref="HeaderValueProtection"/>. Round-trip is transparent — the

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -133,7 +133,7 @@ public static class ShellComposition
         //      change. Must receive the SAME TelemetrySettings instance the
         //      versioned-settings registration produced so settings-UI mutations
         //      to TagExports flow through to the scrubber per span without
-        //      restart (see SingletonOptionsMonitor in TelemetryHostExtensions).
+        //      restart (see NotifyPropertyChangedOptionsMonitor in TelemetryHostExtensions).
         services.AddMithrilVersionedSettings<TelemetrySettings>(
             Path.Combine(o.ShellSettingsDir, "telemetry.json"),
             TelemetrySettingsJsonContext.Default.TelemetrySettings);

--- a/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
+++ b/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
@@ -73,19 +73,24 @@
                 </StackPanel>
             </Border>
 
-            <!-- Endpoint -->
-            <TextBlock Text="Endpoint" Foreground="#88FFFFFF"
+            <!-- Endpoint. Restart-required: the OTel SDK 1.15.x exporter captures
+                 the endpoint in its transmission handler at provider build; a live
+                 swap needs a provider rebuild (tracked in follow-up). -->
+            <TextBlock Text="Endpoint [Restart Required]" Foreground="#88FFFFFF"
                        FontWeight="SemiBold" Margin="0,4,0,4"/>
             <TextBox Text="{Binding Settings.Endpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      Background="#FF252525" Foreground="#FFE8E8E8" BorderBrush="#44FFFFFF"
-                     Padding="6,4" Margin="0,0,0,12"/>
+                     Padding="6,4" Margin="0,0,0,12"
+                     ToolTip="Restart required to apply. OTel SDK 1.15.x captures the endpoint in the exporter at provider build; live swap needs a provider rebuild (tracked in follow-up)."/>
 
-            <!-- Protocol -->
-            <TextBlock Text="Protocol" Foreground="#88FFFFFF"
+            <!-- Protocol. Restart-required for the same reason as Endpoint:
+                 the protocol selects the exporter transport at provider build. -->
+            <TextBlock Text="Protocol [Restart Required]" Foreground="#88FFFFFF"
                        FontWeight="SemiBold" Margin="0,0,0,4"/>
             <ComboBox ItemsSource="{Binding Source={x:Static vm:TelemetrySettingsViewModel.ProtocolOptions}}"
                       SelectedItem="{Binding Settings.Protocol, Mode=TwoWay}"
-                      Width="220" HorizontalAlignment="Left" Margin="0,0,0,12">
+                      Width="220" HorizontalAlignment="Left" Margin="0,0,0,12"
+                      ToolTip="Restart required to apply. OTel SDK 1.15.x selects the exporter transport at provider build; live swap needs a provider rebuild (tracked in follow-up).">
                 <!-- Explicit ItemTemplate so the selection box renders the enum name
                      consistently with the dropdown items (avoids the
                      ComboBox-renders-ToString fallback called out in wpf-gotchas.md). -->
@@ -96,19 +101,23 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <!-- Service name -->
-            <TextBlock Text="Service name" Foreground="#88FFFFFF"
+            <!-- Service name. Restart-required: service.name flows into the OTel
+                 ResourceBuilder, captured at provider build and cached on the
+                 exporter's first export. -->
+            <TextBlock Text="Service name [Restart Required]" Foreground="#88FFFFFF"
                        FontWeight="SemiBold" Margin="0,0,0,4"/>
             <TextBox Text="{Binding Settings.ServiceName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      Background="#FF252525" Foreground="#FFE8E8E8" BorderBrush="#44FFFFFF"
-                     Padding="6,4" Width="280" HorizontalAlignment="Left" Margin="0,0,0,16"/>
+                     Padding="6,4" Width="280" HorizontalAlignment="Left" Margin="0,0,0,16"
+                     ToolTip="Restart required to apply. service.name flows into the OTel resource, captured at provider build; live swap needs a provider rebuild (tracked in follow-up)."/>
 
-            <!-- Headers -->
-            <TextBlock Text="Headers" Foreground="#88FFFFFF"
+            <!-- Headers. Restart-required: header values are baked into the
+                 exporter's HTTP transmission handler at provider build. -->
+            <TextBlock Text="Headers [Restart Required]" Foreground="#88FFFFFF"
                        FontWeight="SemiBold" Margin="0,0,0,4"/>
             <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF"
                        FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,6"
-                       Text="HTTP headers added to every OTLP request (typically an API key / bearer token). Save each row after editing — values are DPAPI-wrapped at rest before persisting."/>
+                       Text="HTTP headers added to every OTLP request (typically an API key / bearer token). Save each row after editing — values are DPAPI-wrapped at rest before persisting. Restart required to apply: header values are baked into the exporter transport at provider build (tracked in follow-up)."/>
 
             <DataGrid ItemsSource="{Binding Headers}"
                       AutoGenerateColumns="False"

--- a/tests/Mithril.Shared.Telemetry.Tests/Hosting/TelemetryHostExtensionsTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Hosting/TelemetryHostExtensionsTests.cs
@@ -92,6 +92,78 @@ public class TelemetryHostExtensionsTests
     }
 
     [Fact]
+    public void OptionsMonitor_OnChange_fires_on_singleton_mutation()
+    {
+        // The prior SingletonOptionsMonitor shim's OnChange was a no-op, so any
+        // subscriber (settings UI, future live consumers) silently never heard
+        // about edits. The replacement must actually fire (mithril#833).
+        var settings = new TelemetrySettings
+        {
+            EnableOtlpExport = true,
+            Endpoint = "http://localhost:65535/",
+        };
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(settings);
+                services.AddSingleton<ITagDescriptorProvider, MithrilSharedTagDescriptors>();
+                services.AddMithrilOtlpExport(settings);
+            })
+            .Build();
+
+        var monitor = host.Services.GetRequiredService<IOptionsMonitor<TelemetrySettings>>();
+        TelemetrySettings? observed = null;
+        var fireCount = 0;
+        using var sub = monitor.OnChange((value, _) => { observed = value; fireCount++; });
+
+        // A scalar field edit (Endpoint) — restart-required for the exporter, but
+        // the OnChange signal must still fire so the UI / future consumers react.
+        settings.Endpoint = "http://localhost:4318/";
+
+        fireCount.Should().BeGreaterThanOrEqualTo(1,
+            "OnChange listeners must fire on the settings-singleton mutation path; " +
+            "a no-op OnChange silently strands every subscriber.");
+        observed.Should().BeSameAs(settings,
+            "the change callback must hand back the live singleton, not a snapshot copy.");
+    }
+
+    [Fact]
+    public void OptionsMonitor_OnChange_subscription_dispose_stops_callbacks()
+    {
+        var settings = new TelemetrySettings
+        {
+            EnableOtlpExport = true,
+            Endpoint = "http://localhost:65535/",
+        };
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(settings);
+                services.AddSingleton<ITagDescriptorProvider, MithrilSharedTagDescriptors>();
+                services.AddMithrilOtlpExport(settings);
+            })
+            .Build();
+
+        var monitor = host.Services.GetRequiredService<IOptionsMonitor<TelemetrySettings>>();
+        var fireCount = 0;
+        var sub = monitor.OnChange((_, _) => fireCount++);
+        sub.Should().NotBeNull("the real monitor returns a live subscription, not the BCL's nullable no-op");
+
+        settings.ServiceName = "first";
+        var afterFirst = fireCount;
+        afterFirst.Should().BeGreaterThanOrEqualTo(1);
+
+        sub!.Dispose();
+        settings.ServiceName = "second";
+
+        fireCount.Should().Be(afterFirst,
+            "disposing the OnChange subscription must detach the listener so post-dispose " +
+            "mutations don't invoke it (no leak, no use-after-dispose).");
+    }
+
+    [Fact]
     public void TagExports_mutations_are_visible_when_settings_resolved_via_AddMithrilVersionedSettings()
     {
         // Mirror the production Shell composition: settings come from a persisted

--- a/tests/Mithril.Shared.Telemetry.Tests/Settings/NotifyPropertyChangedOptionsMonitorTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Settings/NotifyPropertyChangedOptionsMonitorTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Mithril.Shared.Telemetry.Settings;
+using Xunit;
+
+namespace Mithril.Shared.Telemetry.Tests.Settings;
+
+public class NotifyPropertyChangedOptionsMonitorTests
+{
+    [Fact]
+    public void CurrentValue_and_Get_return_the_wrapped_singleton()
+    {
+        var settings = new TelemetrySettings();
+        using var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        monitor.CurrentValue.Should().BeSameAs(settings);
+        monitor.Get(name: null).Should().BeSameAs(settings);
+        monitor.Get("anyName").Should().BeSameAs(settings);
+    }
+
+    [Fact]
+    public void OnChange_fires_with_singleton_and_property_name()
+    {
+        var settings = new TelemetrySettings();
+        using var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        TelemetrySettings? value = null;
+        string? changedName = null;
+        using var sub = monitor.OnChange((v, n) => { value = v; changedName = n; });
+
+        settings.Endpoint = "http://localhost:4318/";
+
+        value.Should().BeSameAs(settings);
+        changedName.Should().Be(nameof(TelemetrySettings.Endpoint));
+    }
+
+    [Fact]
+    public void OnChange_fires_for_collection_Touch()
+    {
+        // The settings UI mutates the TagExports / Headers dictionaries in place
+        // then calls Touch(propertyName) to raise PropertyChanged. The monitor
+        // must surface that as an OnChange too.
+        var settings = new TelemetrySettings();
+        using var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        var fired = false;
+        using var sub = monitor.OnChange((_, n) =>
+        {
+            if (n == nameof(TelemetrySettings.TagExports)) fired = true;
+        });
+
+        settings.TagExports["module.id"] = true;
+        settings.Touch(nameof(TelemetrySettings.TagExports));
+
+        fired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Disposing_subscription_detaches_only_that_listener()
+    {
+        var settings = new TelemetrySettings();
+        using var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        var aCount = 0;
+        var bCount = 0;
+        var subA = monitor.OnChange((_, _) => aCount++);
+        using var subB = monitor.OnChange((_, _) => bCount++);
+
+        settings.ServiceName = "x";
+        aCount.Should().Be(1);
+        bCount.Should().Be(1);
+
+        subA.Dispose();
+        settings.ServiceName = "y";
+
+        aCount.Should().Be(1, "disposed listener must not fire");
+        bCount.Should().Be(2, "the other listener must keep firing");
+    }
+
+    [Fact]
+    public void Disposing_monitor_detaches_from_PropertyChanged()
+    {
+        var settings = new TelemetrySettings();
+        var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        var count = 0;
+        monitor.OnChange((_, _) => count++);
+
+        monitor.Dispose();
+        settings.ServiceName = "after-dispose";
+
+        count.Should().Be(0,
+            "after the monitor is disposed it must unhook from the singleton's " +
+            "PropertyChanged so it neither fires stale listeners nor leaks the singleton.");
+    }
+
+    [Fact]
+    public void TagExports_dictionary_identity_is_preserved_for_live_reads()
+    {
+        // The scrubber reads CurrentValue.TagExports per record; the monitor must
+        // never swap the dictionary reference away from the singleton's.
+        var settings = new TelemetrySettings();
+        using var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        ConcurrentDictionary<string, bool> live = monitor.CurrentValue.TagExports;
+        live.Should().BeSameAs(settings.TagExports);
+
+        settings.TagExports["arda.verb"] = false;
+        monitor.CurrentValue.TagExports.Should().ContainKey("arda.verb");
+    }
+}

--- a/tests/Mithril.Shared.Telemetry.Tests/Settings/NotifyPropertyChangedOptionsMonitorTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Settings/NotifyPropertyChangedOptionsMonitorTests.cs
@@ -78,6 +78,27 @@ public class NotifyPropertyChangedOptionsMonitorTests
     }
 
     [Fact]
+    public void Same_delegate_subscribed_twice_disposing_one_leaves_the_other()
+    {
+        // Standard C# multicast `-=` removes a single matching invocation entry,
+        // so subscribing the same delegate twice then disposing one subscription
+        // must leave one live registration. Lock in that behaviour.
+        var settings = new TelemetrySettings();
+        using var monitor = new NotifyPropertyChangedOptionsMonitor<TelemetrySettings>(settings);
+
+        var count = 0;
+        Action<TelemetrySettings, string?> handler = (_, _) => count++;
+        var sub1 = monitor.OnChange(handler);
+        using var sub2 = monitor.OnChange(handler);
+
+        sub1.Dispose();
+        settings.ServiceName = "x";
+
+        count.Should().Be(1,
+            "disposing one of two subscriptions of the same delegate must leave exactly one live registration.");
+    }
+
+    [Fact]
     public void Disposing_monitor_detaches_from_PropertyChanged()
     {
         var settings = new TelemetrySettings();

--- a/tests/Mithril.Shell.Tests/TelemetrySettingsViewModelTests.cs
+++ b/tests/Mithril.Shell.Tests/TelemetrySettingsViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -222,5 +223,32 @@ public sealed class TelemetrySettingsViewModelTests
         await Task.Run(() => observer.Note("brand.new.tag"));
 
         vm.NewlySeenChips.Select(c => c.Key).Should().Contain("brand.new.tag");
+    }
+
+    [Theory]
+    [InlineData("Endpoint [Restart Required]")]
+    [InlineData("Protocol [Restart Required]")]
+    [InlineData("Service name [Restart Required]")]
+    [InlineData("Headers [Restart Required]")]
+    public void TelemetrySettingsControl_marks_restart_required_fields(string expectedLabel)
+    {
+        // Smoke check (mithril#833): the OTel SDK bakes endpoint/headers/protocol/
+        // service-name into the exporter at provider build, so these fields are
+        // restart-required. The settings UI must say so on each field label.
+        var xaml = ReadShellSourceFile(Path.Combine("Views", "TelemetrySettingsControl.xaml"));
+        xaml.Should().Contain(expectedLabel,
+            $"the telemetry settings UI must label '{expectedLabel}' so users know the field " +
+            "does not apply live (mithril#833).");
+    }
+
+    private static string ReadShellSourceFile(string relativePath)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mithril.slnx")))
+            dir = dir.Parent;
+        dir.Should().NotBeNull("the test must run inside the repo tree (Mithril.slnx not found walking up)");
+        var path = Path.Combine(dir!.FullName, "src", "Mithril.Shell", relativePath);
+        File.Exists(path).Should().BeTrue($"expected source file at {path}");
+        return File.ReadAllText(path);
     }
 }


### PR DESCRIPTION
## SummaryFollow-up to #815 (BYOB OTLP exporter). v1 shipped `TagExports` hot-reloading via a `SingletonOptionsMonitor<TelemetrySettings>` shim whose `OnChange` was a **no-op** — any subscriber (settings UI, future live consumers) silently never heard about settings edits.This PR:- **Replaces the shim with a real `NotifyPropertyChangedOptionsMonitor<T>`** (in `Mithril.Shared.Telemetry/Settings/`) that subscribes to the settings singleton's `INotifyPropertyChanged` and **fires `OnChange` on every in-place mutation** — the settings UI's save / `Touch()` path. `CurrentValue`/`Get` still return the live singleton, so the scrubber's per-record `CurrentValue.TagExports` reads are unchanged (chip toggles still apply live, no regression).- **Labels Endpoint / Protocol / Service name / Headers `[Restart Required]`** in the telemetry settings UI, each with a one-line reason. The existing restart banner already enumerated these fields; this adds the per-field marker the issue asked for.- Updates the stale "Hot-reloaded for endpoint/headers" doc comments to the accurate scope.## Caveats — scope vs. the issue bodyIssue #833 point 2 asked to *"switch `AddOtlpExporter` to the `(OtlpExporterOptions, IServiceProvider)` factory overload so each export re-reads `CurrentValue`."* **That overload does not exist on OTel SDK 1.15.x**, and live re-reads are not possible without a provider rebuild. Verified by decompiling `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.3:- `AddOtlpExporter` exposes only `Action<OtlpExporterOptions>` (optionally `(name, Action<…>)`) overloads. The configure callback runs **once**, at provider-build time.- `OtlpTraceExporter`'s constructor snapshots the options into its `transmissionHandler` (the `HttpClient` carrying the baked-in endpoint + headers) and sets `startWritePosition` from `Protocol`. `Export()` reads only the transmission handler / resource / limits — it **never re-reads options**.- `service.name` flows into the `ResourceBuilder`, captured at provider build and cached on the exporter's first export.So **Endpoint, Headers, Protocol, and Service name are all baked at provider-build time** and cannot hot-reload on a live exporter instance on this SDK. The per-export `IServiceProvider` factory overload the issue assumed is an **open upstream feature request** ([open-telemetry/opentelemetry-dotnet#6537](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6537)). The only in-process alternative — disposing and rebuilding the `TracerProvider`/`MeterProvider`/`LoggerProvider` on change — is a much larger, riskier change that touches the zero-cost-when-off contract; it is **out of scope here** and left as a follow-up (tracked in mithril#876).What this PR *does* deliver is the honest, useful subset: a working `OnChange` (so UI / future consumers can react live), TagExports live-reads preserved, and accurate `[Restart Required]` documentation grounded in the decompiled SDK behaviour rather than a guess.Metric-only `TagExports` hot-reload (PR #844's once-per-instrument view capture) is **untouched** — explicitly out of scope per the umbrella.## Test delta- `NotifyPropertyChangedOptionsMonitorTests` (new): `CurrentValue`/`Get` return the wrapped singleton; `OnChange` fires with the singleton + property name; fires on collection `Touch()`; per-subscription dispose detaches only that listener; monitor dispose unhooks from `PropertyChanged`; `TagExports` dictionary identity preserved for live reads.- `TelemetryHostExtensionsTests` (extended): host-level `OnChange` fires on singleton mutation; subscription dispose stops callbacks. Existing TagExports-propagation tests remain as regression guards.- `TelemetrySettingsViewModelTests` (extended): smoke `[Theory]` asserting the four `[Restart Required]` field labels are present in `TelemetrySettingsControl.xaml`.- Full suite green (`dotnet test Mithril.slnx`), build clean under warnings-as-errors.## Verification owed- UI not exercised in a running shell (no live OTLP collector handy); the `[Restart Required]` labels + tooltips are verified by source smoke test, not by visual inspection. Behaviour of the new `OnChange` path is covered by unit + host tests.Closes #833— drafted by Claude (Opus 4.7), posted by @arthur-conde