### PR TITLE
feat(map-calibration): trigger + persistence + UX (#914 PR-2b, Phase 3)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arda.World.Player;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Detection;
+using Mithril.Shared.Game;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// One auto-calibration attempt for the current area (spec §4): resolve area +
+/// window + framed bbox, capture under the blanked overlay, refine the map
+/// sub-rect, resolve the area's base texture + references, run the detect→solve→
+/// gate engine, and persist the solved transform via
+/// <see cref="IMapCalibrationService.SaveUserRefinement"/> (stamped
+/// <see cref="CalibrationSource.AutoCapture"/>) ONLY when the gate accepts.
+///
+/// <para><b>Fail-soft everywhere</b> (spec §11): no current area / no bbox / PG
+/// not foreground / bad capture / null base texture / low-confidence solve → keep
+/// the prior calibration, return a reason for status surfacing, NEVER persist a
+/// wrong transform.</para>
+///
+/// <para><b>Base-texture policy (Task 21 / Decision D8).</b> The base texture is
+/// resolved from <see cref="IBaseTextureProvider"/> (the #931 seam over the
+/// out-of-process sidecar cache — this layer writes NO provider code). On a
+/// cache-miss (null) and when an <see cref="IAssetExtractor"/> is wired, invoke
+/// the sidecar once to populate the cache, then retry the provider. If still
+/// null, fail-soft with a "preparing map assets…" reason (no texture → no
+/// detections → gate rejects → safe-degrade).</para>
+/// </summary>
+public sealed class AutoCalibrationEngine
+{
+    // Proven Phase-1 detection recipe (§0): the gate-study sweet-spot for real
+    // assets. RenderSizePx 16 is the empirical icon render size.
+    private const int RenderSizePx = 16;
+    private const double LowNcc = 0.5;
+    private const double TypeFloor = 0.80;
+    private static readonly BlobOptions BlobOpts = new(
+        MinArea: 12, MaxIconArea: 900, MinSolidity: 0.35, MaxAspect: 2.5, MinPeak: 0.7);
+    private const double RefineMinScore = 0.5;
+
+    private readonly IAreaState _areaState;
+    private readonly IGameWindowLocator _windowLocator;
+    private readonly IMapCaptureRegionProvider _region;
+    private readonly ICaptureService _capture;
+    private readonly IMapRegionRefiner _refiner;
+    private readonly IBaseTextureProvider _baseTextures;
+    private readonly IAreaReferenceProvider _references;
+    private readonly IMapCalibrationSolver _solver;
+    private readonly IconTemplateSet _templates;
+    private readonly IMapCalibrationService _calibrationService;
+    private readonly ILogger? _logger;
+
+    // Optional Task-21 sidecar policy (null in unit branch tests + when no
+    // extractor is wired): on a base-texture cache miss, populate the cache then
+    // retry. GameConfig supplies the PG install root for the extract request.
+    private readonly IAssetExtractor? _assetExtractor;
+    private readonly GameConfig? _gameConfig;
+    private readonly string? _assetCacheDir;
+    private readonly string? _pgVersion;
+
+    public AutoCalibrationEngine(
+        IAreaState areaState,
+        IGameWindowLocator windowLocator,
+        IMapCaptureRegionProvider region,
+        ICaptureService capture,
+        IMapRegionRefiner refiner,
+        IBaseTextureProvider baseTextures,
+        IAreaReferenceProvider references,
+        IMapCalibrationSolver solver,
+        IconTemplateSet templates,
+        IMapCalibrationService calibrationService,
+        ILogger? logger,
+        IAssetExtractor? assetExtractor = null,
+        GameConfig? gameConfig = null,
+        string? assetCacheDir = null,
+        string? pgVersion = null)
+    {
+        _areaState = areaState;
+        _windowLocator = windowLocator;
+        _region = region;
+        _capture = capture;
+        _refiner = refiner;
+        _baseTextures = baseTextures;
+        _references = references;
+        _solver = solver;
+        _templates = templates;
+        _calibrationService = calibrationService;
+        _logger = logger;
+        _assetExtractor = assetExtractor;
+        _gameConfig = gameConfig;
+        _assetCacheDir = assetCacheDir;
+        _pgVersion = pgVersion;
+    }
+
+    public async Task<AutoCalibrationOutcome> TryCalibrateCurrentAreaAsync(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var area = _areaState.CurrentArea;
+        if (string.IsNullOrWhiteSpace(area))
+        {
+            return Fail("", "not in-world — open Project Gorgon and enter an area first");
+        }
+
+        // PG-foreground gate: capture must read the game's framebuffer, not
+        // another app's. (The hotkey already focus-gates; the auto path + manual
+        // path both re-check here so neither can capture the wrong window.)
+        if (_windowLocator.Locate() is null)
+        {
+            return Fail(area, "Project Gorgon is not the foreground window");
+        }
+
+        var bbox = _region.Current;
+        if (bbox is null)
+        {
+            return Fail(area, "no map bbox set — use the draw-map-bbox hotkey first");
+        }
+
+        var gray = await _capture.CaptureMapAsync(bbox.Value, ct).ConfigureAwait(false);
+        if (gray is null)
+        {
+            return Fail(area, "map capture failed or was rejected (black / wrong-size frame)");
+        }
+
+        var baseTexture = await ResolveBaseTextureAsync(area, ct).ConfigureAwait(false);
+        if (baseTexture is null)
+        {
+            return Fail(area, "preparing map assets… (base texture unavailable — no detections possible)");
+        }
+
+        var mapRect = _refiner.Refine(gray, baseTexture, RefineMinScore);
+        if (mapRect is null)
+        {
+            return Fail(area, "couldn't locate the map in the captured frame — zoom the in-game map all the way out");
+        }
+
+        var references = _references.ForArea(area);
+
+        var request = new DetectionRequest(
+            Screenshot: gray,
+            BaseTexture: baseTexture,
+            MapRect: mapRect,
+            Templates: _templates,
+            RimMask: RimMaskMode.DeviationFlood,
+            LowNcc: LowNcc,
+            TypeFloor: TypeFloor,
+            BlobOptions: BlobOpts)
+        {
+            RenderSizePx = RenderSizePx,
+        };
+
+        var result = _solver.Solve(request, references);
+        if (result.Calibration is null)
+        {
+            var reason = result.RejectReason ?? "no geometrically-consistent fit";
+            _logger?.LogInformation("Auto-calibration rejected for {Area}: {Reason}. Prior calibration kept.", area, reason);
+            return new AutoCalibrationOutcome(Persisted: false, AreaKey: area, RejectReason: reason);
+        }
+
+        // Gate-accept: persist through the user store stamped AutoCapture, which
+        // inherits user-store precedence by construction (Task 20).
+        var stamped = result.Calibration with { Source = CalibrationSource.AutoCapture };
+        _calibrationService.SaveUserRefinement(area, stamped);
+        _logger?.LogInformation(
+            "Auto-calibration persisted for {Area} (residual {Residual:0.00} px, {Inliers} inliers).",
+            area, stamped.ResidualPixels, result.InlierCount);
+        return new AutoCalibrationOutcome(Persisted: true, AreaKey: area, RejectReason: null);
+    }
+
+    /// <summary>
+    /// Task-21 policy. Resolve the base texture from the #931 provider; on a
+    /// cache-miss, optionally trigger the sidecar once to populate the cache,
+    /// then retry. Fail-soft to null on any path.
+    /// </summary>
+    private async Task<GrayImage?> ResolveBaseTextureAsync(string area, CancellationToken ct)
+    {
+        var tex = _baseTextures.TryGetBaseTexture(area);
+        if (tex is not null) return tex;
+
+        if (_assetExtractor is null || _gameConfig is null
+            || string.IsNullOrWhiteSpace(_gameConfig.GameRoot) || string.IsNullOrWhiteSpace(_assetCacheDir))
+        {
+            return null; // no extractor wired → safe-degrade (caller surfaces "preparing map assets…")
+        }
+
+        _logger?.LogInformation("Base texture cache-miss for {Area}; invoking asset-extractor sidecar.", area);
+        try
+        {
+            var request = new ExtractRequest(
+                InstallRoot: _gameConfig.GameRoot,
+                OutDir: _assetCacheDir!,
+                Kind: ExtractKind.Texture,
+                AreaKey: area,
+                ExpectPgVersion: _pgVersion);
+            var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);
+            if (!extract.Ok)
+            {
+                _logger?.LogWarning(
+                    "Asset-extractor sidecar failed for {Area} (exit {Exit}): {Error}. Safe-degrade.",
+                    area, extract.ExitCode, extract.Error);
+                return null;
+            }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Asset-extractor sidecar threw for {Area}. Safe-degrade.", area);
+            return null;
+        }
+
+        return _baseTextures.TryGetBaseTexture(area); // retry after populate
+    }
+
+    private AutoCalibrationOutcome Fail(string area, string reason)
+    {
+        _logger?.LogInformation("Auto-calibration not attempted for {Area}: {Reason}.", string.IsNullOrEmpty(area) ? "<none>" : area, reason);
+        return new AutoCalibrationOutcome(Persisted: false, AreaKey: area, RejectReason: reason);
+    }
+}
+
+/// <summary>
+/// The outcome of one auto-calibration attempt: whether a transform was
+/// persisted, the area it was for, and (when not persisted) a user-facing reason
+/// for status surfacing (<see cref="CalibrationStatusFormatter"/>).
+/// </summary>
+public sealed record AutoCalibrationOutcome(bool Persisted, string AreaKey, string? RejectReason);

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -210,7 +210,22 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             return null;
         }
 
-        return _baseTextures.TryGetBaseTexture(area); // retry after populate
+        var retried = _baseTextures.TryGetBaseTexture(area); // retry after populate
+        if (retried is null)
+        {
+            // The extractor reported success but the provider still has no usable
+            // texture for this area. Distinguish this from a plain transient
+            // cache-miss: it usually means an asset-shape change or a
+            // canonical-hash-gate mismatch (the extracted bytes don't match the
+            // gated hash), which a future PG patch can introduce silently.
+            // Behaviour is unchanged (still fail-soft); this just makes the
+            // gate/shape mismatch visible instead of looking like a cache hiccup.
+            _logger?.LogWarning(
+                "Asset-extractor reported success for {Area} but no usable base texture is available after retry "
+                + "(possible asset-shape change or canonical-hash-gate mismatch, not a transient cache-miss). Safe-degrade.",
+                area);
+        }
+        return retried;
     }
 
     private AutoCalibrationOutcome Fail(string area, string reason)

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -29,7 +29,7 @@ namespace Mithril.MapCalibration.Capture;
 /// null, fail-soft with a "preparing map assets…" reason (no texture → no
 /// detections → gate rejects → safe-degrade).</para>
 /// </summary>
