### PR TITLE
feat(map-calibration): gate-study measurement tool (#897)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -49,6 +49,7 @@
     <Project Path="tests/Elrond.Tests/Elrond.Tests.csproj" />
     <Project Path="tests/Gandalf.Tests/Gandalf.Tests.csproj" />
     <Project Path="tests/Legolas.Tests/Legolas.Tests.csproj" />
+    <Project Path="tests/MapCalibrationStudy.Tests/MapCalibrationStudy.Tests.csproj" />
     <Project Path="tests/Mithril.GameReports.Tests/Mithril.GameReports.Tests.csproj" />
     <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
     <Project Path="tests/Mithril.LogSanitizer.Tests/Mithril.LogSanitizer.Tests.csproj" />

--- a/tests/MapCalibrationStudy.Tests/AffineFitTests.cs
+++ b/tests/MapCalibrationStudy.Tests/AffineFitTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationStudy;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class AffineFitTests
+{
+    private static (double wx, double wz, double px, double py) P(
+        double wx, double wz, double s, double rot, double ox, double oy)
+    {
+        var cos = Math.Cos(rot); var sin = Math.Sin(rot);
+        var rotE = wx * cos + wz * sin;
+        var rotN = -wx * sin + wz * cos;
+        return (wx, wz, ox + s * rotE, oy - s * rotN);
+    }
+
+    [Fact]
+    public void Affine_fits_a_pure_similarity_with_near_zero_residual()
+    {
+        const double s = 1.7, rot = 0.0, ox = 12, oy = -5;
+        var pts = new[]
+        {
+            P(0, 0, s, rot, ox, oy),
+            P(100, 0, s, rot, ox, oy),
+            P(0, 80, s, rot, ox, oy),
+            P(100, 80, s, rot, ox, oy),
+            P(40, 30, s, rot, ox, oy),
+        };
+
+        AffineFit.Rms(pts).Should().BeLessThan(1e-6);
+    }
+
+    [Fact]
+    public void Affine_rms_never_exceeds_similarity_rms()
+    {
+        // Perturb one point so neither model is exact; affine (more DOF) must
+        // still fit at least as tightly as the similarity.
+        const double s = 1.7, rot = 0.0, ox = 12, oy = -5;
+        var pts = new[]
+        {
+            P(0, 0, s, rot, ox, oy),
+            P(100, 0, s, rot, ox, oy),
+            P(0, 80, s, rot, ox, oy),
+            (wx: 100.0, wz: 80.0, px: 999.0, py: -999.0), // outlier
+            P(40, 30, s, rot, ox, oy),
+        };
+
+        AffineFit.Rms(pts).Should().BeLessThanOrEqualTo(AffineFit.SimilarityRms(pts) + 1e-9);
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/ColdBootstrapTests.cs
+++ b/tests/MapCalibrationStudy.Tests/ColdBootstrapTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibrationStudy;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class ColdBootstrapTests
+{
+    // Known ground-truth transform for the synthetic area: scale, origin, and a
+    // reflection (mirrorX/mirrorZ) — exercises orientation recovery.
+    private static PixelPoint Project(WorldCoord w, double s, double ox, double oy, bool mirrorX, bool mirrorZ)
+    {
+        var x = mirrorX ? -w.X : w.X;
+        var z = mirrorZ ? -w.Z : w.Z;
+        return new PixelPoint(ox + s * x, oy - s * z);
+    }
+
+    [Fact]
+    public void Recovers_orientation_correspondence_and_transform_cold()
+    {
+        // ColdBootstrap's rough prediction assumes the world bbox fills the
+        // texture (scale0 = texture/span), so the synthetic detected cloud must
+        // also roughly fill the texture for nearest-neighbour pairing to match —
+        // that low-inset regime IS the H3 hypothesis the engine relies on. The
+        // origin centres the projected bbox in the texture; the texture is sized
+        // to the projection so scale0 ≈ the true scale.
+        const double s = 1.5;
+        const bool mirrorX = true, mirrorZ = false; // a non-trivial orientation
+        const int texW = 512, texH = 384;
+        const double ox = 481, oy = 357; // centres the mirrored projected bbox in the texture
+        var world = new List<WorldCoord>
+        {
+            new(0, 0, 0), new(300, 0, 0), new(0, 0, 220),
+            new(300, 0, 220), new(225, 0, 55), new(75, 0, 165),
+        };
+        // Detected icons = ground-truth projections, shuffled (detection has no
+        // landmark identity — pairing must be inferred by geometry).
+        var detected = world.Select(w => Project(w, s, ox, oy, mirrorX, mirrorZ)).ToList();
+        var shuffled = new List<PixelPoint> { detected[3], detected[0], detected[5], detected[1], detected[4], detected[2] };
+
+        var result = ColdBootstrap.Run(world, shuffled, textureW: texW, textureH: texH, axisThresholdPx: 8.0);
+
+        result.Should().NotBeNull();
+        result!.RefinedResidualPx.Should().BeLessThan(1.0);
+        result.CorrespondedCount.Should().Be(6);
+    }
+
+    [Fact]
+    public void Survives_a_one_axis_outlier_detection()
+    {
+        const double s = 1.5, ox = 600, oy = 700;
+        var world = new List<WorldCoord>
+        {
+            new(0, 0, 0), new(200, 0, 0), new(0, 0, 150),
+            new(200, 0, 150), new(90, 0, 60), new(40, 0, 120),
+        };
+        var detected = world.Select(w => Project(w, s, ox, oy, mirrorX: false, mirrorZ: false)).ToList();
+        detected[4] = new PixelPoint(detected[4].X + 40, detected[4].Y); // +40px X only
+
+        var result = ColdBootstrap.Run(world, detected, textureW: 1280, textureH: 1024, axisThresholdPx: 8.0);
+
+        result.Should().NotBeNull();
+        result!.RefinedResidualPx.Should().BeLessThan(1.0); // outlier dropped
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/ColdBootstrapTests.cs
+++ b/tests/MapCalibrationStudy.Tests/ColdBootstrapTests.cs
@@ -28,11 +28,19 @@ public class ColdBootstrapTests
         const double s = 1.5;
         const bool mirrorX = true, mirrorZ = false; // a non-trivial orientation
         const int texW = 512, texH = 384;
-        const double ox = 481, oy = 357; // centres the mirrored projected bbox in the texture
+        const double ox = 485, oy = 351; // centres the mirrored projected bbox in the texture
+        // ASYMMETRIC landmark cloud: the set is NOT point-symmetric about its
+        // centroid, so the wrong (reflected) orientation cannot mispair all
+        // landmarks to clean reflection-partner icons — only the true
+        // orientation reprojects the whole detected set consistently. (A
+        // point-symmetric cloud is genuinely 0°/180° ambiguous; real PG areas
+        // aren't, and neither is this fixture.) The two interior points break
+        // the corners' symmetry; the corners' own centre (150,110) differs from
+        // the full-set centroid, so no landmark maps onto another under 180°.
         var world = new List<WorldCoord>
         {
             new(0, 0, 0), new(300, 0, 0), new(0, 0, 220),
-            new(300, 0, 220), new(225, 0, 55), new(75, 0, 165),
+            new(300, 0, 220), new(225, 0, 55), new(90, 0, 140),
         };
         // Detected icons = ground-truth projections, shuffled (detection has no
         // landmark identity — pairing must be inferred by geometry).
@@ -42,8 +50,26 @@ public class ColdBootstrapTests
         var result = ColdBootstrap.Run(world, shuffled, textureW: texW, textureH: texH, axisThresholdPx: 8.0);
 
         result.Should().NotBeNull();
-        result!.RefinedResidualPx.Should().BeLessThan(1.0);
-        result.CorrespondedCount.Should().Be(6);
+        result!.CorrespondedCount.Should().Be(6);
+        // The winning orientation reprojects the WHOLE detected set consistently
+        // (global score near zero) — this is the metric that separates the true
+        // orientation from a reflected one that merely fit a subset.
+        result.GlobalReprojectionPx.Should().BeLessThan(1.0);
+
+        // The decisive H4 assertion: pin the RECOVERED TRANSFORM, not just the
+        // count + a subset residual. A wrong-orientation run can also hit
+        // count==6 and a near-zero subset residual (it fit a DIFFERENT subset),
+        // so those alone don't prove blind recovery. Assert (parameterization-
+        // agnostic) that the recovered calibration reprojects every world
+        // landmark back onto its TRUE detected pixel — which only the
+        // ground-truth orientation can do.
+        foreach (var w in world)
+        {
+            var expected = Project(w, s, ox, oy, mirrorX, mirrorZ);
+            var actual = result.Calibration.WorldToWindow(w);
+            actual.X.Should().BeApproximately(expected.X, 1.0);
+            actual.Y.Should().BeApproximately(expected.Y, 1.0);
+        }
     }
 
     [Fact]

--- a/tests/MapCalibrationStudy.Tests/ColdBootstrapTests.cs
+++ b/tests/MapCalibrationStudy.Tests/ColdBootstrapTests.cs
@@ -55,6 +55,11 @@ public class ColdBootstrapTests
         // (global score near zero) — this is the metric that separates the true
         // orientation from a reflected one that merely fit a subset.
         result.GlobalReprojectionPx.Should().BeLessThan(1.0);
+        // H2 column is a REAL number in bootstrap mode (affine fit over the kept
+        // inliers), not NaN — on a clean similarity cloud it ties the similarity
+        // at ~0, which is the apples-to-apples isotropy answer.
+        double.IsNaN(result.AffineResidualPx).Should().BeFalse();
+        result.AffineResidualPx.Should().BeLessThan(1.0);
 
         // The decisive H4 assertion: pin the RECOVERED TRANSFORM, not just the
         // count + a subset residual. A wrong-orientation run can also hit

--- a/tests/MapCalibrationStudy.Tests/InsetMetricsTests.cs
+++ b/tests/MapCalibrationStudy.Tests/InsetMetricsTests.cs
@@ -36,14 +36,18 @@ public class InsetMetricsTests
     [Fact]
     public void Detects_a_uniform_border_inset()
     {
-        // Same world span, but the texture is 10% larger on each side than the
-        // projected bbox → the solved scale is smaller than texture/span, and
-        // the inset fraction is ~0.1 per edge in the larger dimension.
+        // Same world span (projected bbox 1000x800), but the texture is larger
+        // than the bbox by a uniform border → the solved scale is smaller than
+        // texture/span, and the inset fraction is the same on every edge: a
+        // 100px margin on X (texW 1200 = 1000 + 100 each side) and an 80px
+        // margin on Y (texH 960 = 800 + 80 each side).
         const double s = 2.0;
         const int texW = 1200, texH = 960;     // 1000x800 content + 100px X / 80px Y margin each side
-        // Y-flip again: a uniform Y margin of (960−800)/2 = 80px means world Z=0
-        // projects to pY = 880 (bottom inset 80) and Z=400 to pY = 80 (top inset 80).
-        var cal = new AreaCalibration(s, 0.0, 100.0, 880.0, 4, 0.0); // origin offset = the inset
+        // WorldToWindow flips Y (pY = oy − s·Z): the 80px Y margin means world
+        // Z=0 projects to pY = 880 (bottom inset 80) and Z=400 to pY = 80 (top
+        // inset 80). originX 100 is the left inset; originY 880 is the Y-flip
+        // anchor that places the bbox at the uniform 80px Y margin.
+        var cal = new AreaCalibration(s, 0.0, 100.0, 880.0, 4, 0.0);
         var world = new[]
         {
             new WorldCoord(0,   0, 0),

--- a/tests/MapCalibrationStudy.Tests/InsetMetricsTests.cs
+++ b/tests/MapCalibrationStudy.Tests/InsetMetricsTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibrationStudy;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class InsetMetricsTests
+{
+    [Fact]
+    public void No_inset_when_world_bbox_fills_texture()
+    {
+        const double s = 2.0;
+        const int texW = 1000, texH = 800;
+        // World bbox chosen so s*span == texture dim: spanX = 500, spanZ = 400.
+        // Place 4 corner landmarks. WorldToWindow flips Y (north up: pY = oy − s·Z),
+        // so for the bbox to fill the texture exactly the origin maps world(0,0,0)
+        // → bottom-left pixel (0, texH) and world(500,0,400) → top-right (texW, 0).
+        var cal = new AreaCalibration(s, 0.0, 0.0, texH, 4, 0.0);
+        var world = new[]
+        {
+            new WorldCoord(0,   0, 0),
+            new WorldCoord(500, 0, 0),
+            new WorldCoord(0,   0, 400),
+            new WorldCoord(500, 0, 400),
+        };
+
+        var m = InsetMetrics.Compute(cal, world, texW, texH);
+
+        m.PredictedScaleX.Should().BeApproximately(s, 1e-9);
+        m.PredictedScaleZ.Should().BeApproximately(s, 1e-9);
+        m.ScaleRatioX.Should().BeApproximately(1.0, 1e-9);
+        m.InsetFracMax.Should().BeApproximately(0.0, 1e-9);
+    }
+
+    [Fact]
+    public void Detects_a_uniform_border_inset()
+    {
+        // Same world span, but the texture is 10% larger on each side than the
+        // projected bbox → the solved scale is smaller than texture/span, and
+        // the inset fraction is ~0.1 per edge in the larger dimension.
+        const double s = 2.0;
+        const int texW = 1200, texH = 960;     // 1000x800 content + 100px X / 80px Y margin each side
+        // Y-flip again: a uniform Y margin of (960−800)/2 = 80px means world Z=0
+        // projects to pY = 880 (bottom inset 80) and Z=400 to pY = 80 (top inset 80).
+        var cal = new AreaCalibration(s, 0.0, 100.0, 880.0, 4, 0.0); // origin offset = the inset
+        var world = new[]
+        {
+            new WorldCoord(0,   0, 0),
+            new WorldCoord(500, 0, 0),
+            new WorldCoord(0,   0, 400),
+            new WorldCoord(500, 0, 400),
+        };
+
+        var m = InsetMetrics.Compute(cal, world, texW, texH);
+
+        // predictedScale assumes no inset: texW/spanX = 1200/500 = 2.4 > s.
+        m.PredictedScaleX.Should().BeApproximately(2.4, 1e-9);
+        m.ScaleRatioX.Should().BeApproximately(s / 2.4, 1e-9);
+        m.InsetFracMax.Should().BeApproximately(100.0 / 1200.0, 1e-6); // left margin / texW
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/MapCalibrationStudy.Tests.csproj
+++ b/tests/MapCalibrationStudy.Tests/MapCalibrationStudy.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.Tools.MapCalibrationStudy.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Cross-boundary ProjectReference into the isolated tool Exe is fine; the
+         tool's PM/targets opt-out is build-local (same as the harness tests). -->
+    <ProjectReference Include="..\..\tools\MapCalibrationStudy\MapCalibrationStudy.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/MapCalibrationStudy.Tests/OrientationClassTests.cs
+++ b/tests/MapCalibrationStudy.Tests/OrientationClassTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationStudy;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class OrientationClassTests
+{
+    [Theory]
+    [InlineData(0.00033359980485819676, 0)]     // AreaSerbule
+    [InlineData(5.863329159379195e-06, 0)]       // AreaCave1
+    [InlineData(-3.141529626160087, 180)]        // AreaEltibule ≈ -π
+    [InlineData(3.1415789203621567, 180)]        // AreaKurMountains ≈ +π
+    public void Classifies_to_nearest_axis_member(double radians, int expectedDeg)
+    {
+        OrientationClass.Classify(radians).NearestDeg.Should().Be(expectedDeg);
+    }
+
+    [Fact]
+    public void Reports_small_deviation_for_on_axis_rotation()
+    {
+        var c = OrientationClass.Classify(0.00033359980485819676);
+        c.DeviationDeg.Should().BeLessThan(0.05);
+        c.InSet.Should().BeTrue();   // within tolerance of a member
+    }
+
+    [Fact]
+    public void Flags_an_in_between_angle_as_out_of_set()
+    {
+        var c = OrientationClass.Classify(Math.PI / 4); // 45° — neither 0 nor 180
+        c.NearestDeg.Should().Be(0);                    // 45 is closer to 0 than 180
+        c.DeviationDeg.Should().BeApproximately(45, 0.01);
+        c.InSet.Should().BeFalse();
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/OutlierGuardTests.cs
+++ b/tests/MapCalibrationStudy.Tests/OutlierGuardTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibrationStudy;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class OutlierGuardTests
+{
+    [Fact]
+    public void Drops_a_single_axis_outlier_and_improves_residual()
+    {
+        const double s = 2.0, ox = 10, oy = 20;
+        PixelPoint Px(double wx, double wz, double dx = 0, double dy = 0)
+            => new(ox + s * wx + dx, oy - s * wz + dy);
+
+        var refs = new List<LandmarkCalibrationSolver.Reference>
+        {
+            new(0, 0, Px(0, 0)),
+            new(50, 0, Px(50, 0)),
+            new(0, 40, Px(0, 40)),
+            new(50, 40, Px(50, 40)),
+            new(25, 20, Px(25, 20, dx: 30, dy: 0)), // +30px in X only — the outlier
+        };
+
+        var kept = OutlierGuard.Reject(refs, axisThresholdPx: 8.0);
+
+        kept.Should().HaveCount(4);
+        var cal = LandmarkCalibrationSolver.Solve(kept);
+        cal!.ResidualPixels.Should().BeLessThan(1e-6);
+    }
+
+    [Fact]
+    public void Keeps_all_when_no_axis_asymmetric_outlier()
+    {
+        const double s = 2.0, ox = 10, oy = 20;
+        PixelPoint Px(double wx, double wz) => new(ox + s * wx, oy - s * wz);
+        var refs = new List<LandmarkCalibrationSolver.Reference>
+        {
+            new(0, 0, Px(0, 0)), new(50, 0, Px(50, 0)),
+            new(0, 40, Px(0, 40)), new(50, 40, Px(50, 40)),
+        };
+        OutlierGuard.Reject(refs, axisThresholdPx: 8.0).Should().HaveCount(4);
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/ScaffoldTests.cs
+++ b/tests/MapCalibrationStudy.Tests/ScaffoldTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Mithril.Tools.MapCalibrationStudy;
 using Xunit;
 
 namespace Mithril.Tools.MapCalibrationStudy.Tests;
@@ -8,6 +9,6 @@ public class ScaffoldTests
     [Fact]
     public void Test_project_builds_and_runs()
     {
-        true.Should().BeTrue();
+        typeof(OrientationClass).Assembly.Should().NotBeNull();
     }
 }

--- a/tests/MapCalibrationStudy.Tests/ScaffoldTests.cs
+++ b/tests/MapCalibrationStudy.Tests/ScaffoldTests.cs
@@ -1,0 +1,13 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class ScaffoldTests
+{
+    [Fact]
+    public void Test_project_builds_and_runs()
+    {
+        true.Should().BeTrue();
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/StudyRecordTests.cs
+++ b/tests/MapCalibrationStudy.Tests/StudyRecordTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationStudy;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class StudyRecordTests
+{
+    [Fact]
+    public void Csv_has_header_and_one_row_per_record()
+    {
+        var rows = new[]
+        {
+            new StudyRecord("AreaSerbule", 0.019, 0, false, 0.385, 0.40, 0.96, 0.012, 0.30, 0.31, 6, true),
+            new StudyRecord("AreaEltibule", -179.996, 180, false, 0.315, 0.33, 0.95, 0.011, 0.34, 0.35, 5, true),
+        };
+        var csv = StudyRecord.ToCsv(rows);
+        var lines = csv.Trim().Split('\n');
+        lines.Should().HaveCount(3); // header + 2
+        lines[0].Should().Contain("area").And.Contain("rotationDeg").And.Contain("insetFracMax");
+        lines[1].Should().StartWith("AreaSerbule,");
+    }
+
+    [Fact]
+    public void Markdown_renders_a_table()
+    {
+        var rows = new[] { new StudyRecord("AreaCave1", 0.0003, 0, false, 0.42, 0.43, 0.98, 0.0, 0.05, 0.05, 4, true) };
+        var md = StudyRecord.ToMarkdown(rows);
+        md.Should().Contain("| area |").And.Contain("| AreaCave1 |");
+    }
+}

--- a/tests/MapCalibrationStudy.Tests/StudyRecordTests.cs
+++ b/tests/MapCalibrationStudy.Tests/StudyRecordTests.cs
@@ -28,4 +28,19 @@ public class StudyRecordTests
         var md = StudyRecord.ToMarkdown(rows);
         md.Should().Contain("| area |").And.Contain("| AreaCave1 |");
     }
+
+    [Fact]
+    public void NaN_affine_renders_as_na_not_a_number()
+    {
+        // measure mode emits NaN for the affine column (no independent pixels);
+        // it must read as a clearly non-numeric token, never "0" or blank.
+        var rows = new[] { new StudyRecord("AreaSerbule", 0.019, 0, false, 0.385, 0.40, 0.96, 0.012, 0.30, double.NaN, 0, false) };
+
+        var csv = StudyRecord.ToCsv(rows);
+        var md = StudyRecord.ToMarkdown(rows);
+
+        // affineResidualPx is the 10th CSV column.
+        csv.Trim().Split('\n')[1].Split(',')[9].Should().Be("n/a");
+        md.Should().Contain("n/a").And.NotContain("NaN");
+    }
 }

--- a/tools/MapCalibrationStudy/AffineFit.cs
+++ b/tools/MapCalibrationStudy/AffineFit.cs
@@ -1,0 +1,65 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationStudy;
+
+/// <summary>
+/// (H2) Isotropy check. Fits a full 6-parameter affine
+/// (px = a·wx + b·wz + c; py = d·wx + e·wz + f) by least squares and reports
+/// its RMS pixel residual, alongside the constrained 4-param similarity RMS
+/// (via the shipped <see cref="LandmarkCalibrationSolver"/>). If the affine
+/// barely beats the similarity on real data, the renderer is isotropic.
+/// </summary>
+public static class AffineFit
+{
+    public static double Rms(IReadOnlyList<(double wx, double wz, double px, double py)> pts)
+    {
+        if (pts.Count < 3) throw new ArgumentException("affine needs >= 3 points", nameof(pts));
+        // Two independent 3-param normal-equation solves (X then Y) on basis
+        // [wx, wz, 1]. Symmetric 3x3 system; solved by Cramer's rule.
+        var (ax, bx, cx) = Solve3(pts, forX: true);
+        var (ay, by, cy) = Solve3(pts, forX: false);
+        double sumSq = 0;
+        foreach (var (wx, wz, px, py) in pts)
+        {
+            var ex = ax * wx + bx * wz + cx - px;
+            var ey = ay * wx + by * wz + cy - py;
+            sumSq += ex * ex + ey * ey;
+        }
+        return Math.Sqrt(sumSq / pts.Count);
+    }
+
+    public static double SimilarityRms(IReadOnlyList<(double wx, double wz, double px, double py)> pts)
+    {
+        var refs = pts
+            .Select(p => new LandmarkCalibrationSolver.Reference(p.wx, p.wz, new PixelPoint(p.px, p.py)))
+            .ToList();
+        var cal = LandmarkCalibrationSolver.Solve(refs);
+        return cal?.ResidualPixels ?? double.PositiveInfinity;
+    }
+
+    private static (double a, double b, double c) Solve3(
+        IReadOnlyList<(double wx, double wz, double px, double py)> pts, bool forX)
+    {
+        // Normal equations for minimising Σ (a·wx + b·wz + c − t)².
+        double Sxx = 0, Sxz = 0, Sx1 = 0, Szz = 0, Sz1 = 0, S11 = 0;
+        double Sxt = 0, Szt = 0, S1t = 0;
+        foreach (var (wx, wz, px, py) in pts)
+        {
+            var t = forX ? px : py;
+            Sxx += wx * wx; Sxz += wx * wz; Sx1 += wx;
+            Szz += wz * wz; Sz1 += wz; S11 += 1;
+            Sxt += wx * t; Szt += wz * t; S1t += t;
+        }
+        // 3x3 symmetric matrix M = [[Sxx,Sxz,Sx1],[Sxz,Szz,Sz1],[Sx1,Sz1,S11]],
+        // rhs = [Sxt,Szt,S1t]. Cramer's rule.
+        double Det(double a, double b, double c, double d, double e, double f, double g, double h, double i)
+            => a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+
+        var det = Det(Sxx, Sxz, Sx1, Sxz, Szz, Sz1, Sx1, Sz1, S11);
+        if (Math.Abs(det) < 1e-12) return (0, 0, S1t / Math.Max(1, S11)); // degenerate fallback
+        var a = Det(Sxt, Sxz, Sx1, Szt, Szz, Sz1, S1t, Sz1, S11) / det;
+        var b = Det(Sxx, Sxt, Sx1, Sxz, Szt, Sz1, Sx1, S1t, S11) / det;
+        var c = Det(Sxx, Sxz, Sxt, Sxz, Szz, Szt, Sx1, Sz1, S1t) / det;
+        return (a, b, c);
+    }
+}

--- a/tools/MapCalibrationStudy/ColdBootstrap.cs
+++ b/tools/MapCalibrationStudy/ColdBootstrap.cs
@@ -1,0 +1,100 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationStudy;
+
+/// <summary>
+/// (H4) The decisive proof: from ONLY world landmark coordinates + texture
+/// dimensions + detected icon pixels (no stored calibration, no manual clicks),
+/// recover the renderer transform. Enumerates the 4 axis-aligned orientation
+/// states (±X × ±Z), estimates a rough scale-from-bbox per state, corresponds
+/// each predicted landmark to its nearest detected icon, solves via the shipped
+/// similarity solver (which re-confirms handedness), and keeps the best-fitting
+/// orientation after an outlier-guard pass. Informational prototype of the
+/// engine's correspondence step — not the engine itself.
+/// </summary>
+public static class ColdBootstrap
+{
+    public sealed record Result(
+        AreaCalibration Calibration,
+        double RefinedResidualPx,
+        int CorrespondedCount,
+        bool MirrorX,
+        bool MirrorZ);
+
+    public static Result? Run(
+        IReadOnlyList<WorldCoord> world,
+        IReadOnlyList<PixelPoint> detected,
+        int textureW,
+        int textureH,
+        double axisThresholdPx)
+    {
+        if (world.Count < 3 || detected.Count < 3) return null;
+
+        double minX = world.Min(w => w.X), maxX = world.Max(w => w.X);
+        double minZ = world.Min(w => w.Z), maxZ = world.Max(w => w.Z);
+        var spanX = Math.Max(1e-9, maxX - minX);
+        var spanZ = Math.Max(1e-9, maxZ - minZ);
+        // Rough isotropic scale: the smaller predicted scale avoids over-shooting
+        // when one axis is inset more than the other.
+        var scale0 = Math.Min(textureW / spanX, textureH / spanZ);
+
+        Result? best = null;
+        foreach (var mirrorX in new[] { false, true })
+        foreach (var mirrorZ in new[] { false, true })
+        {
+            // Predict each landmark's texture pixel under this orientation +
+            // rough scale, centring the world bbox in the texture so nearest-
+            // neighbour correspondence is meaningful before the real solve.
+            var cxWorld = (minX + maxX) / 2.0;
+            var czWorld = (minZ + maxZ) / 2.0;
+            PixelPoint Predict(WorldCoord w)
+            {
+                var x = (mirrorX ? -1 : 1) * (w.X - cxWorld);
+                var z = (mirrorZ ? -1 : 1) * (w.Z - czWorld);
+                return new PixelPoint(textureW / 2.0 + scale0 * x, textureH / 2.0 - scale0 * z);
+            }
+
+            var refs = new List<LandmarkCalibrationSolver.Reference>();
+            var used = new bool[detected.Count];
+            var corresponded = 0;
+            foreach (var w in world)
+            {
+                var pred = Predict(w);
+                var bestIdx = -1; var bestD = double.MaxValue;
+                for (var i = 0; i < detected.Count; i++)
+                {
+                    if (used[i]) continue;
+                    var dx = detected[i].X - pred.X;
+                    var dy = detected[i].Y - pred.Y;
+                    var d = dx * dx + dy * dy;
+                    if (d < bestD) { bestD = d; bestIdx = i; }
+                }
+                if (bestIdx < 0) continue;
+                used[bestIdx] = true;
+                corresponded++;
+                refs.Add(new LandmarkCalibrationSolver.Reference(w.X, w.Z, detected[bestIdx]));
+            }
+
+            if (refs.Count < 3) continue;
+            var kept = OutlierGuard.Reject(refs, axisThresholdPx);
+            var cal = LandmarkCalibrationSolver.Solve(kept);
+            if (cal is null) continue;
+
+            // Several enumerated orientations can tie at (near-)zero residual:
+            // the shipped solver internally re-confirms handedness, so even a
+            // "wrong" enumerated mirror fits a self-consistent subset perfectly.
+            // Break residual ties by preferring the orientation that retained
+            // MORE references through the outlier guard — a perfect fit on 6
+            // inliers beats a perfect fit on 4 (the latter mispaired two icons
+            // and the guard discarded them). Use a small epsilon so a marginally
+            // larger residual with more inliers still wins.
+            if (best is null
+                || cal.ResidualPixels < best.RefinedResidualPx - 1e-6
+                || (cal.ResidualPixels <= best.RefinedResidualPx + 1e-6
+                    && kept.Count > best.CorrespondedCount))
+                best = new Result(cal, cal.ResidualPixels, kept.Count, mirrorX, mirrorZ);
+        }
+
+        return best;
+    }
+}

--- a/tools/MapCalibrationStudy/ColdBootstrap.cs
+++ b/tools/MapCalibrationStudy/ColdBootstrap.cs
@@ -36,6 +36,18 @@ public static class ColdBootstrap
         /// only when it is small.
         /// </summary>
         public double GlobalReprojectionPx { get; init; }
+
+        /// <summary>
+        /// (H2) RMS pixel residual of a full 6-parameter affine fit over the
+        /// SAME kept-inlier (world ↔ detected-pixel) pairs the 4-param similarity
+        /// (<see cref="RefinedResidualPx"/>) was solved on — an apples-to-apples
+        /// affine-vs-similarity contest on identical points. This is the ONLY
+        /// place H2 is honestly measurable: bootstrap has independent detected
+        /// pixels, whereas measure mode would have to reproject through the
+        /// solved similarity (degenerate). If the affine barely beats the
+        /// similarity here, the renderer is isotropic.
+        /// </summary>
+        public double AffineResidualPx { get; init; }
     }
 
     public static Result? Run(
@@ -110,9 +122,18 @@ public static class ColdBootstrap
             // 0°/180° ambiguous — both orientations score equally and the first
             // enumerated wins; real PG areas aren't point-symmetric.)
             var globalPx = GlobalReprojection(cal, world, detected);
+            // H2: fit a 6-param affine over the SAME kept-inlier pairs the
+            // similarity was solved on, so the affine-vs-similarity comparison is
+            // on identical points. Needs >= 3 pairs (affine has 6 DOF / 3 points
+            // per axis); the kept set is already guaranteed >= 3 above.
+            var affinePts = kept
+                .Select(r => (r.WorldX, r.WorldZ, r.Pixel.X, r.Pixel.Y))
+                .ToList();
+            var affineRms = affinePts.Count >= 3 ? AffineFit.Rms(affinePts) : double.NaN;
             var candidate = new Result(cal, cal.ResidualPixels, kept.Count, mirrorX, mirrorZ)
             {
                 GlobalReprojectionPx = globalPx,
+                AffineResidualPx = affineRms,
             };
             if (best is null
                 || candidate.GlobalReprojectionPx < best.GlobalReprojectionPx - 1e-6

--- a/tools/MapCalibrationStudy/ColdBootstrap.cs
+++ b/tools/MapCalibrationStudy/ColdBootstrap.cs
@@ -8,9 +8,12 @@ namespace Mithril.Tools.MapCalibrationStudy;
 /// recover the renderer transform. Enumerates the 4 axis-aligned orientation
 /// states (±X × ±Z), estimates a rough scale-from-bbox per state, corresponds
 /// each predicted landmark to its nearest detected icon, solves via the shipped
-/// similarity solver (which re-confirms handedness), and keeps the best-fitting
-/// orientation after an outlier-guard pass. Informational prototype of the
-/// engine's correspondence step — not the engine itself.
+/// similarity solver (which re-confirms handedness) after an outlier-guard pass,
+/// and selects the orientation by GLOBAL reprojection consistency over the full
+/// detection cloud (see <see cref="Result.GlobalReprojectionPx"/>) — not the
+/// kept-subset solver residual, which a reflected orientation can also drive to
+/// zero on a different subset. Informational prototype of the engine's
+/// correspondence step — not the engine itself.
 /// </summary>
 public static class ColdBootstrap
 {
@@ -19,7 +22,21 @@ public static class ColdBootstrap
         double RefinedResidualPx,
         int CorrespondedCount,
         bool MirrorX,
-        bool MirrorZ);
+        bool MirrorZ)
+    {
+        /// <summary>
+        /// Median over ALL world landmarks of the distance from the recovered
+        /// transform's reprojection to its nearest detected icon. Unlike
+        /// <see cref="RefinedResidualPx"/> (which is the solver residual over the
+        /// kept SUBSET, and is near-zero even for a mispaired orientation that
+        /// fit a different self-consistent subset), this scores the whole set
+        /// against the whole detection cloud — so a reflected orientation that
+        /// reprojects landmarks onto the WRONG icons is penalised. Selection
+        /// minimises this first; the recovered transform reproduces ground truth
+        /// only when it is small.
+        /// </summary>
+        public double GlobalReprojectionPx { get; init; }
+    }
 
     public static Result? Run(
         IReadOnlyList<WorldCoord> world,
@@ -56,7 +73,6 @@ public static class ColdBootstrap
 
             var refs = new List<LandmarkCalibrationSolver.Reference>();
             var used = new bool[detected.Count];
-            var corresponded = 0;
             foreach (var w in world)
             {
                 var pred = Predict(w);
@@ -71,7 +87,6 @@ public static class ColdBootstrap
                 }
                 if (bestIdx < 0) continue;
                 used[bestIdx] = true;
-                corresponded++;
                 refs.Add(new LandmarkCalibrationSolver.Reference(w.X, w.Z, detected[bestIdx]));
             }
 
@@ -80,21 +95,62 @@ public static class ColdBootstrap
             var cal = LandmarkCalibrationSolver.Solve(kept);
             if (cal is null) continue;
 
-            // Several enumerated orientations can tie at (near-)zero residual:
-            // the shipped solver internally re-confirms handedness, so even a
-            // "wrong" enumerated mirror fits a self-consistent subset perfectly.
-            // Break residual ties by preferring the orientation that retained
-            // MORE references through the outlier guard — a perfect fit on 6
-            // inliers beats a perfect fit on 4 (the latter mispaired two icons
-            // and the guard discarded them). Use a small epsilon so a marginally
-            // larger residual with more inliers still wins.
+            // Score by GLOBAL reprojection consistency over the FULL detected
+            // set, NOT just the kept-subset solver residual. The subset residual
+            // is blind to the failure mode the reviewer found: because the
+            // shipped solver internally re-confirms handedness, a "wrong"
+            // enumerated mirror can mispair landmarks onto reflection-partner
+            // icons and still fit that DIFFERENT subset at ~0 residual. The
+            // global score re-corresponds every world landmark to its nearest
+            // detected icon under THIS orientation's solved transform; a
+            // reflected orientation reprojects onto the wrong icons (or far from
+            // any), inflating the score, while the true orientation reprojects
+            // the whole set consistently. Minimise the global score; break exact
+            // ties by inlier count. (A genuinely point-symmetric area is truly
+            // 0°/180° ambiguous — both orientations score equally and the first
+            // enumerated wins; real PG areas aren't point-symmetric.)
+            var globalPx = GlobalReprojection(cal, world, detected);
+            var candidate = new Result(cal, cal.ResidualPixels, kept.Count, mirrorX, mirrorZ)
+            {
+                GlobalReprojectionPx = globalPx,
+            };
             if (best is null
-                || cal.ResidualPixels < best.RefinedResidualPx - 1e-6
-                || (cal.ResidualPixels <= best.RefinedResidualPx + 1e-6
-                    && kept.Count > best.CorrespondedCount))
-                best = new Result(cal, cal.ResidualPixels, kept.Count, mirrorX, mirrorZ);
+                || candidate.GlobalReprojectionPx < best.GlobalReprojectionPx - 1e-6
+                || (candidate.GlobalReprojectionPx <= best.GlobalReprojectionPx + 1e-6
+                    && candidate.CorrespondedCount > best.CorrespondedCount))
+                best = candidate;
         }
 
         return best;
+    }
+
+    /// <summary>
+    /// Median over all world landmarks of the distance from
+    /// <c>cal.WorldToWindow(w)</c> to its nearest detected icon. Median (not
+    /// mean) so a single spurious detection or one outlier landmark can't
+    /// dominate the orientation score.
+    /// </summary>
+    private static double GlobalReprojection(
+        AreaCalibration cal, IReadOnlyList<WorldCoord> world, IReadOnlyList<PixelPoint> detected)
+    {
+        var dists = new List<double>(world.Count);
+        foreach (var w in world)
+        {
+            var p = cal.WorldToWindow(w);
+            var nearest = double.MaxValue;
+            foreach (var d in detected)
+            {
+                var dx = d.X - p.X;
+                var dy = d.Y - p.Y;
+                var dist = Math.Sqrt(dx * dx + dy * dy);
+                if (dist < nearest) nearest = dist;
+            }
+            dists.Add(nearest);
+        }
+        dists.Sort();
+        var n = dists.Count;
+        return n == 0 ? double.PositiveInfinity
+            : n % 2 == 1 ? dists[n / 2]
+            : (dists[n / 2 - 1] + dists[n / 2]) / 2.0;
     }
 }

--- a/tools/MapCalibrationStudy/ColdBootstrap.cs
+++ b/tools/MapCalibrationStudy/ColdBootstrap.cs
@@ -25,15 +25,16 @@ public static class ColdBootstrap
         bool MirrorZ)
     {
         /// <summary>
-        /// Median over ALL world landmarks of the distance from the recovered
+        /// MEAN over ALL world landmarks of the distance from the recovered
         /// transform's reprojection to its nearest detected icon. Unlike
         /// <see cref="RefinedResidualPx"/> (which is the solver residual over the
         /// kept SUBSET, and is near-zero even for a mispaired orientation that
         /// fit a different self-consistent subset), this scores the whole set
         /// against the whole detection cloud — so a reflected orientation that
-        /// reprojects landmarks onto the WRONG icons is penalised. Selection
-        /// minimises this first; the recovered transform reproduces ground truth
-        /// only when it is small.
+        /// reprojects even a FEW landmarks onto the WRONG icons is penalised
+        /// (mean, not median, so a minority of mispairs still moves the score).
+        /// Selection minimises this first; the recovered transform reproduces
+        /// ground truth only when it is small.
         /// </summary>
         public double GlobalReprojectionPx { get; init; }
 
@@ -146,15 +147,22 @@ public static class ColdBootstrap
     }
 
     /// <summary>
-    /// Median over all world landmarks of the distance from
-    /// <c>cal.WorldToWindow(w)</c> to its nearest detected icon. Median (not
-    /// mean) so a single spurious detection or one outlier landmark can't
-    /// dominate the orientation score.
+    /// MEAN over all world landmarks of the distance from
+    /// <c>cal.WorldToWindow(w)</c> to its nearest detected icon. Mean — not
+    /// median — because the failure mode is a MINORITY of mispaired landmarks: a
+    /// reflected orientation can mispair just the interior points while the
+    /// corners still reproject at distance 0, so a median washes the mispairs out
+    /// (it reads 0 for every orientation and the metric becomes decorative). The
+    /// mean keeps the mispaired-landmark distances in the score, so the true
+    /// orientation (every landmark at ~0) separates from a reflected one (a few
+    /// landmarks far away) — making the selection genuinely load-bearing rather
+    /// than reliant on the secondary inlier-count tie-break.
     /// </summary>
     private static double GlobalReprojection(
         AreaCalibration cal, IReadOnlyList<WorldCoord> world, IReadOnlyList<PixelPoint> detected)
     {
-        var dists = new List<double>(world.Count);
+        if (world.Count == 0) return double.PositiveInfinity;
+        double sum = 0;
         foreach (var w in world)
         {
             var p = cal.WorldToWindow(w);
@@ -166,12 +174,8 @@ public static class ColdBootstrap
                 var dist = Math.Sqrt(dx * dx + dy * dy);
                 if (dist < nearest) nearest = dist;
             }
-            dists.Add(nearest);
+            sum += nearest;
         }
-        dists.Sort();
-        var n = dists.Count;
-        return n == 0 ? double.PositiveInfinity
-            : n % 2 == 1 ? dists[n / 2]
-            : (dists[n / 2 - 1] + dists[n / 2]) / 2.0;
+        return sum / world.Count;
     }
 }

--- a/tools/MapCalibrationStudy/InsetMetrics.cs
+++ b/tools/MapCalibrationStudy/InsetMetrics.cs
@@ -1,0 +1,63 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationStudy;
+
+/// <summary>
+/// (H3) Measures how the landmark world bounding-box projects into the texture:
+/// the scale you would predict assuming the bbox fills the texture
+/// (texture_dim / world_span), the ratio of that to the solved scale, and the
+/// fractional margin (inset) between the projected bbox and the texture edges.
+/// A constant inset fraction across areas is what makes scale computable cold.
+/// </summary>
+public static class InsetMetrics
+{
+    public readonly record struct Result(
+        double PredictedScaleX,
+        double PredictedScaleZ,
+        double ScaleRatioX,
+        double ScaleRatioZ,
+        double InsetFracLeft,
+        double InsetFracRight,
+        double InsetFracTop,
+        double InsetFracBottom)
+    {
+        public double InsetFracMax =>
+            Math.Max(Math.Max(InsetFracLeft, InsetFracRight),
+                     Math.Max(InsetFracTop, InsetFracBottom));
+    }
+
+    public static Result Compute(
+        AreaCalibration cal, IReadOnlyList<WorldCoord> world, int textureW, int textureH)
+    {
+        if (world.Count < 2)
+            throw new ArgumentException("need >= 2 world points for a bbox", nameof(world));
+
+        double minX = double.MaxValue, maxX = double.MinValue;
+        double minZ = double.MaxValue, maxZ = double.MinValue;
+        double pMinX = double.MaxValue, pMaxX = double.MinValue;
+        double pMinY = double.MaxValue, pMaxY = double.MinValue;
+        foreach (var w in world)
+        {
+            minX = Math.Min(minX, w.X); maxX = Math.Max(maxX, w.X);
+            minZ = Math.Min(minZ, w.Z); maxZ = Math.Max(maxZ, w.Z);
+            var p = cal.WorldToWindow(w);
+            pMinX = Math.Min(pMinX, p.X); pMaxX = Math.Max(pMaxX, p.X);
+            pMinY = Math.Min(pMinY, p.Y); pMaxY = Math.Max(pMaxY, p.Y);
+        }
+
+        var spanX = maxX - minX;
+        var spanZ = maxZ - minZ;
+        var predX = spanX > 1e-9 ? textureW / spanX : 0.0;
+        var predZ = spanZ > 1e-9 ? textureH / spanZ : 0.0;
+
+        return new Result(
+            PredictedScaleX: predX,
+            PredictedScaleZ: predZ,
+            ScaleRatioX: predX > 1e-9 ? cal.Scale / predX : 0.0,
+            ScaleRatioZ: predZ > 1e-9 ? cal.Scale / predZ : 0.0,
+            InsetFracLeft: pMinX / textureW,
+            InsetFracRight: (textureW - pMaxX) / textureW,
+            InsetFracTop: pMinY / textureH,
+            InsetFracBottom: (textureH - pMaxY) / textureH);
+    }
+}

--- a/tools/MapCalibrationStudy/MapCalibrationStudy.csproj
+++ b/tools/MapCalibrationStudy/MapCalibrationStudy.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Tools.MapCalibrationStudy</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Throwaway gate-study tool (mithril#897), deleted once the verdict lands.
+         Same isolation pattern as tools/MapCalibrationFromScreenshot: out of
+         central PM + Directory.Build.targets to avoid the versionless analyzer /
+         GitVersioning clash. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <!-- System.Drawing image IO + registry reads — Windows-only. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AssetsTools.NET" Version="3.0.4" />
+    <PackageReference Include="AssetsTools.NET.Texture" Version="3.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+    <ProjectReference Include="..\Mithril.MapCalibration.Tools.Common\Mithril.MapCalibration.Tools.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/MapCalibrationStudy/OrientationClass.cs
+++ b/tools/MapCalibrationStudy/OrientationClass.cs
@@ -1,0 +1,30 @@
+namespace Mithril.Tools.MapCalibrationStudy;
+
+/// <summary>
+/// (H1) Classifies a solved rotation against the discrete axis-aligned set the
+/// renderer is hypothesised to use: {0°, 180°}. A π rotation is a real
+/// orientation flip, not drift; an in-between angle (large deviation) would
+/// falsify the hypothesis.
+/// </summary>
+public static class OrientationClass
+{
+    /// <summary>Default tolerance for membership, in degrees (per the §6 H1 gate).</summary>
+    public const double DefaultToleranceDeg = 0.1;
+
+    public readonly record struct Result(int NearestDeg, double DeviationDeg, bool InSet);
+
+    public static Result Classify(double radians, double toleranceDeg = DefaultToleranceDeg)
+    {
+        var deg = radians * 180.0 / Math.PI;
+        // Normalise to (-180, 180].
+        deg %= 360.0;
+        if (deg > 180.0) deg -= 360.0;
+        if (deg <= -180.0) deg += 360.0;
+
+        // Distance to 0 vs ±180 (same magnitude either sign).
+        var dTo0 = Math.Abs(deg);
+        var dTo180 = Math.Abs(Math.Abs(deg) - 180.0);
+        var (nearest, dev) = dTo0 <= dTo180 ? (0, dTo0) : (180, dTo180);
+        return new Result(nearest, dev, dev <= toleranceDeg);
+    }
+}

--- a/tools/MapCalibrationStudy/OutlierGuard.cs
+++ b/tools/MapCalibrationStudy/OutlierGuard.cs
@@ -1,0 +1,47 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationStudy;
+
+/// <summary>
+/// (H4 support) Rejects references whose fit residual is large in a single axis
+/// only — the signature of a detection/transcription error rather than a real
+/// map offset (a genuine offset shows up roughly isotropically). Iteratively
+/// solves, finds the worst single-axis-asymmetric residual above the threshold,
+/// drops it, and re-solves until none remain or too few refs survive.
+/// </summary>
+public static class OutlierGuard
+{
+    public static List<LandmarkCalibrationSolver.Reference> Reject(
+        IReadOnlyList<LandmarkCalibrationSolver.Reference> refs, double axisThresholdPx)
+    {
+        var live = refs.ToList();
+        while (live.Count > 3)
+        {
+            var cal = LandmarkCalibrationSolver.Solve(live);
+            if (cal is null) break;
+
+            int worst = -1;
+            double worstAsymmetry = axisThresholdPx;
+            for (var i = 0; i < live.Count; i++)
+            {
+                var p = cal.WorldToWindow(new WorldCoord(live[i].WorldX, 0, live[i].WorldZ));
+                var dx = Math.Abs(p.X - live[i].Pixel.X);
+                var dy = Math.Abs(p.Y - live[i].Pixel.Y);
+                var maxAxis = Math.Max(dx, dy);
+                var minAxis = Math.Min(dx, dy);
+                // "One axis only" = the larger axis error clears the threshold
+                // while the other stays small. Asymmetry = maxAxis - minAxis.
+                var asymmetry = maxAxis - minAxis;
+                if (maxAxis >= axisThresholdPx && asymmetry > worstAsymmetry)
+                {
+                    worstAsymmetry = asymmetry;
+                    worst = i;
+                }
+            }
+
+            if (worst < 0) break;
+            live.RemoveAt(worst);
+        }
+        return live;
+    }
+}

--- a/tools/MapCalibrationStudy/Program.cs
+++ b/tools/MapCalibrationStudy/Program.cs
@@ -1,16 +1,200 @@
+using System.Text.Json;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibration.Common;
+
 namespace Mithril.Tools.MapCalibrationStudy;
 
 internal static class Program
 {
     private static int Main(string[] args)
     {
-        if (args.Length == 0)
+        try
         {
-            Console.Error.WriteLine("usage: MapCalibrationStudy <measure|bootstrap> [options]");
-            return 1;
+            if (args.Length == 0) return Usage();
+            return args[0] switch
+            {
+                "measure" => Measure(ParseOptions(args)),
+                "bootstrap" => Bootstrap(ParseOptions(args)),
+                _ => Usage(),
+            };
         }
-        // Subcommand dispatch is implemented in Task 7. Scaffolding only here.
-        Console.WriteLine($"MapCalibrationStudy: '{args[0]}' (not yet implemented)");
+        catch (UserFacingException ex)
+        {
+            Console.Error.WriteLine($"error: {ex.Message}");
+            return 2;
+        }
+    }
+
+    private static int Usage()
+    {
+        Console.Error.WriteLine("""
+            usage:
+              MapCalibrationStudy measure   --refinements <refinements.json> --baseline <baseline.json>
+                                            --landmarks <landmarks.json> --npcs <npcs.json>
+                                            --textures <dir> --areas <A,B,C> --out <dir>
+              MapCalibrationStudy bootstrap --screenshots <dir> --textures <dir> --icons <dir>
+                                            --landmarks <landmarks.json> --npcs <npcs.json>
+                                            --areas <A,B,C> --out <dir>
+            """);
+        return 1;
+    }
+
+    // ---- measure (Half A) --------------------------------------------------
+
+    private static int Measure(Dictionary<string, string> o)
+    {
+        var areas = o["--areas"].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var source0 = LoadRefinements(o["--refinements"]);   // overlay-frame: rotation + handedness only
+        var rows = new List<StudyRecord>();
+
+        foreach (var area in areas)
+        {
+            // Rotation/handedness come from whichever solve we have (source 0
+            // is enough for those, frame-invariant).
+            source0.TryGetValue(area, out var overlayCal);
+            var rotationDeg = overlayCal is null ? double.NaN : overlayCal.RotationRadians * 180.0 / Math.PI;
+            var orient = overlayCal is null ? -1 : OrientationClass.Classify(overlayCal.RotationRadians).NearestDeg;
+            var mirror = overlayCal?.MirrorNorth ?? false;
+
+            // Scale/inset/affine need a TEXTURE-frame solve (the committed
+            // baseline) + the texture dims + the world points.
+            var textureCal = BaselineFile.TryReadAnchor(o["--baseline"], area);
+            double solvedScale = 0, predX = 0, ratioX = 0, insetMax = 0, simRms = 0, affRms = 0;
+            if (textureCal is not null && TryTextureSize(o["--textures"], area, out var tw, out var th))
+            {
+                var world = LoadWorldPoints(o["--landmarks"], o["--npcs"], area).Select(l => l.World).ToList();
+                var m = InsetMetrics.Compute(textureCal, world, tw, th);
+                solvedScale = textureCal.Scale; predX = m.PredictedScaleX;
+                ratioX = m.ScaleRatioX; insetMax = m.InsetFracMax;
+                simRms = textureCal.ResidualPixels;
+                // affine RMS needs the (world↔pixel) pairs the baseline was fit
+                // on; we don't persist those, so re-project the world points
+                // through the solved transform as the pixel side (affine then
+                // measures self-consistency of the model, the H2 question).
+                var pts = world.Select(w => { var p = textureCal.WorldToWindow(w); return (w.X, w.Z, p.X, p.Y); }).ToList();
+                affRms = pts.Count >= 3 ? AffineFit.Rms(pts) : 0;
+            }
+
+            rows.Add(new StudyRecord(area, rotationDeg, orient, mirror,
+                solvedScale, predX, ratioX, insetMax, simRms, affRms, 0, false));
+        }
+
+        Emit(o["--out"], "measure", rows);
         return 0;
+    }
+
+    // ---- bootstrap (Half B) ------------------------------------------------
+
+    private static int Bootstrap(Dictionary<string, string> o)
+    {
+        var areas = o["--areas"].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var icons = IconTemplateExtractor.Load(o["--icons"]);
+        var rows = new List<StudyRecord>();
+
+        foreach (var area in areas)
+        {
+            var shotPath = Path.Combine(o["--screenshots"], area + ".png");
+            if (!File.Exists(shotPath)) { Console.WriteLine($"[skip] no screenshot for {area}"); continue; }
+            if (!TryTextureSize(o["--textures"], area, out var tw, out var th)) { Console.WriteLine($"[skip] no texture for {area}"); continue; }
+
+            var world = LoadWorldPoints(o["--landmarks"], o["--npcs"], area).Select(l => l.World).ToList();
+            var detected = DetectIcons(shotPath, o["--textures"], area, o["--icons"], icons);
+            if (detected.Count < 3) { Console.WriteLine($"[skip] <3 icons detected in {area}"); continue; }
+
+            var result = ColdBootstrap.Run(world, detected, tw, th, axisThresholdPx: 8.0);
+            if (result is null) { Console.WriteLine($"[skip] bootstrap returned null for {area}"); continue; }
+
+            var orient = OrientationClass.Classify(result.Calibration.RotationRadians).NearestDeg;
+            rows.Add(new StudyRecord(area,
+                result.Calibration.RotationRadians * 180.0 / Math.PI, orient,
+                result.Calibration.MirrorNorth, result.Calibration.Scale, 0, 0, 0,
+                result.RefinedResidualPx, 0, result.CorrespondedCount, result.CorrespondedCount >= 3));
+        }
+
+        Emit(o["--out"], "bootstrap", rows);
+        return 0;
+    }
+
+    // ---- detection (texture-frame icon pixels) -----------------------------
+
+    private static List<PixelPoint> DetectIcons(
+        string screenshotPath, string texturesDir, string area, string iconsDir, IconIndex icons)
+    {
+        var screen = ImageIo.LoadGray(screenshotPath);
+        var texturePath = MapTextureExtractor.EnsureExtractedOrCached(texturesDir, area)
+            ?? throw new UserFacingException($"no cached texture PNG for {area} in {texturesDir}");
+        var texture = ImageIo.LoadGray(texturePath);
+        var rect = MapRectLocator.AutoDetect(screen, texture, minScore: 0.30)
+            ?? throw new UserFacingException($"could not locate the map rect in {Path.GetFileName(screenshotPath)} — is it zoomed fully out?");
+
+        var pixels = new List<PixelPoint>();
+        foreach (var meta in icons.Icons)
+        {
+            var (gray, alpha) = ImageIo.LoadGrayAndAlpha(Path.Combine(iconsDir, meta.File));
+            var hits = NccTemplateMatch.FindAll(screen, gray, alpha, minScore: 0.5, maxResults: 64);
+            foreach (var hit in hits)
+            {
+                var (cx, cy) = hit.Centre(meta.Width, meta.Height);
+                // pivot-correct: anchor pixel = centre + (w*(pivot.x-0.5), h*(0.5-pivot.y))
+                var ax = cx + meta.Width * (meta.PivotX - 0.5);
+                var ay = cy + meta.Height * (0.5 - meta.PivotY);
+                var (tx, ty) = rect.ScreenshotToTexture(ax, ay);
+                pixels.Add(new PixelPoint(tx, ty));
+            }
+        }
+        return pixels;
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static Dictionary<string, AreaCalibration> LoadRefinements(string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var map = new Dictionary<string, AreaCalibration>(StringComparer.Ordinal);
+        if (!doc.RootElement.TryGetProperty("calibrations", out var cals)) return map;
+        foreach (var p in cals.EnumerateObject())
+        {
+            var v = p.Value;
+            double D(string k) => v.TryGetProperty(k, out var e) ? e.GetDouble() : 0;
+            bool B(string k) => v.TryGetProperty(k, out var e) && e.GetBoolean();
+            int I(string k) => v.TryGetProperty(k, out var e) ? e.GetInt32() : 0;
+            map[p.Name] = new AreaCalibration(D("scale"), D("rotationRadians"), D("originX"), D("originY"),
+                I("referenceCount"), D("residualPixels")) { MirrorNorth = B("mirrorNorth") };
+        }
+        return map;
+    }
+
+    private static List<LandmarkRef> LoadWorldPoints(string landmarksPath, string npcsPath, string area)
+    {
+        var list = new List<LandmarkRef>(LandmarksReader.LoadForArea(landmarksPath, area));
+        list.AddRange(NpcsReader.LoadForArea(npcsPath, area));
+        return list;
+    }
+
+    private static bool TryTextureSize(string texturesDir, string area, out int w, out int h)
+    {
+        w = h = 0;
+        var path = MapTextureExtractor.EnsureExtractedOrCached(texturesDir, area);
+        if (path is null || !File.Exists(path)) return false;
+        var (_, iw, ih) = ImageIo.LoadBgra(path);
+        w = iw; h = ih;
+        return true;
+    }
+
+    private static void Emit(string outDir, string mode, IReadOnlyList<StudyRecord> rows)
+    {
+        Directory.CreateDirectory(outDir);
+        File.WriteAllText(Path.Combine(outDir, $"{mode}.csv"), StudyRecord.ToCsv(rows));
+        File.WriteAllText(Path.Combine(outDir, $"{mode}.md"), StudyRecord.ToMarkdown(rows));
+        Console.WriteLine(StudyRecord.ToMarkdown(rows));
+        Console.WriteLine($"[{mode}] wrote {rows.Count} rows to {outDir}");
+    }
+
+    private static Dictionary<string, string> ParseOptions(string[] args)
+    {
+        var o = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (var i = 1; i < args.Length - 1; i++)
+            if (args[i].StartsWith("--", StringComparison.Ordinal)) o[args[i]] = args[i + 1];
+        return o;
     }
 }

--- a/tools/MapCalibrationStudy/Program.cs
+++ b/tools/MapCalibrationStudy/Program.cs
@@ -1,0 +1,16 @@
+namespace Mithril.Tools.MapCalibrationStudy;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("usage: MapCalibrationStudy <measure|bootstrap> [options]");
+            return 1;
+        }
+        // Subcommand dispatch is implemented in Task 7. Scaffolding only here.
+        Console.WriteLine($"MapCalibrationStudy: '{args[0]}' (not yet implemented)");
+        return 0;
+    }
+}

--- a/tools/MapCalibrationStudy/Program.cs
+++ b/tools/MapCalibrationStudy/Program.cs
@@ -118,7 +118,9 @@ internal static class Program
             rows.Add(new StudyRecord(area,
                 result.Calibration.RotationRadians * 180.0 / Math.PI, orient,
                 result.Calibration.MirrorNorth, result.Calibration.Scale, 0, 0, 0,
-                result.RefinedResidualPx, double.NaN, result.CorrespondedCount, paired));
+                // H2 is real here: affine fit over the same kept-inlier detected
+                // pixels vs. that orientation's similarity residual (apples-to-apples).
+                result.RefinedResidualPx, result.AffineResidualPx, result.CorrespondedCount, paired));
         }
 
         Emit(o["--out"], "bootstrap", rows);

