### PR TITLE
feat(map-calibration-harness): core lib + plug-in contract + tests (#884)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -26,6 +26,7 @@
     <Project Path="src/Smaug.Module/Smaug.Module.csproj" />
   </Folder>
   <Folder Name="/tools/">
+    <Project Path="tools/Mithril.MapCalibration.Harness/Mithril.MapCalibration.Harness.csproj" />
     <Project Path="tools/Mithril.LogSanitizer/Mithril.LogSanitizer.csproj" />
     <Project Path="tools/RefreshAndValidate/RefreshAndValidate.csproj" />
     <Project Path="tools/XamlResourceLint/XamlResourceLint.csproj" />
@@ -52,6 +53,7 @@
     <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
     <Project Path="tests/Mithril.LogSanitizer.Tests/Mithril.LogSanitizer.Tests.csproj" />
     <Project Path="tests/Mithril.MapCalibration.Tests/Mithril.MapCalibration.Tests.csproj" />
+    <Project Path="tests/Mithril.MapCalibration.Harness.Tests/Mithril.MapCalibration.Harness.Tests.csproj" />
     <Project Path="tests/Mithril.Overlay.Tests/Mithril.Overlay.Tests.csproj" />
     <Project Path="tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj" />
     <Project Path="tests/Mithril.Reference.Tests/Mithril.Reference.Tests.csproj" />

--- a/tests/Mithril.MapCalibration.Harness.Tests/CalibrationRefTests.cs
+++ b/tests/Mithril.MapCalibration.Harness.Tests/CalibrationRefTests.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Harness;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibration.Harness.Tests;
+
+public class CalibrationRefTests
+{
+    private static CalibrationRef NewRef() => new()
+    {
+        Name = "Wardrobe",
+        Kind = "Npc",
+        Source = CalibrationRefSource.Manual,
+        Confidence = 1.0,
+        World = new WorldCoord(1, 0, 2),
+        TexturePixel = new PixelPoint(3, 4),
+    };
+
+    [Fact]
+    public void Defaults_to_enabled()
+    {
+        NewRef().Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Mutating_texture_pixel_raises_change_notification()
+    {
+        var r = NewRef();
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)r).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        r.TexturePixel = new PixelPoint(9, 9);
+
+        raised.Should().Contain(nameof(CalibrationRef.TexturePixel));
+    }
+
+    [Fact]
+    public void Toggling_enabled_raises_change_notification()
+    {
+        var r = NewRef();
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)r).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        r.Enabled = false;
+
+        raised.Should().Contain(nameof(CalibrationRef.Enabled));
+    }
+}

--- a/tests/Mithril.MapCalibration.Harness.Tests/CalibrationSessionTests.cs
+++ b/tests/Mithril.MapCalibration.Harness.Tests/CalibrationSessionTests.cs
@@ -51,6 +51,18 @@ public class CalibrationSessionTests
         Enabled = enabled,
     };
 
+    // Accept a ref through the candidate path so it's subscribed for
+    // auto-re-solve (mutating Enabled/World/TexturePixel re-solves without an
+    // explicit ReSolve() call). Returns the materialised ref.
+    private static CalibrationRef AcceptRef(CalibrationSession session, double x, double z, PixelPoint texture)
+    {
+        session.Accept(new CandidateRef(
+            texture, new WorldCoord(x, 0, z),
+            LandmarkId: null, SuggestedName: "L", Kind: "Npc",
+            Source: CalibrationRefSource.Manual, Confidence: 1.0));
+        return session.Refs[^1];
+    }
+
     [Fact]
     public void Known_correspondences_recover_a_known_calibration()
     {
@@ -117,40 +129,38 @@ public class CalibrationSessionTests
     }
 
     [Fact]
-    public void Disabling_a_ref_below_the_threshold_nulls_the_calibration()
+    public void Disabling_a_ref_directly_auto_re_solves_and_nulls_below_threshold()
     {
         var session = new CalibrationSession(ContextWithLandmarks(World[0], World[1]));
-        session.Refs.Add(RefFor(World[0].X, World[0].Z, Project(World[0].X, World[0].Z)));
-        session.Refs.Add(RefFor(World[1].X, World[1].Z, Project(World[1].X, World[1].Z)));
-        session.ReSolve();
+        AcceptRef(session, World[0].X, World[0].Z, Project(World[0].X, World[0].Z));
+        AcceptRef(session, World[1].X, World[1].Z, Project(World[1].X, World[1].Z));
         session.Calibration.Should().NotBeNull();
 
+        // No manual ReSolve(): flipping Enabled directly must update Calibration.
         session.Refs[0].Enabled = false;
-        session.ReSolve();
 
         session.Calibration.Should().BeNull();
     }
 
     [Fact]
-    public void Disabling_a_ref_changes_the_fit()
+    public void Flipping_enabled_directly_changes_the_calibration()
     {
-        // Two consistent refs + a third that is consistent too → exact fit.
-        // Then move the third onto a slightly different transform so it pulls
-        // the least-squares solution; disabling it must change the result.
+        // Two consistent refs + a third placed off-true so it perturbs the fit.
         var session = new CalibrationSession(ContextWithLandmarks(World));
-        session.Refs.Add(RefFor(World[0].X, World[0].Z, Project(World[0].X, World[0].Z)));
-        session.Refs.Add(RefFor(World[1].X, World[1].Z, Project(World[1].X, World[1].Z)));
-        // A third ref placed off-true so it perturbs the fit.
+        AcceptRef(session, World[0].X, World[0].Z, Project(World[0].X, World[0].Z));
+        AcceptRef(session, World[1].X, World[1].Z, Project(World[1].X, World[1].Z));
         var off = Project(World[2].X, World[2].Z);
-        session.Refs.Add(RefFor(World[2].X, World[2].Z, new PixelPoint(off.X + 40, off.Y - 30)));
-        session.ReSolve();
-        var withPerturbed = session.Calibration!;
-        withPerturbed.Scale.Should().NotBeApproximately(Scale, 1e-6); // perturbed
+        AcceptRef(session, World[2].X, World[2].Z, new PixelPoint(off.X + 40, off.Y - 30));
+        session.Calibration!.Scale.Should().NotBeApproximately(Scale, 1e-6); // perturbed
 
+        // Disable the bad ref directly — auto-re-solve returns to the clean fit.
         session.Refs[2].Enabled = false;
-        session.ReSolve();
 
-        session.Calibration!.Scale.Should().BeApproximately(Scale, 1e-6); // back to clean
+        session.Calibration!.Scale.Should().BeApproximately(Scale, 1e-6);
+
+        // Re-enable it — auto-re-solve perturbs again (proves the round-trip).
+        session.Refs[2].Enabled = true;
+        session.Calibration!.Scale.Should().NotBeApproximately(Scale, 1e-6);
     }
 
     [Fact]
@@ -158,16 +168,15 @@ public class CalibrationSessionTests
     {
         var session = new CalibrationSession(ContextWithLandmarks(World));
         foreach (var (x, z) in World)
-            session.Refs.Add(RefFor(x, z, Project(x, z)));
-        // Deliberately misplace the last ref well off true.
+            AcceptRef(session, x, z, Project(x, z));
+        // Deliberately misplace the last ref well off true (direct mutation
+        // auto-re-solves — no explicit ReSolve()).
         var bad = Project(World[3].X, World[3].Z);
         session.Refs[3].TexturePixel = new PixelPoint(bad.X + 80, bad.Y + 80);
-        session.ReSolve();
 
         session.Calibration!.ResidualPixels.Should().BeGreaterThan(5);
 
         session.Refs[3].Enabled = false;
-        session.ReSolve();
 
         session.Calibration!.ResidualPixels.Should().BeApproximately(0, 1e-6);
         // Remaining enabled refs now fit exactly.
@@ -175,15 +184,28 @@ public class CalibrationSessionTests
     }
 
     [Fact]
