### PR TITLE
fix(map-calibration-study): detection threshold + cold-bootstrap scale guard (#897)

### DIFF
--- a/tools/MapCalibrationStudy/ColdBootstrap.cs
+++ b/tools/MapCalibrationStudy/ColdBootstrap.cs
@@ -108,6 +108,19 @@ public static class ColdBootstrap
             var cal = LandmarkCalibrationSolver.Solve(kept);
             if (cal is null) continue;
 
+            // Scale-sanity guard: a correspondence dominated by false-positive
+            // detections can collapse to a degenerate near-zero scale that fits a
+            // tiny spurious subset (observed on real PG screenshots: a flood of
+            // mid-score noise matches → solved scale ~0.03 vs a true ~scale0). The
+            // true scale is ~scale0 (texture span / world span, modulo the border
+            // inset and the min-axis choice); reject fits far outside a generous
+            // band so a degenerate collapse can't out-score a real orientation —
+            // and if EVERY orientation is degenerate, Run returns null (an honest
+            // "could not recover" skip) rather than a garbage row. The band is
+            // wide on the low side because scale0 over-estimates when the icon
+            // cloud doesn't fill the texture.
+            if (cal.Scale < 0.1 * scale0 || cal.Scale > 3.0 * scale0) continue;
+
             // Score by GLOBAL reprojection consistency over the FULL detected
             // set, NOT just the kept-subset solver residual. The subset residual
             // is blind to the failure mode the reviewer found: because the

--- a/tools/MapCalibrationStudy/Program.cs
+++ b/tools/MapCalibrationStudy/Program.cs
@@ -38,6 +38,10 @@ internal static class Program
                                             [--map-rect full | "left,top,width,height"]
                                             [--icon-render-size <px>] [--icon-size <name>=<W>x<H>]
 
+            --icon-min-score (bootstrap): NCC threshold for accepting an icon match
+              (default 0.5). Raise toward 0.8 to cut false-positive detections that
+              flood the cold correspondence on noisy terrain (the run logs each
+              template's top score, so set this just under the real icons' scores).
             --icon-render-size (bootstrap): force the on-screen icon size (px) instead
               of the auto render-size sweep. Use if the sweep picks wrong (the run
               logs the per-size evidence + the chosen size).
@@ -113,6 +117,8 @@ internal static class Program
         o.TryGetValue("--map-rect", out var mapRectOpt);
         var iconRenderSize = o.TryGetValue("--icon-render-size", out var irs) && int.TryParse(irs, out var irsv) ? irsv : 0;
         var iconSizeOverride = ParseIconSizeOverride(o);
+        var iconMinScore = o.TryGetValue("--icon-min-score", out var ims)
+            && double.TryParse(ims, System.Globalization.CultureInfo.InvariantCulture, out var imsv) ? imsv : 0.5;
         var rows = new List<StudyRecord>();
 
         foreach (var area in areas)
@@ -128,7 +134,7 @@ internal static class Program
             if (!TryTextureSize(o["--textures"], area, out var tw, out var th)) { Console.WriteLine($"[skip] no texture for {area}"); continue; }
 
             var world = LoadWorldPoints(o["--landmarks"], o["--npcs"], area).Select(l => l.World).ToList();
-            var detected = DetectIcons(shotPath, o["--textures"], area, o["--icons"], icons, mapRectOpt, iconRenderSize, iconSizeOverride);
+            var detected = DetectIcons(shotPath, o["--textures"], area, o["--icons"], icons, mapRectOpt, iconRenderSize, iconSizeOverride, iconMinScore);
             if (detected.Count < 3) { Console.WriteLine($"[skip] <3 icons detected in {area}"); continue; }
 
             var result = ColdBootstrap.Run(world, detected, tw, th, axisThresholdPx: 8.0);
@@ -163,9 +169,8 @@ internal static class Program
 
     private static List<PixelPoint> DetectIcons(
         string screenshotPath, string texturesDir, string area, string iconsDir, IconIndex icons,
-        string? mapRectOpt, int iconRenderSize, (string Name, int W, int H)? iconSizeOverride)
+        string? mapRectOpt, int iconRenderSize, (string Name, int W, int H)? iconSizeOverride, double iconMinScore)
     {
-        const double iconMinScore = 0.5;
         var screen = ImageIo.LoadGray(screenshotPath);
         var texturePath = MapTextureExtractor.EnsureExtractedOrCached(texturesDir, area)
             ?? throw new UserFacingException($"no cached texture PNG for {area} in {texturesDir}");


### PR DESCRIPTION
Third Task-9 unblock. With map-rect + icon-scaling solved, `bootstrap` produced **garbage rows** on real data: ~64 false-positive detections per icon (0.5 NCC threshold on noisy terrain) flooded the greedy correspondence, and `ColdBootstrap` had no scale sanity check, so it accepted a degenerate ~0.03-scale collapse (Serbule 134°→180° wrong orientation; Eltibule -43°; both `paired=False`).

- **`--icon-min-score <d>`** (default 0.5) — raise toward 0.8 to keep only strong matches (the run logs each template's top score, so it's tunable against real data).
- **`ColdBootstrap` scale-sanity guard** — reject a solved orientation whose scale falls outside `[0.1, 3]×` the bbox-predicted `scale0`. A noise-collapsed degenerate can't out-score a real orientation; if every orientation is degenerate, `Run` returns `null` (an honest skip) rather than a misleading row.

Build clean, 18/18 tests pass (the guard's band is wide enough to keep the H4 test's legitimate scale). Part of #897. These mirror how the proven `MapCalibrationFromScreenshot` detector handles noise (high threshold + RANSAC + scale check); a full RANSAC/type-aware port remains the heavier option if thresholding proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)