### PR TITLE
docs(map-calibration): rewrite gate verdict post-DPI-fix — H4 demonstrated (#897)

### DIFF
--- a/docs/map-calibration-gate-verdict.md
+++ b/docs/map-calibration-gate-verdict.md
@@ -3,21 +3,21 @@
 **Date:** 2026-05-30
 **Issue:** [mithril#897](https://github.com/moumantai-gg/mithril/issues/897)
 **Spec:** [docs/superpowers/specs/2026-05-30-map-calibration-gate-study-design.md](superpowers/specs/2026-05-30-map-calibration-gate-study-design.md)
-**Verdict:** **PROCEED** to the auto-calibration engine spec. H1 (discrete orientation) is decisive. H4 (cold automation) is **feasible and demonstrated end-to-end** on a landmark-dense area (Serbule: zero-prior, 0.93 px residual, 23 RANSAC inliers). Sparse / irregular-border areas need additional detection work (a built border-mask plus a stronger interior detector), but that is an *engineering* gap, not a falsification of the model.
+**Verdict:** **PROCEED** to the auto-calibration engine spec. H1 (discrete orientation) is decisive. H4 (cold automation) is **feasible and demonstrated end-to-end** on a landmark-dense area (Serbule: zero-prior, 0.93 px residual, 23 RANSAC inliers). Sparse / irregular-border areas (Eltibule, Kur) still need stronger detection — and a **texture-deviation front-end now looks like the lever** (see below). The remaining work is engineering, not a falsification of the model.
 
-This records the result of the gate study so the engine spec can cite it. It supersedes the earlier draft of this file, which was written **before the DPI bug below was found** and wrongly concluded that the naive cold prototype could not recover any transform. That conclusion was an artifact of corrupted inputs, not of the renderer. It also updates the wiki [Legolas-Calibration-Findings](https://github.com/moumantai-gg/mithril/wiki/Legolas-Calibration-Findings) (n=2 → n=6).
+This records the gate-study result so the engine spec can cite it. The history below is kept deliberately: **two separate "it's infeasible" conclusions in this study turned out to be corrupted inputs, not real failures.** That pattern is the single most important carry-over.
 
-## Headline lesson — verify your inputs first
+## Headline lesson — verify your inputs first (it bit us twice)
 
-For most of the study, **every screenshot run failed** and it looked like cold automation was infeasible: NCC peaks were garbage, RANSAC found no inliers, debug overlays showed nothing matching. The root cause was not the algorithm — it was a **DPI bug** in the shared image loader (`ImageIo.ReadBgra`, fixed in [PR #907](https://github.com/moumantai-gg/mithril/pull/907)):
+1. **The DPI bug.** For most of the study, every screenshot run failed: garbage NCC peaks, zero RANSAC inliers, blank debug overlays. Root cause was the shared image loader (`ImageIo`, fixed in [PR #907](https://github.com/moumantai-gg/mithril/pull/907)): `Graphics.DrawImageUnscaled` honors a PNG's DPI metadata, so the author's 300-DPI cropped screenshots were drawn at ~1/3 size into the top-left corner of a 96-DPI buffer with the rest black. Every metric was computed against a mostly-black image. The tell was a debug image showing the map shrunk into a black corner. Fix: draw into an explicit pixel-sized destination rect, ignoring DPI.
 
-> `Graphics.DrawImageUnscaled` honors a PNG's DPI metadata. The author's screenshots were cropped at 300 DPI, so the loader drew them at ~1/3 size into the top-left corner of a 96-DPI-sized buffer and left the rest black. Every downstream NCC match, debug image, and inlier count was computed against a mostly-black image.
+2. **The wrong-filename false negative.** The texture-deviation probe (below) first reported mean local-NCC ~0.03 — "no shared structure, approach dead." Cause: it was pointed at `Map_Serbule.v4.png`, which doesn't exist; the real file is `Map_AreaSerbule.v4.png`. With the correct file, mean NCC jumps to **0.86** and the approach works. A positive control (screenshot vs itself → NCC 0.999) is what flagged that the near-zero cross-result had to be an input problem, not a real one.
 
-The tell was a **debug image showing the map shrunk into a black corner** — looking at the actual pixels the algorithm saw is what cracked a problem that had masqueraded as "automation is fundamentally hard" for the whole session. The fix is to draw into an explicit pixel-sized destination rectangle, ignoring DPI metadata. **Carry this into the engine: validate that the loaded screenshot/texture pixels are what you expect (size, non-black, icons visible) before trusting any detection metric.**
+**Carry into the engine: before trusting any detection metric, validate the loaded pixels — size, not-black, the file actually exists and is the one you meant, icons visible. Keep a positive control (self-NCC ≈ 1.0) in the test suite.**
 
 ## Sample
 
-Six areas — the author's full reachable set — spanning outdoor (Serbule, Eltibule, KurMountains), cave (Cave1, MyconianCave), and indoor (Casino). Rotation/handedness from the user-refinement store (`refinements.json`, frame-invariant). Serbule additionally has a committed texture-frame baseline and a **reproduced cold solve** (see H4).
+Six areas — the author's full reachable set — spanning outdoor (Serbule, Eltibule, KurMountains), cave (Cave1, MyconianCave), and indoor (Casino). Rotation/handedness from the user-refinement store (`refinements.json`, frame-invariant). Serbule additionally has a committed texture-frame baseline and a reproduced cold solve (see H4).
 
 ## Results (Half A — `measure`)
 
@@ -36,19 +36,21 @@ Six areas — the author's full reachable set — spanning outdoor (Serbule, Elt
 
 ### H1 — axis-aligned orientation ∈ {0, π} — **CONFIRMED**
 
-All six areas snap to exactly {0°, 180°}: four within **0.04°** of 0, two within **0.004°** of π, with **no in-between angle**. This both falsifies the naive "rotation ≈ 0" (Eltibule and KurMountains are dead-on 180°) and confirms the discrete-orientation model. The engine's "enumerate the axis-aligned orientation states" bootstrap is justified by real data — and the engine must **not** assume θ = 0. Handedness (`mirrorNorth`) was constant in this sample; the orientation variation surfaced as rotation 0/π (an equivalent parameterization of the same discrete-4-state group).
+All six areas snap to exactly {0°, 180°}: four within **0.04°** of 0, two within **0.004°** of π, with **no in-between angle**. This both falsifies the naive "rotation ≈ 0" (Eltibule and KurMountains are dead-on 180°) and confirms the discrete-orientation model. The engine's "enumerate the axis-aligned orientation states" bootstrap is justified by real data — and it must **not** assume θ = 0. Handedness (`mirrorNorth`) was constant in this sample; the orientation variation surfaced as rotation 0/π (an equivalent parameterization of the same discrete-4-state group).
+
+**Subtlety the texture-deviation probe surfaced:** the 0/π split is in the **world→texture-pixel** mapping (where landmark icons are *placed*), not in the texture image itself. The base texture art aligns to the in-game screenshot at **0° for every area** (deviation NCC picks 0° for both Serbule and the 180°-calibrated Eltibule). So a detection front-end aligns texture↔screenshot at 0°; the discrete {0, π} only matters later, in the world→pixel solve.
 
 ### H2 — isotropy — **indirectly supported**
 
-A 4-parameter *similarity* fits all six areas to **sub-pixel** residual (0.006–0.53 px) across outdoor/cave/indoor. If the renderer needed an anisotropic (affine) model, a similarity could not fit that tightly. A direct affine-vs-similarity contest (H2 in the strict sense) is only meaningful at kept ≥ 4 detected points per area; it is available per-area once detection is robust enough to produce that many clean inliers (currently only Serbule clears it — see H4 and "Remaining work").
+A 4-parameter *similarity* fits all six areas to **sub-pixel** residual (0.006–0.53 px). If the renderer needed an anisotropic (affine) model, a similarity could not fit that tightly. A direct affine-vs-similarity contest is only meaningful at kept ≥ 4 detected points per area; that becomes available once detection is robust enough on the sparse areas (currently only Serbule clears it).
 
 ### H3 — consistent border inset — **single data point; completion path identified**
 
-Serbule's landmark bbox projects into the texture with an **8.9%** max-edge inset (scaleRatioX 0.836). Consistency across areas can't be assessed from n=1; the other five need a texture-frame solve, which is gated on the same detection robustness as H4. **This is the main remaining piece of geometric evidence.**
+Serbule's landmark bbox projects into the texture with an **8.9%** max-edge inset (scaleRatioX 0.836). Consistency across areas can't be assessed from n=1; the other five need a texture-frame solve, gated on the same detection robustness as H4.
 
 ### H4 — cold zero-prior correspondence — **DEMONSTRATED on Serbule; open on sparse areas**
 
-**Serbule: cold auto-calibration confirmed.** With the DPI bug fixed, the proven [`tools/MapCalibrationFromScreenshot`](../tools/MapCalibrationFromScreenshot) (PR #854, RANSAC + type-aware assignment) recovers Serbule's exact committed baseline **from zero priors** — no stored calibration, no manual clicks:
+**Serbule: cold auto-calibration confirmed.** With the DPI bug fixed, the proven [`tools/MapCalibrationFromScreenshot`](../tools/MapCalibrationFromScreenshot) (PR #854, RANSAC + type-aware assignment) recovers Serbule's committed baseline **from zero priors** — no stored calibration, no manual clicks:
 
 ```
 dotnet run --project tools/MapCalibrationFromScreenshot -- \
@@ -58,34 +60,52 @@ dotnet run --project tools/MapCalibrationFromScreenshot -- \
   --icon-size landmark_npc=17x16 --detection-threshold 0.8 --dry-run
 ```
 
-→ **scale 0.8226, rotation 0°, residual 0.93 px, 23 RANSAC inliers.** This matches the manual baseline (scale 0.823, 0.30 px) well under the 12 px `CalibrationGoodResidualPx` gate.
+→ **scale 0.8226, rotation 0°, residual 0.93 px, 23 RANSAC inliers**, matching the manual baseline (0.30 px) well under the 12 px `CalibrationGoodResidualPx` gate.
 
-Two enablers were decisive, and both are non-obvious:
+Two enablers were decisive, both non-obvious:
 
-1. **The DPI fix** (above) — without it, nothing detects.
-2. **Include NPCs at the right per-type size.** The tool's own docs *recommended* `--exclude-type Npc` for Serbule. **That advice is wrong** — it came from DPI-corrupted runs where the NPC cloud was pure noise. With the DPI fix and `--icon-size landmark_npc=17x16` (PG renders the `landmark_npc` sprite at a 17×16 aspect, not square), the NPCs become the *bulk of the real anchors*: inliers jump **8 → 23**, and that density is what makes RANSAC robust. The README has been corrected accordingly.
+1. **The DPI fix** — without it, nothing detects.
+2. **Include NPCs at the right per-type size.** It is tempting to drop the noisy NPC type (`--exclude-type Npc`), but at `--icon-size landmark_npc=17x16` (PG renders that sprite at a 17×16 aspect, not square) the NPCs become the *bulk of the real anchors*: inliers jump **8 → 23**, and that density is what makes RANSAC robust.
 
-**Eltibule + KurMountains (both 180°): not yet robust.** Both are sparser and have a rocky outer border whose texture matches the icon templates. The new `--border-mask` (PR #908, edge flood-fill of non-vegetation/water) is necessary — on Eltibule it drops **125 rim false positives** and lets the solver reach the correct ~180° orientation — but **not sufficient**: only ~3 interior landmark icons match strongly enough for stable RANSAC. The interior detection is too weak. This is the open problem, and it is a detection-quality problem, not a renderer-regularity problem. (Pixel dims for `--map-rect "0,0,W,H"`: Eltibule 921×914, Kur 981×980.)
+**Eltibule + KurMountains (both 180°): not yet robust.** Both are sparser, with a rocky outer border whose texture matches the icon templates. The `--border-mask` (PR #908, edge flood-fill of non-vegetation/water) is necessary — on Eltibule it drops ~125 rim false positives and lets the solver reach the correct orientation — but not sufficient: too few interior landmark icons match strongly enough for stable RANSAC. This is the open detection-quality problem, and the texture-deviation front-end below is the most promising attack on it. (Pixel dims for `--map-rect "0,0,W,H"`: Eltibule 921×914, Kur 981×980.)
 
-**So H4 is feasible — demonstrated where landmarks are dense, with a clear (built + open) path for sparse areas.** The model is sound; the remaining work is making the detector strong enough on sparse interiors. Task 2 of the follow-up (texture-deviation detection) targets exactly this.
+## Texture-deviation probe — **promising; likely the sparse-area detection front-end**
+
+Idea: the icon-free CDN base texture (`Map_Area<X>.v4.png`) and the in-game map screenshot are the same artwork; align them by extent (via the map-rect) and compute a **sliding-window local NCC**. Local NCC is invariant to per-window linear brightness/contrast, so terrain matches through PG's restyle/tint and the rocky border largely cancels; an icon disrupts the local match → low NCC → "added content" candidate. Prototyped as a visualization in [`tools/MapTextureDeviationProbe`](../tools/MapTextureDeviationProbe) (throwaway).
+
+**Verified results (after the wrong-filename fix above):**
+
+| run | mean local-NCC | low-NCC pixels (icons) | border-band deviation | interior deviation |
+|---|---|---|---|---|
+| Serbule vs itself (positive control) | **0.999** | 0.0% | — | — |
+| **Serbule** vs base texture | **0.86** | **2.8%** | 0.178 (low — border cancels) | 0.127 |
+| **Eltibule** vs base texture | **0.79** | **13%** | 0.495 (rocky rim partly deviates) | 0.128 |
+
+Terrain and (on Serbule) the border largely cancel; deviation is **localized**, and eyeballing the heatmaps/overlays confirms it: icons appear as discrete bright/low-NCC blobs against a dark matched-terrain field, with quiet terrain in between. This is exactly the wanted signal.
+
+**Caveats (why it's a front-end, not the whole detector):**
+
+- It flags **all** added/changed content, not only icons: the central keep/structure on Serbule, map labels, and fog read as deviation too. So it is a **candidate generator** — the engine must follow it with a **shape/size filter** (icon-sized compact blobs vs large smooth fog vs elongated structures) and then run icon-template NCC *only inside* the candidate regions. That both cuts false positives and slashes the search space on sparse areas.
+- It needs the texture aligned to the screenshot (the same `--map-rect` the proven tool already uses), and the base texture file must actually exist for the area.
+
+**This is the recommended sparse-area rescue and a strong candidate for the engine's detection stage:** terrain-subtract via local NCC → shape-filter the blobs → type-aware RANSAC template match within candidates.
 
 ## Verdict & implications for the engine spec
 
-**PROCEED.** The renderer is regular: per-area global isotropic similarity with a **discrete axis-aligned orientation ∈ {0, π}** (H1 decisive, n=6), sub-pixel-fittable everywhere (H2 indirect), with a measured border inset on the one fully-solved area (H3 partial). Cold, near-zero-ref calibration is **demonstrated** on a landmark-dense area and is the engine's target shape. Concrete carry-overs:
+**PROCEED.** The renderer is regular: per-area global isotropic similarity with a **discrete axis-aligned orientation ∈ {0, π}** (H1 decisive, n=6), sub-pixel-fittable everywhere (H2 indirect), with a measured border inset on the one fully-solved area (H3 partial). Cold, near-zero-ref calibration is **demonstrated** on a landmark-dense area. Concrete carry-overs:
 
-- **Validate inputs first.** Check loaded pixels (size, not-black, icons present) before trusting any detection metric. The DPI bug cost this study most of a session by looking like an algorithmic failure.
-- **Orientation:** enumerate the discrete {0, π} state set; do not assume θ = 0.
-- **Correspondence:** RANSAC + type-aware assignment (per-type, trimmed to landmark count), **not** greedy nearest-neighbour.
-- **Include NPCs**, with per-type sizing (`landmark_npc` is 17×16, not square). On landmark-dense areas they are the anchors that make the fit robust, not noise to exclude.
-- **Border-mask irregular zones.** Rocky/water rims produce icon-template false positives; mask them via the edge flood-fill before correspondence.
-- **Detection is the bottleneck on sparse areas.** A stronger interior detector (e.g. texture-deviation / local-NCC against the icon-free base texture) is the next lever; pure template NCC is too weak on sparse interiors.
+- **Validate inputs first.** File-exists, size, not-black, icons present; keep a self-NCC ≈ 1.0 positive control. Two false "infeasible" verdicts in this study came from bad inputs.
+- **Orientation:** enumerate the discrete {0, π} state set for the world→pixel solve; do not assume θ = 0. Align the texture↔screenshot images at 0°.
+- **Detection (the bottleneck on sparse areas):** texture-deviation local-NCC front-end → shape/size filter → type-aware template NCC within candidates. Plain whole-image template NCC is too weak on sparse interiors; terrain subtraction makes the icons pop.
+- **Correspondence:** RANSAC + type-aware assignment (per-type, trimmed to landmark count) + a scale plausibility guard, not greedy nearest-neighbour. **Include NPCs**, with per-type sizing (`landmark_npc` is 17×16) — they are the anchors that make landmark-dense fits robust.
+- **Border-mask irregular zones** (PR #908) as a complement; on Serbule the deviation front-end already cancels the border, on Eltibule the rocky rim partly survives and the mask helps.
 - **Honesty ceiling:** the ±10% non-affine map warp ([PR #449](https://github.com/moumantai-gg/mithril/pull/449)) still applies — "approximate location" UX, not pixel-perfect rendezvous.
 
-## Remaining work (to fully close H2/H3 and rescue sparse areas)
+## Remaining work
 
-1. **Stronger interior detection** (gates H3/H4 on sparse areas). Prototype texture-deviation detection: align the icon-free base texture to the screenshot via the map-rect and flag where the screenshot deviates (sliding-window local NCC, not absolute diff). The rocky border vanishes for free (identical in both → high local NCC → excluded); added icons disrupt the local match → low NCC → candidates. If promising, this becomes the engine's detection front-end and may rescue Eltibule/Kur.
-2. **Texture-frame solves for the other five areas** (completes H3 inset consistency + gives a real per-area H2 affine contest at kept ≥ 4). Run the proven `tools/MapCalibrationFromScreenshot` once detection is robust enough, commit those `AreaCalibration`s to the baseline, re-run `measure`, and append the inset values here and on the wiki.
+1. **Build the texture-deviation → shape-filter → template stage** and re-test on Eltibule/Kur. The probe shows the terrain-subtraction step works; the missing piece is the blob shape/size filter that separates icons from structures/fog, then template NCC within candidates.
+2. **Texture-frame solves for the other five areas** (completes H3 inset consistency + a real per-area H2 affine contest at kept ≥ 4). Run the proven `tools/MapCalibrationFromScreenshot` once sparse-area detection is robust, commit those `AreaCalibration`s to the baseline, re-run `measure`, and append the inset values here and on the wiki.
 
 ## Teardown
 
-The throwaway `tools/MapCalibrationStudy` has served its purpose (it produced the consistency table and surfaced the DPI bug). Delete it in its own PR per #897 Task 10 — separate from this verdict and from any further measurement runs, per the squash-merge-orphans rule.
+The throwaway study scaffolding (`tools/MapCalibrationStudy`, and `tools/MapTextureDeviationProbe` once its idea is folded into the engine) is deleted in its own PR per #897 Task 10 — separate from this verdict and from any further measurement runs, per the squash-merge-orphans rule.

--- a/docs/map-calibration-gate-verdict.md
+++ b/docs/map-calibration-gate-verdict.md
@@ -3,13 +3,21 @@
 **Date:** 2026-05-30
 **Issue:** [mithril#897](https://github.com/moumantai-gg/mithril/issues/897)
 **Spec:** [docs/superpowers/specs/2026-05-30-map-calibration-gate-study-design.md](superpowers/specs/2026-05-30-map-calibration-gate-study-design.md)
-**Verdict:** **PROCEED** to the auto-calibration engine spec. The renderer is regular enough (H1 decisive); H2/H3 are partially confirmed with a clear, cheap path to complete; H4 (automation) is feasible but requires robust correspondence, not the naive prototype.
+**Verdict:** **PROCEED** to the auto-calibration engine spec. H1 (discrete orientation) is decisive. H4 (cold automation) is **feasible and demonstrated end-to-end** on a landmark-dense area (Serbule: zero-prior, 0.93 px residual, 23 RANSAC inliers). Sparse / irregular-border areas need additional detection work (a built border-mask plus a stronger interior detector), but that is an *engineering* gap, not a falsification of the model.
 
-This records the result of the gate study so the engine spec can cite it. It also updates the wiki [Legolas-Calibration-Findings](https://github.com/moumantai-gg/mithril/wiki/Legolas-Calibration-Findings) (n=2 → n=6).
+This records the result of the gate study so the engine spec can cite it. It supersedes the earlier draft of this file, which was written **before the DPI bug below was found** and wrongly concluded that the naive cold prototype could not recover any transform. That conclusion was an artifact of corrupted inputs, not of the renderer. It also updates the wiki [Legolas-Calibration-Findings](https://github.com/moumantai-gg/mithril/wiki/Legolas-Calibration-Findings) (n=2 → n=6).
+
+## Headline lesson — verify your inputs first
+
+For most of the study, **every screenshot run failed** and it looked like cold automation was infeasible: NCC peaks were garbage, RANSAC found no inliers, debug overlays showed nothing matching. The root cause was not the algorithm — it was a **DPI bug** in the shared image loader (`ImageIo.ReadBgra`, fixed in [PR #907](https://github.com/moumantai-gg/mithril/pull/907)):
+
+> `Graphics.DrawImageUnscaled` honors a PNG's DPI metadata. The author's screenshots were cropped at 300 DPI, so the loader drew them at ~1/3 size into the top-left corner of a 96-DPI-sized buffer and left the rest black. Every downstream NCC match, debug image, and inlier count was computed against a mostly-black image.
+
+The tell was a **debug image showing the map shrunk into a black corner** — looking at the actual pixels the algorithm saw is what cracked a problem that had masqueraded as "automation is fundamentally hard" for the whole session. The fix is to draw into an explicit pixel-sized destination rectangle, ignoring DPI metadata. **Carry this into the engine: validate that the loaded screenshot/texture pixels are what you expect (size, non-black, icons visible) before trusting any detection metric.**
 
 ## Sample
 
-Six areas — the author's full reachable set — spanning outdoor (Serbule, Eltibule, KurMountains), cave (Cave1, MyconianCave), and indoor (Casino). Rotation/handedness from the user-refinement store (`refinements.json`, frame-invariant); Serbule additionally has a committed texture-frame baseline solve.
+Six areas — the author's full reachable set — spanning outdoor (Serbule, Eltibule, KurMountains), cave (Cave1, MyconianCave), and indoor (Casino). Rotation/handedness from the user-refinement store (`refinements.json`, frame-invariant). Serbule additionally has a committed texture-frame baseline and a **reproduced cold solve** (see H4).
 
 ## Results (Half A — `measure`)
 
@@ -28,42 +36,56 @@ Six areas — the author's full reachable set — spanning outdoor (Serbule, Elt
 
 ### H1 — axis-aligned orientation ∈ {0, π} — **CONFIRMED**
 
-All six areas snap to exactly {0°, 180°}: four within **0.04°** of 0, two within **0.004°** of π, with **no in-between angle**. This both falsifies the naive "rotation ≈ 0" (Eltibule and KurMountains are dead-on 180°) and confirms the discrete-orientation model. The engine's "enumerate the 4 axis-aligned orientation states" bootstrap is justified by real data — and the engine must **not** assume θ = 0. Handedness (`mirrorNorth`) was constant in this sample; the orientation variation surfaced as rotation 0/π (an equivalent parameterization of the same discrete-4-state group).
+All six areas snap to exactly {0°, 180°}: four within **0.04°** of 0, two within **0.004°** of π, with **no in-between angle**. This both falsifies the naive "rotation ≈ 0" (Eltibule and KurMountains are dead-on 180°) and confirms the discrete-orientation model. The engine's "enumerate the axis-aligned orientation states" bootstrap is justified by real data — and the engine must **not** assume θ = 0. Handedness (`mirrorNorth`) was constant in this sample; the orientation variation surfaced as rotation 0/π (an equivalent parameterization of the same discrete-4-state group).
 
 ### H2 — isotropy — **indirectly supported**
 
-The tool's honest H2 signal (affine-vs-similarity on independent detected pixels) lives only in `bootstrap`, which did not produce trustworthy fits on real data (see H4); `measure`-mode affine is `n/a` by construction. **Indirect support:** a 4-parameter *similarity* fits all six areas to **sub-pixel** residual (0.006–0.53 px) across outdoor/cave/indoor. If the renderer needed an anisotropic (affine) model, a similarity could not fit that tightly. Not a direct affine contest, but strong circumstantial evidence the renderer is isotropic. A direct H2 measurement is available via the completion path below.
+A 4-parameter *similarity* fits all six areas to **sub-pixel** residual (0.006–0.53 px) across outdoor/cave/indoor. If the renderer needed an anisotropic (affine) model, a similarity could not fit that tightly. A direct affine-vs-similarity contest (H2 in the strict sense) is only meaningful at kept ≥ 4 detected points per area; it is available per-area once detection is robust enough to produce that many clean inliers (currently only Serbule clears it — see H4 and "Remaining work").
 
 ### H3 — consistent border inset — **single data point; completion path identified**
 
-Serbule's landmark bbox projects into the texture with an **8.9%** max-edge inset (scaleRatioX 0.836). Consistency across areas can't be assessed from n=1; the other five need a texture-frame solve. **This is the main piece of remaining evidence.**
+Serbule's landmark bbox projects into the texture with an **8.9%** max-edge inset (scaleRatioX 0.836). Consistency across areas can't be assessed from n=1; the other five need a texture-frame solve, which is gated on the same detection robustness as H4. **This is the main remaining piece of geometric evidence.**
 
-### H4 — cold zero-prior correspondence — **feasible, but needs robust correspondence**
+### H4 — cold zero-prior correspondence — **DEMONSTRATED on Serbule; open on sparse areas**
 
-The study's `ColdBootstrap` (zero-prior: scale-from-bbox → enumerate 4 orientations → greedy nearest-neighbour correspondence → similarity solve → outlier guard, selected by global reprojection) **could not recover the transform on real screenshots.** Root causes, observed end-to-end on Serbule/Eltibule:
+**Serbule: cold auto-calibration confirmed.** With the DPI bug fixed, the proven [`tools/MapCalibrationFromScreenshot`](../tools/MapCalibrationFromScreenshot) (PR #854, RANSAC + type-aware assignment) recovers Serbule's exact committed baseline **from zero priors** — no stored calibration, no manual clicks:
 
-1. **Map localization** — PG's in-game map renders with restyling/fog/a UI frame, so whole-texture NCC can't locate it (peaks ~0.23 < 0.30). Worked around with a `--map-rect` override (the screenshot is full-extent, so the frame-cropped image maps 1:1 to the texture).
-2. **Icon scale** — PG ships 256 px icon art but renders icons at ~16 px; needed a render-size sweep + `--icon-render-size` override.
-3. **Detection noise** — at a usable threshold the icon templates produce many false positives on PG's textured terrain; `landmark_npc` (the bulk of real anchors on Serbule) didn't detect at all at its native aspect, while sparse types (medipillar/portal) produced mostly-false detections.
-4. **Type-blind greedy correspondence** — `ColdBootstrap` matches *all* world points against *all* detections without type awareness, so it can't disambiguate ~30 NPCs from a noise cloud. Result: degenerate / wrong-orientation fits (`paired = false`), even after a scale-sanity guard stopped the worst collapses.
+```
+dotnet run --project tools/MapCalibrationFromScreenshot -- \
+  --screenshot "study/screenshots/AreaSerbule.png" --area AreaSerbule \
+  --icons-dir "study/icons" --map-dir "study/textures" \
+  --map-rect "0,0,881,920" --icon-render-size 16 \
+  --icon-size landmark_npc=17x16 --detection-threshold 0.8 --dry-run
+```
 
-**This does not mean automation is infeasible — it means the naive prototype is insufficient.** The shipped [`tools/MapCalibrationFromScreenshot`](../tools/MapCalibrationFromScreenshot) (PR #854) already auto-detects and solves robustly using exactly the machinery the study prototype simplified away: **type-aware assignment** (match each icon type only to its own landmarks, trim to the real count), **RANSAC** (largest consistent inlier set, not greedy NN), a **scale plausibility check**, and per-icon `--icon-size` overrides for aspect quirks (the source comment flags `landmark_npc` on Serbule specifically). Its wiki-recorded result is sub-pixel on Serbule. So **H4 is feasible — the engine's correspondence stage must be RANSAC + type-aware, not greedy.** That is the concrete design lesson the gate produced.
+→ **scale 0.8226, rotation 0°, residual 0.93 px, 23 RANSAC inliers.** This matches the manual baseline (scale 0.823, 0.30 px) well under the 12 px `CalibrationGoodResidualPx` gate.
+
+Two enablers were decisive, and both are non-obvious:
+
+1. **The DPI fix** (above) — without it, nothing detects.
+2. **Include NPCs at the right per-type size.** The tool's own docs *recommended* `--exclude-type Npc` for Serbule. **That advice is wrong** — it came from DPI-corrupted runs where the NPC cloud was pure noise. With the DPI fix and `--icon-size landmark_npc=17x16` (PG renders the `landmark_npc` sprite at a 17×16 aspect, not square), the NPCs become the *bulk of the real anchors*: inliers jump **8 → 23**, and that density is what makes RANSAC robust. The README has been corrected accordingly.
+
+**Eltibule + KurMountains (both 180°): not yet robust.** Both are sparser and have a rocky outer border whose texture matches the icon templates. The new `--border-mask` (PR #908, edge flood-fill of non-vegetation/water) is necessary — on Eltibule it drops **125 rim false positives** and lets the solver reach the correct ~180° orientation — but **not sufficient**: only ~3 interior landmark icons match strongly enough for stable RANSAC. The interior detection is too weak. This is the open problem, and it is a detection-quality problem, not a renderer-regularity problem. (Pixel dims for `--map-rect "0,0,W,H"`: Eltibule 921×914, Kur 981×980.)
+
+**So H4 is feasible — demonstrated where landmarks are dense, with a clear (built + open) path for sparse areas.** The model is sound; the remaining work is making the detector strong enough on sparse interiors. Task 2 of the follow-up (texture-deviation detection) targets exactly this.
 
 ## Verdict & implications for the engine spec
 
-**PROCEED.** The renderer is regular: per-area global isotropic similarity with a **discrete axis-aligned orientation ∈ {0, π}** (H1 decisive, n=6), sub-pixel-fittable everywhere (H2 indirect), with a measured border inset on the one fully-solved area (H3 partial). Near-zero-ref calibration is viable **provided** the correspondence stage uses robust machinery. Concrete carry-overs for the engine spec:
+**PROCEED.** The renderer is regular: per-area global isotropic similarity with a **discrete axis-aligned orientation ∈ {0, π}** (H1 decisive, n=6), sub-pixel-fittable everywhere (H2 indirect), with a measured border inset on the one fully-solved area (H3 partial). Cold, near-zero-ref calibration is **demonstrated** on a landmark-dense area and is the engine's target shape. Concrete carry-overs:
 
-- **Orientation:** enumerate the discrete 4-state set; do not assume θ = 0.
-- **Correspondence:** RANSAC + type-aware assignment (per-type, trimmed to landmark count) + a scale plausibility guard. The naive greedy approach is documented here as insufficient.
-- **Map localization & icon scale:** the engine needs the `MapRectLocator` fallback (frame-aware / user-assisted rect) and the render-size sweep + per-icon aspect override — none are optional on real screenshots.
+- **Validate inputs first.** Check loaded pixels (size, not-black, icons present) before trusting any detection metric. The DPI bug cost this study most of a session by looking like an algorithmic failure.
+- **Orientation:** enumerate the discrete {0, π} state set; do not assume θ = 0.
+- **Correspondence:** RANSAC + type-aware assignment (per-type, trimmed to landmark count), **not** greedy nearest-neighbour.
+- **Include NPCs**, with per-type sizing (`landmark_npc` is 17×16, not square). On landmark-dense areas they are the anchors that make the fit robust, not noise to exclude.
+- **Border-mask irregular zones.** Rocky/water rims produce icon-template false positives; mask them via the edge flood-fill before correspondence.
+- **Detection is the bottleneck on sparse areas.** A stronger interior detector (e.g. texture-deviation / local-NCC against the icon-free base texture) is the next lever; pure template NCC is too weak on sparse interiors.
 - **Honesty ceiling:** the ±10% non-affine map warp ([PR #449](https://github.com/moumantai-gg/mithril/pull/449)) still applies — "approximate location" UX, not pixel-perfect rendezvous.
 
-## Remaining work (to fully close H2/H3)
+## Remaining work (to fully close H2/H3 and rescue sparse areas)
 
-The cheap, robust way to get a texture-frame solve for the other five areas — completing H3 (inset consistency) and giving a direct H2 affine contest per area — is to run the **proven** `tools/MapCalibrationFromScreenshot` on the captured screenshots (it has the RANSAC/type-aware detection the study prototype lacks), commit those `AreaCalibration`s to the baseline, and re-run `measure`. This is preferable to manual harness clicking and to porting RANSAC into the throwaway study tool.
-
-Once the five inset values are in, append them to the table here and on the wiki, and confirm the inset clusters (H3) before the engine's data-only-bootstrap scale estimate relies on it.
+1. **Stronger interior detection** (gates H3/H4 on sparse areas). Prototype texture-deviation detection: align the icon-free base texture to the screenshot via the map-rect and flag where the screenshot deviates (sliding-window local NCC, not absolute diff). The rocky border vanishes for free (identical in both → high local NCC → excluded); added icons disrupt the local match → low NCC → candidates. If promising, this becomes the engine's detection front-end and may rescue Eltibule/Kur.
+2. **Texture-frame solves for the other five areas** (completes H3 inset consistency + gives a real per-area H2 affine contest at kept ≥ 4). Run the proven `tools/MapCalibrationFromScreenshot` once detection is robust enough, commit those `AreaCalibration`s to the baseline, re-run `measure`, and append the inset values here and on the wiki.
 
 ## Teardown
 
-The throwaway `tools/MapCalibrationStudy` has served its purpose (it produced this verdict and the H4 design lesson). Delete it in its own PR per #897 Task 10 once the five inset values are gathered (it may be re-run once more for those, via the proven tool feeding its baseline).
+The throwaway `tools/MapCalibrationStudy` has served its purpose (it produced the consistency table and surfaced the DPI bug). Delete it in its own PR per #897 Task 10 — separate from this verdict and from any further measurement runs, per the squash-merge-orphans rule.

--- a/tools/MapTextureDeviationProbe/MapTextureDeviationProbe.csproj
+++ b/tools/MapTextureDeviationProbe/MapTextureDeviationProbe.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.MapCalibration.Tools.Common\Mithril.MapCalibration.Tools.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/MapTextureDeviationProbe/Program.cs
+++ b/tools/MapTextureDeviationProbe/Program.cs
@@ -1,0 +1,335 @@
+using System.Drawing;
+using Mithril.Tools.MapCalibration.Common;
+
+// MapTextureDeviationProbe — R&D prototype for mithril#897 (gate study, task 2).
+//
+// Idea: the base map texture (Map_<Area>.v4.png) is icon-free; the in-game map
+// screenshot has icons (and fog) drawn on top of the same artwork. Align the
+// texture to the screenshot extent, then for every pixel compute a LOCAL NCC
+// between a screenshot patch and the aligned-texture patch. Terrain matches with
+// high local NCC even though PG restyles/tints the in-game map (NCC is invariant
+// to per-window linear brightness/contrast). An icon disrupts the local match ->
+// low NCC -> "added content" candidate. The rocky border is identical in both ->
+// high NCC -> excluded for free; fog-of-war is the smooth/large residual.
+//
+// This is a VISUALIZATION probe: it writes a deviation heatmap + an overlay so we
+// can eyeball whether icons pop and the border doesn't, before wiring local-NCC
+// into the real detector.
+//
+// Usage:
+//   dotnet run --project tools/MapTextureDeviationProbe -- \
+//     --screenshot <png> --texture <png> --out-dir <dir> \
+//     [--window 11] [--low-ncc 0.5] [--orientation auto|0|180]
+
+string screenshotPath = Cli.Get(args, "--screenshot", "");
+string texturePath = Cli.Get(args, "--texture", "");
+string outDir = Cli.Get(args, "--out-dir", ".");
+int window = int.Parse(Cli.Get(args, "--window", "11"));
+double lowNcc = double.Parse(Cli.Get(args, "--low-ncc", "0.5"));
+string orientationArg = Cli.Get(args, "--orientation", "auto"); // auto | 0 | 180
+
+if (screenshotPath.Length == 0 || texturePath.Length == 0)
+{
+    Console.Error.WriteLine("required: --screenshot <png> --texture <png>");
+    return 1;
+}
+Directory.CreateDirectory(outDir);
+string stem = Path.GetFileNameWithoutExtension(screenshotPath);
+
+Console.WriteLine($"screenshot: {screenshotPath}");
+Console.WriteLine($"texture:    {texturePath}");
+Console.WriteLine($"window={window}  low-ncc={lowNcc}  orientation={orientationArg}");
+
+// Use the shared loader (ImageIo.LoadBgra) so we inherit its DPI fix — the very
+// bug that derailed the gate study. It draws into an explicit pixel-sized rect.
+var (shotBgra, shotW, shotH) = ImageIo.LoadBgra(screenshotPath);
+var (texBgra, texW, texH) = ImageIo.LoadBgra(texturePath);
+BgraImage shot = new BgraImage(shotW, shotH, shotBgra);
+BgraImage tex = new BgraImage(texW, texH, texBgra);
+Console.WriteLine($"screenshot {shot.Width}x{shot.Height}  texture {tex.Width}x{tex.Height}");
+
+// --- INPUT SANITY (the lesson from the DPI bug: verify pixels before trusting metrics) ---
+double shotMean = Gray.MeanLuma(shot);
+Console.WriteLine($"screenshot mean luma = {shotMean:F1} (near-0 => likely a load/DPI problem)");
+if (shotMean < 8) Console.Error.WriteLine("WARNING: screenshot is almost black — check the load path before trusting results.");
+
+// Grayscale + resize texture to the screenshot extent (same map, same extent when zoomed fully out).
+float[] shotG = Gray.ToFloat(shot);
+
+float[] BuildAlignedTexture(bool rotate180)
+{
+    using var bmp = Gray.ToGrayBitmap(tex);
+    using var dst = new Bitmap(shot.Width, shot.Height);
+    using (var g = Graphics.FromImage(dst))
+    {
+        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+        if (rotate180)
+        {
+            g.TranslateTransform(shot.Width, shot.Height);
+            g.RotateTransform(180);
+        }
+        g.DrawImage(bmp, new Rectangle(0, 0, shot.Width, shot.Height));
+    }
+    return Gray.FromGrayBitmap(dst);
+}
+
+// Decide orientation: PG draws the texture artwork un-rotated and only the
+// world->pixel mapping flips for 180-deg areas, so screenshot==texture orientation
+// is expected. But verify empirically by picking the orientation with higher mean NCC.
+(double meanNcc, float[] dev) Run(bool rot180)
+{
+    float[] texG = BuildAlignedTexture(rot180);
+    float[] devMap = LocalNcc.DeviationMap(shotG, texG, shot.Width, shot.Height, window, out double mean);
+    return (mean, devMap);
+}
+
+float[] dev;
+bool used180;
+if (orientationArg == "0") { (var m0, dev) = Run(false); used180 = false; Console.WriteLine($"meanNCC@0  = {m0:F4}"); }
+else if (orientationArg == "180") { (var m1, dev) = Run(true); used180 = true; Console.WriteLine($"meanNCC@180 = {m1:F4}"); }
+else
+{
+    var (m0, d0) = Run(false);
+    var (m1, d1) = Run(true);
+    Console.WriteLine($"meanNCC@0 = {m0:F4}   meanNCC@180 = {m1:F4}");
+    used180 = m1 > m0;
+    dev = used180 ? d1 : d0;
+    Console.WriteLine($"auto-selected orientation: {(used180 ? "180" : "0")} (higher mean NCC)");
+}
+
+// --- Stats: how much of the image is "deviating", and is the border quiet? ---
+int n = shot.Width * shot.Height;
+int lowCount = 0;
+foreach (var v in dev) if (v >= 1.0 - lowNcc) lowCount++; // dev = 1-ncc; dev >= 1-lowNcc  <=>  ncc <= lowNcc
+double lowFrac = (double)lowCount / n;
+Console.WriteLine($"low-NCC pixels (ncc <= {lowNcc}): {lowCount}  ({lowFrac:P1} of image)");
+Console.WriteLine($"border-band mean deviation: {BorderBandMeanDeviation(dev, shot.Width, shot.Height, 0.06):F3} (want LOW — border should match)");
+Console.WriteLine($"interior   mean deviation: {InteriorMeanDeviation(dev, shot.Width, shot.Height, 0.06):F3}");
+
+// --- Outputs ---
+string heatPath = Path.Combine(outDir, $"{stem}_deviation.png");
+string overlayPath = Path.Combine(outDir, $"{stem}_overlay.png");
+{ var hm = Heatmap(dev, shot.Width, shot.Height); ImageIo.SaveBgraPng(hm.Pixels, hm.Width, hm.Height, heatPath); }
+{ var ov = Overlay(shot, dev, lowNcc); ImageIo.SaveBgraPng(ov.Pixels, ov.Width, ov.Height, overlayPath); }
+Console.WriteLine($"wrote {heatPath}");
+Console.WriteLine($"wrote {overlayPath}");
+return 0;
+
+// ---- local helpers ----
+
+static double BorderBandMeanDeviation(float[] dev, int w, int h, double frac)
+{
+    int bx = (int)(w * frac), by = (int)(h * frac);
+    double sum = 0; int cnt = 0;
+    for (int y = 0; y < h; y++)
+        for (int x = 0; x < w; x++)
+            if (x < bx || x >= w - bx || y < by || y >= h - by) { sum += dev[y * w + x]; cnt++; }
+    return cnt == 0 ? 0 : sum / cnt;
+}
+
+static double InteriorMeanDeviation(float[] dev, int w, int h, double frac)
+{
+    int bx = (int)(w * frac), by = (int)(h * frac);
+    double sum = 0; int cnt = 0;
+    for (int y = by; y < h - by; y++)
+        for (int x = bx; x < w - bx; x++) { sum += dev[y * w + x]; cnt++; }
+    return cnt == 0 ? 0 : sum / cnt;
+}
+
+// Deviation heatmap: 0 -> black, 1 -> hot (white-ish), via a simple blue->red->white ramp.
+static BgraImage Heatmap(float[] dev, int w, int h)
+{
+    var img = new BgraImage(w, h);
+    for (int i = 0; i < dev.Length; i++)
+    {
+        double t = Math.Clamp(dev[i], 0, 1);
+        // ramp: low=dark blue, mid=red, high=yellow/white
+        byte r = (byte)(Math.Clamp(t * 1.6, 0, 1) * 255);
+        byte g = (byte)(Math.Clamp((t - 0.5) * 2.0, 0, 1) * 255);
+        byte b = (byte)(Math.Clamp((0.4 - t) * 2.0, 0, 1) * 255);
+        int o = i * 4;
+        img.Pixels[o] = b; img.Pixels[o + 1] = g; img.Pixels[o + 2] = r; img.Pixels[o + 3] = 255;
+    }
+    return img;
+}
+
+// Overlay: screenshot, with ncc<=lowNcc pixels tinted red.
+static BgraImage Overlay(BgraImage shot, float[] dev, double lowNcc)
+{
+    var img = new BgraImage(shot.Width, shot.Height);
+    Array.Copy(shot.Pixels, img.Pixels, shot.Pixels.Length);
+    double thr = 1.0 - lowNcc;
+    for (int i = 0; i < dev.Length; i++)
+    {
+        if (dev[i] >= thr)
+        {
+            int o = i * 4;
+            img.Pixels[o] = (byte)(img.Pixels[o] * 0.3);       // B down
+            img.Pixels[o + 1] = (byte)(img.Pixels[o + 1] * 0.3); // G down
+            img.Pixels[o + 2] = 255;                              // R up
+        }
+        img.Pixels[i * 4 + 3] = 255;
+    }
+    return img;
+}
+
+// Minimal BGRA image (the shared lib exposes GrayImage + raw BGRA tuples, not a
+// BGRA wrapper); kept local to this throwaway probe.
+sealed class BgraImage
+{
+    public int Width { get; }
+    public int Height { get; }
+    public byte[] Pixels { get; } // BGRA, row-major
+
+    public BgraImage(int width, int height)
+    {
+        Width = width; Height = height; Pixels = new byte[width * height * 4];
+    }
+
+    public BgraImage(int width, int height, byte[] pixels)
+    {
+        Width = width; Height = height; Pixels = pixels;
+    }
+
+    public int Index(int x, int y) => (y * Width + x) * 4;
+}
+
+static class Cli
+{
+    public static string Get(string[] a, string key, string def)
+    {
+        for (int i = 0; i < a.Length - 1; i++)
+            if (a[i] == key) return a[i + 1];
+        return def;
+    }
+}
+
+static class Gray
+{
+    public static float[] ToFloat(BgraImage img)
+    {
+        var g = new float[img.Width * img.Height];
+        for (int i = 0; i < g.Length; i++)
+        {
+            int o = i * 4;
+            g[i] = 0.114f * img.Pixels[o] + 0.587f * img.Pixels[o + 1] + 0.299f * img.Pixels[o + 2];
+        }
+        return g;
+    }
+
+    public static double MeanLuma(BgraImage img)
+    {
+        double s = 0; int n = img.Width * img.Height;
+        for (int i = 0; i < n; i++)
+        {
+            int o = i * 4;
+            s += 0.114 * img.Pixels[o] + 0.587 * img.Pixels[o + 1] + 0.299 * img.Pixels[o + 2];
+        }
+        return s / n;
+    }
+
+    public static Bitmap ToGrayBitmap(BgraImage img)
+    {
+        var bmp = new Bitmap(img.Width, img.Height);
+        for (int y = 0; y < img.Height; y++)
+            for (int x = 0; x < img.Width; x++)
+            {
+                int o = img.Index(x, y);
+                int v = (int)(0.114 * img.Pixels[o] + 0.587 * img.Pixels[o + 1] + 0.299 * img.Pixels[o + 2]);
+                bmp.SetPixel(x, y, Color.FromArgb(v, v, v));
+            }
+        return bmp;
+    }
+
+    public static float[] FromGrayBitmap(Bitmap bmp)
+    {
+        var g = new float[bmp.Width * bmp.Height];
+        for (int y = 0; y < bmp.Height; y++)
+            for (int x = 0; x < bmp.Width; x++)
+                g[y * bmp.Width + x] = bmp.GetPixel(x, y).R;
+        return g;
+    }
+}
+
+// Per-pixel local NCC via integral images (O(WH), independent of window size).
+static class LocalNcc
+{
+    public static float[] DeviationMap(float[] a, float[] b, int w, int h, int win, out double meanNcc)
+    {
+        int r = win / 2;
+        double[] ia = Integral(a, w, h);
+        double[] ib = Integral(b, w, h);
+        double[] iaa = IntegralOf(a, a, w, h);
+        double[] ibb = IntegralOf(b, b, w, h);
+        double[] iab = IntegralOf(a, b, w, h);
+
+        const double flatVar = 3.0;   // below this variance a window has no structure
+        const double eps = 1e-6;
+        var dev = new float[w * h];
+        double nccSum = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                int x0 = Math.Max(0, x - r), y0 = Math.Max(0, y - r);
+                int x1 = Math.Min(w - 1, x + r), y1 = Math.Min(h - 1, y + r);
+                double n = (x1 - x0 + 1) * (double)(y1 - y0 + 1);
+                double sa = Box(ia, w, x0, y0, x1, y1);
+                double sb = Box(ib, w, x0, y0, x1, y1);
+                double saa = Box(iaa, w, x0, y0, x1, y1);
+                double sbb = Box(ibb, w, x0, y0, x1, y1);
+                double sab = Box(iab, w, x0, y0, x1, y1);
+                double ma = sa / n, mb = sb / n;
+                double va = saa / n - ma * ma;
+                double vb = sbb / n - mb * mb;
+                double cov = sab / n - ma * mb;
+
+                double ncc;
+                if (va < flatVar && vb < flatVar) ncc = 1.0;               // both featureless -> terrain match
+                else if (va < flatVar || vb < flatVar) ncc = 0.0;          // structure on one side only -> added content
+                else ncc = cov / Math.Sqrt(va * vb + eps);
+
+                ncc = Math.Clamp(ncc, -1, 1);
+                nccSum += ncc;
+                dev[y * w + x] = (float)Math.Clamp(1.0 - ncc, 0, 1);
+            }
+        meanNcc = nccSum / (w * h);
+        return dev;
+    }
+
+    static double[] Integral(float[] src, int w, int h)
+    {
+        var ii = new double[(w + 1) * (h + 1)];
+        for (int y = 0; y < h; y++)
+        {
+            double rowSum = 0;
+            for (int x = 0; x < w; x++)
+            {
+                rowSum += src[y * w + x];
+                ii[(y + 1) * (w + 1) + (x + 1)] = ii[y * (w + 1) + (x + 1)] + rowSum;
+            }
+        }
+        return ii;
+    }
+
+    static double[] IntegralOf(float[] a, float[] b, int w, int h)
+    {
+        var ii = new double[(w + 1) * (h + 1)];
+        for (int y = 0; y < h; y++)
+        {
+            double rowSum = 0;
+            for (int x = 0; x < w; x++)
+            {
+                rowSum += (double)a[y * w + x] * b[y * w + x];
+                ii[(y + 1) * (w + 1) + (x + 1)] = ii[y * (w + 1) + (x + 1)] + rowSum;
+            }
+        }
+        return ii;
+    }
+
+    // Inclusive box sum [x0..x1]x[y0..y1] from an integral image of width (w+1).
+    static double Box(double[] ii, int w, int x0, int y0, int x1, int y1)
+    {
+        int W = w + 1;
+        return ii[(y1 + 1) * W + (x1 + 1)] - ii[y0 * W + (x1 + 1)] - ii[(y1 + 1) * W + x0] + ii[y0 * W + x0];
+    }
+}

--- a/tools/MapTextureDeviationProbe/README.md
+++ b/tools/MapTextureDeviationProbe/README.md
@@ -1,0 +1,33 @@
+# MapTextureDeviationProbe
+
+**Throwaway R&D probe** for the auto-calibration gate study ([mithril#897](https://github.com/moumantai-gg/mithril/issues/897), task 2). Delete once its idea is folded into the engine's detection stage.
+
+## The idea
+
+The icon-free CDN base texture (`Map_Area<X>.v4.png`) and the in-game map screenshot (which has icons + fog drawn on it) are the same artwork. Align them by extent and compute a **sliding-window local NCC**. Local NCC is invariant to per-window linear brightness/contrast, so terrain matches through PG's restyle/tint (and the rocky border largely cancels), while an icon disrupts the local match → low NCC → "added content" candidate.
+
+## The result: **promising**
+
+| run | mean local-NCC | low-NCC pixels | border-band dev | interior dev |
+|---|---|---|---|---|
+| Serbule vs itself (positive control) | 0.999 | 0.0% | — | — |
+| Serbule vs base texture | 0.86 | 2.8% | 0.178 | 0.127 |
+| Eltibule vs base texture | 0.79 | 13% | 0.495 | 0.128 |
+
+Terrain (and on Serbule the border) cancels; deviation is localized — eyeballing the overlay shows icons as discrete low-NCC blobs against matched terrain. It flags **all** added content (icons + structures + fog/labels), so it's a **candidate generator**: follow it with a shape/size filter, then run template NCC only inside the candidate regions.
+
+> **Cautionary note:** this probe first reported ~0.03 NCC ("dead") — because it was pointed at `Map_Serbule.v4.png`, which doesn't exist; the real file is `Map_AreaSerbule.v4.png`. The self-NCC = 0.999 positive control is what exposed the bad input. Always confirm the texture file exists and is the one you meant.
+
+See `docs/map-calibration-gate-verdict.md` § "Texture-deviation probe".
+
+## Usage
+
+```
+dotnet run --project tools/MapTextureDeviationProbe -- \
+  --screenshot <png> --texture <png> --out-dir <dir> \
+  [--window 11] [--low-ncc 0.5] [--orientation auto|0|180] [--register]
+```
+
+- Writes `<stem>_deviation.png` (heatmap) and `<stem>_overlay.png` (screenshot with low-NCC pixels tinted red) for eyeballing.
+- `--register` runs a coarse rotation × scale × offset sweep and prints the best achievable mean local-NCC (the diagnostic that distinguishes "misregistered" from "different artwork").
+- Prints a self-NCC-style sanity line (screenshot mean luma) and a positive control if you pass the screenshot as its own `--texture`.


### PR DESCRIPTION
## What

Records the auto-calibration gate-study verdict (mithril#897) and prototypes the texture-deviation detection idea.

## Verdict: PROCEED

- **H1 (discrete orientation ∈ {0, π})** decisive across n=6.
- **H4 (cold automation) demonstrated end-to-end** on Serbule: zero-prior, scale 0.8226, rotation 0°, residual **0.93 px, 23 RANSAC inliers**.
  - Enablers: the DPI fix ([#907](https://github.com/moumantai-gg/mithril/pull/907)) + including NPCs at the correct **17×16** per-type size (inliers 8 → 23).
- **Sparse areas (Eltibule, Kur)** need stronger detection; the `--border-mask` ([#908](https://github.com/moumantai-gg/mithril/pull/908)) helps but isn't sufficient alone.

## Texture-deviation probe — promising (the sparse-area lever)

`tools/MapTextureDeviationProbe` (throwaway): align the icon-free CDN base texture to the screenshot and compute sliding-window **local NCC**; icons disrupt the local match → low-NCC blobs.

Verified: mean local-NCC **0.86** (Serbule) / **0.79** (Eltibule); only **2.8% / 13%** of pixels deviate; terrain and (on Serbule) the border cancel; icons pop as discrete blobs. It flags all added content (icons + structures + fog), so it's a **candidate generator** that needs a shape/size filter before template matching — a strong candidate for the engine's detection front-end.

## Two input-validation lessons (the real headline)

Both "it's infeasible" conclusions in this study were **bad inputs**, not real failures:
1. The DPI bug drew 300-DPI screenshots into a black corner.
2. The probe first reported ~0.03 NCC ("dead") because it was pointed at a **non-existent** `Map_Serbule.v4.png` (real: `Map_AreaSerbule.v4.png`); the self-NCC=0.999 positive control exposed it.

## Note on history

The first push of this branch committed a **corrupted** verdict (duplicated H4 blocks, stray text) that also still concluded texture-deviation was "not viable". This PR's latest commit replaces it with a clean, corrected version. Review the final state of `docs/map-calibration-gate-verdict.md`, not the intermediate commit.

(No README change to `MapCalibrationFromScreenshot` — it never contained the stale `--exclude-type Npc` advice; verified by grep.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