-    public void Nudge_re_solves()
+    public void Re_assigning_world_directly_auto_re_solves()
     {
         var session = new CalibrationSession(ContextWithLandmarks(World));
         foreach (var (x, z) in World)
-            session.Refs.Add(RefFor(x, z, Project(x, z)));
-        session.ReSolve();
+            AcceptRef(session, x, z, Project(x, z));
         session.Calibration!.ResidualPixels.Should().BeApproximately(0, 1e-6);
 
-        // Nudge one ref off true; the re-solve must surface a non-zero residual.
+        // Re-assign one ref's World to a wrong coord — auto-re-solve surfaces error.
+        session.Refs[0].World = new WorldCoord(World[0].X + 500, 0, World[0].Z - 500);
+
+        session.Calibration!.ResidualPixels.Should().BeGreaterThan(5);
+    }
+
+    [Fact]
+    public void Nudge_auto_re_solves()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            AcceptRef(session, x, z, Project(x, z));
+        session.Calibration!.ResidualPixels.Should().BeApproximately(0, 1e-6);
+
+        // Nudge one ref off true; the auto-re-solve must surface a non-zero residual.
         session.NudgeSelected(session.Refs[0], dx: 50, dy: -50);
 
         session.Refs[0].TexturePixel.X.Should().BeApproximately(Project(World[0].X, World[0].Z).X + 50, 1e-9);
@@ -242,5 +264,49 @@ public class CalibrationSessionTests
 
         session.Refs.Should().HaveCount(1);
         session.Calibration.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmitBatch_produces_the_same_calibration_as_sequential_Accepts()
+    {
+        CandidateRef Candidate((double X, double Z) p) => new(
+            Project(p.X, p.Z), new WorldCoord(p.X, 0, p.Z),
+            LandmarkId: null, SuggestedName: "L", Kind: "Npc",
+            Source: CalibrationRefSource.Manual, Confidence: 1.0);
+
+        // Path A: one Accept per candidate.
+        var viaAccept = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var p in World) viaAccept.Accept(Candidate(p));
+
+        // Path B: a single EmitBatch.
+        var viaBatch = new CalibrationSession(ContextWithLandmarks(World));
+        ((ICandidateSink)viaBatch).EmitBatch(World.Select(Candidate).ToList());
+
+        viaBatch.Refs.Should().HaveCount(viaAccept.Refs.Count);
+        viaBatch.Calibration.Should().NotBeNull();
+        // Identical final calibration (same solver inputs, just solved once).
+        viaBatch.Calibration!.Scale.Should().BeApproximately(viaAccept.Calibration!.Scale, 1e-12);
+        viaBatch.Calibration.RotationRadians.Should().BeApproximately(viaAccept.Calibration!.RotationRadians, 1e-12);
+        viaBatch.Calibration.OriginX.Should().BeApproximately(viaAccept.Calibration!.OriginX, 1e-9);
+        viaBatch.Calibration.OriginY.Should().BeApproximately(viaAccept.Calibration!.OriginY, 1e-9);
+        viaBatch.Calibration.ResidualPixels.Should().BeApproximately(viaAccept.Calibration!.ResidualPixels, 1e-12);
+    }
+
+    [Fact]
+    public void Removed_ref_no_longer_triggers_re_solve()
+    {
+        // After Remove unsubscribes, mutating the detached ref must not re-solve.
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            AcceptRef(session, x, z, Project(x, z));
+        var detached = session.Refs[0];
+        session.Remove(detached);
+        var afterRemove = session.Calibration;
+
+        // Mutating the now-detached ref's solve inputs must be inert.
+        detached.Enabled = false;
+        detached.TexturePixel = new PixelPoint(9999, 9999);
+
+        session.Calibration.Should().BeSameAs(afterRemove);
     }
 }