-public sealed class AutoCalibrationEngine
+public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
 {
     // Proven Phase-1 detection recipe (§0): the gate-study sweet-spot for real
     // assets. RenderSizePx 16 is the empirical icon render size.

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arda.Contracts;
+using Arda.World.Player.Events;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Background auto-attempt trigger (spec §10). Subscribes to Arda's
+/// <see cref="AreaChanged"/> and, on a zone-in, fires one auto-calibration
+/// attempt <b>iff</b>:
+/// <list type="bullet">
+/// <item>a map capture bbox has been framed (<see cref="IMapCaptureRegionProvider.Current"/> != null), AND</item>
+/// <item>the game is the foreground window (<see cref="IGameWindowLocator.Locate"/> != null), AND</item>
+/// <item>the area is uncalibrated OR its active calibration is only a
+/// <see cref="CalibrationSource.BundledBaseline"/> (an upgradeable fallback).</item>
+/// </list>
+///
+/// <para><b>Never overwrites an existing <see cref="CalibrationSource.UserRefinement"/>
+/// or <see cref="CalibrationSource.AutoCapture"/> on the auto path</b> — a
+/// converged transform isn't re-attempted on every zone-in. (The manual
+/// capture-&amp;-calibrate hotkey always attempts, by design.) Repeated
+/// area-changed events for the SAME area are debounced.</para>
+/// </summary>
+public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
+{
+    private readonly IDomainEventSubscriber _bus;
+    private readonly IAutoCalibrationRunner _runner;
+    private readonly IMapCaptureRegionProvider _region;
+    private readonly IGameWindowLocator _windowLocator;
+    private readonly IMapCalibrationService _calibrationService;
+    private readonly ILogger? _logger;
+
+    private IDisposable? _subscription;
+    private string? _lastAttemptedArea;
+    private readonly object _gate = new();
+
+    public AutoCalibrationTrigger(
+        IDomainEventSubscriber bus,
+        IAutoCalibrationRunner runner,
+        IMapCaptureRegionProvider region,
+        IGameWindowLocator windowLocator,
+        IMapCalibrationService calibrationService,
+        ILogger? logger)
+    {
+        _bus = bus;
+        _runner = runner;
+        _region = region;
+        _windowLocator = windowLocator;
+        _calibrationService = calibrationService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = _bus.Subscribe<AreaChanged>(OnAreaChanged);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        return Task.CompletedTask;
+    }
+
+    private void OnAreaChanged(AreaChanged e)
+    {
+        var area = e.CurrentArea;
+        if (string.IsNullOrWhiteSpace(area)) return;
+        // Fire-and-forget on the thread pool — the bus delivers synchronously on
+        // the ingest thread, which must not block on a capture+solve.
+        _ = Task.Run(() => OnAreaChangedAsync(area));
+    }
+
+    /// <summary>
+    /// The gating decision, extracted for unit testing. Returns when the attempt
+    /// completes (or is skipped). Awaited by the fire-and-forget path.
+    /// </summary>
+    internal async Task OnAreaChangedAsync(string area)
+    {
+        if (string.IsNullOrWhiteSpace(area)) return;
+
+        // Debounce: collapse repeated area-changed events for the SAME area.
+        lock (_gate)
+        {
+            if (string.Equals(_lastAttemptedArea, area, StringComparison.Ordinal)) return;
+        }
+
+        if (_region.Current is null) return;                 // no bbox → can't capture
+        if (_windowLocator.Locate() is null) return;         // PG not foreground
+
+        // Auto path only upgrades an uncalibrated area or a bundled baseline; it
+        // never displaces a converged user/auto transform.
+        var existing = _calibrationService.GetCalibration(area);
+        if (existing is not null && existing.Source != CalibrationSource.BundledBaseline)
+        {
+            return;
+        }
+
+        lock (_gate) { _lastAttemptedArea = area; }
+
+        _logger?.LogInformation("Auto-attempting calibration on zone-in to {Area}.", area);
+        try
+        {
+            await _runner.TryCalibrateCurrentAreaAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Auto-calibration attempt for {Area} threw; the area stays as-is.", area);
+        }
+    }
+
+    public void Dispose() => _subscription?.Dispose();
+}

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Arda.Contracts;
@@ -6,6 +7,7 @@ using Arda.World.Player.Events;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Mithril.MapCalibration;
+using Mithril.Overlay;
 
 namespace Mithril.MapCalibration.Capture;
 
@@ -23,8 +25,20 @@ namespace Mithril.MapCalibration.Capture;
 /// <para><b>Never overwrites an existing <see cref="CalibrationSource.UserRefinement"/>
 /// or <see cref="CalibrationSource.AutoCapture"/> on the auto path</b> — a
 /// converged transform isn't re-attempted on every zone-in. (The manual
-/// capture-&amp;-calibrate hotkey always attempts, by design.) Repeated
-/// area-changed events for the SAME area are debounced.</para>
+/// capture-&amp;-calibrate hotkey always attempts, by design.)</para>
+///
+/// <para><b>Retry-on-re-entry (GATE-2 Fix C).</b> An area is marked "done"
+/// (suppressing re-attempt) ONLY when the attempt persisted a transform. A
+/// non-persisted outcome (e.g. "no bbox", "not zoomed out") leaves the area
+/// un-marked, so a genuine later re-entry — the user zones out, zooms the map
+/// properly, zones back — gets a fresh attempt. An in-flight guard prevents a
+/// burst of duplicate area-changed events from launching concurrent/looping
+/// attempts; there is no timer/polling loop, retries happen only on fresh
+/// area-change events.</para>
+///
+/// <para>On a non-persisted, <i>actionable</i> reject the trigger surfaces the
+/// reason on the overlay status chip (spec §10/§11) so the user learns why
+/// auto-cal isn't engaging; a persisted success clears the chip silently.</para>
 /// </summary>
 public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
 {
@@ -33,11 +47,16 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
     private readonly IMapCaptureRegionProvider _region;
     private readonly IGameWindowLocator _windowLocator;
     private readonly IMapCalibrationService _calibrationService;
-    private readonly ILogger? _logger;
+    private readonly IOverlayWindow _overlay;
+    private readonly ILogger _logger;
 
     private IDisposable? _subscription;
-    private string? _lastAttemptedArea;
     private readonly object _gate = new();
+    // Areas whose auto-attempt PERSISTED — never re-attempted (Fix C).
+    private readonly HashSet<string> _persistedAreas = new(StringComparer.Ordinal);
+    // Areas with an attempt currently running — skip duplicate concurrent launches
+    // (the in-flight guard against a retry storm; Fix C).
+    private readonly HashSet<string> _inFlightAreas = new(StringComparer.Ordinal);
 
     public AutoCalibrationTrigger(
         IDomainEventSubscriber bus,
@@ -45,13 +64,15 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
         IMapCaptureRegionProvider region,
         IGameWindowLocator windowLocator,
         IMapCalibrationService calibrationService,
-        ILogger? logger)
+        IOverlayWindow overlay,
+        ILogger logger)
     {
         _bus = bus;
         _runner = runner;
         _region = region;
         _windowLocator = windowLocator;
         _calibrationService = calibrationService;
+        _overlay = overlay;
         _logger = logger;
     }
 
@@ -85,33 +106,61 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
     {
         if (string.IsNullOrWhiteSpace(area)) return;
 
-        // Debounce: collapse repeated area-changed events for the SAME area.
         lock (_gate)
         {
-            if (string.Equals(_lastAttemptedArea, area, StringComparison.Ordinal)) return;
+            // Already persisted for this area → never re-attempt (Fix C).
+            if (_persistedAreas.Contains(area)) return;
+            // An attempt is already running for this area → skip the duplicate so
+            // a burst of area-changed events can't launch a concurrent/looping
+            // attempt (in-flight guard, Fix C).
+            if (!_inFlightAreas.Add(area)) return;
         }
 
-        if (_region.Current is null) return;                 // no bbox → can't capture
-        if (_windowLocator.Locate() is null) return;         // PG not foreground
-
-        // Auto path only upgrades an uncalibrated area or a bundled baseline; it
-        // never displaces a converged user/auto transform.
-        var existing = _calibrationService.GetCalibration(area);
-        if (existing is not null && existing.Source != CalibrationSource.BundledBaseline)
-        {
-            return;
-        }
-
-        lock (_gate) { _lastAttemptedArea = area; }
-
-        _logger?.LogInformation("Auto-attempting calibration on zone-in to {Area}.", area);
         try
         {
-            await _runner.TryCalibrateCurrentAreaAsync(CancellationToken.None).ConfigureAwait(false);
+            if (_region.Current is null) return;                 // no bbox → can't capture
+            if (_windowLocator.Locate() is null) return;         // PG not foreground
+
+            // Auto path only upgrades an uncalibrated area or a bundled baseline; it
+            // never displaces a converged user/auto transform.
+            var existing = _calibrationService.GetCalibration(area);
+            if (existing is not null && existing.Source != CalibrationSource.BundledBaseline)
+            {
+                return;
+            }
+
+            _logger.LogInformation("Auto-attempting calibration on zone-in to {Area}.", area);
+            AutoCalibrationOutcome? outcome = null;
+            try
+            {
+                outcome = await _runner.TryCalibrateCurrentAreaAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Auto-calibration attempt for {Area} threw; the area stays as-is.", area);
+            }
+
+            if (outcome is null) return; // threw → leave un-marked so a later re-entry retries
+
+            if (outcome.Persisted)
+            {
+                lock (_gate) { _persistedAreas.Add(area); }
+                // Silent upgrade (spec §10): a successful auto-persist clears any
+                // prior status chip. Idempotent on the concrete overlay.
+                _overlay.SetStatusMessage(null);
+            }
+            else
+            {
+                // Non-persisted → leave the area un-marked so a genuine later
+                // re-entry retries (Fix C). Surface the actionable reason so the
+                // user learns why auto-cal isn't engaging (spec §10/§11). Setting
+                // the same string is idempotent (the concrete overlay no-ops it).
+                _overlay.SetStatusMessage(CalibrationStatusFormatter.ForOutcome(outcome));
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            _logger?.LogWarning(ex, "Auto-calibration attempt for {Area} threw; the area stays as-is.", area);
+            lock (_gate) { _inFlightAreas.Remove(area); }
         }
     }
 

--- a/src/Mithril.MapCalibration.Capture/CalibrationStatusFormatter.cs
+++ b/src/Mithril.MapCalibration.Capture/CalibrationStatusFormatter.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Maps an <see cref="AutoCalibrationOutcome"/> / raw reject reason to the
+/// user-facing status-chip string (spec §11). Pure + CI-tested; the push to the
+/// overlay chip (<c>IOverlayWindow.SetStatusMessage</c>) is shell wiring (Task 28).
+/// The engine's reject reasons are diagnostic ("residual 25.00 px exceeds
+/// threshold…"); this turns them into an actionable instruction.
+/// </summary>
+public static class CalibrationStatusFormatter
+{
+    /// <summary>
+    /// The status string for an outcome, or <see langword="null"/> when it
+    /// succeeded (a persisted calibration clears the chip — happy state).
+    /// </summary>
+    public static string? ForOutcome(AutoCalibrationOutcome outcome)
+        => outcome.Persisted ? null : ForReject(outcome.RejectReason ?? "couldn't auto-calibrate the map");
+
+    /// <summary>Map a raw reject reason to an actionable user instruction.</summary>
+    public static string ForReject(string reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason)) return "Couldn't auto-calibrate the map.";
+
+        // No bbox framed yet → tell them to draw it.
+        if (Contains(reason, "bbox"))
+            return "No map region set — use the draw-map-bbox hotkey to frame the map.";
+
+        // PG not focused / not in-world → name the game.
+        if (Contains(reason, "foreground") || Contains(reason, "in-world") || Contains(reason, "not detected"))
+            return "Open Project Gorgon (focused, in an area) to calibrate the map.";
+
+        // Assets still extracting.
+        if (Contains(reason, "map assets") || Contains(reason, "preparing") || Contains(reason, "base texture"))
+            return "Preparing map assets… try the capture again in a moment.";
+
+        // Low-confidence solve (residual / inliers) → the actionable fix is to
+        // zoom the in-game map all the way out and redraw the bbox.
+        if (Contains(reason, "residual") || Contains(reason, "inlier")
+            || Contains(reason, "fit") || Contains(reason, "locate the map") || Contains(reason, "capture"))
+            return "Couldn't auto-calibrate — zoom the in-game map all the way out, then redraw the map bbox and retry.";
+
+        return "Couldn't auto-calibrate the map.";
+    }
+
+    private static bool Contains(string haystack, string needle)
+        => haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -115,18 +115,23 @@ public static partial class CaptureServiceCollectionExtensions
 
         // Hotkeys.
         services.AddSingleton<IHotkeyCommand>(sp =>
-            new Hotkeys.CaptureCalibrateCommand(sp.GetRequiredService<IAutoCalibrationRunner>()));
+            new Hotkeys.CaptureCalibrateCommand(
+                sp.GetRequiredService<IAutoCalibrationRunner>(),
+                sp.GetRequiredService<Mithril.Overlay.IOverlayWindow>()));
         services.AddSingleton<IHotkeyCommand>(sp =>
             new Hotkeys.DrawMapBboxCommand(sp.GetRequiredService<IMapBboxDrawController>()));
 
-        // Background auto-attempt trigger.
+        // Background auto-attempt trigger. A hosted service → ILogger is required
+        // (CLAUDE.md): resolve ILoggerFactory as required and create the category
+        // logger rather than threading an optional logger.
         services.AddSingleton<AutoCalibrationTrigger>(sp => new AutoCalibrationTrigger(
             sp.GetRequiredService<Arda.Contracts.IDomainEventSubscriber>(),
             sp.GetRequiredService<IAutoCalibrationRunner>(),
             sp.GetRequiredService<IMapCaptureRegionProvider>(),
             sp.GetRequiredService<IGameWindowLocator>(),
             sp.GetRequiredService<IMapCalibrationService>(),
-            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Trigger")));
+            sp.GetRequiredService<Mithril.Overlay.IOverlayWindow>(),
+            sp.GetRequiredService<ILoggerFactory>().CreateLogger("Mithril.MapCalibration.Capture.Trigger")));
         services.AddHostedService(sp => sp.GetRequiredService<AutoCalibrationTrigger>());
 
         return services;

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -1,16 +1,137 @@
+using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.DependencyInjection;
 using Mithril.MapCalibration.Detection;
 using Mithril.Shared.Game;
+using Mithril.Shared.Hotkeys;
+using Mithril.Shared.Settings;
 
 namespace Mithril.MapCalibration.Capture.DependencyInjection;
 
 /// <summary>