--- a/tools/MapCalibrationStudy/Program.cs
+++ b/tools/MapCalibrationStudy/Program.cs
@@ -59,7 +59,16 @@ internal static class Program
             // Scale/inset/affine need a TEXTURE-frame solve (the committed
             // baseline) + the texture dims + the world points.
             var textureCal = BaselineFile.TryReadAnchor(o["--baseline"], area);
-            double solvedScale = 0, predX = 0, ratioX = 0, insetMax = 0, simRms = 0, affRms = 0;
+            double solvedScale = 0, predX = 0, ratioX = 0, insetMax = 0, simRms = 0;
+            // H2 (affine-vs-similarity isotropy) has NO honest signal in measure
+            // mode. The baseline doesn't persist the original click pixels the
+            // similarity was fit on, so the only pixel side available is the
+            // world points reprojected through that same solved similarity — an
+            // affine fit to a pure-similarity cloud is ~0 by construction and
+            // would read as a (false) "renderer is isotropic" result. Emit N/A
+            // (NaN) here; the real affine-vs-similarity contest only exists in
+            // `bootstrap` mode, where the pixel side is independently detected.
+            var affRms = double.NaN;
             if (textureCal is not null && TryTextureSize(o["--textures"], area, out var tw, out var th))
             {
                 var world = LoadWorldPoints(o["--landmarks"], o["--npcs"], area).Select(l => l.World).ToList();
@@ -67,12 +76,6 @@ internal static class Program
                 solvedScale = textureCal.Scale; predX = m.PredictedScaleX;
                 ratioX = m.ScaleRatioX; insetMax = m.InsetFracMax;
                 simRms = textureCal.ResidualPixels;
-                // affine RMS needs the (world↔pixel) pairs the baseline was fit
-                // on; we don't persist those, so re-project the world points
-                // through the solved transform as the pixel side (affine then
-                // measures self-consistency of the model, the H2 question).
-                var pts = world.Select(w => { var p = textureCal.WorldToWindow(w); return (w.X, w.Z, p.X, p.Y); }).ToList();
-                affRms = pts.Count >= 3 ? AffineFit.Rms(pts) : 0;
             }
 
             rows.Add(new StudyRecord(area, rotationDeg, orient, mirror,
@@ -105,10 +108,17 @@ internal static class Program
             if (result is null) { Console.WriteLine($"[skip] bootstrap returned null for {area}"); continue; }
 
             var orient = OrientationClass.Classify(result.Calibration.RotationRadians).NearestDeg;
+            // `paired` must mean the recovered transform actually reproduces the
+            // detection cloud — i.e. blind correspondence found GROUND TRUTH —
+            // not merely that ≥3 icons were paired (a presence check that's true
+            // even for a wrong-orientation run that fit a reflected subset). Tie
+            // it to the global reprojection score: every world landmark must
+            // reproject within detection-noise tolerance of a detected icon.
+            var paired = result.CorrespondedCount >= 3 && result.GlobalReprojectionPx <= 8.0;
             rows.Add(new StudyRecord(area,
                 result.Calibration.RotationRadians * 180.0 / Math.PI, orient,
                 result.Calibration.MirrorNorth, result.Calibration.Scale, 0, 0, 0,
-                result.RefinedResidualPx, 0, result.CorrespondedCount, result.CorrespondedCount >= 3));
+                result.RefinedResidualPx, double.NaN, result.CorrespondedCount, paired));
         }
 
         Emit(o["--out"], "bootstrap", rows);

