### PR TITLE
fix(shell): seed relocated GameConfig values in SelfCheck (#927)

### DIFF
--- a/src/Mithril.Shell/SelfCheck.cs
+++ b/src/Mithril.Shell/SelfCheck.cs
@@ -67,7 +67,21 @@ internal static class SelfCheck
 #pragma warning disable VSTHRD002 // no dispatcher yet; mirrors Program's pre-host load
             var shellSettings = shellStore.LoadAsync().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
-            var gameConfig = new GameConfig { GameRoot = shellSettings.GameRoot };
+            // Mirror the real launch path's GameConfig seeding (Program.cs): seed
+            // the relocated game-config fields from ShellSettings, not just
+            // GameRoot, so this DI-graph self-check resolves against the same
+            // config shape the app runs with. GameProcessName +
+            // CalibrationGoodResidualPx were relocated here in #919 (#927).
+            // PollIntervalSeconds is not persisted in ShellSettings, so it keeps
+            // GameConfig's default — same as Program.cs. The carry-over migration
+            // is deliberately NOT run in this headless, process-isolated check —
+            // it only validates that the graph resolves, not runtime behaviour.
+            var gameConfig = new GameConfig
+            {
+                GameRoot = shellSettings.GameRoot,
+                GameProcessName = shellSettings.GameProcessName,
+                CalibrationGoodResidualPx = shellSettings.CalibrationGoodResidualPx,
+            };
 
             var options = new ShellCompositionOptions(
                 PreferencesPath: Path.Combine(localApp, "Mithril", "preferences.json"),


### PR DESCRIPTION
Closes #927. Follow-up to #919 / #925.

## What
`SelfCheck` (the #365 DI-graph self-check) constructed `new GameConfig { GameRoot = shellSettings.GameRoot }`, seeding only `GameRoot`. After #919 relocated `GameProcessName` + `CalibrationGoodResidualPx` into `GameConfig`, that construction no longer mirrors the real launch path (`Program.cs`). This seeds the relocated fields from `ShellSettings` so the self-check resolves against the same config shape the app actually ships with.

## Why it was harmless (and why fix anyway)
SelfCheck runs headless + process-isolated and only validates that the DI graph **resolves**, not runtime behaviour — it never reads those two values, so there was no bug. Fixed for fidelity with the real launch path and to stop a future contributor copying the partial construction as canonical.

## Notes
- The cross-file carry-over migration (`GameConfigCarryOver`) is deliberately **not** run here — out of scope for a graph-resolution check.
- `PollIntervalSeconds` is not persisted in `ShellSettings`, so it keeps `GameConfig`'s default — same as `Program.cs`.

## Verification
- `dotnet build src/Mithril.Shell/Mithril.Shell.csproj` → **Build succeeded, 0 Warning(s), 0 Error(s)**
- `dotnet test tests/Mithril.Shell.Tests` → **Passed! Failed: 0, Passed: 54, Total: 54**

Single-file change (+15/-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)