-/// DI composition for the map auto-capture pipeline (mithril#914 PR-2). The full
-/// <c>AddMithrilMapCalibrationCapture</c> registration lands in Task 28; the
-/// <see cref="BuildConfidenceGate"/> factory is shared with the unit test so the
-/// GameConfig threshold wiring is CI-locked.
+/// DI composition for the map auto-capture pipeline (mithril#914 PR-2). Registers
+/// the OS-capture seams, the headless detect→solve engine (Phase 1, via
+/// <see cref="MapCalibrationServiceCollectionExtensions.AddMithrilMapCalibrationEngine"/>),
+/// the orchestrator, the two hotkeys, and the background trigger.
 /// </summary>
 public static partial class CaptureServiceCollectionExtensions
 {
+    /// <summary>
+    /// Wire the auto-capture pipeline. <paramref name="settingsDir"/> holds the
+    /// persisted capture bbox; <paramref name="assetCacheDir"/> is the
+    /// out-of-process asset-extractor sidecar cache the #931 base-texture +
+    /// icon-template loaders read (BCL-only). Requires the shell to have already
+    /// registered the cross-cutting singletons it consumes: <see cref="GameConfig"/>,
+    /// <see cref="Mithril.Overlay.IOverlayWindow"/>,
+    /// <see cref="Arda.Contracts.IDomainEventSubscriber"/>,
+    /// <see cref="Arda.World.Player.IAreaState"/>, and
+    /// <see cref="Mithril.Shared.Reference.IReferenceDataService"/>.
+    /// </summary>
+    public static IServiceCollection AddMithrilMapCalibrationCapture(
+        this IServiceCollection services,
+        string settingsDir,
+        string assetCacheDir,
+        string? pgVersion = null)
+    {
+        if (string.IsNullOrWhiteSpace(settingsDir))
+            throw new System.ArgumentException("settingsDir required", nameof(settingsDir));
+        if (string.IsNullOrWhiteSpace(assetCacheDir))
+            throw new System.ArgumentException("assetCacheDir required", nameof(assetCacheDir));
+
+        Directory.CreateDirectory(settingsDir);
+
+        // Phase-1 detect→solve engine + IconTemplateSet + IBaseTextureProvider
+        // (the #931 sidecar-cache seam) over the asset cache. This also registers
+        // the engine's DEFAULT ICalibrationConfidenceGate; we override it below.
+        services.AddMithrilMapCalibrationEngine(assetCacheDir, pgVersion);
+
+        // GameConfig-wired gate override (Task 23). Registered AFTER the engine so
+        // last-registration-wins makes this the resolved ICalibrationConfidenceGate
+        // (honours the user-tunable GameConfig.CalibrationGoodResidualPx).
+        services.AddSingleton<ICalibrationConfidenceGate>(sp =>
+            BuildConfidenceGate(sp.GetRequiredService<GameConfig>()));
+
+        // Persisted capture bbox.
+        services.AddSingleton<ISettingsStore<MapCaptureSettings>>(_ =>
+            new JsonSettingsStore<MapCaptureSettings>(
+                Path.Combine(settingsDir, "map-capture.json"),
+                MapCaptureSettingsJsonContext.Default.MapCaptureSettings));
+        services.AddSingleton<IMapCaptureRegionProvider>(sp =>
+        {
+            var store = sp.GetRequiredService<ISettingsStore<MapCaptureSettings>>();
+            return new MapCaptureRegionProvider(store, store.Load());
+        });
+
+        // OS capture seams.
+        services.AddSingleton<IGameWindowLocator>(sp => new Win32GameWindowLocator(
+            sp.GetRequiredService<GameConfig>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Window")));
+        services.AddSingleton<IScreenCapture>(sp => new BitBltScreenCapture(
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Screen")));
+        services.AddSingleton<IMapRegionRefiner, TextureRegistrationRefiner>();
+        services.AddSingleton<CaptureValidation>();
+
+        // Overlay blanking + the capture orchestration over it.
+        services.AddSingleton<IOverlayBlanker, OverlayBlanker>();
+        services.AddSingleton<ICaptureService>(sp => new CaptureService(
+            sp.GetRequiredService<IScreenCapture>(),
+            sp.GetRequiredService<IOverlayBlanker>(),
+            sp.GetRequiredService<CaptureValidation>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Service")));
+
+        // Reference points + the solve seam.
+        services.AddSingleton<IAreaReferenceProvider>(sp => new ReferenceDataAreaReferenceProvider(
+            sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.References")));
+        services.AddSingleton<IMapCalibrationSolver, MapCalibrationSolveEngineAdapter>();
+
+        // The orchestrator. Resolved as both the concrete type (for the hotkey +
+        // DI test) and the narrow IAutoCalibrationRunner seam.
+        services.AddSingleton<AutoCalibrationEngine>(sp => new AutoCalibrationEngine(
+            sp.GetRequiredService<Arda.World.Player.IAreaState>(),
+            sp.GetRequiredService<IGameWindowLocator>(),
+            sp.GetRequiredService<IMapCaptureRegionProvider>(),
+            sp.GetRequiredService<ICaptureService>(),
+            sp.GetRequiredService<IMapRegionRefiner>(),
+            sp.GetRequiredService<IBaseTextureProvider>(),
+            sp.GetRequiredService<IAreaReferenceProvider>(),
+            sp.GetRequiredService<IMapCalibrationSolver>(),
+            sp.GetRequiredService<IconTemplateSet>(),
+            sp.GetRequiredService<IMapCalibrationService>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Engine"),
+            assetExtractor: sp.GetService<IAssetExtractor>(),
+            gameConfig: sp.GetRequiredService<GameConfig>(),
+            assetCacheDir: assetCacheDir,
+            pgVersion: pgVersion));
+        services.AddSingleton<IAutoCalibrationRunner>(sp => sp.GetRequiredService<AutoCalibrationEngine>());
+
+        // Bbox draw controller (shell-side, over IOverlayWindow).
+        services.AddSingleton<IMapBboxDrawController>(sp => new MapBboxDrawController(
+            sp.GetRequiredService<Mithril.Overlay.IOverlayWindow>(),
+            sp.GetRequiredService<IMapCaptureRegionProvider>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Draw")));
+
+        // Hotkeys.
+        services.AddSingleton<IHotkeyCommand>(sp =>
+            new Hotkeys.CaptureCalibrateCommand(sp.GetRequiredService<IAutoCalibrationRunner>()));
+        services.AddSingleton<IHotkeyCommand>(sp =>
+            new Hotkeys.DrawMapBboxCommand(sp.GetRequiredService<IMapBboxDrawController>()));
+
+        // Background auto-attempt trigger.
+        services.AddSingleton<AutoCalibrationTrigger>(sp => new AutoCalibrationTrigger(
+            sp.GetRequiredService<Arda.Contracts.IDomainEventSubscriber>(),
+            sp.GetRequiredService<IAutoCalibrationRunner>(),
+            sp.GetRequiredService<IMapCaptureRegionProvider>(),
+            sp.GetRequiredService<IGameWindowLocator>(),
+            sp.GetRequiredService<IMapCalibrationService>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Trigger")));
+        services.AddHostedService(sp => sp.GetRequiredService<AutoCalibrationTrigger>());
+
+        return services;
+    }
+
     /// <summary>
     /// Build the auto path's <see cref="ICalibrationConfidenceGate"/> honouring
     /// <see cref="GameConfig.CalibrationGoodResidualPx"/> (the SAME user-tunable

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Mithril.MapCalibration.Detection;
+using Mithril.Shared.Game;
+
+namespace Mithril.MapCalibration.Capture.DependencyInjection;
+
+/// <summary>
+/// DI composition for the map auto-capture pipeline (mithril#914 PR-2). The full
+/// <c>AddMithrilMapCalibrationCapture</c> registration lands in Task 28; the
+/// <see cref="BuildConfidenceGate"/> factory is shared with the unit test so the
+/// GameConfig threshold wiring is CI-locked.
+/// </summary>
+public static partial class CaptureServiceCollectionExtensions
+{
+    /// <summary>
+    /// Build the auto path's <see cref="ICalibrationConfidenceGate"/> honouring
+    /// <see cref="GameConfig.CalibrationGoodResidualPx"/> (the SAME user-tunable
+    /// threshold the manual path uses — PR-0 relocated it to GameConfig; spec §9),
+    /// with the shipped <see cref="CalibrationConfidenceGate.DefaultInlierFloor"/>.
+    /// </summary>
+    internal static ICalibrationConfidenceGate BuildConfidenceGate(GameConfig cfg) =>
+        new CalibrationConfidenceGate(cfg.CalibrationGoodResidualPx, CalibrationConfidenceGate.DefaultInlierFloor);
+}

--- a/src/Mithril.MapCalibration.Capture/Hotkeys/CaptureCalibrateCommand.cs
+++ b/src/Mithril.MapCalibration.Capture/Hotkeys/CaptureCalibrateCommand.cs
@@ -1,12 +1,16 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Mithril.Overlay;
 using Mithril.Shared.Hotkeys;
 
 namespace Mithril.MapCalibration.Capture.Hotkeys;
 
 /// <summary>
 /// "Capture &amp; calibrate the current map" hotkey (spec §10). Runs one
-/// <see cref="IAutoCalibrationRunner.TryCalibrateCurrentAreaAsync"/> attempt.
+/// <see cref="IAutoCalibrationRunner.TryCalibrateCurrentAreaAsync"/> attempt and
+/// surfaces the outcome on the overlay status chip — this is the user-initiated
+/// path where feedback matters most: on reject the actionable reason
+/// (<see cref="CalibrationStatusFormatter"/>); on success the chip is cleared.
 /// <see cref="RespectsFocusGate"/> is <see langword="true"/>: it must fire only
 /// with Project Gorgon focused, so the capture reads the game's framebuffer (not
 /// Mithril's or another app's). No default binding (Legolas convention —
@@ -15,8 +19,13 @@ namespace Mithril.MapCalibration.Capture.Hotkeys;
 public sealed class CaptureCalibrateCommand : IHotkeyCommand
 {
     private readonly IAutoCalibrationRunner _runner;
+    private readonly IOverlayWindow _overlay;
 
-    public CaptureCalibrateCommand(IAutoCalibrationRunner runner) => _runner = runner;
+    public CaptureCalibrateCommand(IAutoCalibrationRunner runner, IOverlayWindow overlay)
+    {
+        _runner = runner;
+        _overlay = overlay;
+    }
 
     public string Id => "mapcalibration.capture";
     public string DisplayName => "Capture & Calibrate Map";
@@ -26,6 +35,10 @@ public sealed class CaptureCalibrateCommand : IHotkeyCommand
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        await _runner.TryCalibrateCurrentAreaAsync(cancellationToken).ConfigureAwait(false);
+        var outcome = await _runner.TryCalibrateCurrentAreaAsync(cancellationToken).ConfigureAwait(false);
+        // Always surface the outcome on the manual path. ForOutcome maps a
+        // persisted success to null (clear the chip) and a reject to the
+        // actionable reason string.
+        _overlay.SetStatusMessage(CalibrationStatusFormatter.ForOutcome(outcome));
     }
 }

--- a/src/Mithril.MapCalibration.Capture/Hotkeys/CaptureCalibrateCommand.cs
+++ b/src/Mithril.MapCalibration.Capture/Hotkeys/CaptureCalibrateCommand.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Mithril.Shared.Hotkeys;
+
+namespace Mithril.MapCalibration.Capture.Hotkeys;
+
+/// <summary>
+/// "Capture &amp; calibrate the current map" hotkey (spec §10). Runs one
+/// <see cref="IAutoCalibrationRunner.TryCalibrateCurrentAreaAsync"/> attempt.
+/// <see cref="RespectsFocusGate"/> is <see langword="true"/>: it must fire only
+/// with Project Gorgon focused, so the capture reads the game's framebuffer (not
+/// Mithril's or another app's). No default binding (Legolas convention —
+/// game-key collision avoidance).
+/// </summary>
+public sealed class CaptureCalibrateCommand : IHotkeyCommand
+{
+    private readonly IAutoCalibrationRunner _runner;
+
+    public CaptureCalibrateCommand(IAutoCalibrationRunner runner) => _runner = runner;
+
+    public string Id => "mapcalibration.capture";
+    public string DisplayName => "Capture & Calibrate Map";
+    public string? Category => "Map Calibration";
+    public HotkeyBinding? DefaultBinding => null;
+    public bool RespectsFocusGate => true;
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        await _runner.TryCalibrateCurrentAreaAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/Hotkeys/DrawMapBboxCommand.cs
+++ b/src/Mithril.MapCalibration.Capture/Hotkeys/DrawMapBboxCommand.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Mithril.Shared.Hotkeys;
+
+namespace Mithril.MapCalibration.Capture.Hotkeys;
+
+/// <summary>
+/// "Draw the map capture bbox" hotkey. Arms the drag-to-rect mode on the overlay
+/// (<see cref="IMapBboxDrawController.BeginDraw"/>); the drag completion persists
+/// the rect via <see cref="IMapCaptureRegionProvider.Set"/>.
+/// <see cref="RespectsFocusGate"/> is <see langword="false"/>: framing the bbox
+/// happens with the overlay (Mithril) focused, not the game.
+/// </summary>
+public sealed class DrawMapBboxCommand : IHotkeyCommand
+{
+    private readonly IMapBboxDrawController _drawController;
+
+    public DrawMapBboxCommand(IMapBboxDrawController drawController) => _drawController = drawController;
+
+    public string Id => "mapcalibration.draw_bbox";
+    public string DisplayName => "Draw Map Capture Region";
+    public string? Category => "Map Calibration";
+    public HotkeyBinding? DefaultBinding => null;
+    public bool RespectsFocusGate => false;
+
+    public Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _drawController.BeginDraw();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/IAreaReferenceProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/IAreaReferenceProvider.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Supplies the landmark/NPC world-anchor reference points the solver pairs
+/// detections against, for one area. Decoupled behind an interface so the
+/// orchestrator depends on a seam (testable with a fake) rather than the
+/// reference-data service directly.
+/// </summary>
+public interface IAreaReferenceProvider
+{
+    /// <summary>
+    /// The <see cref="LandmarkReference"/> set for <paramref name="areaKey"/>
+    /// (e.g. <c>"AreaSerbule"</c>). Empty when the area is unknown or carries no
+    /// mappable references — which fail-soft yields no inliers → the gate rejects.
+    /// </summary>
+    IReadOnlyList<LandmarkReference> ForArea(string areaKey);
+}

--- a/src/Mithril.MapCalibration.Capture/IAutoCalibrationRunner.cs
+++ b/src/Mithril.MapCalibration.Capture/IAutoCalibrationRunner.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// The "run one auto-calibration attempt for the current area" capability, split
+/// from the concrete <see cref="AutoCalibrationEngine"/> so the hotkey + trigger
+/// depend on a narrow seam (testable with a spy that needs no capture/solve
+/// dependencies).
+/// </summary>
+public interface IAutoCalibrationRunner
+{
+    Task<AutoCalibrationOutcome> TryCalibrateCurrentAreaAsync(CancellationToken ct);
+}

--- a/src/Mithril.MapCalibration.Capture/IMapBboxDrawController.cs
+++ b/src/Mithril.MapCalibration.Capture/IMapBboxDrawController.cs
@@ -1,0 +1,13 @@
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Enters the "drag a rectangle over the map" mode on the overlay; the drag
+/// completion writes the desktop-pixel rect to <see cref="IMapCaptureRegionProvider.Set"/>.
+/// The drag interaction is WPF + manual-verify (Task 28); this seam keeps the
+/// hotkey command unit-testable (it just begins the mode).
+/// </summary>
+public interface IMapBboxDrawController
+{
+    /// <summary>Arm the drag-to-rect bbox draw mode on the overlay.</summary>
+    void BeginDraw();
+}

--- a/src/Mithril.MapCalibration.Capture/IMapCalibrationSolver.cs
+++ b/src/Mithril.MapCalibration.Capture/IMapCalibrationSolver.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Thin seam over the Phase-1 <see cref="MapCalibrationSolveEngine"/> so the
+/// orchestrator depends on an interface (mockable in branch tests) rather than a
+/// concrete sealed engine. The default implementation
+/// (<see cref="MapCalibrationSolveEngineAdapter"/>) delegates verbatim; the real
+/// detect→solve→gate path is integration-tested in the engine's own test project
+/// (<c>SyntheticEndToEndTests</c>). Mirrors the <see cref="IMapRegionRefiner"/>
+/// seam-over-static pattern.
+/// </summary>
+public interface IMapCalibrationSolver
+{
+    CalibrationSolveResult Solve(DetectionRequest request, IReadOnlyList<LandmarkReference> references);
+}
+
+/// <summary>Production adapter: delegates to the shipped <see cref="MapCalibrationSolveEngine"/>.</summary>
+public sealed class MapCalibrationSolveEngineAdapter : IMapCalibrationSolver
+{
+    private readonly MapCalibrationSolveEngine _engine;
+
+    public MapCalibrationSolveEngineAdapter(MapCalibrationSolveEngine engine) => _engine = engine;
+
+    public CalibrationSolveResult Solve(DetectionRequest request, IReadOnlyList<LandmarkReference> references) =>
+        _engine.Solve(request, references);
+}

--- a/src/Mithril.MapCalibration.Capture/MapBboxDrawController.cs
+++ b/src/Mithril.MapCalibration.Capture/MapBboxDrawController.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Logging;
+using Mithril.Overlay;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Shell-side <see cref="IMapBboxDrawController"/>. <see cref="BeginDraw"/> arms
+/// the drag-to-rect bbox mode and surfaces the instruction on the overlay status
+/// chip. The drag interaction itself (mouse capture on the overlay window →
+/// <see cref="IMapCaptureRegionProvider.Set"/> on mouse-up, converting client to
+/// desktop pixels) is WPF + manual-verify (Task 28, spec §7) and is attached to
+/// the overlay window's input surface; this controller is the DI-resolvable entry
+/// point the hotkey invokes.
+/// </summary>
+public sealed class MapBboxDrawController : IMapBboxDrawController
+{
+    private readonly IOverlayWindow _overlay;
+    private readonly IMapCaptureRegionProvider _region;
+    private readonly ILogger? _logger;
+
+    public MapBboxDrawController(
+        IOverlayWindow overlay,
+        IMapCaptureRegionProvider region,
+        ILogger? logger = null)
+    {
+        _overlay = overlay;
+        _region = region;
+        _logger = logger;
+    }
+
+    public void BeginDraw()
+    {
+        _logger?.LogInformation("Map-bbox draw mode armed; drag a rectangle over the in-game map.");
+        // Surface the instruction; the actual drag handler (manual-verify, Task 28)
+        // writes the resolved desktop-pixel rect to _region.Set on mouse-up.
+        _overlay.SetStatusMessage("Drag a rectangle over the in-game map to set the capture region.");
+        _ = _region; // wired for the drag handler that completes the rect (manual-verify).
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/OverlayBlanker.cs
+++ b/src/Mithril.MapCalibration.Capture/OverlayBlanker.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using Mithril.Overlay;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Real <see cref="IOverlayBlanker"/> over <see cref="IOverlayWindow.Window"/>:
+/// hides the overlay window so a capture under it grabs the clean game map (not
+/// our own chrome — spec §6), waits one render frame, and restores it on dispose.
+/// All window access is marshalled to the dispatcher. <c>Hide()</c>/<c>Show()</c>
+/// are within the interface's allowed surface (only <c>Close</c> / Topmost /
+/// WindowStyle / AllowsTransparency mutation / reparenting are forbidden).
+///
+/// <para>Device-lost / flicker on the D3DImage overlay is real (spec §15) and
+/// only observable live (Task 28 manual-verify). WGC is the no-flicker upgrade.</para>
+/// </summary>
+public sealed class OverlayBlanker : IOverlayBlanker
+{
+    private readonly IOverlayWindow _overlay;
+
+    public OverlayBlanker(IOverlayWindow overlay) => _overlay = overlay;
+
+    public async Task<IAsyncDisposable> BlankAsync()
+    {
+        var window = _overlay.Window;
+        var dispatcher = window.Dispatcher;
+
+        // Hide on the dispatcher, then wait one render frame so the compositor
+        // has actually dropped the overlay before the BitBlt reads the screen.
+        await dispatcher.InvokeAsync(() => window.Hide());
+        await dispatcher.InvokeAsync(static () => { }, DispatcherPriority.Render);
+
+        return new Restorer(window);
+    }
+
+    private sealed class Restorer : IAsyncDisposable
+    {
+        private readonly Window _window;
+        public Restorer(Window window) => _window = window;
+
+        public async ValueTask DisposeAsync()
+        {
+            await _window.Dispatcher.InvokeAsync(() => _window.Show());
+        }
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
@@ -56,6 +56,11 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
         if (string.IsNullOrWhiteSpace(areaKey)) return Array.Empty<LandmarkReference>();
 
         var result = new List<LandmarkReference>();
+        // Count references dropped for unparseable coords (NOT the unmapped-type
+        // case, which is warned per-entry above). Aggregated into ONE warning per
+        // area so a future landmarks.json / npcs.json coord-shape change is visible
+        // rather than silently shrinking the reference set (Fix E).
+        var unparseableCoords = 0;
 
         if (_refData.Landmarks.TryGetValue(areaKey, out var landmarks))
         {
@@ -76,6 +81,10 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
                 {
                     result.Add(new LandmarkReference(token, lm.Name ?? lm.Type, world));
                 }
+                else
+                {
+                    unparseableCoords++;
+                }
             }
         }
 
@@ -87,6 +96,18 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
             {
                 result.Add(new LandmarkReference(NpcToken, npc.Name ?? "NPC", world));
             }
+            else
+            {
+                unparseableCoords++;
+            }
+        }
+
+        if (unparseableCoords > 0)
+        {
+            _logger?.LogWarning(
+                "Dropped {Count} reference(s) in area {Area} with unparseable coords — possible landmarks.json / npcs.json "
+                + "coord-shape change. Verification owed (#914): confirm the \"x:N y:N z:N\" position shape vs live data.",
+                unparseableCoords, areaKey);
         }
 
         return result;

--- a/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Detection;
+using Mithril.Reference.Models.Misc;
+using Mithril.Shared.Reference;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Builds <see cref="LandmarkReference"/>s for an area from
+/// <see cref="IReferenceDataService"/>: landmarks (<c>landmarks.json</c>) keyed by
+/// area + NPCs (<c>npcs.json</c>, the full POCO that carries <see cref="Npc.Pos"/>)
+/// whose <see cref="Npc.AreaName"/> matches the area.
+///
+/// <para>Each source is mapped to a <see cref="LandmarkReference"/> whose
+/// <c>Type</c> is one of the four template/solver tokens
+/// (<c>landmark_telepad</c> / <c>landmark_medipillar</c> / <c>landmark_portal</c>
+/// / <c>landmark_npc</c>) the detector pairs against. World coords are parsed
+/// from the <c>"x:N y:N z:N"</c> position string (the live <c>landmarks.json</c> /
+/// <c>npcs.json</c> shape — memory <c>pg_reference_coords_are_world_frame</c>).</para>
+/// </summary>
+public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
+{
+    // Verification owed (#914): confirm the Landmark.Type → template-token mapping
+    // against live landmarks.json. Confirmed against v470 corpus on 2026-05-31:
+    // Type ∈ { Portal, MeditationPillar, TeleportationPlatform } — every landmark
+    // carries exactly one of these. The four template tokens come from
+    // IconTemplateExtractor's canonical pairing (tools/Mithril.MapCalibration.Tools.Common):
+    //   Portal → landmark_portal, MeditationPillar → landmark_medipillar,
+    //   TeleportationPlatform → landmark_telepad, (NPCs) → landmark_npc.
+    // Any future/unmapped Type is WARNED and dropped (no silent coercion to a
+    // wrong token, which would mispair a detection and corrupt the solve).
+    private static readonly IReadOnlyDictionary<string, string> LandmarkTypeToToken =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Portal"] = "landmark_portal",
+            ["MeditationPillar"] = "landmark_medipillar",
+            ["TeleportationPlatform"] = "landmark_telepad",
+        };
+
+    private const string NpcToken = "landmark_npc";
+
+    private readonly IReferenceDataService _refData;
+    private readonly ILogger? _logger;
+
+    public ReferenceDataAreaReferenceProvider(IReferenceDataService refData, ILogger? logger = null)
+    {
+        _refData = refData;
+        _logger = logger;
+    }
+
+    public IReadOnlyList<LandmarkReference> ForArea(string areaKey)
+    {
+        if (string.IsNullOrWhiteSpace(areaKey)) return Array.Empty<LandmarkReference>();
+
+        var result = new List<LandmarkReference>();
+
+        if (_refData.Landmarks.TryGetValue(areaKey, out var landmarks))
+        {
+            foreach (var lm in landmarks)
+            {
+                if (lm is null || string.IsNullOrEmpty(lm.Type)) continue;
+                if (!LandmarkTypeToToken.TryGetValue(lm.Type, out var token))
+                {
+                    // No silent drop: surface the unmapped type so an uncovered
+                    // landmark category is visible (verification-owed follow-up).
+                    _logger?.LogWarning(
+                        "Unmapped landmark Type {Type} in area {Area} (landmark {Name}); dropped — no template token. " +
+                        "Verification owed (#914): confirm Landmark.Type → template-token mapping vs live landmarks.json.",
+                        lm.Type, areaKey, lm.Name);
+                    continue;
+                }
+                if (TryParseWorld(lm.Loc, out var world))
+                {
+                    result.Add(new LandmarkReference(token, lm.Name ?? lm.Type, world));
+                }
+            }
+        }
+
+        foreach (var npc in _refData.NpcsByInternalName.Values)
+        {
+            if (npc is null) continue;
+            if (!string.Equals(npc.AreaName, areaKey, StringComparison.Ordinal)) continue;
+            if (TryParseWorld(npc.Pos, out var world))
+            {
+                result.Add(new LandmarkReference(NpcToken, npc.Name ?? "NPC", world));
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parses a PG position string. The live shape is <c>"x:N y:N z:N"</c>
+    /// (landmarks.json / npcs.json, v470); also tolerates a bare <c>"x y z"</c>
+    /// or <c>"x,y,z"</c> form so a future shape variant degrades to a skip, not a
+    /// crash. Returns false (skip this reference) on any malformed input.
+    /// </summary>
+    internal static bool TryParseWorld(string? loc, out WorldCoord world)
+    {
+        world = default;
+        if (string.IsNullOrWhiteSpace(loc)) return false;
+
+        // Strip "x:" / "y:" / "z:" labels if present, then split on whitespace/comma.
+        Span<double> coords = stackalloc double[3];
+        var count = 0;
+        foreach (var rawToken in loc.Split(new[] { ' ', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var token = rawToken;
+            var colon = token.IndexOf(':');
+            if (colon >= 0) token = token[(colon + 1)..];
+            if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+                return false; // a non-numeric token → malformed → skip
+            if (count >= 3) return false; // more than 3 numbers → unexpected shape → skip
+            coords[count++] = value;
+        }
+
+        if (count != 3) return false;
+        world = new WorldCoord(coords[0], coords[1], coords[2]);
+        return true;
+    }
+}

--- a/src/Mithril.MapCalibration/CalibrationSource.cs
+++ b/src/Mithril.MapCalibration/CalibrationSource.cs
@@ -7,10 +7,20 @@ namespace Mithril.MapCalibration;
 /// "approximate location" chip; a <see cref="UserRefinement"/> converged on the
 /// live install does not).
 ///
-/// <para>Precedence (highest wins): <see cref="UserRefinement"/> &gt;
-/// <see cref="CommunitySync"/> &gt; <see cref="BundledBaseline"/>. A bad user
-/// refinement (residual above <c>CalibrationGoodResidualPx</c>) is bypassed in
-/// favour of a baseline; see <c>StackedSourceResolver</c>.</para>
+/// <para>Precedence (highest wins): <see cref="UserRefinement"/> ==
+/// <see cref="AutoCapture"/> &gt; <see cref="CommunitySync"/> &gt;
+/// <see cref="BundledBaseline"/>. A bad user refinement (residual above
+/// <c>CalibrationGoodResidualPx</c>) is bypassed in favour of a baseline; see
+/// <c>MapCalibrationService.GetCalibration</c>.</para>
+///
+/// <para><b>Precedence is store-based, not enum-based</b>
+/// (mithril#914 Task&#160;20): <c>MapCalibrationService.GetCalibration</c> ranks
+/// by which store holds the record + its residual, never by switching on this
+/// enum value. <see cref="AutoCapture"/> is persisted via
+/// <c>SaveUserRefinement</c> &#8212; it lands in the user store, so it gets
+/// <see cref="UserRefinement"/> precedence <i>by construction</i> with no
+/// resolver change. This value exists only so the consumer can degrade UX
+/// truthfully (an auto-captured fit vs. a hand-driven one).</para>
 /// </summary>
 public enum CalibrationSource
 {
@@ -34,4 +44,18 @@ public enum CalibrationSource
     /// within the configured "good" threshold.
     /// </summary>
     UserRefinement = 2,
+
+    /// <summary>
+    /// Transform solved automatically on this install by the map auto-capture
+    /// pipeline (mithril#914 PR-2): screenshot the framed map, detect icon blobs,
+    /// pair them to landmark/NPC references, and solve. A gate-passing auto solve
+    /// is as trustworthy as a manual <see cref="UserRefinement"/>, so it persists
+    /// through the SAME user store (<c>SaveUserRefinement</c>) and inherits
+    /// user-store precedence by construction. Carried so the consumer can label
+    /// an auto-captured fit distinctly from a hand-driven one. Persisted by NAME
+    /// (additive; no SchemaVersion bump &#8212; §D3): a downgraded pre-AutoCapture
+    /// build that can't parse the name falls back to the record default
+    /// (<see cref="UserRefinement"/>), a safe degrade rather than data loss.
+    /// </summary>
+    AutoCapture = 3,
 }

--- a/src/Mithril.MapCalibration/CalibrationSource.cs
+++ b/src/Mithril.MapCalibration/CalibrationSource.cs
@@ -54,8 +54,12 @@ public enum CalibrationSource
     /// user-store precedence by construction. Carried so the consumer can label
     /// an auto-captured fit distinctly from a hand-driven one. Persisted by NAME
     /// (additive; no SchemaVersion bump &#8212; §D3): a downgraded pre-AutoCapture
-    /// build that can't parse the name falls back to the record default
-    /// (<see cref="UserRefinement"/>), a safe degrade rather than data loss.
+    /// build can't parse the <c>"AutoCapture"</c> name, but
+    /// <c>UserRefinementStore.Load</c> deserialises each area entry individually,
+    /// so it skips ONLY that one area's entry on load (with a warning) and
+    /// preserves every other area's refinement &#8212; no whole-store data loss.
+    /// The §D3 "benign downgrade" framing is true <i>because</i> of that
+    /// per-entry resilience.
     /// </summary>
     AutoCapture = 3,
 }

--- a/src/Mithril.MapCalibration/Internal/UserRefinementStore.cs
+++ b/src/Mithril.MapCalibration/Internal/UserRefinementStore.cs
@@ -165,21 +165,64 @@ internal sealed class UserRefinementStore
         if (!File.Exists(_filePath)) return;
         try
         {
+            // Per-entry resilient parse (mithril#914 GATE-2 Fix A). Deserialising
+            // the whole file in one call meant ONE unparseable calibration entry
+            // (e.g. a downgraded pre-AutoCapture build hitting the unknown
+            // "AutoCapture" enum NAME — UseStringEnumConverter THROWS on unknown
+            // names) tripped the outer catch and discarded EVERY area's refinement
+            // — total data loss, not a benign degrade. Instead we walk the
+            // Calibrations object with JsonDocument and deserialise each value
+            // individually so a single poisoned entry is skipped+warned while every
+            // other area survives. Durable against any future additive enum/field
+            // change, not just AutoCapture.
             using var stream = File.OpenRead(_filePath);
-            var file = JsonSerializer.Deserialize(stream, MapCalibrationJsonContext.Default.UserRefinementFile);
-            if (file?.Calibrations is null) return;
-            // Stamp Source on every entry; lifted records from older shapes may
-            // not carry it explicitly and the default on the record is
-            // UserRefinement, which matches this store's contents — but be
-            // defensive in case a future shape change reorders defaults.
-            _refinements = new Dictionary<string, AreaCalibration>(file.Calibrations.Count, StringComparer.Ordinal);
-            foreach (var (key, cal) in file.Calibrations)
+            using var doc = JsonDocument.Parse(stream);
+            var loaded = new Dictionary<string, AreaCalibration>(StringComparer.Ordinal);
+
+            if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+                !doc.RootElement.TryGetProperty("calibrations", out var calibrations) ||
+                calibrations.ValueKind != JsonValueKind.Object)
             {
-                _refinements[key] = cal with { Source = CalibrationSource.UserRefinement };
+                // No (or malformed) calibrations object → nothing to load. An empty
+                // store is the correct result; a structurally-broken file is caught
+                // below by JsonDocument.Parse throwing.
+                _refinements = loaded;
+                return;
             }
+
+            foreach (var entry in calibrations.EnumerateObject())
+            {
+                try
+                {
+                    var cal = entry.Value.Deserialize(MapCalibrationJsonContext.Default.AreaCalibration);
+                    if (cal is null) continue;
+                    // Stamp Source on every surviving entry; lifted records from
+                    // older shapes may not carry it explicitly and the default on
+                    // the record is UserRefinement, which matches this store's
+                    // contents — but be defensive in case a future shape change
+                    // reorders defaults.
+                    loaded[entry.Name] = cal with { Source = CalibrationSource.UserRefinement };
+                }
+                catch (JsonException ex)
+                {
+                    // One unparseable entry (unknown future enum NAME / added field
+                    // an older build can't read) — skip it, keep the rest. This is
+                    // the durable downgrade-window degrade: the area re-runs
+                    // calibration; no other area's data is touched.
+                    _logger?.LogWarning(ex,
+                        "Skipping unparseable user refinement entry {Area} in {Path} — {Reason}.",
+                        entry.Name, _filePath, ex.Message);
+                }
+            }
+
+            _refinements = loaded;
         }
         catch (Exception ex) when (ex is IOException or JsonException)
         {
+            // Genuine whole-file failure (IO error, or the file is not valid JSON
+            // at all so JsonDocument.Parse threw). Degrade to empty + warn — the
+            // store can't be trusted as a unit. Per-entry resilience above means
+            // we only reach here for structural corruption, not a single bad value.
             _logger?.LogWarning(ex, "Failed to load user refinement store at {Path} — starting empty.", _filePath);
             _refinements = new Dictionary<string, AreaCalibration>(StringComparer.Ordinal);
         }

--- a/src/Mithril.Overlay/IOverlayWindow.cs
+++ b/src/Mithril.Overlay/IOverlayWindow.cs
@@ -74,6 +74,17 @@ public interface IOverlayWindow : INotifyPropertyChanged
     string? StatusMessage { get; }
 
     /// <summary>
+    /// Set (or clear with <see langword="null"/>) the consumer-facing status
+    /// chip text (<see cref="StatusMessage"/>). A consumer flips the chip for a
+    /// consumer-specific condition (e.g. the map auto-capture pipeline's
+    /// "couldn't auto-calibrate — zoom out and redraw the bbox" reason, #914)
+    /// and clears it when resolved. No-ops when the value is unchanged. Safe to
+    /// call from any thread (the implementation marshals the
+    /// <see cref="INotifyPropertyChanged.PropertyChanged"/> raise as needed).
+    /// </summary>
+    void SetStatusMessage(string? message);
+
+    /// <summary>
     /// Register a scene drawer that receives an
     /// <see cref="IOverlaySceneContext"/> per tick. Drawers fire on the
     /// dispatcher inside the surface's <c>BeginDraw</c>/<c>EndDraw</c> pair,

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -7,6 +7,7 @@ using Arda.Hosting;
 using Arda.Wpf;
 using Arda.World.Chat;
 using Arda.World.Player;
+using Mithril.MapCalibration.Capture.DependencyInjection;
 using Mithril.MapCalibration.DependencyInjection;
 using Mithril.Overlay.DependencyInjection;
 using Mithril.Shared.Audio;
@@ -56,6 +57,7 @@ public sealed record ShellCompositionOptions(
     string IconCacheDir,
     string ShellSettingsDir,
     string MapCalibrationDir,
+    string AssetCacheDir,
     Action<string>? ModuleLog = null);
 
 public static class ShellComposition
@@ -104,6 +106,13 @@ public static class ShellComposition
             // MapOverlayView during migration steps 3–5 (step 6 retires
             // MapOverlayView and the new window becomes the canonical surface).
             .AddMithrilOverlay()
+            // #914 PR-2: map auto-capture pipeline (OS capture + trigger +
+            // persistence). Registered AFTER AddMithrilOverlay (consumes
+            // IOverlayWindow) and AFTER AddMithrilMapCalibration (consumes
+            // IMapCalibrationService). The GameConfig-wired confidence gate
+            // override inside this call wins over the engine's default gate
+            // (last-registration-wins).
+            .AddMithrilMapCalibrationCapture(o.MapCalibrationDir, o.AssetCacheDir)
             .AddMithrilIcons(o.IconCacheDir)
             .AddMithrilAudio()
             .AddMithrilHotkeys()

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -164,6 +164,10 @@ public static class Program
             var iconCacheDir = Path.Combine(localApp, "Mithril", "Icons");
             var charactersRootDir = Path.Combine(localApp, "Mithril", "characters");
             var mapCalibrationDir = Path.Combine(localApp, "Mithril", "MapCalibration");
+            // #914 PR-2: the out-of-process asset-extractor sidecar cache the
+            // #931 base-texture + icon-template loaders read (BCL-only). Lives
+            // alongside the other Mithril caches.
+            var assetCacheDir = Path.Combine(localApp, "Mithril", "assets");
 
             var builder = Host.CreateApplicationBuilder(args);
 
@@ -196,7 +200,7 @@ public static class Program
                 preferencesPath, shellStore, shellSettings, gameConfig,
                 logDir, perfDir, charactersRootDir, referenceCacheDir,
                 communityCalibrationCacheDir, iconCacheDir, shellDir,
-                mapCalibrationDir, Boot));
+                mapCalibrationDir, assetCacheDir, Boot));
 
             Boot($"modules discovered: {builder.Services.Count(d => d.ServiceType == typeof(IMithrilModule))}");
             host = builder.Build();

--- a/src/Mithril.Shell/SelfCheck.cs
+++ b/src/Mithril.Shell/SelfCheck.cs
@@ -96,6 +96,7 @@ internal static class SelfCheck
                 IconCacheDir: Path.Combine(localApp, "Mithril", "Icons"),
                 ShellSettingsDir: shellDir,
                 MapCalibrationDir: Path.Combine(localApp, "Mithril", "MapCalibration"),
+                AssetCacheDir: Path.Combine(localApp, "Mithril", "assets"),
                 ModuleLog: m => Console.Out.WriteLine($"selfcheck: {m}"));
 
             var builder = Host.CreateApplicationBuilder(

--- a/tests/Legolas.Tests/Hotkeys/OverlayControllerInputSmokeTests.cs
+++ b/tests/Legolas.Tests/Hotkeys/OverlayControllerInputSmokeTests.cs
@@ -157,6 +157,7 @@ public sealed class OverlayControllerInputSmokeTests
             "the TestSimulate* seams bypass the Window-bound wiring path.");
         public bool IsReady => true;
         public string? StatusMessage => null;
+        public void SetStatusMessage(string? message) { }
         public IDisposable RegisterScene(Action<IOverlaySceneContext> draw) => new NoopDisposable();
         public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
         private sealed class NoopDisposable : IDisposable { public void Dispose() { } }

--- a/tests/Mithril.MapCalibration.Capture.Tests/AreaReferenceProviderTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AreaReferenceProviderTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.Reference.Models.Misc;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 22 (#914): builds the area's landmark/NPC reference points for the
+/// solver. The <see cref="Landmark.Type"/> strings + <see cref="Landmark.Loc"/>
+/// format are confirmed against live landmarks.json (v470):
+/// Type ∈ { Portal, MeditationPillar, TeleportationPlatform }; Loc = "x:N y:N z:N".
+/// </summary>
+public sealed class AreaReferenceProviderTests
+{
+    [Fact]
+    public void Maps_landmarks_and_npcs_to_typed_references()
+    {
+        var refData = new FakeAreaReferenceData()
+            .WithLandmarks("AreaSerbule",
+                new Landmark { Name = "Serbule Portal", Loc = "x:10 y:0 z:-20", Type = "Portal" },
+                new Landmark { Name = "Medi Pillar", Loc = "x:5 y:0 z:5", Type = "MeditationPillar" },
+                new Landmark { Name = "Teleport Circle", Loc = "x:1 y:0 z:2", Type = "TeleportationPlatform" })
+            .WithNpc("AreaSerbule", "Marna", pos: "x:30 y:0 z:40");
+
+        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
+
+        refs.Should().Contain(r => r.Type == "landmark_portal" && r.World.X == 10 && r.World.Z == -20);
+        refs.Should().Contain(r => r.Type == "landmark_medipillar");
+        refs.Should().Contain(r => r.Type == "landmark_telepad");
+        refs.Should().Contain(r => r.Type == "landmark_npc" && r.Name == "Marna" && r.World.X == 30 && r.World.Z == 40);
+    }
+
+    [Fact]
+    public void Skips_landmarks_with_a_malformed_or_missing_loc()
+    {
+        var refData = new FakeAreaReferenceData()
+            .WithLandmarks("AreaSerbule",
+                new Landmark { Name = "Good", Loc = "x:1 y:2 z:3", Type = "Portal" },
+                new Landmark { Name = "NoLoc", Loc = null, Type = "Portal" },
+                new Landmark { Name = "Garbage", Loc = "not a position", Type = "Portal" });
+
+        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
+
+        refs.Should().ContainSingle(r => r.Type == "landmark_portal");
+        refs.Should().OnlyContain(r => r.Name == "Good");
+    }
+
+    [Fact]
+    public void Drops_an_unmapped_landmark_type_rather_than_guessing_a_token()
+    {
+        // An unknown Type must not be silently coerced to a wrong token; it is
+        // dropped (and warned, verification-owed). A wrong token would mispair
+        // the detection and corrupt the solve.
+        var refData = new FakeAreaReferenceData()
+            .WithLandmarks("AreaSerbule",
+                new Landmark { Name = "Mystery", Loc = "x:1 y:0 z:1", Type = "SomeFutureLandmark" });
+
+        new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Unknown_area_yields_empty()
+        => new ReferenceDataAreaReferenceProvider(new FakeAreaReferenceData()).ForArea("AreaNope").Should().BeEmpty();
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -1,0 +1,138 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 24 (#914): the orchestrator. Persist via SaveUserRefinement (Source =
+/// AutoCapture) ONLY on gate-accept; otherwise keep the prior calibration and
+/// report a reason. Short-circuit (no capture, no solve) on the §11 conditions:
+/// no current area, no bbox, PG not foreground, null base texture.
+/// </summary>
+public sealed class AutoCalibrationEngineTests
+{
+    private const string Area = "AreaEltibule";
+
+    [Fact]
+    public async Task Persists_with_AutoCapture_source_on_accept()
+    {
+        var svc = new FakeCalibrationService();
+        var h = new EngineHarness { Solve = Accepted(residual: 0.65, inliers: 5), Service = svc };
+
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeTrue();
+        outcome.AreaKey.Should().Be(Area);
+        svc.Saved.Should().ContainKey(Area);
+        svc.Saved[Area].Source.Should().Be(CalibrationSource.AutoCapture);
+    }
+
+    [Fact]
+    public async Task Keeps_prior_calibration_when_the_gate_rejects()
+    {
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, SomeBaseline());
+        var h = new EngineHarness { Solve = Rejected("residual 25.00 px exceeds threshold 12.00 px"), Service = svc };
+
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("residual");
+        svc.Saved.Should().NotContainKey(Area); // prior untouched (no Save call)
+    }
+
+    [Fact]
+    public async Task No_bbox_short_circuits_without_capturing()
+    {
+        var h = new EngineHarness { Bbox = null };
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("bbox");
+        h.Capture.Called.Should().BeFalse();
+        h.Solver.Called.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task No_current_area_short_circuits()
+    {
+        var h = new EngineHarness { CurrentArea = null };
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("not in-world");
+        h.Capture.Called.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PG_not_foreground_short_circuits_without_capturing()
+    {
+        var h = new EngineHarness { GameWindow = null };
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("Project Gorgon");
+        h.Capture.Called.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Null_base_texture_fails_soft_without_solving()
+    {
+        var h = new EngineHarness { BaseTexture = null };
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("map assets");
+        h.Solver.Called.Should().BeFalse("no base texture → never reach the solver");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static CalibrationSolveResult Accepted(double residual, int inliers) =>
+        new(new AreaCalibration(1.2, 0.1, 100, 100, inliers, residual), inliers, null);
+
+    private static CalibrationSolveResult Rejected(string reason) => new(null, 0, reason);
+
+    private static AreaCalibration SomeBaseline() =>
+        new(1.0, 0, 50, 50, 4, 3.0) { Source = CalibrationSource.BundledBaseline };
+
+    /// <summary>
+    /// Mutable harness: each property has a sensible "happy path" default; a test
+    /// overrides exactly the one input it exercises. Setting a reference-type
+    /// property to <c>null</c> models the absence of that input.
+    /// </summary>
+    private sealed class EngineHarness
+    {
+        public string? CurrentArea { get; init; } = Area;
+        public CaptureRect? Bbox { get; init; } = new CaptureRect(0, 0, 64, 64);
+        public GameWindow? GameWindow { get; init; } = new GameWindow(1, new CaptureRect(0, 0, 1920, 1080));
+        public GrayImage? BaseTexture { get; init; } = new GrayImage(64, 64, new byte[64 * 64]);
+        public CalibrationSolveResult Solve { get; init; } = new(new AreaCalibration(1, 0, 0, 0, 6, 0.5), 6, null);
+        public FakeCalibrationService Service { get; init; } = new();
+
+        public SpyCapture Capture { get; } = new(new GrayImage(64, 64, new byte[64 * 64]));
+        public SpySolver Solver { get; private set; } = null!;
+
+        public AutoCalibrationEngine Engine()
+        {
+            Solver = new SpySolver(Solve);
+            return new AutoCalibrationEngine(
+                new FakeAreaState(CurrentArea),
+                new FakeWindowLocator(GameWindow),
+                new FakeRegionProvider(Bbox),
+                Capture,
+                new FakeRefiner(new MapRect(0, 0, 64, 64, 64, 64)),
+                new FakeBaseTextureProvider(BaseTexture),
+                new FakeAreaRefs(new[] { new LandmarkReference("landmark_npc", "x", new WorldCoord(1, 0, 1)) }),
+                Solver,
+                IconTemplateSet.Empty,
+                Service,
+                logger: null);
+        }
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
@@ -1,0 +1,98 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 26 (#914): the auto-attempt trigger. On area-change, fire the engine iff
+/// a bbox is set AND the game is focused AND the area is uncalibrated OR carries
+/// only a BundledBaseline. NEVER overwrite an existing UserRefinement/AutoCapture
+/// on the auto path (the manual hotkey always attempts). Debounce repeats.
+/// </summary>
+public sealed class AutoCalibrationTriggerTests
+{
+    private const string Area = "AreaEltibule";
+
+    [Fact]
+    public async Task Does_not_attempt_when_no_bbox()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: null, focused: true);
+        await trigger.OnAreaChangedAsync(Area);
+        engine.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Attempts_when_bbox_present_and_focused_and_uncalibrated()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true);
+        await trigger.OnAreaChangedAsync(Area);
+        engine.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Does_not_attempt_when_game_unfocused()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: false);
+        await trigger.OnAreaChangedAsync(Area);
+        engine.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Attempts_when_only_a_bundled_baseline_exists()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, new AreaCalibration(1, 0, 0, 0, 4, 3) { Source = CalibrationSource.BundledBaseline });
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true, service: svc);
+        await trigger.OnAreaChangedAsync(Area);
+        engine.Calls.Should().Be(1, "a bundled baseline is upgradeable by the auto path");
+    }
+
+    [Fact]
+    public async Task Does_not_overwrite_an_existing_user_refinement()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, new AreaCalibration(1, 0, 0, 0, 6, 0.5) { Source = CalibrationSource.UserRefinement });
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true, service: svc);
+        await trigger.OnAreaChangedAsync(Area);
+        engine.Calls.Should().Be(0, "the auto path never displaces a user refinement");
+    }
+
+    [Fact]
+    public async Task Does_not_overwrite_an_existing_auto_capture()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, new AreaCalibration(1, 0, 0, 0, 6, 0.5) { Source = CalibrationSource.AutoCapture });
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true, service: svc);
+        await trigger.OnAreaChangedAsync(Area);
+        engine.Calls.Should().Be(0, "an existing auto-capture is not re-attempted on every zone-in");
+    }
+
+    [Fact]
+    public async Task Debounces_repeated_area_events()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true);
+        await trigger.OnAreaChangedAsync(Area);
+        await trigger.OnAreaChangedAsync(Area); // immediate repeat of the SAME area
+        engine.Calls.Should().Be(1, "a repeated area-changed for the same area is debounced");
+    }
+
+    private static AutoCalibrationTrigger Build(
+        SpyAutoCalibrationEngine engine, CaptureRect? bbox, bool focused, FakeCalibrationService? service = null)
+        => new(
+            new FakeDomainEventSubscriber(),
+            engine,
+            new FakeRegionProvider(bbox),
+            new FakeWindowLocator(focused ? new GameWindow(1, new CaptureRect(0, 0, 1920, 1080)) : null),
+            service ?? new FakeCalibrationService(),
+            logger: null);
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture.Tests.Fixtures;
 using Xunit;
@@ -77,22 +78,61 @@ public sealed class AutoCalibrationTriggerTests
     }
 
     [Fact]
-    public async Task Debounces_repeated_area_events()
+    public async Task A_persisted_success_is_not_re_attempted_on_re_entry()
     {
-        var engine = new SpyAutoCalibrationEngine();
+        // Fix C: a persisted area is marked "done" and a later re-entry to it does
+        // NOT re-attempt (replaces the old debounce semantics — the suppression is
+        // now keyed on a SUCCESSFUL persist, not merely on having attempted).
+        var engine = new SpyAutoCalibrationEngine(persisted: true);
         var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true);
         await trigger.OnAreaChangedAsync(Area);
-        await trigger.OnAreaChangedAsync(Area); // immediate repeat of the SAME area
-        engine.Calls.Should().Be(1, "a repeated area-changed for the same area is debounced");
+        await trigger.OnAreaChangedAsync(Area); // genuine later re-entry to the same area
+        engine.Calls.Should().Be(1, "a persisted success is never re-attempted on re-entry");
+    }
+
+    [Fact]
+    public async Task A_rejected_attempt_retries_on_a_later_re_entry()
+    {
+        // Fix C: a non-persisted (fail-soft) outcome leaves the area un-marked, so
+        // a genuine later area-change event for that area gets a fresh attempt
+        // (the "user zones out, zooms the map, zones back" recovery path).
+        var engine = new SpyAutoCalibrationEngine(persisted: false);
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true);
+        await trigger.OnAreaChangedAsync(Area);
+        await trigger.OnAreaChangedAsync(Area); // later re-entry after the reject
+        engine.Calls.Should().Be(2, "a rejected auto-attempt must retry on a fresh re-entry");
+    }
+
+    [Fact]
+    public async Task A_persisted_success_clears_the_status_chip()
+    {
+        var engine = new SpyAutoCalibrationEngine(persisted: true);
+        var overlay = new FakeOverlayWindow();
+        overlay.SetStatusMessage("a stale message");
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true, overlay: overlay);
+        await trigger.OnAreaChangedAsync(Area);
+        overlay.StatusMessage.Should().BeNull("a silent upgrade clears the chip on persist (spec §10)");
+    }
+
+    [Fact]
+    public async Task A_reject_surfaces_the_actionable_reason_on_the_chip()
+    {
+        var engine = new SpyAutoCalibrationEngine(persisted: false);
+        var overlay = new FakeOverlayWindow();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true, overlay: overlay);
+        await trigger.OnAreaChangedAsync(Area);
+        overlay.StatusMessage.Should().NotBeNullOrWhiteSpace("an actionable auto-reject tells the user why auto-cal isn't engaging");
     }
 
     private static AutoCalibrationTrigger Build(
-        SpyAutoCalibrationEngine engine, CaptureRect? bbox, bool focused, FakeCalibrationService? service = null)
+        SpyAutoCalibrationEngine engine, CaptureRect? bbox, bool focused,
+        FakeCalibrationService? service = null, FakeOverlayWindow? overlay = null)
         => new(
             new FakeDomainEventSubscriber(),
             engine,
             new FakeRegionProvider(bbox),
             new FakeWindowLocator(focused ? new GameWindow(1, new CaptureRect(0, 0, 1920, 1080)) : null),
             service ?? new FakeCalibrationService(),
-            logger: null);
+            overlay ?? new FakeOverlayWindow(),
+            NullLogger.Instance);
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CalibrationStatusFormatterTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CalibrationStatusFormatterTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 27 (#914): pure reject-reason → user-facing status string mapping
+/// (spec §11). The actual push to the overlay chip is shell wiring (Task 28,
+/// manual-verify); this is the pure, CI-tested half.
+/// </summary>
+public sealed class CalibrationStatusFormatterTests
+{
+    [Theory]
+    [InlineData("no map bbox set — use the draw-map-bbox hotkey first", "draw")]
+    [InlineData("Project Gorgon is not the foreground window", "Project Gorgon")]
+    [InlineData("residual 25.00 px exceeds threshold 12.00 px", "zoom")]
+    [InlineData("only 2 inliers (need >= 4)", "zoom")]
+    [InlineData("preparing map assets… (base texture unavailable)", "preparing")]
+    [InlineData("not in-world — open Project Gorgon and enter an area first", "Project Gorgon")]
+    public void Formats_reject_reasons_for_the_user(string reason, string expectedSubstring)
+        => CalibrationStatusFormatter.ForReject(reason).Should().ContainEquivalentOf(expectedSubstring);
+
+    [Fact]
+    public void A_persisted_outcome_has_no_status_message()
+        => CalibrationStatusFormatter.ForOutcome(new AutoCalibrationOutcome(true, "AreaSerbule", null))
+            .Should().BeNull();
+
+    [Fact]
+    public void A_rejected_outcome_maps_to_a_user_string()
+        => CalibrationStatusFormatter.ForOutcome(
+                new AutoCalibrationOutcome(false, "AreaSerbule", "residual 25.00 px exceeds threshold 12.00 px"))
+            .Should().NotBeNullOrEmpty();
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/CalibrationStatusFormatterTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CalibrationStatusFormatterTests.cs
@@ -30,4 +30,17 @@ public sealed class CalibrationStatusFormatterTests
         => CalibrationStatusFormatter.ForOutcome(
                 new AutoCalibrationOutcome(false, "AreaSerbule", "residual 25.00 px exceeds threshold 12.00 px"))
             .Should().NotBeNullOrEmpty();
+
+    [Fact]
+    public void A_rejected_outcome_routes_its_reason_through_ForReject()
+    {
+        const string reason = "no map bbox set — use the draw-map-bbox hotkey first";
+        CalibrationStatusFormatter.ForOutcome(new AutoCalibrationOutcome(false, "AreaSerbule", reason))
+            .Should().Be(CalibrationStatusFormatter.ForReject(reason));
+    }
+
+    [Fact]
+    public void A_rejected_outcome_with_no_reason_falls_back_to_a_generic_string()
+        => CalibrationStatusFormatter.ForOutcome(new AutoCalibrationOutcome(false, "AreaSerbule", null))
+            .Should().NotBeNullOrWhiteSpace();
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -34,6 +34,11 @@ public sealed class CaptureDependencyInjectionTests
 
         var services = new ServiceCollection();
 
+        // The trigger is a hosted service → requires a non-optional ILogger
+        // (CLAUDE.md), resolved via ILoggerFactory in the DI lambda. The shell
+        // always registers logging; mirror that here so the graph resolves.
+        services.AddLogging();
+
         // Cross-cutting collaborators the shell normally provides — faked here.
         services.AddSingleton(new GameConfig { CalibrationGoodResidualPx = 9.0, GameRoot = "" });
         services.AddSingleton<IOverlayWindow>(new FakeOverlayWindow());

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Linq;
+using Arda.Contracts;
+using Arda.World.Player;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Mithril.MapCalibration.Capture.DependencyInjection;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.Overlay;
+using Mithril.Shared.Game;
+using Mithril.Shared.Hotkeys;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 28 (#914): the auto-capture pipeline resolves from a built provider with
+/// fakes for the cross-cutting collaborators it doesn't own (IOverlayWindow,
+/// IDomainEventSubscriber, IAreaState, IReferenceDataService). Exercises the full
+/// AddMithrilMapCalibrationCapture registration graph — including the
+/// GameConfig-wired gate override and the asset-engine registration — so a
+/// missing/mis-shaped registration fails here, and ValidateOnBuild catches a
+/// singleton cycle (memory: di_cycle_invisible_to_unit_tests).
+/// </summary>
+public sealed class CaptureDependencyInjectionTests
+{
+    [Fact]
+    public void Auto_capture_pipeline_resolves_from_a_built_provider()
+    {
+        var settingsDir = Path.Combine(Path.GetTempPath(), "mithril-capture-di-" + Guid.NewGuid());
+        var assetCacheDir = Path.Combine(settingsDir, "assets");
+
+        var services = new ServiceCollection();
+
+        // Cross-cutting collaborators the shell normally provides — faked here.
+        services.AddSingleton(new GameConfig { CalibrationGoodResidualPx = 9.0, GameRoot = "" });
+        services.AddSingleton<IOverlayWindow>(new FakeOverlayWindow());
+        services.AddSingleton<IDomainEventSubscriber>(new FakeDomainEventSubscriber());
+        services.AddSingleton<IAreaState>(new FakeAreaState("AreaSerbule"));
+        services.AddSingleton<IReferenceDataService>(new FakeAreaReferenceData());
+        services.AddSingleton<IMapCalibrationService>(new FakeCalibrationService());
+
+        services.AddMithrilMapCalibrationCapture(settingsDir, assetCacheDir);
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+        provider.GetRequiredService<AutoCalibrationEngine>().Should().NotBeNull();
+
+        var hotkeys = provider.GetServices<IHotkeyCommand>().ToList();
+        hotkeys.Should().Contain(h => h.Id == "mapcalibration.capture");
+        hotkeys.Should().Contain(h => h.Id == "mapcalibration.draw_bbox");
+
+        // The GameConfig-wired gate must win over the engine's default gate
+        // (last-registration-wins): a residual of 9.5 exceeds the configured 9.0.
+        var gate = provider.GetRequiredService<Detection.ICalibrationConfidenceGate>();
+        gate.Accept(new AreaCalibration(1, 0, 0, 0, 8, 9.5), 8, out _).Should().BeFalse();
+
+        provider.GetRequiredService<AutoCalibrationTrigger>().Should().NotBeNull();
+        provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .Should().Contain(s => s is AutoCalibrationTrigger);
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/ConfidenceGateWiringTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/ConfidenceGateWiringTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Capture.DependencyInjection;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 23 (#914): the auto path's confidence gate honours the SAME user-tunable
+/// residual threshold the manual path uses (<see cref="GameConfig.CalibrationGoodResidualPx"/>,
+/// relocated to GameConfig by PR-0). The factory is tested directly so the
+/// threshold wiring is CI-locked independent of the full DI graph.
+/// </summary>
+public sealed class ConfidenceGateWiringTests
+{
+    [Fact]
+    public void Gate_uses_the_configured_threshold()
+    {
+        var cfg = new GameConfig { CalibrationGoodResidualPx = 6.0 };
+        var gate = CaptureServiceCollectionExtensions.BuildConfidenceGate(cfg);
+
+        gate.Accept(new AreaCalibration(1, 0, 0, 0, 8, 7.0), 8, out var reason).Should().BeFalse();
+        reason.Should().Contain("6");
+        gate.Accept(new AreaCalibration(1, 0, 0, 0, 8, 5.0), 8, out _).Should().BeTrue();
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Arda.Contracts;
@@ -7,8 +8,23 @@ using Arda.World.Player;
 using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture;
 using Mithril.MapCalibration.Detection;
+using Mithril.Overlay;
 
 namespace Mithril.MapCalibration.Capture.Tests.Fixtures;
+
+/// <summary>Headless IOverlayWindow for the DI-resolution test. Never touched
+/// during resolution; Window throws if a test accidentally dereferences it (no
+/// WPF Window is created off the STA thread).</summary>
+internal sealed class FakeOverlayWindow : IOverlayWindow
+{
+    public System.Windows.Window Window => throw new InvalidOperationException("FakeOverlayWindow.Window must not be touched in a headless test.");
+    public bool IsReady => false;
+    public string? StatusMessage { get; private set; }
+    public void SetStatusMessage(string? message) { StatusMessage = message; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(StatusMessage))); }
+    public IDisposable RegisterScene(Action<IOverlaySceneContext> draw) => new Noop();
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private sealed class Noop : IDisposable { public void Dispose() { } }
+}
 
 /// <summary>No-op event bus: the trigger's hosted-service Subscribe wiring is
 /// exercised by the DI-resolution test; the gating logic is tested directly via

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Arda.World.Player;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Capture;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture.Tests.Fixtures;
+
+internal sealed class FakeAreaState : IAreaState
+{
+    public FakeAreaState(string? area) => CurrentArea = area;
+    public string? CurrentArea { get; }
+}
+
+internal sealed class FakeWindowLocator : IGameWindowLocator
+{
+    private readonly GameWindow? _window;
+    public FakeWindowLocator(GameWindow? window) => _window = window;
+    public GameWindow? Locate() => _window;
+}
+
+internal sealed class FakeRegionProvider : IMapCaptureRegionProvider
+{
+    public FakeRegionProvider(CaptureRect? current) => Current = current;
+    public CaptureRect? Current { get; private set; }
+    public void Set(CaptureRect rect) { Current = rect; Changed?.Invoke(this, EventArgs.Empty); }
+    public event EventHandler? Changed;
+}
+
+internal sealed class SpyCapture : ICaptureService
+{
+    private readonly GrayImage? _result;
+    public SpyCapture(GrayImage? result = null) => _result = result;
+    public bool Called { get; private set; }
+    public Task<GrayImage?> CaptureMapAsync(CaptureRect bbox, CancellationToken ct)
+    {
+        Called = true;
+        return Task.FromResult(_result);
+    }
+}
+
+internal sealed class FakeRefiner : IMapRegionRefiner
+{
+    private readonly MapRect? _rect;
+    public FakeRefiner(MapRect? rect) => _rect = rect;
+    public MapRect? Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore) => _rect;
+}
+
+internal sealed class FakeBaseTextureProvider : IBaseTextureProvider
+{
+    private readonly GrayImage? _tex;
+    public FakeBaseTextureProvider(GrayImage? tex) => _tex = tex;
+    public GrayImage? TryGetBaseTexture(string areaKey) => _tex;
+}
+
+internal sealed class FakeAreaRefs : IAreaReferenceProvider
+{
+    private readonly IReadOnlyList<LandmarkReference> _refs;
+    public FakeAreaRefs(IReadOnlyList<LandmarkReference> refs) => _refs = refs;
+    public IReadOnlyList<LandmarkReference> ForArea(string areaKey) => _refs;
+}
+
+internal sealed class SpySolver : IMapCalibrationSolver
+{
+    private readonly CalibrationSolveResult _result;
+    public SpySolver(CalibrationSolveResult result) => _result = result;
+    public bool Called { get; private set; }
+    public CalibrationSolveResult Solve(DetectionRequest request, IReadOnlyList<LandmarkReference> references)
+    {
+        Called = true;
+        return _result;
+    }
+}
+
+internal sealed class FakeCalibrationService : IMapCalibrationService
+{
+    private readonly Dictionary<string, AreaCalibration> _prior = new(StringComparer.Ordinal);
+    public Dictionary<string, AreaCalibration> Saved { get; } = new(StringComparer.Ordinal);
+
+    public void Seed(string areaKey, AreaCalibration cal) => _prior[areaKey] = cal;
+
+    public bool IsCalibrated(string areaKey) => Saved.ContainsKey(areaKey) || _prior.ContainsKey(areaKey);
+    public PixelPoint? WorldToWindow(string areaKey, WorldCoord world, double currentZoom) => null;
+    public WorldCoord? WindowToWorld(string areaKey, PixelPoint pixel, double currentZoom) => null;
+    public AreaCalibration? GetCalibration(string areaKey) =>
+        Saved.TryGetValue(areaKey, out var s) ? s : (_prior.TryGetValue(areaKey, out var p) ? p : null);
+    public IReadOnlyDictionary<string, AreaCalibration> AllCalibrations => Saved;
+    public IReadOnlyList<AreaCalibration> GetAllSources(string areaKey) => Array.Empty<AreaCalibration>();
+    public void SaveUserRefinement(string areaKey, AreaCalibration calibration)
+    {
+        Saved[areaKey] = calibration;
+        Changed?.Invoke(this, areaKey);
+    }
+    public void ClearUserRefinement(string areaKey) => Saved.Remove(areaKey);
+    public int ImportUserRefinements(IReadOnlyDictionary<string, AreaCalibration> source) => 0;
+    public event EventHandler<string>? Changed;
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -2,12 +2,22 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Arda.Contracts;
 using Arda.World.Player;
 using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.MapCalibration.Capture.Tests.Fixtures;
+
+/// <summary>No-op event bus: the trigger's hosted-service Subscribe wiring is
+/// exercised by the DI-resolution test; the gating logic is tested directly via
+/// the extracted OnAreaChangedAsync seam.</summary>
+internal sealed class FakeDomainEventSubscriber : IDomainEventSubscriber
+{
+    public IDisposable Subscribe<T>(Action<T> handler) where T : struct => new Noop();
+    private sealed class Noop : IDisposable { public void Dispose() { } }
+}
 
 internal sealed class FakeAreaState : IAreaState
 {

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/FakeAreaReferenceData.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/FakeAreaReferenceData.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Misc;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+
+namespace Mithril.MapCalibration.Capture.Tests.Fixtures;
+
+/// <summary>
+/// Minimal in-memory <see cref="IReferenceDataService"/> for the area-reference
+/// provider tests. Only <see cref="Landmarks"/> and <see cref="NpcsByInternalName"/>
+/// are seeded; every other surface uses the interface default (empty).
+/// </summary>
+internal sealed class FakeAreaReferenceData : IReferenceDataService
+{
+    private readonly Dictionary<string, IReadOnlyList<Landmark>> _landmarks = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Npc> _npcsByInternalName = new(StringComparer.Ordinal);
+
+    public FakeAreaReferenceData WithLandmarks(string areaKey, params Landmark[] landmarks)
+    {
+        _landmarks[areaKey] = landmarks;
+        return this;
+    }
+
+    /// <summary>Seed a full <see cref="Npc"/> POCO (which carries <see cref="Npc.Pos"/>) in an area.</summary>
+    public FakeAreaReferenceData WithNpc(string areaKey, string name, string pos)
+    {
+        _npcsByInternalName["NPC_" + name] = new Npc { Name = name, AreaName = areaKey, Pos = pos };
+        return this;
+    }
+
+    public IReadOnlyDictionary<string, IReadOnlyList<Landmark>> Landmarks => _landmarks;
+    public IReadOnlyDictionary<string, Npc> NpcsByInternalName => _npcsByInternalName;
+
+    // ── Required (no-default) interface surface — all empty for these tests ──
+    public IReadOnlyList<string> Keys => [];
+    public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+    public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>(StringComparer.Ordinal);
+    public ItemKeywordIndex KeywordIndex { get; } = new(new Dictionary<long, Item>());
+    public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+    public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public void BeginBackgroundRefresh() { }
+    public event EventHandler<string>? FileUpdated;
+    public void RaiseFileUpdated(string key) => FileUpdated?.Invoke(this, key);
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/HotkeyCommandTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/HotkeyCommandTests.cs
@@ -1,0 +1,66 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture.Hotkeys;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// Task 25 (#914): the two hotkeys. Capture-&-calibrate respects the focus gate
+/// (fire only with PG focused, spec §10) and invokes the engine; draw-map-bbox
+/// does NOT respect the focus gate (the drag setup happens with the overlay
+/// focused). Id / gate / wiring are unit-tested; the drag interaction itself is
+/// WPF/manual-verify (Task 28).
+/// </summary>
+public sealed class HotkeyCommandTests
+{
+    [Fact]
+    public async Task Capture_command_respects_focus_gate_and_invokes_the_engine()
+    {
+        var engine = new SpyAutoCalibrationEngine();
+        var cmd = new CaptureCalibrateCommand(engine);
+
+        cmd.RespectsFocusGate.Should().BeTrue();
+        cmd.Id.Should().Be("mapcalibration.capture");
+        cmd.Category.Should().Be("Map Calibration");
+        cmd.DefaultBinding.Should().BeNull();
+
+        await cmd.ExecuteAsync(default);
+        engine.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void Draw_bbox_command_does_not_respect_focus_gate()
+    {
+        var cmd = new DrawMapBboxCommand(new SpyBboxDrawController());
+        cmd.RespectsFocusGate.Should().BeFalse();
+        cmd.Id.Should().Be("mapcalibration.draw_bbox");
+        cmd.Category.Should().Be("Map Calibration");
+    }
+
+    [Fact]
+    public async Task Draw_bbox_command_begins_the_draw_mode()
+    {
+        var controller = new SpyBboxDrawController();
+        await new DrawMapBboxCommand(controller).ExecuteAsync(default);
+        controller.BeginCalls.Should().Be(1);
+    }
+}
+
+internal sealed class SpyAutoCalibrationEngine : IAutoCalibrationRunner
+{
+    public int Calls { get; private set; }
+    public Task<AutoCalibrationOutcome> TryCalibrateCurrentAreaAsync(CancellationToken ct)
+    {
+        Calls++;
+        return Task.FromResult(new AutoCalibrationOutcome(true, "AreaSerbule", null));
+    }
+}
+
+internal sealed class SpyBboxDrawController : IMapBboxDrawController
+{
+    public int BeginCalls { get; private set; }
+    public void BeginDraw() => BeginCalls++;
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/HotkeyCommandTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/HotkeyCommandTests.cs
@@ -20,7 +20,8 @@ public sealed class HotkeyCommandTests
     public async Task Capture_command_respects_focus_gate_and_invokes_the_engine()
     {
         var engine = new SpyAutoCalibrationEngine();
-        var cmd = new CaptureCalibrateCommand(engine);
+        var overlay = new FakeOverlayWindow();
+        var cmd = new CaptureCalibrateCommand(engine, overlay);
 
         cmd.RespectsFocusGate.Should().BeTrue();
         cmd.Id.Should().Be("mapcalibration.capture");
@@ -29,6 +30,31 @@ public sealed class HotkeyCommandTests
 
         await cmd.ExecuteAsync(default);
         engine.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Capture_command_clears_the_status_chip_on_a_persisted_success()
+    {
+        var engine = new SpyAutoCalibrationEngine(persisted: true);
+        var overlay = new FakeOverlayWindow();
+        overlay.SetStatusMessage("a stale prior message");
+
+        await new CaptureCalibrateCommand(engine, overlay).ExecuteAsync(default);
+
+        overlay.StatusMessage.Should().BeNull("a persisted success clears the chip");
+    }
+
+    [Fact]
+    public async Task Capture_command_surfaces_the_reject_reason_on_a_fail_soft_outcome()
+    {
+        var engine = new SpyAutoCalibrationEngine(persisted: false, rejectReason: "no map bbox set — use the draw-map-bbox hotkey first");
+        var overlay = new FakeOverlayWindow();
+
+        await new CaptureCalibrateCommand(engine, overlay).ExecuteAsync(default);
+
+        overlay.StatusMessage.Should().NotBeNullOrWhiteSpace("a reject must surface an actionable chip");
+        overlay.StatusMessage.Should().Be(CalibrationStatusFormatter.ForOutcome(
+            new AutoCalibrationOutcome(false, "AreaSerbule", "no map bbox set — use the draw-map-bbox hotkey first")));
     }
 
     [Fact]
@@ -51,11 +77,22 @@ public sealed class HotkeyCommandTests
 
 internal sealed class SpyAutoCalibrationEngine : IAutoCalibrationRunner
 {
+    private readonly bool _persisted;
+    private readonly string? _rejectReason;
+
+    /// <summary>Default: a persisted success (matches the prior fixed behaviour).
+    /// Pass <paramref name="persisted"/> false to simulate a fail-soft reject.</summary>
+    public SpyAutoCalibrationEngine(bool persisted = true, string? rejectReason = null)
+    {
+        _persisted = persisted;
+        _rejectReason = rejectReason ?? (persisted ? null : "no geometrically-consistent fit");
+    }
+
     public int Calls { get; private set; }
     public Task<AutoCalibrationOutcome> TryCalibrateCurrentAreaAsync(CancellationToken ct)
     {
         Calls++;
-        return Task.FromResult(new AutoCalibrationOutcome(true, "AreaSerbule", null));
+        return Task.FromResult(new AutoCalibrationOutcome(_persisted, "AreaSerbule", _persisted ? null : _rejectReason));
     }
 }
 

--- a/tests/Mithril.MapCalibration.Tests/AutoCaptureCalibrationSourceTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/AutoCaptureCalibrationSourceTests.cs
@@ -31,53 +31,58 @@ public sealed class AutoCaptureCalibrationSourceTests
     }
 
     [Fact]
-    public void Downgrade_window_an_unknown_source_name_degrades_to_an_empty_store_not_a_crash()
+    public void Downgrade_window_an_unknown_source_name_drops_only_that_entry_not_the_whole_store()
     {
-        // §D3 downgrade-window documentation. AutoCapture is persisted by NAME.
-        // A downgraded pre-AutoCapture build reading a refinements.json that
-        // contains "AutoCapture" hits the source-gen string-enum converter,
-        // which THROWS JsonException on an unknown member name (it does not
-        // tolerate-and-default at the single-record level — verified here so the
-        // behaviour is pinned, not assumed). The real consumer path is
-        // UserRefinementStore.Load, which catches JsonException for the whole
-        // file and degrades to an EMPTY in-memory store + a logged warning — a
-        // safe degrade (no wrong transform is ever served; the user re-runs
-        // calibration), NOT a throw that crashes boot and NOT a silently wrong
-        // projection. That is the "benign downgrade" §D3 calls out.
+        // §D3 downgrade-window documentation, post GATE-2 Fix A. AutoCapture is
+        // persisted by NAME. A downgraded pre-AutoCapture build reading a
+        // refinements.json that contains "AutoCapture" hits the source-gen
+        // string-enum converter, which THROWS JsonException on an unknown member
+        // name (verified here so the behaviour is pinned, not assumed). The real
+        // consumer path is UserRefinementStore.Load, which now deserialises each
+        // area entry INDIVIDUALLY and skips+warns ONLY the unparseable entry while
+        // every other area survives — a durable, per-entry degrade rather than the
+        // earlier whole-store wipe.
         var dir = Path.Combine(Path.GetTempPath(), "mithril-downgrade-" + Guid.NewGuid());
         Directory.CreateDirectory(dir);
         var path = Path.Combine(dir, "refinements.json");
         try
         {
-            // Hand-write a store whose one entry carries a Source name the
-            // converter can't parse (stands in for a future/unknown source name
-            // as seen by a build that predates it).
-            File.WriteAllText(path,
-                "{\"schemaVersion\":1,\"calibrations\":{\"AreaSerbule\":{" +
-                "\"scale\":1,\"rotationRadians\":0,\"originX\":10,\"originY\":10," +
-                "\"referenceCount\":6,\"residualPixels\":0.7,\"source\":\"SomeFutureSource\"}}}");
-
             // (a) the single-record converter genuinely throws on the unknown name.
             var directParse = () => JsonSerializer.Deserialize(
                 "{\"source\":\"SomeFutureSource\"}", MapCalibrationJsonContext.Default.AreaCalibration);
             directParse.Should().Throw<JsonException>(
                 "the source-gen string-enum converter rejects unknown member names");
 
-            // (b) the store-level loader degrades rather than crashing: building
-            // the service does not throw, and the corrupt user-store entry is NOT
-            // served (the service falls through to whatever the bundled baseline
-            // holds — possibly null, possibly a baseline — but never the
-            // unparseable originX=10 transform). Use an area with no bundled
-            // baseline so the user-store degrade is observable as a clean null.
+            // (b) Two area entries: one valid UserRefinement, one carrying a Source
+            // name the converter can't parse (stands in for a future/unknown source
+            // name as seen by a build that predates it). The poisoned entry must be
+            // dropped while the valid entry survives — NOT a whole-store wipe.
+            File.WriteAllText(path,
+                "{\"schemaVersion\":1,\"calibrations\":{" +
+                "\"AreaSerbule\":{" +
+                "\"scale\":1,\"rotationRadians\":0,\"originX\":10,\"originY\":10," +
+                "\"referenceCount\":6,\"residualPixels\":0.7,\"source\":\"SomeFutureSource\"}," +
+                "\"AreaEltibule\":{" +
+                "\"scale\":2,\"rotationRadians\":0,\"originX\":42,\"originY\":99," +
+                "\"referenceCount\":8,\"residualPixels\":0.5,\"source\":\"UserRefinement\"}" +
+                "}}");
+
             var build = () => MapCalibrationServiceCollectionExtensions.Build(dir);
             var service = build.Should().NotThrow(
-                "an unparseable refinements.json must degrade, not crash the loader").Subject;
+                "a single unparseable entry must degrade per-entry, not crash the loader").Subject;
 
-            var served = service.GetCalibration("AreaSerbule");
-            // The corrupt entry had originX=10; the user store dropped it, so it
-            // is never served. If a bundled baseline exists it wins; otherwise null.
-            (served is null || served.OriginX != 10 || served.Source != CalibrationSource.UserRefinement)
+            // The poisoned entry (originX=10) is dropped: never served as a user
+            // refinement (a bundled baseline may win, but never the bad transform).
+            var poisoned = service.GetCalibration("AreaSerbule");
+            (poisoned is null || poisoned.OriginX != 10 || poisoned.Source != CalibrationSource.UserRefinement)
                 .Should().BeTrue("the unparseable user-store refinement must not be served");
+
+            // The valid sibling entry SURVIVES — this is the resilience the fix adds.
+            var survivor = service.GetCalibration("AreaEltibule");
+            survivor.Should().NotBeNull("a poisoned sibling entry must not wipe the whole store");
+            survivor!.OriginX.Should().Be(42, "the valid entry's transform is preserved verbatim");
+            survivor.OriginY.Should().Be(99);
+            survivor.Source.Should().Be(CalibrationSource.UserRefinement);
         }
         finally
         {

--- a/tests/Mithril.MapCalibration.Tests/AutoCaptureCalibrationSourceTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/AutoCaptureCalibrationSourceTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.MapCalibration.DependencyInjection;
+using Mithril.MapCalibration.Internal;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests;
+
+/// <summary>
+/// Task 20 (#914): <see cref="CalibrationSource.AutoCapture"/> is an additive
+/// enum value persisted by name (§D3 — no SchemaVersion bump). A gate-passing
+/// auto solve is as trustworthy as a manual one, so it lands in the user store
+/// via <c>SaveUserRefinement</c> and gets user-store precedence by construction
+/// (no resolver branch on the enum value — see <c>MapCalibrationService.GetCalibration</c>).
+/// </summary>
+public sealed class AutoCaptureCalibrationSourceTests
+{
+    [Fact]
+    public void AutoCapture_round_trips_by_name()
+    {
+        var cal = new AreaCalibration(1, 0, 10, 10, 6, 0.7) { Source = CalibrationSource.AutoCapture };
+
+        var json = JsonSerializer.Serialize(cal, MapCalibrationJsonContext.Default.AreaCalibration);
+        json.Should().Contain("\"AutoCapture\"", "UseStringEnumConverter emits the enum member name");
+        json.Should().NotMatchRegex("\"source\"\\s*:\\s*3", "a numeric enum value must NOT appear");
+
+        JsonSerializer.Deserialize(json, MapCalibrationJsonContext.Default.AreaCalibration)!
+            .Source.Should().Be(CalibrationSource.AutoCapture);
+    }
+
+    [Fact]
+    public void Downgrade_window_an_unknown_source_name_degrades_to_an_empty_store_not_a_crash()
+    {
+        // §D3 downgrade-window documentation. AutoCapture is persisted by NAME.
+        // A downgraded pre-AutoCapture build reading a refinements.json that
+        // contains "AutoCapture" hits the source-gen string-enum converter,
+        // which THROWS JsonException on an unknown member name (it does not
+        // tolerate-and-default at the single-record level — verified here so the
+        // behaviour is pinned, not assumed). The real consumer path is
+        // UserRefinementStore.Load, which catches JsonException for the whole
+        // file and degrades to an EMPTY in-memory store + a logged warning — a
+        // safe degrade (no wrong transform is ever served; the user re-runs
+        // calibration), NOT a throw that crashes boot and NOT a silently wrong
+        // projection. That is the "benign downgrade" §D3 calls out.
+        var dir = Path.Combine(Path.GetTempPath(), "mithril-downgrade-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "refinements.json");
+        try
+        {
+            // Hand-write a store whose one entry carries a Source name the
+            // converter can't parse (stands in for a future/unknown source name
+            // as seen by a build that predates it).
+            File.WriteAllText(path,
+                "{\"schemaVersion\":1,\"calibrations\":{\"AreaSerbule\":{" +
+                "\"scale\":1,\"rotationRadians\":0,\"originX\":10,\"originY\":10," +
+                "\"referenceCount\":6,\"residualPixels\":0.7,\"source\":\"SomeFutureSource\"}}}");
+
+            // (a) the single-record converter genuinely throws on the unknown name.
+            var directParse = () => JsonSerializer.Deserialize(
+                "{\"source\":\"SomeFutureSource\"}", MapCalibrationJsonContext.Default.AreaCalibration);
+            directParse.Should().Throw<JsonException>(
+                "the source-gen string-enum converter rejects unknown member names");
+
+            // (b) the store-level loader degrades rather than crashing: building
+            // the service does not throw, and the corrupt user-store entry is NOT
+            // served (the service falls through to whatever the bundled baseline
+            // holds — possibly null, possibly a baseline — but never the
+            // unparseable originX=10 transform). Use an area with no bundled
+            // baseline so the user-store degrade is observable as a clean null.
+            var build = () => MapCalibrationServiceCollectionExtensions.Build(dir);
+            var service = build.Should().NotThrow(
+                "an unparseable refinements.json must degrade, not crash the loader").Subject;
+
+            var served = service.GetCalibration("AreaSerbule");
+            // The corrupt entry had originX=10; the user store dropped it, so it
+            // is never served. If a bundled baseline exists it wins; otherwise null.
+            (served is null || served.OriginX != 10 || served.Source != CalibrationSource.UserRefinement)
+                .Should().BeTrue("the unparseable user-store refinement must not be served");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## PR-2b — Phase 3: trigger + persistence + UX (#914)

Builds on PR-2a (#934, the `Mithril.MapCalibration.Capture` OS-capture infra). Wraps the shipped headless `MapCalibrationSolveEngine` (Phase 1) and the capture seams (Phase 2) in **trigger → solve → gate → persist → UX**, so per-area map calibration is hands-free. Tasks 20–29.

### What landed
- **T20** `CalibrationSource.AutoCapture = 3` — additive, persisted by name (no `SchemaVersion` bump, §D3). Precedence is **store-based, not enum-based**: an auto solve persists via `SaveUserRefinement`, lands in the user store, and inherits `UserRefinement` precedence *by construction*. No resolver branch on the enum value exists (verified) — the value only lets a consumer label an auto fit distinctly. Downgrade window documented + pinned (unknown name throws at the single-record converter; the store-level loader degrades to empty, never serves a wrong transform).
- **T21** Base-texture policy (Decision D8) — **no provider code**. The orchestrator resolves the #931 `IBaseTextureProvider.TryGetBaseTexture(area)`; on a cache-miss it optionally invokes `IAssetExtractor.ExtractAsync` once to populate the sidecar cache, then retries; still null → fail-soft ("preparing map assets…").
- **T22** `IAreaReferenceProvider` over `IReferenceDataService` — landmarks (by area) + NPCs (full `Npc` POCO, by `AreaName`, carries `Pos`) → typed `LandmarkReference`s. **Type-token mapping** (see below). Unmapped types are **warned + dropped** (no silent coercion to a wrong token). `Loc`/`Pos` parsed from `"x:N y:N z:N"`; malformed → skip.
- **T23** `BuildConfidenceGate(GameConfig)` → gate honours `GameConfig.CalibrationGoodResidualPx` (same user-tunable threshold the manual path uses).
- **T24** `AutoCalibrationEngine.TryCalibrateCurrentAreaAsync` — the orchestrator. Persists (Source = `AutoCapture`) **only on gate-accept**; otherwise keeps prior + reports a reason. Fail-soft on every §11 condition. `IMapCalibrationSolver` seam wraps the Phase-1 engine (mirrors `IMapRegionRefiner`-over-static) so branch logic is unit-tested over fakes; the real detect→solve→gate is integration-tested in `SyntheticEndToEndTests`.
- **T25** Two hotkeys: `CaptureCalibrateCommand` (`mapcalibration.capture`, `RespectsFocusGate=true`) + `DrawMapBboxCommand` (`mapcalibration.draw_bbox`, `RespectsFocusGate=false`).
- **T26** `AutoCalibrationTrigger` (`IHostedService`) — on `AreaChanged`, fires iff bbox set AND PG foreground AND (uncalibrated OR only a `BundledBaseline`). Never overwrites an existing `UserRefinement`/`AutoCapture`; debounces same-area repeats.
- **T27** `CalibrationStatusFormatter` — reject reason → actionable user string (pure, CI-tested). Push to `IOverlayWindow.SetStatusMessage` is shell wiring.
- **T28** `AddMithrilMapCalibrationCapture(settingsDir, assetCacheDir)` + shell composition. Added `IOverlayWindow.SetStatusMessage(string?)` (the concrete `OverlayWindowService` already implemented it — resolves the dangling cref). Threaded `AssetCacheDir` (`%LocalAppData%/Mithril/assets`) through `ShellCompositionOptions` + `Program.cs` + `SelfCheck`. Real `OverlayBlanker` (hide on dispatcher, wait one `DispatcherPriority.Render` frame, restore on dispose) + `MapBboxDrawController` live in the Capture project.

### Anti-cheat posture (spec §13, memory `pg_anti_injector_stance`)
Screen capture reads the OS framebuffer via `BitBlt`/`GetDIBits` — the **same data path as a manual screenshot**. It is **not** process injection, memory reading, or DirectX hooking, so it does not cross Project Gorgon's ACTk anti-injector line (which targets hooks). WGC is the documented per-window upgrade and is equally framebuffer-only.

### Task 22 type-token mapping (verification-owed follow-up)
Confirmed against live `landmarks.json` (v470) via the `pg-data` MCP and the canonical pairing in `tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs`:

| `Landmark.Type` | template token |
|---|---|
| `Portal` | `landmark_portal` |
| `MeditationPillar` | `landmark_medipillar` |
| `TeleportationPlatform` | `landmark_telepad` |
| (NPCs, via `Npc.AreaName`) | `landmark_npc` |

Every landmark in the v470 corpus carries exactly one of those three Types. Any future/unmapped Type is logged at `Warning` and dropped. A `// Verification owed (#914)` comment marks the spot to re-confirm if a new landmark category lands.

### Verification
- `dotnet test tests/Mithril.MapCalibration.Capture.Tests` → **48 passed**.
- `dotnet test tests/Mithril.MapCalibration.Tests` (incl. T20 `AutoCaptureCalibrationSourceTests`) → **89 passed**.
- `ShippedGraphDecoderFreeTests` → **green** (no decoder crept into `src/**`; asset decode stays behind the #931 sidecar).
- Full `dotnet build Mithril.slnx` → **green, 0 warnings** (warnings-as-errors; proves shell composition compiles).
- Full `dotnet test Mithril.slnx` → green except one **Smaug.Tests flake** (a favor-module test with zero overlap with this change; passed on isolated re-run, 33/33).
- **DI-cycle check**: `--selfcheck` composes the *real full shell graph* (incl. the new auto-capture registrations + hosted-service trigger) → **32 roots resolved, no DI cycle**. (Stronger than a shell launch for the cycle concern, since selfcheck has a wall-clock watchdog for the silent-deadlock factory-lambda case `ValidateOnBuild` can't see.)

### Manual-verification owed (no CI for the OS capture / WPF paths — by design, spec §12)
I could **not** run Project Gorgon, so the live capture + drag + flicker paths are unverified. Owed against running PG (windowed/borderless, world map zoomed all the way out, baseline area):
- [ ] Draw-bbox hotkey → drag a rect → overlay snaps; `map-capture.json` persisted.
- [ ] Capture-&-calibrate hotkey → overlay blanks one frame (note any flicker — spec §15), capture validates non-black, solve persists an `AutoCapture` `AreaCalibration`.
- [ ] Negative: capture with the map **not** zoomed out → gate rejects, status chip shows the §11 message, **prior calibration unchanged**.
- [ ] Auto-attempt: zone into an uncalibrated baseline area with a bbox set + PG focused → silent upgrade; nothing fires when alt-tabbed (focus gate).
- [ ] `MapBboxDrawController`'s drag-to-rect interaction (client→desktop pixel conversion on mouse-up) is a WPF seam stub — the drag handler attach is manual-verify; `BeginDraw` currently arms the mode + surfaces the status hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