--- a/tools/MapCalibrationStudy/StudyRecord.cs
+++ b/tools/MapCalibrationStudy/StudyRecord.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using System.Text;
+
+namespace Mithril.Tools.MapCalibrationStudy;
+
+/// <summary>
+/// One area's row in the study table. Combines the Half-A geometric metrics
+/// (rotation/handedness/scale/inset/affine) and the Half-B cold-bootstrap
+/// outcome (corresponded count, refined residual). Emitted as CSV (machine)
+/// and markdown (the wiki + notebook write-up).
+/// </summary>
+public sealed record StudyRecord(
+    string Area,
+    double RotationDeg,
+    int OrientationDeg,
+    bool MirrorNorth,
+    double SolvedScale,
+    double PredictedScaleX,
+    double ScaleRatioX,
+    double InsetFracMax,
+    double SimilarityResidualPx,
+    double AffineResidualPx,
+    int BootstrapCorresponded,
+    bool BootstrapPaired)
+{
+    private const string Header =
+        "area,rotationDeg,orientationDeg,mirrorNorth,solvedScale,predictedScaleX,scaleRatioX,insetFracMax,similarityResidualPx,affineResidualPx,bootstrapCorresponded,bootstrapPaired";
+
+    public static string ToCsv(IReadOnlyList<StudyRecord> rows)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(Header);
+        foreach (var r in rows)
+        {
+            sb.AppendLine(string.Join(",", new[]
+            {
+                r.Area,
+                F(r.RotationDeg), r.OrientationDeg.ToString(CultureInfo.InvariantCulture),
+                r.MirrorNorth.ToString(), F(r.SolvedScale), F(r.PredictedScaleX), F(r.ScaleRatioX),
+                F(r.InsetFracMax), F(r.SimilarityResidualPx), F(r.AffineResidualPx),
+                r.BootstrapCorresponded.ToString(CultureInfo.InvariantCulture), r.BootstrapPaired.ToString(),
+            }));
+        }
+        return sb.ToString();
+    }
+
+    public static string ToMarkdown(IReadOnlyList<StudyRecord> rows)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("| area | rotationDeg | orient | mirror | scale | predScaleX | ratioX | insetMax | simResid | affResid | corr | paired |");
+        sb.AppendLine("|---|---|---|---|---|---|---|---|---|---|---|---|");
+        foreach (var r in rows)
+        {
+            sb.AppendLine($"| {r.Area} | {F(r.RotationDeg)} | {r.OrientationDeg} | {r.MirrorNorth} | {F(r.SolvedScale)} | {F(r.PredictedScaleX)} | {F(r.ScaleRatioX)} | {F(r.InsetFracMax)} | {F(r.SimilarityResidualPx)} | {F(r.AffineResidualPx)} | {r.BootstrapCorresponded} | {r.BootstrapPaired} |");
+        }
+        return sb.ToString();
+    }
+
+    private static string F(double d) => d.ToString("0.#####", CultureInfo.InvariantCulture);
+}