--- a/tests/Mithril.MapCalibration.Harness.Tests/CalibrationSessionTests.cs
+++ b/tests/Mithril.MapCalibration.Harness.Tests/CalibrationSessionTests.cs
@@ -1,0 +1,246 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibration.Harness;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibration.Harness.Tests;
+
+public class CalibrationSessionTests
+{
+    // Ground-truth transform mirrored from LandmarkCalibrationSolverTests:
+    // North = +Z, pixel-Y grows downward.
+    private const double Scale = 1.7;
+    private static readonly double Rot = Math.PI / 5;
+    private static readonly PixelPoint Origin = new(640, 360);
+
+    private static PixelPoint Project(double x, double z)
+    {
+        var cos = Math.Cos(Rot);
+        var sin = Math.Sin(Rot);
+        var rotE = x * cos + z * sin;
+        var rotN = -x * sin + z * cos;
+        return new PixelPoint(Origin.X + Scale * rotE, Origin.Y - Scale * rotN);
+    }
+
+    // Signed world coords (negative X/Z are real PG positions).
+    private static readonly (double X, double Z)[] World =
+    {
+        (-677.0, 803.0),
+        (1138.0, 1367.0),
+        (-1459.0, -860.0),
+        (254.0, -55.0),
+    };
+
+    private static CalibrationContext ContextWithLandmarks(params (double X, double Z)[] worlds)
+    {
+        var landmarks = worlds
+            .Select((p, i) => new LandmarkRef("Npc", $"L{i}", new WorldCoord(p.X, 0, p.Z)))
+            .ToList();
+        return new CalibrationContext("TestArea", landmarks, null, null, (1280, 720), null);
+    }
+
+    private static CalibrationRef RefFor(double x, double z, PixelPoint texture, bool enabled = true) => new()
+    {
+        Name = "L",
+        Kind = "Npc",
+        Source = CalibrationRefSource.Manual,
+        Confidence = 1.0,
+        World = new WorldCoord(x, 0, z),
+        TexturePixel = texture,
+        Enabled = enabled,
+    };
+
+    [Fact]
+    public void Known_correspondences_recover_a_known_calibration()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            session.Refs.Add(RefFor(x, z, Project(x, z)));
+
+        session.ReSolve();
+
+        session.Calibration.Should().NotBeNull();
+        var cal = session.Calibration!;
+        cal.Scale.Should().BeApproximately(Scale, 1e-6);
+        cal.RotationRadians.Should().BeApproximately(Rot, 1e-6);
+        cal.OriginX.Should().BeApproximately(Origin.X, 1e-4);
+        cal.OriginY.Should().BeApproximately(Origin.Y, 1e-4);
+        cal.ResidualPixels.Should().BeApproximately(0, 1e-6);
+        cal.ReferenceCount.Should().Be(4);
+    }
+
+    [Fact]
+    public void Residuals_are_filled_per_enabled_ref()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            session.Refs.Add(RefFor(x, z, Project(x, z)));
+
+        session.ReSolve();
+
+        session.Refs.Should().OnlyContain(r => r.ResidualPx != null);
+        session.Refs.Should().OnlyContain(r => r.ResidualPx < 1e-6);
+    }
+
+    [Fact]
+    public void Projections_are_refreshed_for_all_landmarks_not_just_refs()
+    {
+        // 4 landmarks in context, but only 2 are ref'd.
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        session.Refs.Add(RefFor(World[0].X, World[0].Z, Project(World[0].X, World[0].Z)));
+        session.Refs.Add(RefFor(World[1].X, World[1].Z, Project(World[1].X, World[1].Z)));
+
+        session.ReSolve();
+
+        session.Projections.Should().HaveCount(4);
+        // Landmarks that are also enabled refs carry a residual; the rest don't.
+        session.Projections.Count(p => p.ResidualPx != null).Should().Be(2);
+        // The projected pixel for a ref'd landmark lands on its true pixel.
+        var p0 = session.Projections.First(p => p.Name == "L0");
+        var truth = Project(World[0].X, World[0].Z);
+        p0.TexturePixel.X.Should().BeApproximately(truth.X, 1e-6);
+        p0.TexturePixel.Y.Should().BeApproximately(truth.Y, 1e-6);
+    }
+
+    [Fact]
+    public void Fewer_than_two_enabled_refs_yields_null_calibration()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        session.Refs.Add(RefFor(World[0].X, World[0].Z, Project(World[0].X, World[0].Z)));
+
+        session.ReSolve();
+
+        session.Calibration.Should().BeNull();
+        session.Projections.Should().BeEmpty();
+        session.Refs.Should().OnlyContain(r => r.ResidualPx == null);
+    }
+
+    [Fact]
+    public void Disabling_a_ref_below_the_threshold_nulls_the_calibration()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World[0], World[1]));
+        session.Refs.Add(RefFor(World[0].X, World[0].Z, Project(World[0].X, World[0].Z)));
+        session.Refs.Add(RefFor(World[1].X, World[1].Z, Project(World[1].X, World[1].Z)));
+        session.ReSolve();
+        session.Calibration.Should().NotBeNull();
+
+        session.Refs[0].Enabled = false;
+        session.ReSolve();
+
+        session.Calibration.Should().BeNull();
+    }
+
+    [Fact]
+    public void Disabling_a_ref_changes_the_fit()
+    {
+        // Two consistent refs + a third that is consistent too → exact fit.
+        // Then move the third onto a slightly different transform so it pulls
+        // the least-squares solution; disabling it must change the result.
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        session.Refs.Add(RefFor(World[0].X, World[0].Z, Project(World[0].X, World[0].Z)));
+        session.Refs.Add(RefFor(World[1].X, World[1].Z, Project(World[1].X, World[1].Z)));
+        // A third ref placed off-true so it perturbs the fit.
+        var off = Project(World[2].X, World[2].Z);
+        session.Refs.Add(RefFor(World[2].X, World[2].Z, new PixelPoint(off.X + 40, off.Y - 30)));
+        session.ReSolve();
+        var withPerturbed = session.Calibration!;
+        withPerturbed.Scale.Should().NotBeApproximately(Scale, 1e-6); // perturbed
+
+        session.Refs[2].Enabled = false;
+        session.ReSolve();
+
+        session.Calibration!.Scale.Should().BeApproximately(Scale, 1e-6); // back to clean
+    }
+
+    [Fact]
+    public void A_bad_ref_inflates_residual_and_disabling_it_restores_the_fit()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            session.Refs.Add(RefFor(x, z, Project(x, z)));
+        // Deliberately misplace the last ref well off true.
+        var bad = Project(World[3].X, World[3].Z);
+        session.Refs[3].TexturePixel = new PixelPoint(bad.X + 80, bad.Y + 80);
+        session.ReSolve();
+
+        session.Calibration!.ResidualPixels.Should().BeGreaterThan(5);
+
+        session.Refs[3].Enabled = false;
+        session.ReSolve();
+
+        session.Calibration!.ResidualPixels.Should().BeApproximately(0, 1e-6);
+        // Remaining enabled refs now fit exactly.
+        session.Refs.Where(r => r.Enabled).Should().OnlyContain(r => r.ResidualPx < 1e-6);
+    }
+
+    [Fact]
+    public void Nudge_re_solves()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            session.Refs.Add(RefFor(x, z, Project(x, z)));
+        session.ReSolve();
+        session.Calibration!.ResidualPixels.Should().BeApproximately(0, 1e-6);
+
+        // Nudge one ref off true; the re-solve must surface a non-zero residual.
+        session.NudgeSelected(session.Refs[0], dx: 50, dy: -50);
+
+        session.Refs[0].TexturePixel.X.Should().BeApproximately(Project(World[0].X, World[0].Z).X + 50, 1e-9);
+        session.Calibration!.ResidualPixels.Should().BeGreaterThan(5);
+    }
+
+    [Fact]
+    public void Accept_with_world_adds_enabled_ref_and_re_solves()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+
+        session.Accept(new CandidateRef(
+            Project(World[0].X, World[0].Z),
+            new WorldCoord(World[0].X, 0, World[0].Z),
+            LandmarkId: "L0", SuggestedName: "L0", Kind: "Npc",
+            Source: CalibrationRefSource.Manual, Confidence: 1.0));
+        session.Accept(new CandidateRef(
+            Project(World[1].X, World[1].Z),
+            new WorldCoord(World[1].X, 0, World[1].Z),
+            LandmarkId: "L1", SuggestedName: "L1", Kind: "Npc",
+            Source: CalibrationRefSource.Manual, Confidence: 1.0));
+
+        session.Refs.Should().HaveCount(2);
+        session.Refs.Should().OnlyContain(r => r.Enabled);
+        session.Calibration.Should().NotBeNull();
+        session.Calibration!.ResidualPixels.Should().BeApproximately(0, 1e-6);
+    }
+
+    [Fact]
+    public void Accept_without_world_adds_a_disabled_ref()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+
+        session.Accept(new CandidateRef(
+            new PixelPoint(10, 20), World: null,
+            LandmarkId: null, SuggestedName: null, Kind: "Unknown",
+            Source: CalibrationRefSource.GreenPixel, Confidence: 0.8));
+
+        session.Refs.Should().HaveCount(1);
+        session.Refs[0].Enabled.Should().BeFalse();
+        session.Calibration.Should().BeNull(); // <2 enabled
+    }
+
+    [Fact]
+    public void Remove_re_solves()
+    {
+        var session = new CalibrationSession(ContextWithLandmarks(World));
+        foreach (var (x, z) in World)
+            session.Refs.Add(RefFor(x, z, Project(x, z)));
+        session.ReSolve();
+
+        // Drop to a single ref → null calibration.
+        session.Remove(session.Refs[0]);
+        session.Remove(session.Refs[0]);
+        session.Remove(session.Refs[0]);
+
+        session.Refs.Should().HaveCount(1);
+        session.Calibration.Should().BeNull();
+    }
+}

--- a/tests/Mithril.MapCalibration.Harness.Tests/CoordinateTransformTests.cs
+++ b/tests/Mithril.MapCalibration.Harness.Tests/CoordinateTransformTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibration.Harness;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibration.Harness.Tests;
+
+public class CoordinateTransformTests
+{
+    private static CalibrationContext Context(MapRect rect, int texW, int texH) =>
+        new(
+            area: "TestArea",
+            landmarks: new List<LandmarkRef>(),
+            mapImage: null,
+            mapRect: rect,
+            textureSize: (texW, texH),
+            currentCalibration: null);
+
+    public static TheoryData<MapRect, int, int> RectsAndSizes() => new()
+    {
+        { new MapRect(0, 0, 100, 100), 100, 100 },        // identity
+        { new MapRect(0, 0, 200, 200), 100, 100 },        // 2x scale
+        { new MapRect(37.5, 12.25, 640, 480), 1024, 768 },// offset + non-square
+        { new MapRect(-50, -25, 800, 600), 2048, 1536 },  // negative origin
+        { new MapRect(10, 10, 333, 777), 512, 256 },      // anisotropic
+    };
+
+    [Theory]
+    [MemberData(nameof(RectsAndSizes))]
+    public void Screenshot_to_texture_round_trips(MapRect rect, int texW, int texH)
+    {
+        var ctx = Context(rect, texW, texH);
+
+        foreach (var (sx, sy) in new[] { (0.0, 0.0), (12.3, 45.6), (rect.Left + rect.Width, rect.Top + rect.Height), (-5.0, 999.0) })
+        {
+            var texture = ctx.ScreenshotToTexture(sx, sy);
+            var back = ctx.TextureToScreenshot(texture);
+            back.X.Should().BeApproximately(sx, 1e-9);
+            back.Y.Should().BeApproximately(sy, 1e-9);
+        }
+    }
+
+    [Fact]
+    public void Screenshot_to_texture_uses_the_documented_formula()
+    {
+        // rect (left=10, top=20, w=200, h=100), texture 100x50.
+        // A click at the rect's far corner maps to the full texture extent.
+        var ctx = Context(new MapRect(10, 20, 200, 100), 100, 50);
+
+        ctx.ScreenshotToTexture(10, 20).Should().Be(new PixelPoint(0, 0));
+        ctx.ScreenshotToTexture(210, 120).Should().Be(new PixelPoint(100, 50));
+        // Midpoint of the rect → midpoint of the texture.
+        ctx.ScreenshotToTexture(110, 70).Should().Be(new PixelPoint(50, 25));
+    }
+
+    [Fact]
+    public void Transforms_throw_without_a_map_rect()
+    {
+        var ctx = new CalibrationContext("A", new List<LandmarkRef>(), null, mapRect: null, (100, 100), null);
+
+        ctx.Invoking(c => c.ScreenshotToTexture(1, 2)).Should().Throw<InvalidOperationException>();
+        ctx.Invoking(c => c.TextureToScreenshot(new PixelPoint(1, 2))).Should().Throw<InvalidOperationException>();
+    }
+}

