### PR TITLE
Add engineer-continuity rule to shepherd playbook

### DIFF
--- a/.claude/commands/shepherd.md
+++ b/.claude/commands/shepherd.md
@@ -28,6 +28,8 @@ You are the shepherd for issue `<issue-id>` and you own it end-to-end **in this 
 
 When you scale review down, say so, so coverage isn't silently dropped. You may reuse `code-review:code-review` for the heavier passes. Exit the loop as soon as review is clean, or after `<max-iterations>` rounds — whichever comes first. **You are the only party that commits the merge.**
 
+**Engineer continuity — fix with the same agent, re-dispatch on a premise change.** Within a review round, have the *same* engineer fix the findings: it already holds the just-written code in context, so incremental fixes are cheap and stay coherent with the original design. But when the context's premise changes materially — the brief was wrong, the scope pivots, or the engineer went down a wrong path — **re-dispatch a fresh engineer with a corrected brief** instead of message-patching the long-lived one. Stacking corrections onto an accumulating context anchors the engineer to its bad start and leaves superseded instructions lingering in the window; a fresh dispatch starts clean. (A long-lived context also re-reads its full, growing history uncached after any idle gap, so resetting on a premise change is cheaper too.)
+
 **At cap.** If the loop hits the iteration cap without a clean review, decide between (a) merging with follow-up issues filed for outstanding concerns, or (b) escalating back to the user. Do not merge silently over unresolved blockers.
 
 **Wind-down.** Once the PR is merged (or escalated), dismantle the team, file any follow-up issues you own, and return a brief summary covering: what was delivered, the final iteration count, and any follow-ups created or recommended.


### PR DESCRIPTION
## What

Adds one rule to the `/shepherd` playbook governing engineer context across a review loop:

- **Same engineer fixes findings within a round** — it already holds the just-written code, so incremental fixes are cheap and stay coherent with the original design.
- **Re-dispatch a fresh engineer on a material premise change** — wrong brief, scope pivot, or a wrong-path run — rather than message-patching the long-lived agent.

## Why

Stacking corrections onto an accumulating context anchors the engineer to its bad start and leaves superseded instructions lingering in the window — exactly the #924 fabricated-constant correction cascade (brief → HALT → corrected → final, all in one context). A fresh dispatch starts clean. A long-lived context also re-reads its full, growing history *uncached* after any idle gap (which shepherd sessions had), so resetting on a premise change is cheaper too.

This is the continuity-vs-freshness rule SDD applies implicitly (same implementer within a task's review loop, fresh per task), made explicit for the shepherd's loop.

Docs-only change to `.claude/commands/shepherd.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