--- a/tools/MapCalibrationStudy/StudyRecord.cs
+++ b/tools/MapCalibrationStudy/StudyRecord.cs
@@ -56,5 +56,9 @@ public sealed record StudyRecord(
         return sb.ToString();
     }
 
-    private static string F(double d) => d.ToString("0.#####", CultureInfo.InvariantCulture);
+    // NaN is the in-band "no honest value" marker (e.g. the affine column in
+    // measure mode, where there are no independent pixels to fit) — render it
+    // as a clearly non-numeric token so a reader never mistakes it for evidence.
+    private static string F(double d) =>
+        double.IsNaN(d) ? "n/a" : d.ToString("0.#####", CultureInfo.InvariantCulture);
 }

--- a/tools/Mithril.MapCalibration.Tools.Common/MapTextureExtractor.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/MapTextureExtractor.cs
@@ -98,6 +98,18 @@ public static class MapTextureExtractor
         return outPng;
     }
 
+    /// <summary>
+    /// Returns the cached <c>Map_&lt;Area&gt;.v{N}.png</c> in <paramref name="mapDir"/>
+    /// if it exists, without requiring a PG install / bundle decode. Used by the
+    /// gate-study tool, which runs against pre-extracted textures. Returns null if
+    /// no cached PNG is present.
+    /// </summary>
+    public static string? EnsureExtractedOrCached(string mapDir, string area)
+    {
+        var outPng = Path.Combine(mapDir, $"Map_{area}.v{CacheFormatVersion}.png");
+        return File.Exists(outPng) ? outPng : null;
+    }
+
     private static string FindBundleForArea(string bundleDir, string area)
     {
         // Bundle name convention (lowercase): maps_assets_assets_art_maps_map_<area>.png_<hash>.bundle


### PR DESCRIPTION
## What this delivers

A throwaway console tool **`tools/MapCalibrationStudy`** (mithril#897) that measures whether PG's per-area map renderer is regular enough — rotation ∈ {0, π}, isotropy, consistent inset, cold-correspondence — to justify a near-zero-ref auto-calibration engine.

Two subcommands:
- **`measure`** (Half A) — emits the per-area geometric-consistency table (rotation/handedness, predicted-vs-solved scale, inset fraction, affine-vs-similarity residual).
- **`bootstrap`** (Half B) — the zero-prior correspondence proof: from world landmarks + texture dims + NCC-detected icon pixels (no stored calibration, no clicks), recover the renderer transform.

All decision math lives in **5 pure, unit-tested classes** plus the record/emitter:
- `OrientationClass` (H1 — discrete {0°,180°} classifier)
- `InsetMetrics` (H3 — scale/inset measurement)
- `AffineFit` (H2 — 6-param affine vs. 4-param similarity isotropy check)
- `OutlierGuard` (one-axis-residual rejection)
- `ColdBootstrap` (H4 — orientation enumeration → nearest-neighbour correspondence → outlier-guarded solve)
- `StudyRecord` (per-area CSV + markdown emit)

`Program.cs` is thin IO glue (readers, NCC detection, CSV/markdown emit), manually verified, not unit-tested. The tool reuses the shipped solver + detectors verbatim and is **isolated** (opts out of central PM + `Directory.Build.targets`), exactly like `tools/MapCalibrationFromScreenshot`.

One helper added to the shared lib: `MapTextureExtractor.EnsureExtractedOrCached` — returns the cached `Map_<Area>.v{N}.png` without requiring a PG install/decode (the study runs against pre-extracted textures).

## Tests

`dotnet test tests/MapCalibrationStudy.Tests` — **17 passed, 0 failed**. TDD throughout (failing test → implement → green → commit per task).

## Scope

Tasks 1–8 only. **Tasks 9 (live-corpus capture + verdict) and 10 (teardown) are deliberately out of scope and user-owned** — the verdict and the throwaway-delete PR remain to be done against real game data.

`Part of #897` (intentionally NOT auto-closing — the verdict still owes Tasks 9–10).

## Plan deviations (all reported to the shepherd, tests stay green)

1. **`Mithril.slnx`** — `dotnet sln add` transitively pulled in the isolated tool Exe + `Tools.Common`; I hand-edited the slnx to add **only** the test project (matching the plan's intent and the `Mithril.MapCalibration.Harness` precedent already in `/tools/`).
2. **Task 3 `InsetMetricsTests`** — the plan's two test scenarios picked origin-Y values inconsistent with the real `AreaCalibration.WorldToWindow` Y-flip (north up: `pY = OriginY − scale·Z`), so the projected bbox fell outside the texture and `InsetFracMax` came out 1.0 / 0.917. Fixed the two test origins only (implementation verbatim, every asserted value unchanged).
3. **Task 6 `ColdBootstrap`** — surfaced a genuine logic gap: because the shipped similarity solver internally re-confirms handedness, **multiple enumerated orientations tie at zero residual** on a self-consistent subset, and the plan's strict-`<` tie-break locked onto the first one (which had mispaired + guard-dropped two icons → `CorrespondedCount` 4 instead of 6). Fixed the `best` selection to break residual ties by **inlier count** (more kept references wins). Also sized the test's synthetic texture to the projection so `scale0 ≈` true scale (the low-inset regime is the H3 hypothesis the cold correspondence relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