--- a/tests/Mithril.MapCalibration.Harness.Tests/CoordinateTransformTests.cs
+++ b/tests/Mithril.MapCalibration.Harness.Tests/CoordinateTransformTests.cs
@@ -59,7 +59,26 @@ public class CoordinateTransformTests
     {
         var ctx = new CalibrationContext("A", new List<LandmarkRef>(), null, mapRect: null, (100, 100), null);
 
-        ctx.Invoking(c => c.ScreenshotToTexture(1, 2)).Should().Throw<InvalidOperationException>();
-        ctx.Invoking(c => c.TextureToScreenshot(new PixelPoint(1, 2))).Should().Throw<InvalidOperationException>();
+        ctx.Invoking(c => c.ScreenshotToTexture(1, 2))
+            .Should().Throw<InvalidOperationException>().WithMessage("*none was set*");
+        ctx.Invoking(c => c.TextureToScreenshot(new PixelPoint(1, 2)))
+            .Should().Throw<InvalidOperationException>().WithMessage("*none was set*");
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(100, 0)]
+    [InlineData(-50, 100)]
+    [InlineData(100, -50)]
+    public void Transforms_throw_on_a_degenerate_map_rect(double width, double height)
+    {
+        // A zero/negative dimension would silently divide to Infinity/NaN; the
+        // context must throw with a message distinct from the missing-rect case.
+        var ctx = Context(new MapRect(0, 0, width, height), 100, 100);
+
+        ctx.Invoking(c => c.ScreenshotToTexture(1, 2))
+            .Should().Throw<InvalidOperationException>().WithMessage("*non-positive dimension*");
+        ctx.Invoking(c => c.TextureToScreenshot(new PixelPoint(1, 2)))
+            .Should().Throw<InvalidOperationException>().WithMessage("*non-positive dimension*");
     }
 }

