### PR TITLE
feat(map-calibration): OS capture infrastructure (#914 PR-2a, Phase 2)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageVersion Include="MahApps.Metro" Version="2.4.11" />

--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/Mithril.GameReports/Mithril.GameReports.csproj" />
     <Project Path="src/Mithril.Leveling/Mithril.Leveling.csproj" />
     <Project Path="src/Mithril.MapCalibration/Mithril.MapCalibration.csproj" />
+    <Project Path="src/Mithril.MapCalibration.Capture/Mithril.MapCalibration.Capture.csproj" />
     <Project Path="src/Mithril.Overlay/Mithril.Overlay.csproj" />
     <Project Path="src/Mithril.Planning/Mithril.Planning.csproj" />
     <Project Path="src/Mithril.Reference/Mithril.Reference.csproj" />
@@ -52,6 +53,7 @@
     <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
     <Project Path="tests/Mithril.LogSanitizer.Tests/Mithril.LogSanitizer.Tests.csproj" />
     <Project Path="tests/Mithril.MapCalibration.Tests/Mithril.MapCalibration.Tests.csproj" />
+    <Project Path="tests/Mithril.MapCalibration.Capture.Tests/Mithril.MapCalibration.Capture.Tests.csproj" />
     <Project Path="tests/Mithril.Overlay.Tests/Mithril.Overlay.Tests.csproj" />
     <Project Path="tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj" />
     <Project Path="tests/Mithril.Reference.Tests/Mithril.Reference.Tests.csproj" />

--- a/src/Mithril.MapCalibration.Capture/BitBltScreenCapture.cs
+++ b/src/Mithril.MapCalibration.Capture/BitBltScreenCapture.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.Logging;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// <see cref="IScreenCapture"/> over GDI <c>BitBlt</c> + <c>GetDIBits</c>
+/// (CsWin32). Reads the OS framebuffer for the requested desktop rect into a
+/// top-down BGRA buffer. Every native handle is released in a <c>finally</c>;
+/// any failure returns <see langword="null"/> and logs a <c>Warning</c> rather
+/// than throwing into the orchestrator.
+///
+/// <para>The GDI calls are manual-verified against a running game (no CI pixel
+/// test — the pure BGRA→gray + validation paths are covered by
+/// <see cref="CaptureValidation"/> tests).</para>
+/// </summary>
+public sealed class BitBltScreenCapture : IScreenCapture
+{
+    private const uint SRCCOPY = 0x00CC0020;
+    private const int BI_RGB = 0;
+
+    private readonly ILogger? _logger;
+
+    public BitBltScreenCapture(ILogger? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public unsafe CapturedFrame? Capture(CaptureRect rect)
+    {
+        if (rect.IsEmpty)
+        {
+            _logger?.LogWarning("BitBlt capture asked for an empty rect {Width}x{Height}", rect.Width, rect.Height);
+            return null;
+        }
+
+        int w = rect.Width;
+        int h = rect.Height;
+
+        HDC screenDc = default;
+        HDC memDc = default;
+        HBITMAP bitmap = default;
+        HGDIOBJ previous = default;
+        try
+        {
+            screenDc = PInvoke.GetDC(default);
+            if (screenDc.IsNull)
+            {
+                _logger?.LogWarning("BitBlt capture: GetDC(screen) returned null");
+                return null;
+            }
+
+            memDc = PInvoke.CreateCompatibleDC(screenDc);
+            if (memDc.IsNull)
+            {
+                _logger?.LogWarning("BitBlt capture: CreateCompatibleDC returned null");
+                return null;
+            }
+
+            bitmap = PInvoke.CreateCompatibleBitmap(screenDc, w, h);
+            if (bitmap.IsNull)
+            {
+                _logger?.LogWarning("BitBlt capture: CreateCompatibleBitmap returned null");
+                return null;
+            }
+
+            previous = PInvoke.SelectObject(memDc, bitmap);
+
+            bool blitted = PInvoke.BitBlt(memDc, 0, 0, w, h, screenDc, rect.X, rect.Y, (ROP_CODE)SRCCOPY);
+            if (!blitted)
+            {
+                _logger?.LogWarning("BitBlt capture: BitBlt failed for {Width}x{Height} at ({X},{Y})", w, h, rect.X, rect.Y);
+                return null;
+            }
+
+            var bgra = new byte[w * h * 4];
+
+            var bmi = new BITMAPINFO();
+            bmi.bmiHeader.biSize = (uint)sizeof(BITMAPINFOHEADER);
+            bmi.bmiHeader.biWidth = w;
+            bmi.bmiHeader.biHeight = -h;   // top-down: row 0 is the top scanline
+            bmi.bmiHeader.biPlanes = 1;
+            bmi.bmiHeader.biBitCount = 32;
+            bmi.bmiHeader.biCompression = BI_RGB;
+
+            int scanned;
+            fixed (byte* p = bgra)
+            {
+                scanned = PInvoke.GetDIBits(
+                    memDc,
+                    bitmap,
+                    0,
+                    (uint)h,
+                    p,
+                    &bmi,
+                    DIB_USAGE.DIB_RGB_COLORS);
+            }
+
+            if (scanned == 0)
+            {
+                _logger?.LogWarning("BitBlt capture: GetDIBits returned 0 scanlines");
+                return null;
+            }
+
+            return new CapturedFrame(w, h, bgra);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "BitBlt capture failed");
+            return null;
+        }
+        finally
+        {
+            if (!memDc.IsNull && !previous.IsNull)
+            {
+                PInvoke.SelectObject(memDc, previous);
+            }
+            if (!bitmap.IsNull)
+            {
+                PInvoke.DeleteObject(bitmap);
+            }
+            if (!memDc.IsNull)
+            {
+                PInvoke.DeleteDC(memDc);
+            }
+            if (!screenDc.IsNull)
+            {
+                PInvoke.ReleaseDC(default, screenDc);
+            }
+        }
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/CaptureRect.cs
+++ b/src/Mithril.MapCalibration.Capture/CaptureRect.cs
@@ -1,0 +1,39 @@
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// A desktop-pixel rectangle: the persisted map bbox and the resolved game
+/// client rect both use it. Deliberately a plain BCL struct (no
+/// <see cref="System.Windows.Rect"/>) so it can cross into the BCL-only
+/// detection core without dragging a WPF dependency through the boundary.
+/// </summary>
+public readonly record struct CaptureRect(int X, int Y, int Width, int Height)
+{
+    /// <summary>An empty rect carries no capturable pixels.</summary>
+    public bool IsEmpty => Width <= 0 || Height <= 0;
+
+    /// <summary>Right edge (exclusive).</summary>
+    public int Right => X + Width;
+
+    /// <summary>Bottom edge (exclusive).</summary>
+    public int Bottom => Y + Height;
+
+    /// <summary>
+    /// The overlapping region of this rect and <paramref name="other"/>, clamped
+    /// to their shared extent. A non-overlapping pair yields an
+    /// <see cref="IsEmpty"/> rect (non-positive width/height).
+    /// </summary>
+    public CaptureRect Intersect(CaptureRect other)
+    {
+        int left = Math.Max(X, other.X);
+        int top = Math.Max(Y, other.Y);
+        int right = Math.Min(Right, other.Right);
+        int bottom = Math.Min(Bottom, other.Bottom);
+        return new CaptureRect(left, top, right - left, bottom - top);
+    }
+
+    /// <summary>
+    /// True when <paramref name="inner"/> lies fully within this rect.
+    /// </summary>
+    public bool Contains(CaptureRect inner) =>
+        inner.X >= X && inner.Y >= Y && inner.Right <= Right && inner.Bottom <= Bottom;
+}

--- a/src/Mithril.MapCalibration.Capture/CaptureService.cs
+++ b/src/Mithril.MapCalibration.Capture/CaptureService.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Orchestrates capture-under-overlay (spec §6): blank the overlay window for
+/// one frame, capture the framed bbox, restore the overlay, then validate before
+/// handing a clean <see cref="GrayImage"/> to the solve engine. The
+/// <c>await using</c> on the blanker guarantees the overlay is restored on every
+/// path — including capture failure and validation rejection.
+/// </summary>
+public sealed class CaptureService : ICaptureService
+{
+    private readonly IScreenCapture _capture;
+    private readonly IOverlayBlanker _blanker;
+    private readonly CaptureValidation _validation;
+    private readonly ILogger? _logger;
+
+    public CaptureService(
+        IScreenCapture capture,
+        IOverlayBlanker blanker,
+        CaptureValidation validation,
+        ILogger? logger)
+    {
+        _capture = capture;
+        _blanker = blanker;
+        _validation = validation;
+        _logger = logger;
+    }
+
+    public async Task<GrayImage?> CaptureMapAsync(CaptureRect bbox, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        // The await using restores the overlay no matter how we leave the block.
+        await using (await _blanker.BlankAsync().ConfigureAwait(false))
+        {
+            CapturedFrame? frame = _capture.Capture(bbox);
+            if (frame is null)
+            {
+                _logger?.LogWarning("Map capture produced no frame for bbox {Width}x{Height} at ({X},{Y})",
+                    bbox.Width, bbox.Height, bbox.X, bbox.Y);
+                return null;
+            }
+
+            if (!_validation.Validate(frame, bbox, out var reason))
+            {
+                _logger?.LogWarning("Map capture rejected: {Reason}", reason);
+                return null;
+            }
+
+            return frame.ToGray();
+        }
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/CaptureValidation.cs
+++ b/src/Mithril.MapCalibration.Capture/CaptureValidation.cs
@@ -1,0 +1,42 @@
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// The spec §6 "verify your inputs" guard, isolated from the P/Invoke capture so
+/// it is CI-testable. A captured frame is valid only when its dimensions match
+/// the requested rect AND it is not a (near-)black frame — the latter catches a
+/// capture that grabbed our own blanked overlay, an occluded window, or a
+/// device-lost surface. A frame that slips past here is still caught downstream
+/// by the Phase-1 confidence gate.
+/// </summary>
+public sealed class CaptureValidation
+{
+    /// <summary>
+    /// Mean-luma floor below which a frame is treated as black. Reuses the
+    /// gate-study probe's <c>shotMean &lt; 8</c> black-frame guard verbatim.
+    /// </summary>
+    public const double BlackFrameLumaFloor = 8.0;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="frame"/> matches the
+    /// expected size and is not black; otherwise <see langword="false"/> with a
+    /// human-readable <paramref name="reason"/>.
+    /// </summary>
+    public bool Validate(CapturedFrame frame, CaptureRect expected, out string? reason)
+    {
+        if (frame.Width != expected.Width || frame.Height != expected.Height)
+        {
+            reason = $"size mismatch: captured {frame.Width}x{frame.Height}, expected {expected.Width}x{expected.Height}";
+            return false;
+        }
+
+        double mean = frame.MeanLuma();
+        if (mean < BlackFrameLumaFloor)
+        {
+            reason = $"black frame: mean luma {mean:F2} < {BlackFrameLumaFloor}";
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/CapturedFrame.cs
+++ b/src/Mithril.MapCalibration.Capture/CapturedFrame.cs
@@ -1,0 +1,46 @@
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// A raw captured rectangle of desktop pixels in BGRA byte order (the layout
+/// <c>GetDIBits</c> produces with a top-down <c>BITMAPINFOHEADER</c>:
+/// 4 bytes/pixel, B then G then R then A, row-major top-to-bottom). The capture
+/// layer hands this across the boundary to the BCL-only detection core via
+/// <see cref="ToGray"/>; no image decoder is involved.
+/// </summary>
+public sealed record CapturedFrame(int Width, int Height, byte[] Bgra)
+{
+    /// <summary>
+    /// Convert to a single-channel <see cref="GrayImage"/> using BT.601 luma
+    /// (<c>0.114*B + 0.587*G + 0.299*R</c>), the same weighting the detection
+    /// pipeline expects. Alpha is ignored.
+    /// </summary>
+    public GrayImage ToGray()
+    {
+        var gray = new byte[Width * Height];
+        for (int i = 0; i < gray.Length; i++)
+        {
+            int o = i * 4;
+            byte b = Bgra[o];
+            byte g = Bgra[o + 1];
+            byte r = Bgra[o + 2];
+            gray[i] = (byte)(0.114 * b + 0.587 * g + 0.299 * r + 0.5);
+        }
+        return new GrayImage(Width, Height, gray);
+    }
+
+    /// <summary>Mean BT.601 luma over every pixel; the black-frame detector.</summary>
+    public double MeanLuma()
+    {
+        if (Width <= 0 || Height <= 0) return 0.0;
+        double sum = 0.0;
+        int count = Width * Height;
+        for (int i = 0; i < count; i++)
+        {
+            int o = i * 4;
+            sum += 0.114 * Bgra[o] + 0.587 * Bgra[o + 1] + 0.299 * Bgra[o + 2];
+        }
+        return sum / count;
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/ICaptureService.cs
+++ b/src/Mithril.MapCalibration.Capture/ICaptureService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Captures the framed map region under the blanked overlay and validates it,
+/// handing a clean <see cref="GrayImage"/> to the solve engine.
+/// </summary>
+public interface ICaptureService
+{
+    /// <summary>
+    /// Blank the overlay, capture <paramref name="bbox"/>, restore the overlay,
+    /// validate the frame, and return it as gray. <see langword="null"/> on any
+    /// failure (capture failed, wrong size, black frame).
+    /// </summary>
+    Task<GrayImage?> CaptureMapAsync(CaptureRect bbox, CancellationToken ct);
+}

--- a/src/Mithril.MapCalibration.Capture/IGameWindowLocator.cs
+++ b/src/Mithril.MapCalibration.Capture/IGameWindowLocator.cs
@@ -1,0 +1,23 @@
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Resolves the foreground game window's client rect in desktop pixels, so the
+/// capture layer knows where the game is drawing. Returns <see langword="null"/>
+/// when the foreground window does not belong to the configured game process
+/// (<c>GameConfig.GameProcessName</c>).
+/// </summary>
+public interface IGameWindowLocator
+{
+    /// <summary>
+    /// Resolve the foreground game window's client rect in DESKTOP pixels, or
+    /// <see langword="null"/> when the foreground window doesn't belong to the
+    /// configured game process. Mirrors <c>ForegroundFocusGate</c>'s
+    /// case-insensitive substring match (#919) — but returns the rect, which
+    /// <c>ForegroundFocusGate</c> (<c>IsInApp</c> only) does not expose, so this
+    /// is new code.
+    /// </summary>
+    GameWindow? Locate();
+}
+
+/// <summary>The located game window handle + its client rect in desktop pixels.</summary>
+public readonly record struct GameWindow(nint Hwnd, CaptureRect ClientRectDesktop);

--- a/src/Mithril.MapCalibration.Capture/IMapCaptureRegionProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/IMapCaptureRegionProvider.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Provides + persists the single map-capture bbox (spec §7). The "draw map
+/// bbox" hotkey and direct overlay move/resize both write here; the auto-attempt
+/// reads <see cref="Current"/> to know whether a region has been framed.
+/// </summary>
+public interface IMapCaptureRegionProvider
+{
+    /// <summary><see langword="null"/> → no bbox set yet (gates the auto-attempt, spec §10/§11).</summary>
+    CaptureRect? Current { get; }
+
+    /// <summary>Persist a new bbox and raise <see cref="Changed"/>.</summary>
+    void Set(CaptureRect rect);
+
+    /// <summary>Raised after <see cref="Current"/> changes.</summary>
+    event EventHandler? Changed;
+}

--- a/src/Mithril.MapCalibration.Capture/IMapRegionRefiner.cs
+++ b/src/Mithril.MapCalibration.Capture/IMapRegionRefiner.cs
@@ -1,0 +1,18 @@
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Locates the map's true sub-rect inside a captured frame (spec §4 step 4) via
+/// texture registration, so eyeball framing slop + per-zone letterboxing are
+/// absorbed before the solve.
+/// </summary>
+public interface IMapRegionRefiner
+{
+    /// <summary>
+    /// Find where <paramref name="baseTexture"/> sits inside
+    /// <paramref name="capturedGray"/>, or <see langword="null"/> on a weak/no
+    /// match (below <paramref name="minScore"/>).
+    /// </summary>
+    MapRect? Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore);
+}

--- a/src/Mithril.MapCalibration.Capture/IOverlayBlanker.cs
+++ b/src/Mithril.MapCalibration.Capture/IOverlayBlanker.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Blanks the overlay so a capture under it grabs the clean map, not our own
+/// chrome (spec §6). <see cref="BlankAsync"/> hides the overlay and returns a
+/// disposable that restores it; the shell implementation (Phase 3) hides
+/// <c>IOverlayWindow.Window</c> on the dispatcher and waits one render frame
+/// before completing, then shows it again on dispose.
+/// </summary>
+public interface IOverlayBlanker
+{
+    /// <summary>Hide the overlay; dispose the result to restore it.</summary>
+    Task<IAsyncDisposable> BlankAsync();
+}

--- a/src/Mithril.MapCalibration.Capture/IScreenCapture.cs
+++ b/src/Mithril.MapCalibration.Capture/IScreenCapture.cs
@@ -1,0 +1,16 @@
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Captures a desktop-pixel rectangle to a raw BGRA frame. Implementations read
+/// the OS framebuffer (the same path a manual screenshot takes — not injection,
+/// memory reads, or hooks) and never throw into the caller: a failed capture
+/// returns <see langword="null"/>.
+/// </summary>
+public interface IScreenCapture
+{
+    /// <summary>
+    /// Capture <paramref name="rect"/> from the desktop, or <see langword="null"/>
+    /// on any failure (resource allocation, BitBlt, GetDIBits).
+    /// </summary>
+    CapturedFrame? Capture(CaptureRect rect);
+}

--- a/src/Mithril.MapCalibration.Capture/MapCaptureRegionProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/MapCaptureRegionProvider.cs
@@ -1,0 +1,33 @@
+using System;
+using Mithril.Shared.Settings;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// <see cref="IMapCaptureRegionProvider"/> backed by an
+/// <see cref="ISettingsStore{T}"/>. The current settings snapshot is supplied at
+/// construction (the composition root loads it once via <c>store.Load()</c>);
+/// <see cref="Set"/> mutates it and persists synchronously.
+/// </summary>
+public sealed class MapCaptureRegionProvider : IMapCaptureRegionProvider
+{
+    private readonly ISettingsStore<MapCaptureSettings> _store;
+    private readonly MapCaptureSettings _settings;
+
+    public MapCaptureRegionProvider(ISettingsStore<MapCaptureSettings> store, MapCaptureSettings settings)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public CaptureRect? Current => _settings.MapBbox;
+
+    public event EventHandler? Changed;
+
+    public void Set(CaptureRect rect)
+    {
+        _settings.MapBbox = rect;
+        _store.Save(_settings);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/MapCaptureSettings.cs
+++ b/src/Mithril.MapCalibration.Capture/MapCaptureSettings.cs
@@ -1,0 +1,23 @@
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Persisted map-capture state: the single overlay/bbox rect in desktop pixels
+/// (spec §7 — the capture region and the overlay rect are the same rect). Module
+/// independent (the Capture engine is shared infra), so it lives in its own
+/// settings file via the standard <c>ISettingsStore&lt;T&gt;</c> pattern, not in
+/// <c>LegolasSettings</c>.
+/// </summary>
+public sealed class MapCaptureSettings
+{
+    /// <summary>
+    /// Persisted-schema version (memory: <c>json_should_be_versioned</c>). Stamp
+    /// 1 on the new root for cheap forward-compat.
+    /// </summary>
+    public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>
+    /// The desktop-pixel map bbox, or <see langword="null"/> when the user has
+    /// not framed one yet (gates the auto-attempt, spec §10/§11).
+    /// </summary>
+    public CaptureRect? MapBbox { get; set; }
+}

--- a/src/Mithril.MapCalibration.Capture/MapCaptureSettingsJsonContext.cs
+++ b/src/Mithril.MapCalibration.Capture/MapCaptureSettingsJsonContext.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Source-generated serialization context for <see cref="MapCaptureSettings"/>
+/// (CLAUDE.md: no reflection serialization). <see cref="CaptureRect"/> is
+/// reachable as a nested member, so the generator emits its converter too.
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(MapCaptureSettings))]
+public partial class MapCaptureSettingsJsonContext : JsonSerializerContext;

--- a/src/Mithril.MapCalibration.Capture/Mithril.MapCalibration.Capture.csproj
+++ b/src/Mithril.MapCalibration.Capture/Mithril.MapCalibration.Capture.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.MapCalibration.Capture</RootNamespace>
+    <UseWPF>true</UseWPF>            <!-- WIC decode + dispatcher marshalling -->
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks> <!-- GetDIBits pixel marshalling -->
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+    <ProjectReference Include="..\Mithril.Overlay\Mithril.Overlay.csproj" />
+    <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+    <ProjectReference Include="..\Arda\Arda.Contracts\Arda.Contracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mithril.MapCalibration.Capture.Tests" />
+  </ItemGroup>
+</Project>

--- a/src/Mithril.MapCalibration.Capture/NativeMethods.txt
+++ b/src/Mithril.MapCalibration.Capture/NativeMethods.txt
@@ -1,0 +1,13 @@
+GetForegroundWindow
+GetWindowThreadProcessId
+GetClientRect
+ClientToScreen
+GetDC
+ReleaseDC
+CreateCompatibleDC
+CreateCompatibleBitmap
+SelectObject
+BitBlt
+GetDIBits
+DeleteObject
+DeleteDC

--- a/src/Mithril.MapCalibration.Capture/TextureRegistrationRefiner.cs
+++ b/src/Mithril.MapCalibration.Capture/TextureRegistrationRefiner.cs
@@ -1,0 +1,16 @@
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// <see cref="IMapRegionRefiner"/> over the Phase-1
+/// <see cref="MapRectLocator.AutoDetect"/> (multi-scale NCC of the base texture
+/// against the captured frame). The seam exists so the orchestrator depends on
+/// an interface rather than a static, and so a Windows.Graphics.Capture-era
+/// refiner can swap in.
+/// </summary>
+public sealed class TextureRegistrationRefiner : IMapRegionRefiner
+{
+    public MapRect? Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore) =>
+        MapRectLocator.AutoDetect(capturedGray, baseTexture, minScore);
+}

--- a/src/Mithril.MapCalibration.Capture/Win32GameWindowLocator.cs
+++ b/src/Mithril.MapCalibration.Capture/Win32GameWindowLocator.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Mithril.Shared.Game;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// CsWin32 implementation of <see cref="IGameWindowLocator"/>. Resolves the
+/// foreground window, checks its process name against
+/// <see cref="GameConfig.GameProcessName"/> (the same case-insensitive substring
+/// rule <c>ForegroundFocusGate</c> uses, #919), and returns the client rect in
+/// desktop pixels.
+///
+/// <para>The P/Invoke path is manual-verified against a running game (no
+/// live-window CI test, consistent with the offline tools). Only the pure
+/// <see cref="ProcessNameMatches"/> predicate is unit-tested.</para>
+/// </summary>
+public sealed class Win32GameWindowLocator : IGameWindowLocator
+{
+    private readonly GameConfig _gameConfig;
+    private readonly ILogger? _logger;
+
+    public Win32GameWindowLocator(GameConfig gameConfig, ILogger? logger = null)
+    {
+        _gameConfig = gameConfig;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The configured-name → process-name match, lifted verbatim from
+    /// <c>ForegroundFocusGate.IsForegroundInApp</c>: a non-blank configured name
+    /// that the process image name contains (case-insensitive). An unconfigured
+    /// (blank) name matches nothing.
+    /// </summary>
+    internal static bool ProcessNameMatches(string configured, string processName) =>
+        !string.IsNullOrWhiteSpace(configured)
+        && processName.Contains(configured, StringComparison.OrdinalIgnoreCase);
+
+    public GameWindow? Locate()
+    {
+        try
+        {
+            HWND hwnd = PInvoke.GetForegroundWindow();
+            if (hwnd.IsNull)
+            {
+                return null;
+            }
+
+            uint pid;
+            unsafe { _ = PInvoke.GetWindowThreadProcessId(hwnd, &pid); }
+            if (pid == 0)
+            {
+                return null;
+            }
+
+            string processName;
+            try
+            {
+                using var proc = Process.GetProcessById((int)pid);
+                processName = proc.ProcessName;
+            }
+            catch
+            {
+                // Process exited between the lookup and us reading it, or access
+                // denied (elevated). Treat as "not the game".
+                return null;
+            }
+
+            if (!ProcessNameMatches(_gameConfig.GameProcessName, processName))
+            {
+                return null;
+            }
+
+            if (!PInvoke.GetClientRect(hwnd, out RECT client))
+            {
+                _logger?.LogWarning("GetClientRect failed for the foreground game window");
+                return null;
+            }
+
+            // Client rect is in client coords (top-left = 0,0); translate to
+            // desktop pixels via ClientToScreen on the top-left corner.
+            var topLeft = new System.Drawing.Point(client.left, client.top);
+            if (!PInvoke.ClientToScreen(hwnd, ref topLeft))
+            {
+                _logger?.LogWarning("ClientToScreen failed for the foreground game window");
+                return null;
+            }
+
+            int width = client.right - client.left;
+            int height = client.bottom - client.top;
+            var rect = new CaptureRect(topLeft.X, topLeft.Y, width, height);
+            if (rect.IsEmpty)
+            {
+                _logger?.LogWarning("Foreground game window has an empty client rect ({Width}x{Height})", width, height);
+                return null;
+            }
+
+            nint hwndValue;
+            unsafe { hwndValue = (nint)hwnd.Value; }
+            return new GameWindow(hwndValue, rect);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to locate the foreground game window");
+            return null;
+        }
+    }
+}

--- a/src/Mithril.Shell/Mithril.Shell.csproj
+++ b/src/Mithril.Shell/Mithril.Shell.csproj
@@ -89,6 +89,11 @@
          arrived transitively via Elrond's ref — fragile; make it explicit. -->
     <ProjectReference Include="..\Mithril.Leveling\Mithril.Leveling.csproj" />
     <ProjectReference Include="..\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+    <!-- Mithril.MapCalibration.Capture (#914 PR-2a): windows-only capture infra
+         (CsWin32 BitBlt). Shell must reference it so the DLL lands in the app
+         base dir even though no DI wiring consumes it yet (Phase 3 wires the
+         orchestrator + hotkeys). Memory pointer: shell_must_projectref_shared_libs. -->
+    <ProjectReference Include="..\Mithril.MapCalibration.Capture\Mithril.MapCalibration.Capture.csproj" />
     <!-- Mithril.Overlay (#835): scaffold-only. Shell must reference so the
          DLL lands in the app base dir for the reflection module loader to
          resolve when consumer modules call IWorldOverlayMarkers / IOverlayWindow

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureRectTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureRectTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class CaptureRectTests
+{
+    [Fact]
+    public void Intersect_clamps_to_overlap()
+    {
+        var a = new CaptureRect(10, 10, 100, 100);
+        var b = new CaptureRect(50, 50, 100, 100);
+        a.Intersect(b).Should().Be(new CaptureRect(50, 50, 60, 60));
+    }
+
+    [Fact]
+    public void IsEmpty_true_for_nonpositive_extent()
+    {
+        new CaptureRect(0, 0, 0, 5).IsEmpty.Should().BeTrue();
+        new CaptureRect(0, 0, 4, 4).IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contains_is_true_only_when_fully_inside()
+    {
+        var outer = new CaptureRect(0, 0, 100, 100);
+        outer.Contains(new CaptureRect(10, 10, 80, 80)).Should().BeTrue();
+        outer.Contains(new CaptureRect(10, 10, 200, 80)).Should().BeFalse();
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureServiceTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureServiceTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class CaptureServiceTests
+{
+    [Fact]
+    public async Task Restores_overlay_even_when_capture_fails()
+    {
+        var blanker = new FakeBlanker();
+        var svc = new CaptureService(new FailingCapture(), blanker, new CaptureValidation(), null);
+        (await svc.CaptureMapAsync(new CaptureRect(0, 0, 8, 8), default)).Should().BeNull();
+        blanker.Restored.Should().BeTrue("the overlay must be shown again on the failure path");
+    }
+
+    [Fact]
+    public async Task Returns_gray_for_a_valid_capture()
+    {
+        var px = new byte[8 * 8 * 4]; Array.Fill(px, (byte)180);
+        var svc = new CaptureService(new FakeCapture(new CapturedFrame(8, 8, px)),
+            new FakeBlanker(), new CaptureValidation(), null);
+        var gray = await svc.CaptureMapAsync(new CaptureRect(0, 0, 8, 8), default);
+        gray.Should().NotBeNull();
+        gray!.Width.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task Rejects_a_black_capture() // spec §11 "captured our own overlay / occlusion"
+    {
+        var svc = new CaptureService(new FakeCapture(new CapturedFrame(8, 8, new byte[8 * 8 * 4])),
+            new FakeBlanker(), new CaptureValidation(), null);
+        (await svc.CaptureMapAsync(new CaptureRect(0, 0, 8, 8), default)).Should().BeNull();
+    }
+
+    private sealed class FakeBlanker : IOverlayBlanker
+    {
+        public bool Restored { get; private set; }
+
+        public Task<IAsyncDisposable> BlankAsync() =>
+            Task.FromResult<IAsyncDisposable>(new Restorer(() => Restored = true));
+
+        private sealed class Restorer(Action onDispose) : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync()
+            {
+                onDispose();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    private sealed class FakeCapture(CapturedFrame frame) : IScreenCapture
+    {
+        public CapturedFrame? Capture(CaptureRect rect) => frame;
+    }
+
+    private sealed class FailingCapture : IScreenCapture
+    {
+        public CapturedFrame? Capture(CaptureRect rect) => null;
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureValidationTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureValidationTests.cs
@@ -1,0 +1,44 @@
+using System;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class CaptureValidationTests
+{
+    [Fact]
+    public void ToGray_uses_bt601_luma()
+    {
+        // single white pixel BGRA = (255,255,255,255) → gray 255
+        var f = new CapturedFrame(1, 1, new byte[] { 255, 255, 255, 255 });
+        f.ToGray().Pixels[0].Should().Be(255);
+    }
+
+    [Fact]
+    public void Validate_rejects_black_frame()
+    {
+        var black = new CapturedFrame(8, 8, new byte[8 * 8 * 4]); // all zero
+        new CaptureValidation().Validate(black, new CaptureRect(0, 0, 8, 8), out var reason)
+            .Should().BeFalse();
+        reason.Should().Contain("black");
+    }
+
+    [Fact]
+    public void Validate_rejects_size_mismatch()
+    {
+        var f = new CapturedFrame(8, 8, new byte[8 * 8 * 4]);
+        new CaptureValidation().Validate(f, new CaptureRect(0, 0, 16, 16), out var reason)
+            .Should().BeFalse();
+        reason.Should().Contain("size");
+    }
+
+    [Fact]
+    public void Validate_accepts_a_non_black_correct_size_frame()
+    {
+        var px = new byte[8 * 8 * 4];
+        Array.Fill(px, (byte)200);
+        new CaptureValidation().Validate(new CapturedFrame(8, 8, px), new CaptureRect(0, 0, 8, 8), out _)
+            .Should().BeTrue();
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/SyntheticMap.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/SyntheticMap.cs
@@ -1,0 +1,42 @@
+using System;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture.Tests.Fixtures;
+
+/// <summary>
+/// Tiny synthetic-image helpers for the capture tests: a high-variance noise
+/// texture (so NCC is well-defined) and a "paste a texture into a larger gray
+/// canvas" blitter (the padding trick the Phase-1 <c>MapRectLocatorTests</c>
+/// uses to give <c>AutoDetect</c> a recoverable origin).
+/// </summary>
+internal static class SyntheticMap
+{
+    /// <summary>A high-variance random grayscale texture.</summary>
+    public static GrayImage NoisyTexture(int seed, int w, int h)
+    {
+        var rng = new Random(seed);
+        var px = new byte[w * h];
+        rng.NextBytes(px);
+        return new GrayImage(w, h, px);
+    }
+
+    /// <summary>
+    /// Paste <paramref name="texture"/> into a larger mid-gray canvas at
+    /// (<paramref name="atX"/>, <paramref name="atY"/>), returning the canvas.
+    /// </summary>
+    public static GrayImage PasteInto(GrayImage texture, int canvasW, int canvasH, int atX, int atY)
+    {
+        var px = new byte[canvasW * canvasH];
+        Array.Fill(px, (byte)128); // mid-gray background, distinct from the noise
+        for (int y = 0; y < texture.Height; y++)
+        {
+            int dstRow = (atY + y) * canvasW + atX;
+            int srcRow = y * texture.Width;
+            for (int x = 0; x < texture.Width; x++)
+            {
+                px[dstRow + x] = texture.Pixels[srcRow + x];
+            }
+        }
+        return new GrayImage(canvasW, canvasH, px);
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/GameWindowMatchTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/GameWindowMatchTests.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class GameWindowMatchTests
+{
+    [Theory]
+    [InlineData("ProjectGorgon", "ProjectGorgon", true)]
+    [InlineData("ProjectGorgon", "ProjectGorgon64", true)]
+    [InlineData("ProjectGorgon", "Project Gorgon", false)]   // process image name has no space
+    [InlineData("ProjectGorgon", "chrome", false)]
+    [InlineData("", "ProjectGorgon", false)]                  // unconfigured → no match
+    public void Process_name_match_mirrors_focus_gate(string configured, string processName, bool expected)
+        => Win32GameWindowLocator.ProcessNameMatches(configured, processName).Should().Be(expected);
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/MapCaptureRegionRoundTripTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/MapCaptureRegionRoundTripTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class MapCaptureRegionRoundTripTests
+{
+    [Fact]
+    public void Bbox_round_trips_through_the_store()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "mithril-capture-" + Guid.NewGuid() + ".json");
+        try
+        {
+            var store = new JsonSettingsStore<MapCaptureSettings>(path, MapCaptureSettingsJsonContext.Default.MapCaptureSettings);
+            var provider = new MapCaptureRegionProvider(store, store.Load());
+            provider.Set(new CaptureRect(120, 80, 800, 600));
+
+            var reloaded = new MapCaptureRegionProvider(store, store.Load());
+            reloaded.Current.Should().Be(new CaptureRect(120, 80, 800, 600));
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void Current_is_null_before_any_bbox_is_set()
+    {
+        var store = new JsonSettingsStore<MapCaptureSettings>(
+            Path.Combine(Path.GetTempPath(), "mithril-capture-" + Guid.NewGuid() + ".json"),
+            MapCaptureSettingsJsonContext.Default.MapCaptureSettings);
+        new MapCaptureRegionProvider(store, store.Load()).Current.Should().BeNull();
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/Mithril.MapCalibration.Capture.Tests.csproj
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Mithril.MapCalibration.Capture.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.MapCalibration.Capture.Tests</RootNamespace>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration.Capture\Mithril.MapCalibration.Capture.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Mithril.MapCalibration.Capture.Tests/TextureRegistrationRefinerTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/TextureRegistrationRefinerTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class TextureRegistrationRefinerTests
+{
+    [Fact]
+    public void Refine_locates_an_embedded_texture()
+    {
+        var tex = SyntheticMap.NoisyTexture(seed: 3, w: 64, h: 64);
+        var frame = SyntheticMap.PasteInto(tex, canvasW: 160, canvasH: 120, atX: 40, atY: 30);
+        var rect = new TextureRegistrationRefiner().Refine(frame, tex, minScore: 0.5);
+        rect.Should().NotBeNull();
+        rect!.OriginX.Should().BeCloseTo(40, 3);
+        rect.OriginY.Should().BeCloseTo(30, 3);
+    }
+}


### PR DESCRIPTION
## Phase 2 of #914 — OS capture infrastructure (PR-2a of a 2-PR split)

This is **PR-2a**, the first of a two-PR split of #914 PR-2. It builds the windows-only `src/Mithril.MapCalibration.Capture` project — the capture/window/region glue that sits between the OS and the BCL-only Phase-1 solve engine. **Phase 3** (trigger, orchestrator, `CalibrationSource.AutoCapture`, hotkeys, shell DI wiring, base-texture policy) lands in a separate follow-up PR (PR-2b).

### Scope: Phase 2, Tasks 12–19

| Task | What landed |
|---|---|
| 12 | Scaffold `Mithril.MapCalibration.Capture` (net10.0-windows, `UseWPF`, `AllowUnsafeBlocks`); add `Microsoft.Windows.CsWin32 0.3.183` to `Directory.Packages.props`; `NativeMethods.txt`; slnx entries; shell `ProjectReference`; matching `tests/Mithril.MapCalibration.Capture.Tests` project. |
| 13 | `CaptureRect` readonly record struct + `IsEmpty`/`Intersect`/`Contains` (pure). |
| 14 | `CapturedFrame(int,int,byte[])` + `ToGray()` (BT.601 luma) + `MeanLuma()`; `CaptureValidation.Validate` (size match AND `MeanLuma >= BlackFrameLumaFloor = 8.0`). |
| 15 | `IGameWindowLocator`/`GameWindow`; `Win32GameWindowLocator(GameConfig, ILogger?)` via CsWin32 `GetForegroundWindow`/`GetWindowThreadProcessId`/`GetClientRect`/`ClientToScreen` + `Process.GetProcessById`. Pure `ProcessNameMatches` predicate is unit-tested; P/Invoke path is manual-verify. |
| 16 | `IScreenCapture`; `BitBltScreenCapture(ILogger?)` via CsWin32 GDI (`BitBlt` + `GetDIBits`, top-down `biHeight = -h`, try/finally handle cleanup, null-on-failure). |
| 17 | `MapCaptureSettings` (`SchemaVersion = 1`, nullable `CaptureRect? MapBbox`) + source-gen `MapCaptureSettingsJsonContext`; `IMapCaptureRegionProvider` + `MapCaptureRegionProvider` persisting via `JsonSettingsStore`. |
| 18 | `IMapRegionRefiner` + `TextureRegistrationRefiner` delegating to the Phase-1 `MapRectLocator.AutoDetect`. |
| 19 | `IOverlayBlanker` + `ICaptureService` + `CaptureService` (blank → capture → restore → validate → gray; `await using` guarantees overlay restore on every path). Only the seam + `CaptureService` + test doubles are here — the real shell `IOverlayBlanker` over `IOverlayWindow.Window.Hide()/Show()` is Phase 3. |

### Guardrails honored

- **Decoder-free guard stays green.** Capture is CsWin32 `BitBlt`+`GetDIBits` only — no `System.Drawing.Common`, no `AssetsTools.NET`, no `Graphics.CopyFromScreen`. `tests/Mithril.Shared.Tests` `ShippedGraphDecoderFreeTests` passes. (`System.Drawing.Point` is used for `ClientToScreen` — that's `System.Drawing.Primitives` in the BCL, not the forbidden `System.Drawing.Common` package.)
- **Shell `ProjectReference`** added (modules-copy only stages `*.Module.dll`; a new shared lib needs the explicit ref) even though nothing wires its DI yet.
- **Fail-soft everywhere:** bad capture / null window / black frame / empty rect → return null + log a Warning, never throw into a caller.

### Test evidence

- `dotnet test tests/Mithril.MapCalibration.Capture.Tests` → **18 passed, 0 failed**.
- `dotnet test tests/Mithril.Shared.Tests --filter ShippedGraphDecoderFreeTests` → **1 passed**.
- `dotnet build Mithril.slnx` → **Build succeeded, 0 warnings** (warnings-as-errors satisfied).

### Manual-verify (deferred to Phase 3 Task 28)

The irreducible native surface has **no CI pixel test**, by design (consistent with the offline tools):
- `Win32GameWindowLocator.Locate()` — the P/Invoke foreground-window resolve path (only the pure `ProcessNameMatches` predicate is unit-tested).
- `BitBltScreenCapture.Capture()` — the GDI `BitBlt`/`GetDIBits` calls (the pure BGRA→gray + black/size validation are CI-tested via `CaptureValidation`).

### Anti-cheat note

`BitBlt`/WGC read the OS framebuffer — the same path a manual screenshot takes, not injection/memory/hooks — so this does not cross ACTk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
