### PR TITLE
fix(map-calibration): ImageIo shrank non-96-DPI screenshots into the corner (#897)

### DIFF
--- a/tests/MapCalibrationStudy.Tests/ImageIoDpiTests.cs
+++ b/tests/MapCalibrationStudy.Tests/ImageIoDpiTests.cs
@@ -1,0 +1,44 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using FluentAssertions;
+using Mithril.Tools.MapCalibration.Common;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class ImageIoDpiTests
+{
+    // Regression: a screenshot a crop/editor tool saved at non-96 DPI must load
+    // at full pixel size, not get shrunk into the top-left corner. The old
+    // ReadBgra used DrawImageUnscaled, which honors DPI and draws a 300-DPI
+    // image at ~1/3 size with the rest left black — corrupting NCC + debug.
+    [Fact]
+    public void LoadBgra_does_not_shrink_a_high_dpi_image_into_the_corner()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"imageio-dpi-{Guid.NewGuid():N}.png");
+        try
+        {
+            using (var bmp = new Bitmap(40, 40, PixelFormat.Format32bppArgb))
+            {
+                using (var g = Graphics.FromImage(bmp)) g.Clear(Color.White);
+                bmp.SetResolution(300, 300);   // the trap: physical size ≠ pixel size
+                bmp.Save(path, ImageFormat.Png);
+            }
+
+            var (bgra, w, h) = ImageIo.LoadBgra(path);
+
+            w.Should().Be(40);
+            h.Should().Be(40);
+            // Bottom-right pixel must be the white content, not black background:
+            // if the image were drawn at physical (DPI) size it would sit ~13x13
+            // in the corner and (38,38) would be black.
+            var idx = (38 * w + 38) * 4;
+            bgra[idx + 2].Should().BeGreaterThan(200,
+                "a high-DPI image must map all its pixels 1:1, not shrink into the corner");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tools/Mithril.MapCalibration.Tools.Common/ImageIo.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/ImageIo.cs
@@ -228,7 +228,15 @@ public static class ImageIo
         using var canonical = new Bitmap(bmp.Width, bmp.Height, PixelFormat.Format32bppArgb);
         using (var g = Graphics.FromImage(canonical))
         {
-            g.DrawImageUnscaled(bmp, 0, 0);
+            // Draw into an explicit pixel-sized rectangle, NOT DrawImageUnscaled.
+            // DrawImageUnscaled honors the source bitmap's DPI metadata and draws
+            // at its *physical* size (pixels * 96/DPI). A screenshot a crop/editor
+            // tool saved at e.g. 300 DPI would then be drawn at ~1/3 size into the
+            // top-left corner with the rest left black — silently corrupting both
+            // the NCC grayscale and the debug image (detections cluster in the
+            // corner, the solved scale collapses). Drawing into a Width x Height
+            // dest rect maps source pixels 1:1 regardless of DPI.
+            g.DrawImage(bmp, new Rectangle(0, 0, canonical.Width, canonical.Height));
         }
         var rect = new Rectangle(0, 0, canonical.Width, canonical.Height);
         var data = canonical.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);


### PR DESCRIPTION
**Root cause of every "automated calibration can't lock onto real screenshots" symptom.**

`ImageIo.ReadBgra` (shared by all map tools) used `Graphics.DrawImageUnscaled`, which honors the source PNG's **DPI metadata** and draws at *physical* size (`pixels × 96/DPI`). A screenshot a crop/editor tool saved at **300 DPI** got drawn at ~1/3 scale into the top-left corner, the rest left **black** — corrupting both the NCC grayscale (`LoadGray`) and the debug image. Detections then clustered in the corner and the solved scale collapsed to ~1/4 (observed: `scale 0.147` vs the true `0.82`; debug image showed the map in a black-padded corner).

Diagnosed from a user's debug image: screenshot pixels were full-frame terrain, but `LoadBgra` of the same file returned black past ~282px — and the screenshot measured **300 DPI** while textures/icons are 96.

Fix: draw into an explicit `Width × Height` destination rectangle (`DrawImage(bmp, new Rectangle(0,0,W,H))`), which maps source pixels 1:1 regardless of DPI. + a regression test (40×40 @ 300 DPI must load full-size, bottom-right pixel not black).

Affects `MapCalibrationFromScreenshot`, the harness, and the gate-study tool. Part of #897 but a real shared-infra fix. 19/19 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)