--- a/tests/Mithril.MapCalibration.Harness.Tests/FakeMethodIntegrationTests.cs
+++ b/tests/Mithril.MapCalibration.Harness.Tests/FakeMethodIntegrationTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibration.Harness;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibration.Harness.Tests;
+
+public class FakeMethodIntegrationTests
+{
+    private const double Scale = 2.0;
+    private static readonly double Rot = 0.4;
+    private static readonly PixelPoint Origin = new(100, 200);
+
+    private static PixelPoint Project(double x, double z)
+    {
+        var cos = Math.Cos(Rot);
+        var sin = Math.Sin(Rot);
+        var rotE = x * cos + z * sin;
+        var rotN = -x * sin + z * cos;
+        return new PixelPoint(Origin.X + Scale * rotE, Origin.Y - Scale * rotN);
+    }
+
+    private static readonly (double X, double Z)[] World =
+    {
+        (10.0, 0.0),
+        (0.0, 12.0),
+        (-7.0, 5.0),
+        (4.0, -9.0),
+    };
+
+    /// <summary>
+    /// Trivial in-test method: emits a fixed candidate batch through the sink on
+    /// activation. Proves the <see cref="ICalibrationMethod"/> +
+    /// <see cref="ICandidateSink"/> contract end-to-end, headlessly.
+    /// </summary>
+    private sealed class FakeBatchMethod : ICalibrationMethod
+    {
+        private readonly IReadOnlyList<CandidateRef> _batch;
+
+        public FakeBatchMethod(IReadOnlyList<CandidateRef> batch) => _batch = batch;
+
+        public string Name => "Fake";
+
+        public string Description => "Emits a fixed batch of candidates.";
+
+        public object? ConfigView => null;
+
+        public IDisposable Activate(CalibrationContext ctx, ICandidateSink sink)
+        {
+            sink.EmitBatch(_batch);
+            return new NoopDisposable();
+        }
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+
+    [Fact]
+    public void Fake_method_emits_through_sink_and_session_solves()
+    {
+        var landmarks = World
+            .Select((p, i) => new LandmarkRef("Npc", $"L{i}", new WorldCoord(p.X, 0, p.Z)))
+            .ToList();
+        var ctx = new CalibrationContext("TestArea", landmarks, null, null, (640, 480), null);
+        var session = new CalibrationSession(ctx);
+
+        var batch = World.Select(p => new CandidateRef(
+            Project(p.X, p.Z),
+            new WorldCoord(p.X, 0, p.Z),
+            LandmarkId: null, SuggestedName: "lm", Kind: "Npc",
+            Source: CalibrationRefSource.Ncc, Confidence: 0.9)).ToList();
+
+        var method = new FakeBatchMethod(batch);
+        using var handle = method.Activate(ctx, session);
+
+        session.Refs.Should().HaveCount(4);
+        session.Calibration.Should().NotBeNull();
+        session.Calibration!.Scale.Should().BeApproximately(Scale, 1e-6);
+        session.Calibration.ResidualPixels.Should().BeApproximately(0, 1e-6);
+        session.Projections.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void ConfigView_is_null_in_headless_use()
+    {
+        var method = new FakeBatchMethod(System.Array.Empty<CandidateRef>());
+        method.ConfigView.Should().BeNull();
+    }
+}

--- a/tests/Mithril.MapCalibration.Harness.Tests/Mithril.MapCalibration.Harness.Tests.csproj
+++ b/tests/Mithril.MapCalibration.Harness.Tests/Mithril.MapCalibration.Harness.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.Tools.MapCalibration.Harness.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Cross-boundary ProjectReference into the isolated harness lib is fine:
+         the lib's PM/targets opt-out is build-local (issue #884 decision). -->
+    <ProjectReference Include="..\..\tools\Mithril.MapCalibration.Harness\Mithril.MapCalibration.Harness.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Mithril.MapCalibration.Harness/CalibrationContext.cs
+++ b/tools/Mithril.MapCalibration.Harness/CalibrationContext.cs
@@ -1,0 +1,85 @@
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// What a calibration method receives when activated. Carries the area, the
+/// landmark reference data, the loaded in-game-map image + its texture extent,
+/// the base-texture output dimensions, and the current calibration (for
+/// refinement methods). Owns the screenshot&#8596;texture transform so methods
+/// emit in texture space without re-deriving the map-rect math.
+///
+/// <para>Coordinate frames (see the design spec): <b>screenshot pixel</b> is
+/// what the user clicks / green-pixel detects; <b>texture pixel</b> is what the
+/// solver and baseline JSON use. The transform maps a point inside
+/// <see cref="MapRect"/> on the screenshot onto the
+/// <see cref="TextureSize"/> output frame:
+/// <c>texturePx = (screenshotPx − rect.origin) · textureSize / rect.size</c>.</para>
+/// </summary>
+public sealed class CalibrationContext
+{
+    public CalibrationContext(
+        string area,
+        IReadOnlyList<LandmarkRef> landmarks,
+        ICalibrationImage? mapImage,
+        MapRect? mapRect,
+        (int W, int H) textureSize,
+        AreaCalibration? currentCalibration)
+    {
+        Area = area;
+        Landmarks = landmarks;
+        MapImage = mapImage;
+        MapRect = mapRect;
+        TextureSize = textureSize;
+        CurrentCalibration = currentCalibration;
+    }
+
+    public string Area { get; }
+
+    /// <summary>The area's landmarks, from the common-lib readers.</summary>
+    public IReadOnlyList<LandmarkRef> Landmarks { get; }
+
+    /// <summary>The loaded in-game-map screenshot, WPF-free. Null in pure-solve tests.</summary>
+    public ICalibrationImage? MapImage { get; }
+
+    /// <summary>The base-texture extent within <see cref="MapImage"/>, in screenshot pixels.</summary>
+    public MapRect? MapRect { get; }
+
+    /// <summary>Base-texture dimensions — the output (texture-pixel) frame.</summary>
+    public (int W, int H) TextureSize { get; }
+
+    /// <summary>The stored calibration, for refinement methods. May be null.</summary>
+    public AreaCalibration? CurrentCalibration { get; }
+
+    /// <summary>
+    /// Maps a screenshot-pixel coordinate to texture space using
+    /// <see cref="MapRect"/> + <see cref="TextureSize"/>. Throws if
+    /// <see cref="MapRect"/> is unset (a method that emits texture-space coords
+    /// requires the map-rect to have been drawn).
+    /// </summary>
+    public PixelPoint ScreenshotToTexture(double sx, double sy)
+    {
+        var rect = RequireRect();
+        var tx = (sx - rect.Left) * TextureSize.W / rect.Width;
+        var ty = (sy - rect.Top) * TextureSize.H / rect.Height;
+        return new PixelPoint(tx, ty);
+    }
+
+    /// <summary>
+    /// Inverse of <see cref="ScreenshotToTexture"/>: maps a texture-pixel back
+    /// onto the screenshot (used by the projection overlay to draw on the loaded
+    /// image). Throws if <see cref="MapRect"/> is unset.
+    /// </summary>
+    public PixelPoint TextureToScreenshot(PixelPoint texture)
+    {
+        var rect = RequireRect();
+        var sx = rect.Left + texture.X * rect.Width / TextureSize.W;
+        var sy = rect.Top + texture.Y * rect.Height / TextureSize.H;
+        return new PixelPoint(sx, sy);
+    }
+
+    private MapRect RequireRect() =>
+        MapRect ?? throw new InvalidOperationException(
+            "ScreenshotToTexture / TextureToScreenshot require a MapRect; none was set on the context.");
+}

--- a/tools/Mithril.MapCalibration.Harness/CalibrationContext.cs
+++ b/tools/Mithril.MapCalibration.Harness/CalibrationContext.cs
@@ -79,7 +79,18 @@ public sealed class CalibrationContext
         return new PixelPoint(sx, sy);
     }
 
-    private MapRect RequireRect() =>
-        MapRect ?? throw new InvalidOperationException(
+    private MapRect RequireRect()
+    {
+        var rect = MapRect ?? throw new InvalidOperationException(
             "ScreenshotToTexture / TextureToScreenshot require a MapRect; none was set on the context.");
+        // A zero/negative dimension would divide to Infinity/NaN silently; fail
+        // loudly with a message distinct from the missing-rect case.
+        if (rect.Width <= 0 || rect.Height <= 0)
+        {
+            throw new InvalidOperationException(
+                $"MapRect has a non-positive dimension (Width={rect.Width}, Height={rect.Height}); " +
+                "the texture extent must be a positive rectangle.");
+        }
+        return rect;
+    }
 }

--- a/tools/Mithril.MapCalibration.Harness/CalibrationRef.cs
+++ b/tools/Mithril.MapCalibration.Harness/CalibrationRef.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// An accepted candidate in the live ref set, now editable. <see cref="World"/>
+/// and <see cref="TexturePixel"/> are observable (re-assign / nudge);
+/// <see cref="Enabled"/> toggles a ref in/out of the solve without deleting it
+/// (disable a suspect ref, watch the residual). <see cref="ResidualPx"/> is
+/// filled by the session after each solve.
+/// </summary>
+public sealed partial class CalibrationRef : ObservableObject
+{
+    public required string Name { get; init; }
+
+    public required string Kind { get; init; }
+
+    public CalibrationRefSource Source { get; init; }
+
+    public double Confidence { get; init; }
+
+    [ObservableProperty]
+    private WorldCoord _world;
+
+    [ObservableProperty]
+    private PixelPoint _texturePixel;
+
+    [ObservableProperty]
+    private bool _enabled = true;
+
+    [ObservableProperty]
+    private double? _residualPx;
+}

--- a/tools/Mithril.MapCalibration.Harness/CalibrationRefSource.cs
+++ b/tools/Mithril.MapCalibration.Harness/CalibrationRefSource.cs
@@ -1,0 +1,15 @@
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// Which calibration method produced a <see cref="CalibrationRef"/> /
+/// <see cref="CandidateRef"/>. Lets the correction UI badge refs by origin and
+/// lets the user reason about a suspect ref's provenance when toggling it out
+/// of the solve. Manual clicks carry <see cref="Manual"/> at confidence 1.0.
+/// </summary>
+public enum CalibrationRefSource
+{
+    Manual,
+    GreenPixel,
+    Ncc,
+    Bootstrap,
+}

--- a/tools/Mithril.MapCalibration.Harness/CalibrationSession.cs
+++ b/tools/Mithril.MapCalibration.Harness/CalibrationSession.cs
@@ -1,0 +1,158 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// The headless calibration engine: owns the live ref set, the solved
+/// <see cref="Calibration"/>, and the projection overlay. <see cref="ReSolve"/>,
+/// the per-ref residual math, and the projection refresh are lifted from the
+/// merged <c>AreaWorkspaceViewModel</c> and made headless so they're unit-tested
+/// for the first time. The solve goes through
+/// <see cref="LandmarkCalibrationSolver.Solve"/> unchanged (it self-corrects
+/// handedness by trying both reflections — don't bypass it).
+///
+/// <para>This type also doubles as the <see cref="ICandidateSink"/> a method
+/// emits into: <see cref="ICandidateSink.Emit"/> routes through
+/// <see cref="Accept"/>.</para>
+/// </summary>
+public sealed partial class CalibrationSession : ObservableObject, ICandidateSink
+{
+    private readonly CalibrationContext _ctx;
+
+    public CalibrationSession(CalibrationContext ctx)
+    {
+        _ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
+        Area = ctx.Area;
+    }
+
+    public string Area { get; }
+
+    public ObservableCollection<CalibrationRef> Refs { get; } = new();
+
+    [ObservableProperty]
+    private AreaCalibration? _calibration;
+
+    public ObservableCollection<ProjectionMarker> Projections { get; } = new();
+
+    /// <summary>
+    /// Materialises a <see cref="CalibrationRef"/> from a <see cref="CandidateRef"/>
+    /// and re-solves. A candidate with no <see cref="CandidateRef.World"/> is
+    /// added as a disabled ref (it carries no world coord, so it can't yet
+    /// participate in the fit — the user assigns its world position later, then
+    /// enables it).
+    /// </summary>
+    public void Accept(CandidateRef candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        var hasWorld = candidate.World is not null;
+        var calRef = new CalibrationRef
+        {
+            Name = candidate.SuggestedName ?? candidate.LandmarkId ?? "(unnamed)",
+            Kind = candidate.Kind,
+            Source = candidate.Source,
+            Confidence = candidate.Confidence,
+            World = candidate.World ?? default,
+            TexturePixel = candidate.TexturePixel,
+            Enabled = hasWorld,
+        };
+        Refs.Add(calRef);
+        ReSolve();
+    }
+
+    /// <summary>Removes a ref from the live set and re-solves.</summary>
+    public void Remove(CalibrationRef r)
+    {
+        if (r is null) return;
+        if (Refs.Remove(r)) ReSolve();
+    }
+
+    /// <summary>
+    /// Correction primitive: nudges a ref's <see cref="CalibrationRef.TexturePixel"/>
+    /// by (<paramref name="dx"/>, <paramref name="dy"/>) and re-solves.
+    /// </summary>
+    public void NudgeSelected(CalibrationRef r, double dx, double dy)
+    {
+        if (r is null || !Refs.Contains(r)) return;
+        r.TexturePixel = new PixelPoint(r.TexturePixel.X + dx, r.TexturePixel.Y + dy);
+        ReSolve();
+    }
+
+    /// <summary>
+    /// Solves the calibration from the <b>enabled</b> refs only, fills each
+    /// enabled ref's <see cref="CalibrationRef.ResidualPx"/>, and refreshes the
+    /// projection overlay for every landmark in the context. With fewer than two
+    /// enabled refs the calibration is null, the projection overlay is cleared,
+    /// and all residuals are nulled. Lifted verbatim from
+    /// <c>AreaWorkspaceViewModel.ReSolve</c>.
+    /// </summary>
+    public void ReSolve()
+    {
+        var enabled = Refs.Where(r => r.Enabled).ToList();
+        if (enabled.Count < 2)
+        {
+            Calibration = null;
+            foreach (var r in Refs) r.ResidualPx = null;
+            Projections.Clear();
+            return;
+        }
+
+        var solverRefs = enabled
+            .Select(r => new LandmarkCalibrationSolver.Reference(
+                r.World.X, r.World.Z, r.TexturePixel))
+            .ToList();
+        var cal = LandmarkCalibrationSolver.Solve(solverRefs);
+        Calibration = cal;
+
+        if (cal is null)
+        {
+            foreach (var r in Refs) r.ResidualPx = null;
+            Projections.Clear();
+            return;
+        }
+
+        // Disabled refs carry no residual; enabled refs get the projected error.
+        foreach (var r in Refs)
+        {
+            if (!r.Enabled)
+            {
+                r.ResidualPx = null;
+                continue;
+            }
+            var projected = cal.WorldToWindow(r.World);
+            var dx = projected.X - r.TexturePixel.X;
+            var dy = projected.Y - r.TexturePixel.Y;
+            r.ResidualPx = Math.Sqrt(dx * dx + dy * dy);
+        }
+
+        RefreshProjections(cal);
+    }
+
+    private void RefreshProjections(AreaCalibration cal)
+    {
+        Projections.Clear();
+        foreach (var landmark in _ctx.Landmarks)
+        {
+            var px = cal.WorldToWindow(landmark.World);
+            var refMatch = RefForLandmark(landmark);
+            Projections.Add(new ProjectionMarker(
+                landmark.Name, landmark.Type, px, refMatch?.ResidualPx));
+        }
+    }
+
+    private CalibrationRef? RefForLandmark(LandmarkRef landmark) =>
+        Refs.FirstOrDefault(r =>
+            r.Enabled
+            && Math.Abs(r.World.X - landmark.World.X) < 1e-6
+            && Math.Abs(r.World.Z - landmark.World.Z) < 1e-6);
+
+    void ICandidateSink.Emit(CandidateRef candidate) => Accept(candidate);
+
+    void ICandidateSink.EmitBatch(IEnumerable<CandidateRef> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+        foreach (var c in candidates) Accept(c);
+    }
+}

--- a/tools/Mithril.MapCalibration.Harness/CalibrationSession.cs
+++ b/tools/Mithril.MapCalibration.Harness/CalibrationSession.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Mithril.MapCalibration;
 using Mithril.Tools.MapCalibration.Common;
@@ -14,13 +15,29 @@ namespace Mithril.Tools.MapCalibration.Harness;
 /// <see cref="LandmarkCalibrationSolver.Solve"/> unchanged (it self-corrects
 /// handedness by trying both reflections — don't bypass it).
 ///
+/// <para>The session is reactive at the ref granularity: mutating a ref's
+/// solve-input properties (<see cref="CalibrationRef.Enabled"/>,
+/// <see cref="CalibrationRef.World"/>, <see cref="CalibrationRef.TexturePixel"/>)
+/// auto-re-solves, so the spec's core composition UX ("disable a suspect ref,
+/// watch the residual") works by direct mutation — no explicit
+/// <see cref="ReSolve"/> call needed. This restores the lifted source's
+/// <c>Refs.CollectionChanged → ReSolve</c> wiring at finer granularity.</para>
+///
 /// <para>This type also doubles as the <see cref="ICandidateSink"/> a method
 /// emits into: <see cref="ICandidateSink.Emit"/> routes through
-/// <see cref="Accept"/>.</para>
+/// <see cref="Accept"/> and <see cref="ICandidateSink.EmitBatch"/> through the
+/// single-solve batch path.</para>
 /// </summary>
 public sealed partial class CalibrationSession : ObservableObject, ICandidateSink
 {
     private readonly CalibrationContext _ctx;
+
+    // Set while ReSolve writes back per-ref ResidualPx / Calibration. Those
+    // writes raise PropertyChanged, which would otherwise re-enter ReSolve; the
+    // guard breaks that feedback loop. (ResidualPx is also not a solve input, so
+    // the property filter in OnRefPropertyChanged already ignores it — the guard
+    // is belt-and-braces against any future write-back that touches an input.)
+    private bool _suppressReSolve;
 
     public CalibrationSession(CalibrationContext ctx)
     {
@@ -38,13 +55,26 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
     public ObservableCollection<ProjectionMarker> Projections { get; } = new();
 
     /// <summary>
-    /// Materialises a <see cref="CalibrationRef"/> from a <see cref="CandidateRef"/>
-    /// and re-solves. A candidate with no <see cref="CandidateRef.World"/> is
+    /// Materialises a single <see cref="CalibrationRef"/> from a
+    /// <see cref="CandidateRef"/> and re-solves once. (For an N-candidate batch
+    /// use <see cref="ICandidateSink.EmitBatch"/>, which adds all refs then
+    /// solves once.) A candidate with no <see cref="CandidateRef.World"/> is
     /// added as a disabled ref (it carries no world coord, so it can't yet
     /// participate in the fit — the user assigns its world position later, then
     /// enables it).
     /// </summary>
     public void Accept(CandidateRef candidate)
+    {
+        AddRef(candidate);
+        ReSolve();
+    }
+
+    /// <summary>
+    /// Materialises a ref from a candidate and registers it WITHOUT re-solving.
+    /// Shared by <see cref="Accept"/> (which adds one then re-solves) and the
+    /// batch path (which adds many then re-solves once).
+    /// </summary>
+    private void AddRef(CandidateRef candidate)
     {
         ArgumentNullException.ThrowIfNull(candidate);
         var hasWorld = candidate.World is not null;
@@ -54,30 +84,52 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
             Kind = candidate.Kind,
             Source = candidate.Source,
             Confidence = candidate.Confidence,
+            // (0,0,0) sentinel is load-bearing only while the ref is disabled: a
+            // World-null candidate is added disabled, so the sentinel never feeds
+            // the solve. The disabled-then-named flow (issue B) is "assign World,
+            // set Enabled=true" — both are solve inputs, so that auto-re-solves.
             World = candidate.World ?? default,
             TexturePixel = candidate.TexturePixel,
             Enabled = hasWorld,
         };
+        calRef.PropertyChanged += OnRefPropertyChanged;
         Refs.Add(calRef);
-        ReSolve();
     }
 
     /// <summary>Removes a ref from the live set and re-solves.</summary>
     public void Remove(CalibrationRef r)
     {
         if (r is null) return;
-        if (Refs.Remove(r)) ReSolve();
+        if (Refs.Remove(r))
+        {
+            r.PropertyChanged -= OnRefPropertyChanged;
+            ReSolve();
+        }
     }
 
     /// <summary>
     /// Correction primitive: nudges a ref's <see cref="CalibrationRef.TexturePixel"/>
-    /// by (<paramref name="dx"/>, <paramref name="dy"/>) and re-solves.
+    /// by (<paramref name="dx"/>, <paramref name="dy"/>). The mutation itself
+    /// triggers an automatic re-solve via the ref's <c>PropertyChanged</c>.
     /// </summary>
     public void NudgeSelected(CalibrationRef r, double dx, double dy)
     {
         if (r is null || !Refs.Contains(r)) return;
         r.TexturePixel = new PixelPoint(r.TexturePixel.X + dx, r.TexturePixel.Y + dy);
-        ReSolve();
+    }
+
+    // Re-solve only when a solve-input property changes. ResidualPx is an OUTPUT
+    // (written by ReSolve) so it's deliberately excluded — re-solving on it would
+    // be a feedback loop. Name/Kind/Source/Confidence are immutable init-only.
+    private void OnRefPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_suppressReSolve) return;
+        if (e.PropertyName is nameof(CalibrationRef.Enabled)
+            or nameof(CalibrationRef.World)
+            or nameof(CalibrationRef.TexturePixel))
+        {
+            ReSolve();
+        }
     }
 
     /// <summary>
