### PR TITLE
feat(map-calibration): --border-mask drops rocky-border icon false positives (#897)

### DIFF
--- a/tests/MapCalibrationStudy.Tests/BorderMaskTests.cs
+++ b/tests/MapCalibrationStudy.Tests/BorderMaskTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibration.Common;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationStudy.Tests;
+
+public class BorderMaskTests
+{
+    private static byte[] Bgra(int w, int h, Func<int, int, (byte R, byte G, byte B)> px)
+    {
+        var buf = new byte[w * h * 4];
+        for (var y = 0; y < h; y++)
+        for (var x = 0; x < w; x++)
+        {
+            var i = (y * w + x) * 4;
+            var (r, g, b) = px(x, y);
+            buf[i] = b; buf[i + 1] = g; buf[i + 2] = r; buf[i + 3] = 255;
+        }
+        return buf;
+    }
+
+    private static readonly (byte, byte, byte) Green = (40, 180, 40);
+    private static readonly (byte, byte, byte) Rock = (130, 130, 130);
+
+    [Fact]
+    public void Masks_edge_connected_rock_but_not_the_green_interior()
+    {
+        const int w = 40, h = 40;
+        var bgra = Bgra(w, h, (x, y) => (x is >= 10 and < 30 && y is >= 10 and < 30) ? Green : Rock);
+
+        var mask = BorderMask.Compute(bgra, w, h, step: 1);
+
+        mask[5 * w + 5].Should().BeTrue("the edge-connected gray rim is border");
+        mask[20 * w + 20].Should().BeFalse("the green interior is not border");
+    }
+
+    [Fact]
+    public void Does_not_leak_through_a_green_ring_into_an_enclosed_gray_pocket()
+    {
+        // Gray rim, a green ring at 8..32, and a gray pocket inside 14..26. The
+        // pocket is gray (fillable) but enclosed by green, so the edge flood can't
+        // reach it — an interior stone structure must survive (stay unmasked).
+        const int w = 40, h = 40;
+        var bgra = Bgra(w, h, (x, y) =>
+        {
+            var ring = x is >= 8 and < 32 && y is >= 8 and < 32;
+            var pocket = x is >= 14 and < 26 && y is >= 14 and < 26;
+            return ring && !pocket ? Green : Rock;
+        });
+
+        var mask = BorderMask.Compute(bgra, w, h, step: 1);
+
+        mask[2 * w + 2].Should().BeTrue("outer gray rim is border");
+        mask[20 * w + 20].Should().BeFalse("the enclosed gray pocket is unreachable from the edge");
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -30,7 +30,8 @@ internal sealed record CliArgs(
     string? ProjectionOverlayPath,
     double Zoom,
     Phase Phase,
-    bool DryRun)
+    bool DryRun,
+    bool UseBorderMask)
 {
     public static CliArgs? Parse(string[] argv)
     {
@@ -56,6 +57,7 @@ internal sealed record CliArgs(
         double zoom = 1.0;
         Phase phase = Phase.Full;
         bool dryRun = false;
+        bool useBorderMask = false;
 
         for (int i = 0; i < argv.Length; i++)
         {
@@ -104,6 +106,9 @@ internal sealed record CliArgs(
                 case "--dry-run":
                     dryRun = true;
                     break;
+                case "--border-mask":
+                    useBorderMask = true;
+                    break;
                 case "-h" or "--help":
                     return null;
                 default:
@@ -150,7 +155,8 @@ internal sealed record CliArgs(
             ProjectionOverlayPath: projectionOverlayPath,
             Zoom: zoom,
             Phase: phase,
-            DryRun: dryRun);
+            DryRun: dryRun,
+            UseBorderMask: useBorderMask);
     }
 
     private static (string Name, (int W, int H) Wh) ParseIconSize(string s)
@@ -256,6 +262,14 @@ internal sealed record CliArgs(
                                             landmark_npc source asset is not what PG renders for
                                             NPC pins, and including noisy NPC matches in the pool
                                             misleads RANSAC into wrong-but-self-consistent fits)
+              --border-mask                 drop detections sitting in the map's rocky border.
+                                            Irregular-bordered outdoor zones have a stone rim
+                                            that matches pin templates as noise; a rectangular
+                                            map-rect can't exclude it, so the rim floods RANSAC
+                                            and out-votes sparse interior landmarks (Eltibule,
+                                            KurMountains). Masks the edge-connected
+                                            non-vegetation/water region. Opt-in: flat tan/desert
+                                            areas have no such border.
               --debug-image <path>          write an annotated PNG: cyan rects mark every detection
                                             that cleared threshold, red crosses mark the pivot-
                                             corrected anchor, green rect outlines the map rect

--- a/tools/MapCalibrationFromScreenshot/Pipeline.cs
+++ b/tools/MapCalibrationFromScreenshot/Pipeline.cs
@@ -66,7 +66,8 @@ internal static class Pipeline
             IconSizeOverrides: args.IconSizeOverrides,
             ExcludedLandmarkTypes: args.ExcludedLandmarkTypes,
             DebugImagePath: args.DebugImagePath,
-            ProjectionOverlayPath: args.ProjectionOverlayPath);
+            ProjectionOverlayPath: args.ProjectionOverlayPath,
+            UseBorderMask: args.UseBorderMask);
 
         var result = ScreenshotCalibrator.Calibrate(inputs);
         if (result.Calibration is null)
@@ -195,7 +196,8 @@ internal sealed record CalibrationInputs(
     IReadOnlyDictionary<string, (int W, int H)> IconSizeOverrides,
     IReadOnlySet<string> ExcludedLandmarkTypes,
     string? DebugImagePath,
-    string? ProjectionOverlayPath);
+    string? ProjectionOverlayPath,
+    bool UseBorderMask);
 
 internal sealed record AssignedReference(
     string Label,

--- a/tools/MapCalibrationFromScreenshot/ScreenshotCalibrator.cs
+++ b/tools/MapCalibrationFromScreenshot/ScreenshotCalibrator.cs
@@ -118,6 +118,38 @@ internal static class ScreenshotCalibrator
             .Select(t => (t.Icon, t.Det with { X = t.Det.X + mapRect.OriginX, Y = t.Det.Y + mapRect.OriginY, SubX = t.Det.SubX + mapRect.OriginX, SubY = t.Det.SubY + mapRect.OriginY }, t.RenderW, t.RenderH))
             .ToList();
 
+        // Drop detections sitting in the rocky border of an irregular-bordered
+        // map. The stone rim matches pin templates at noise level and, with a
+        // rectangular map-rect that can't exclude it, floods RANSAC with false
+        // positives that out-vote the sparse interior landmarks (observed:
+        // Eltibule / KurMountains collapse to a tiny-scale wrong fit). The mask
+        // is the edge-connected non-vegetation/water region; interior anchors
+        // survive. Opt-in (--border-mask) since flat tan/desert areas have no
+        // such border and shouldn't pay for the classification.
+        if (inputs.UseBorderMask)
+        {
+            var (maskBgra, maskW, maskH) = ImageIo.LoadBgra(inputs.ScreenshotPath);
+            var border = BorderMask.Compute(maskBgra, maskW, maskH);
+            bool InBorder(double ax, double ay)
+            {
+                var x = (int)Math.Round(ax);
+                var y = (int)Math.Round(ay);
+                return x < 0 || x >= maskW || y < 0 || y >= maskH || border[y * maskW + x];
+            }
+
+            var dropped = 0;
+            foreach (var typeDets in detectionsByType.Values)
+            {
+                dropped += typeDets.RemoveAll(d => InBorder(d.AnchorScreenshotX, d.AnchorScreenshotY));
+            }
+            rawDetections.RemoveAll(t =>
+            {
+                var (cx, cy) = t.Det.Centre(t.RenderW, t.RenderH);
+                return InBorder(cx + t.RenderW * (t.Icon.PivotX - 0.5), cy + t.RenderH * (0.5 - t.Icon.PivotY));
+            });
+            Console.WriteLine($"[border-mask] dropped {dropped} detections sitting in the rocky border");
+        }
+
         // Drop excluded landmark types from the pool BEFORE RANSAC sees them.
         // Used when a template doesn't match PG's actual sprite — keeping its
         // noisy matches in the pool misleads RANSAC into wrong-but-self-

--- a/tools/MapCalibrationFromScreenshot/SelfTest.cs
+++ b/tools/MapCalibrationFromScreenshot/SelfTest.cs
@@ -159,7 +159,8 @@ internal static class SelfTest
             IconSizeOverrides: new Dictionary<string, (int, int)>(),
             ExcludedLandmarkTypes: new HashSet<string>(),
             DebugImagePath: null,
-            ProjectionOverlayPath: null);
+            ProjectionOverlayPath: null,
+            UseBorderMask: false);
         var result = ScreenshotCalibrator.Calibrate(inputs);
 
         if (result.Calibration is null)

--- a/tools/Mithril.MapCalibration.Tools.Common/BorderMask.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/BorderMask.cs
@@ -1,0 +1,74 @@
+namespace Mithril.Tools.MapCalibration.Common;
+
+/// <summary>
+/// Computes a "rocky border" mask for an irregular-bordered area screenshot by
+/// flood-filling inward from the image edges. PG outdoor maps are an irregular
+/// vegetated/water blob inside a stone rim; that rim is a false-positive factory
+/// for icon NCC (its rock texture matches pin templates at noise level), and a
+/// rectangular map-rect can't exclude it — so RANSAC locks onto border noise
+/// instead of the real interior landmarks (observed on Eltibule / KurMountains).
+///
+/// <para>The border is the region connected to the image edge that is <b>not</b>
+/// vegetation (green-dominant) or water (blue-dominant); the interior terrain is
+/// enclosed by that vegetation/water boundary, so the flood stops there. Interior
+/// brown paths/structures are <em>not</em> reached because they're ringed by
+/// green, not connected to the edge except through the rim. Detections whose
+/// anchor falls in the masked border are dropped before RANSAC.</para>
+/// </summary>
+public static class BorderMask
+{
+    /// <summary>
+    /// Returns a per-pixel mask (row-major, <c>true</c> = border / exclude) for a
+    /// BGRA buffer. Classified on a <paramref name="step"/>-downsampled grid for
+    /// speed; each output pixel inherits its grid cell's result.
+    /// </summary>
+    public static bool[] Compute(byte[] bgra, int width, int height, int step = 4)
+    {
+        if (step < 1) step = 1;
+        var gw = (width + step - 1) / step;
+        var gh = (height + step - 1) / step;
+
+        // A grid cell is "fillable" (rock/border candidate) when it is neither
+        // green-dominant (vegetation) nor blue-dominant (water).
+        var fillable = new bool[gw * gh];
+        for (var gy = 0; gy < gh; gy++)
+        for (var gx = 0; gx < gw; gx++)
+        {
+            var x = Math.Min(gx * step, width - 1);
+            var y = Math.Min(gy * step, height - 1);
+            var i = (y * width + x) * 4;
+            int b = bgra[i], g = bgra[i + 1], r = bgra[i + 2];
+            var green = g > r + 8 && g > b + 8;
+            var water = b > r + 8 && b > g + 8;
+            fillable[gy * gw + gx] = !(green || water);
+        }
+
+        // Flood-fill fillable cells reachable from any image edge.
+        var border = new bool[gw * gh];
+        var q = new Queue<int>();
+        void Enq(int gx, int gy)
+        {
+            if (gx < 0 || gx >= gw || gy < 0 || gy >= gh) return;
+            var k = gy * gw + gx;
+            if (fillable[k] && !border[k]) { border[k] = true; q.Enqueue(k); }
+        }
+        for (var gx = 0; gx < gw; gx++) { Enq(gx, 0); Enq(gx, gh - 1); }
+        for (var gy = 0; gy < gh; gy++) { Enq(0, gy); Enq(gw - 1, gy); }
+        while (q.Count > 0)
+        {
+            var k = q.Dequeue();
+            var gx = k % gw;
+            var gy = k / gw;
+            Enq(gx - 1, gy);
+            Enq(gx + 1, gy);
+            Enq(gx, gy - 1);
+            Enq(gx, gy + 1);
+        }
+
+        var mask = new bool[width * height];
+        for (var y = 0; y < height; y++)
+        for (var x = 0; x < width; x++)
+            mask[y * width + x] = border[(y / step) * gw + (x / step)];
+        return mask;
+    }
+}


### PR DESCRIPTION
Irregular-bordered outdoor maps (Eltibule, KurMountains) have a stone rim that matches pin templates at NCC-noise level. A rectangular `--map-rect` can't exclude it, so the rim floods RANSAC with false positives that out-vote the sparse interior landmarks → tiny-scale wrong fits (the cause behind "the π-orientation areas won't calibrate").

`BorderMask` (Tools.Common) flood-fills inward from the image edges through non-vegetation/water pixels; the vegetated/water interior is enclosed by that boundary and survives — including gray pockets ringed by green (an interior stone structure isn't masked). `--border-mask` (opt-in) drops detections whose anchor lands in the masked rim before RANSAC.

**Effect:** on Eltibule it drops 125 border false positives and recovers the correct **~180°** orientation — impossible before (it always collapsed to a tiny-scale wrong fit). It is **necessary but not sufficient** for the sparsest areas: their interior icons match too weakly (≤3 strong detections) to give RANSAC a robust inlier set — a separate detection-quality problem. Opt-in because flat tan/desert areas have no such border.

Shared `Tools.Common` primitive + 2 tests (basic mask + the enclosed-pocket connectivity property). 21/21 tests pass. Part of #897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)