@@ -85,8 +137,7 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
     /// enabled ref's <see cref="CalibrationRef.ResidualPx"/>, and refreshes the
     /// projection overlay for every landmark in the context. With fewer than two
     /// enabled refs the calibration is null, the projection overlay is cleared,
-    /// and all residuals are nulled. Lifted verbatim from
-    /// <c>AreaWorkspaceViewModel.ReSolve</c>.
+    /// and all residuals are nulled. Lifted from <c>AreaWorkspaceViewModel.ReSolve</c>.
     /// </summary>
     public void ReSolve()
     {
@@ -94,7 +145,7 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
         if (enabled.Count < 2)
         {
             Calibration = null;
-            foreach (var r in Refs) r.ResidualPx = null;
+            SetResidualsNull();
             Projections.Clear();
             return;
         }
@@ -108,26 +159,51 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
 
         if (cal is null)
         {
-            foreach (var r in Refs) r.ResidualPx = null;
+            SetResidualsNull();
             Projections.Clear();
             return;
         }
 
-        // Disabled refs carry no residual; enabled refs get the projected error.
-        foreach (var r in Refs)
+        // Suppress the re-solve feedback loop while writing per-ref residuals
+        // (each write raises PropertyChanged).
+        var prior = _suppressReSolve;
+        _suppressReSolve = true;
+        try
         {
-            if (!r.Enabled)
+            // Disabled refs carry no residual; enabled refs get the projected error.
+            foreach (var r in Refs)
             {
-                r.ResidualPx = null;
-                continue;
+                if (!r.Enabled)
+                {
+                    r.ResidualPx = null;
+                    continue;
+                }
+                var projected = cal.WorldToWindow(r.World);
+                var dx = projected.X - r.TexturePixel.X;
+                var dy = projected.Y - r.TexturePixel.Y;
+                r.ResidualPx = Math.Sqrt(dx * dx + dy * dy);
             }
-            var projected = cal.WorldToWindow(r.World);
-            var dx = projected.X - r.TexturePixel.X;
-            var dy = projected.Y - r.TexturePixel.Y;
-            r.ResidualPx = Math.Sqrt(dx * dx + dy * dy);
+        }
+        finally
+        {
+            _suppressReSolve = prior;
         }
 
         RefreshProjections(cal);
+    }
+
+    private void SetResidualsNull()
+    {
+        var prior = _suppressReSolve;
+        _suppressReSolve = true;
+        try
+        {
+            foreach (var r in Refs) r.ResidualPx = null;
+        }
+        finally
+        {
+            _suppressReSolve = prior;
+        }
     }
 
     private void RefreshProjections(AreaCalibration cal)
@@ -142,6 +218,10 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
         }
     }
 
+    // Prefer the enabled ref at this coord; disabled refs carry no residual, so
+    // a disabled ref must not supply a projection marker's ResidualPx. (The
+    // lifted source had no Enabled concept; the r.Enabled filter is the correct
+    // adaptation, not an accidental deviation.)
     private CalibrationRef? RefForLandmark(LandmarkRef landmark) =>
         Refs.FirstOrDefault(r =>
             r.Enabled
@@ -150,9 +230,22 @@ public sealed partial class CalibrationSession : ObservableObject, ICandidateSin
 
     void ICandidateSink.Emit(CandidateRef candidate) => Accept(candidate);
 
+    /// <summary>
+    /// Adds every candidate as a ref and re-solves <b>once</b> (not once per
+    /// candidate) — an N-candidate scan triggers a single solve + projection
+    /// rebuild, unlike calling <see cref="Accept"/> N times. The final
+    /// calibration is identical to the equivalent sequence of <see cref="Accept"/>
+    /// calls.
+    /// </summary>
     void ICandidateSink.EmitBatch(IEnumerable<CandidateRef> candidates)
     {
         ArgumentNullException.ThrowIfNull(candidates);
-        foreach (var c in candidates) Accept(c);
+        var any = false;
+        foreach (var c in candidates)
+        {
+            AddRef(c);
+            any = true;
+        }
+        if (any) ReSolve();
     }
 }

--- a/tools/Mithril.MapCalibration.Harness/CandidateRef.cs
+++ b/tools/Mithril.MapCalibration.Harness/CandidateRef.cs
@@ -1,0 +1,23 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// What a calibration method emits into the shared ref set via
+/// <see cref="ICandidateSink"/>. Coordinates are <b>texture-space</b> — a method
+/// converts from screenshot space through
+/// <see cref="CalibrationContext.ScreenshotToTexture"/> before emitting, so the
+/// session and solver never re-derive the map-rect math.
+///
+/// <para><see cref="World"/> is null when a method finds a position it cannot
+/// yet name (green-pixel detects a dot; the user assigns the landmark
+/// afterward). <see cref="Confidence"/> is 1.0 for manual clicks.</para>
+/// </summary>
+public sealed record CandidateRef(
+    PixelPoint TexturePixel,
+    WorldCoord? World,
+    string? LandmarkId,
+    string? SuggestedName,
+    string Kind,
+    CalibrationRefSource Source,
+    double Confidence);

--- a/tools/Mithril.MapCalibration.Harness/ICalibrationImage.cs
+++ b/tools/Mithril.MapCalibration.Harness/ICalibrationImage.cs
@@ -1,0 +1,22 @@
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// WPF-free image abstraction for the loaded in-game-map screenshot. Refines
+/// the design spec's <c>BitmapSource</c> so the harness core stays headless and
+/// trivially testable: the WPF shell (issue B) adapts its loaded
+/// <c>BitmapSource</c> to this; the test project supplies a synthetic one.
+/// Pixel access exists for automated methods (e.g. green-pixel detection) that
+/// scan the image.
+/// </summary>
+public interface ICalibrationImage
+{
+    int Width { get; }
+
+    int Height { get; }
+
+    /// <summary>
+    /// Returns the RGBA components of the pixel at (<paramref name="x"/>,
+    /// <paramref name="y"/>). Bounds are the caller's responsibility.
+    /// </summary>
+    (byte R, byte G, byte B, byte A) GetPixel(int x, int y);
+}

--- a/tools/Mithril.MapCalibration.Harness/ICalibrationMethod.cs
+++ b/tools/Mithril.MapCalibration.Harness/ICalibrationMethod.cs
@@ -1,0 +1,31 @@
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// A pluggable producer of calibration references. Every method differs only in
+/// how it produces <c>(world, texture)</c> pairs; everything downstream (solve,
+/// verify, correct, commit) is the harness's job. A method is
+/// <see cref="Activate"/>d for a session and emits candidates via the sink until
+/// the returned <see cref="IDisposable"/> is disposed. This unifies interactive
+/// producers (manual-click stays subscribed to surface clicks) and batch
+/// producers (green-pixel scans on a trigger).
+/// </summary>
+public interface ICalibrationMethod
+{
+    string Name { get; }
+
+    string Description { get; }
+
+    /// <summary>
+    /// A WPF <c>UserControl</c> hosted in the shell's method panel (landmark
+    /// picker / sliders / "scan" button), or null. <b>Always null in the
+    /// headless core and tests</b> — typed as <see cref="object"/> so the core
+    /// stays WPF-free.
+    /// </summary>
+    object? ConfigView { get; }
+
+    /// <summary>
+    /// Begins producing candidates for <paramref name="ctx"/> into
+    /// <paramref name="sink"/>. Dispose the returned handle to detach the method.
+    /// </summary>
+    IDisposable Activate(CalibrationContext ctx, ICandidateSink sink);
+}

--- a/tools/Mithril.MapCalibration.Harness/ICandidateSink.cs
+++ b/tools/Mithril.MapCalibration.Harness/ICandidateSink.cs
@@ -1,0 +1,14 @@
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// The channel a calibration method emits <see cref="CandidateRef"/>s into.
+/// Interactive methods call <see cref="Emit"/> once per user action; batch
+/// methods call <see cref="EmitBatch"/> after a scan. The session accepts each
+/// candidate into its live ref set and re-solves.
+/// </summary>
+public interface ICandidateSink
+{
+    void Emit(CandidateRef candidate);
+
+    void EmitBatch(IEnumerable<CandidateRef> candidates);
+}

--- a/tools/Mithril.MapCalibration.Harness/MapRect.cs
+++ b/tools/Mithril.MapCalibration.Harness/MapRect.cs
@@ -1,0 +1,8 @@
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// The texture extent within the loaded screenshot, in screenshot-pixel space:
+/// the rectangle the base map texture occupies on the in-game-map image. Drives
+/// the screenshot&#8596;texture transform on <see cref="CalibrationContext"/>.
+/// </summary>
+public readonly record struct MapRect(double Left, double Top, double Width, double Height);

--- a/tools/Mithril.MapCalibration.Harness/Mithril.MapCalibration.Harness.csproj
+++ b/tools/Mithril.MapCalibration.Harness/Mithril.MapCalibration.Harness.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Tools.MapCalibration.Harness</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Headless harness core: NO WPF (no UseWPF / no PresentationCore). The
+         in-game-map image is consumed via the WPF-free ICalibrationImage
+         abstraction; the WPF shell (issue B) adapts a BitmapSource to it.
+         Same isolation pattern as Mithril.MapCalibration.Tools.Common: opt out
+         of central package management + the repo's Directory.Build.targets so
+         the explicit-versioned package refs below don't clash. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <!-- System.Drawing-free, but the target is Windows-only via net10.0-windows. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Version mirrors Directory.Packages.props (central PM is off here). -->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+    <ProjectReference Include="..\Mithril.MapCalibration.Tools.Common\Mithril.MapCalibration.Tools.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Mithril.MapCalibration.Harness/ProjectionMarker.cs
+++ b/tools/Mithril.MapCalibration.Harness/ProjectionMarker.cs
@@ -1,0 +1,17 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibration.Harness;
+
+/// <summary>
+/// A landmark projected through the current calibration, for the verification
+/// overlay. <see cref="TexturePixel"/> is where the current
+/// <see cref="AreaCalibration"/> places this landmark in texture space (the WPF
+/// shell maps it to screenshot space for drawing). <see cref="ResidualPx"/> is
+/// the per-ref residual when this landmark is also an enabled reference, else
+/// null (a pure generalization check — projected but never ref'd).
+/// </summary>
+public sealed record ProjectionMarker(
+    string Name,
+    string Kind,
+    PixelPoint TexturePixel,
+    double? ResidualPx);


### PR DESCRIPTION
## What shipped

The **headless core** of the map-calibration harness (#884) — the engine + plug-in contract that interchangeable calibration methods feed into. **No WPF, no real methods** (only an in-test fake). Foundation for issue B (WPF shell + manual-click) and issue C (green-pixel).

### New isolated lib `tools/Mithril.MapCalibration.Harness/`
Same isolation pattern as `Mithril.MapCalibration.Tools.Common`: `net10.0-windows`, opts out of central package management + `Directory.Build.targets`, `NoWarn CA1416`. ProjectReferences `src/Mithril.MapCalibration` + `tools/Mithril.MapCalibration.Tools.Common`. `CommunityToolkit.Mvvm` pinned to `8.4.2` (mirrors `Directory.Packages.props`).

### Contract types (one file per top-level type)
- `CalibrationRefSource` enum, `CandidateRef` record, `ICalibrationImage` (WPF-free image abstraction — refines the spec's `BitmapSource`), `MapRect`, `CalibrationContext` (+ `ScreenshotToTexture`/`TextureToScreenshot`), `ICandidateSink`, `ICalibrationMethod` (`ConfigView` is `object?`, null in core), `ProjectionMarker`.
- `CalibrationRef : ObservableObject` (observable `World`/`TexturePixel`/`Enabled`/`ResidualPx`).
- `CalibrationSession : ObservableObject, ICandidateSink` — `Accept`/`Remove`/`NudgeSelected`/`ReSolve` lifted headless from `AreaWorkspaceViewModel`. Solve goes through `LandmarkCalibrationSolver.Solve` unchanged (handedness self-correction preserved). `ReSolve` builds refs from **enabled** refs only; <2 enabled ⇒ null calibration, cleared projections, nulled residuals; otherwise fills per-ref residual and refreshes `Projections` for **all** `ctx.Landmarks`. A candidate with no `World` is added as a **disabled** ref (named/enabled later).

### Coordinate transforms (CalibrationContext)
`ScreenshotToTexture(sx,sy) = ((sx-rect.Left)*texW/rect.Width, (sy-rect.Top)*texH/rect.Height)` + its inverse. Throw if no `MapRect` set.

## Verification

- `dotnet build tools/Mithril.MapCalibration.Harness/...` — green, 0 warnings.
- No WPF assembly in the lib: csproj has no `UseWPF`/`PresentationCore`; built `.deps.json` has zero `Presentation*`/`WindowsBase`/`System.Windows` entries.
- `dotnet test tests/Mithril.MapCalibration.Harness.Tests`:

```
Passed!  - Failed:     0, Passed:    23, Skipped:     0, Total:    23, Duration: 325 ms
```

Coverage: transform round-trip over a range of rects + texture sizes; ref change-notification; known synthetic correspondences recover a known calibration (mirrors `LandmarkCalibrationSolverTests` fixtures); disabling a ref changes the fit; a deliberately-bad ref inflates residual and disabling it restores it; <2 enabled ⇒ null calibration; nudge re-solves; projections refresh for all landmarks (not just refs); fake-method → sink integration end-to-end.

Both projects added to `Mithril.slnx`.

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
