### PR TITLE
fix(hotkeys): log swallowed exceptions in HotkeyService (#936)

### DIFF
--- a/src/Mithril.Shared/Hotkeys/HotkeyService.cs
+++ b/src/Mithril.Shared/Hotkeys/HotkeyService.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Interop;
 using System.Windows.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Mithril.Shared.Hotkeys;
 
@@ -11,6 +12,7 @@ public sealed partial class HotkeyService : IHotkeyService
 
     private readonly HotkeyRegistry _registry;
     private readonly IHotkeyGate _gate;
+    private readonly ILogger<HotkeyService> _logger;
     private readonly Dictionary<int, IHotkeyCommand> _byRegistrationId = new();
     private readonly Dictionary<string, int> _byCommandId = new(StringComparer.Ordinal);
     private IReadOnlyList<HotkeyBinding> _lastBindings = Array.Empty<HotkeyBinding>();
@@ -19,10 +21,11 @@ public sealed partial class HotkeyService : IHotkeyService
     private int _nextId = 0xB000;
     private int _captureDepth;
 
-    public HotkeyService(HotkeyRegistry registry, IHotkeyGate gate)
+    public HotkeyService(HotkeyRegistry registry, IHotkeyGate gate, ILogger<HotkeyService> logger)
     {
         _registry = registry;
         _gate = gate;
+        _logger = logger;
         _gate.PropertyChanged += OnGatePropertyChanged;
         foreach (var gated in _registry.Commands.OfType<IGatedHotkeyCommand>())
         {
@@ -147,16 +150,19 @@ public sealed partial class HotkeyService : IHotkeyService
         public void Dispose() { if (_disposed) return; _disposed = true; _svc.EndCaptureSession(); }
     }
 
+    internal async Task ExecuteCommandSafelyAsync(IHotkeyCommand command)
+    {
+        try { await command.ExecuteAsync(CancellationToken.None); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Hotkey command {CommandId} threw.", command.Id); }
+    }
+
     private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
     {
         if (msg != WM_HOTKEY) return IntPtr.Zero;
         var id = wParam.ToInt32();
         if (!_byRegistrationId.TryGetValue(id, out var command)) return IntPtr.Zero;
         handled = true;
-        _ = Dispatcher.CurrentDispatcher.InvokeAsync(async () =>
-        {
-            try { await command.ExecuteAsync(CancellationToken.None); } catch { }
-        });
+        _ = Dispatcher.CurrentDispatcher.InvokeAsync(() => ExecuteCommandSafelyAsync(command));
         return IntPtr.Zero;
     }
 

--- a/tests/Mithril.Shared.Tests/HotkeyServiceExecuteCommandTests.cs
+++ b/tests/Mithril.Shared.Tests/HotkeyServiceExecuteCommandTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mithril.Shared.Hotkeys;
+using Xunit;
+
+namespace Mithril.Shared.Tests;
+
+public class HotkeyServiceExecuteCommandTests
+{
+    private static HotkeyService BuildService(ILogger<HotkeyService>? logger = null)
+    {
+        var registry = new HotkeyRegistry([]);
+        var gate = new AlwaysOpenHotkeyGate();
+        return new HotkeyService(registry, gate, logger ?? NullLogger<HotkeyService>.Instance);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandSafely_ThrowingCommand_LogsWarningWithException()
+    {
+        var recorder = new RecordingLogger();
+        var svc = BuildService(recorder);
+        var boom = new ThrowingCommand("throw-cmd", new InvalidOperationException("boom"));
+
+        await svc.ExecuteCommandSafelyAsync(boom);
+
+        recorder.Records.Should().ContainSingle(r => r.Level == LogLevel.Warning)
+            .Which.Exception.Should().Be(boom.ThrowException);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandSafely_ThrowingCommand_LogsCommandId()
+    {
+        var recorder = new RecordingLogger();
+        var svc = BuildService(recorder);
+        var boom = new ThrowingCommand("my-cmd-id", new InvalidOperationException("boom"));
+
+        await svc.ExecuteCommandSafelyAsync(boom);
+
+        recorder.Records.Should().ContainSingle(r => r.Level == LogLevel.Warning)
+            .Which.State.Should().Contain(p => p.Key == "CommandId" && Equals(p.Value, "my-cmd-id"));
+    }
+
+    [Fact]
+    public async Task ExecuteCommandSafely_ThrowingThenSuccess_PumpSurvives()
+    {
+        var svc = BuildService();
+        var boom = new ThrowingCommand("fail", new InvalidOperationException("oops"));
+        var ok = new TrackingCommand("ok");
+
+        await svc.ExecuteCommandSafelyAsync(boom);
+        await svc.ExecuteCommandSafelyAsync(ok);
+
+        ok.WasExecuted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteCommandSafely_NonThrowingCommand_NoWarningLogged()
+    {
+        var recorder = new RecordingLogger();
+        var svc = BuildService(recorder);
+        var ok = new TrackingCommand("ok");
+
+        await svc.ExecuteCommandSafelyAsync(ok);
+
+        recorder.Records.Should().BeEmpty();
+    }
+
+    // --- fakes ---
+
+    private sealed class ThrowingCommand(string id, Exception throwException) : IHotkeyCommand
+    {
+        public Exception ThrowException { get; } = throwException;
+        public string Id => id;
+        public string DisplayName => id;
+        public string? Category => null;
+        public HotkeyBinding? DefaultBinding => null;
+        public bool RespectsFocusGate => false;
+        public Task ExecuteAsync(CancellationToken ct) => throw ThrowException;
+    }
+
+    private sealed class TrackingCommand(string id) : IHotkeyCommand
+    {
+        public bool WasExecuted { get; private set; }
+        public string Id => id;
+        public string DisplayName => id;
+        public string? Category => null;
+        public HotkeyBinding? DefaultBinding => null;
+        public bool RespectsFocusGate => false;
+        public Task ExecuteAsync(CancellationToken ct) { WasExecuted = true; return Task.CompletedTask; }
+    }
+
+    // --- recording logger (mirrors DomainEventBusTests.RecordingLogger) ---
+
+    private sealed class RecordingLogger : ILogger<HotkeyService>
+    {
+        public List<LogRecord> Records { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var pairs = state as IReadOnlyList<KeyValuePair<string, object?>>
+                ?? [new KeyValuePair<string, object?>("{OriginalFormat}", formatter(state, exception))];
+            Records.Add(new LogRecord(logLevel, pairs.ToList(), exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    private sealed record LogRecord(
+        LogLevel Level,
+        IReadOnlyList<KeyValuePair<string, object?>> State,
+        Exception? Exception);
+}


### PR DESCRIPTION
## Summary

- The shared hotkey pump (`HotkeyService.WndProc` dispatcher lambda) was swallowing all exceptions from `IHotkeyCommand.ExecuteAsync` with a bare `catch { }`, making failures completely invisible across every module's hotkey commands.
- Inject `ILogger<HotkeyService>` (non-nullable, matching the `DomainEventBus` precedent) and extract an `internal ExecuteCommandSafelyAsync` method that logs a `LogWarning` with the exception and the `{CommandId}` structured property, while still catching so one command failure cannot tear down the pump.
- `WndProc` now calls `ExecuteCommandSafelyAsync` instead of inlining the try/catch.
- New unit tests in `HotkeyServiceExecuteCommandTests` verify: throwing command produces exactly one `Warning`-level log carrying the exception; `{CommandId}` appears in the structured log state; pump survives (subsequent command runs normally after a throw); non-throwing command produces no log.

Closes #936

**Scope:** `Mithril.Shared` — shared infra affecting every module's hotkey commands.

## Test plan
- [x] `dotnet build Mithril.slnx` — green, 0 warnings, 0 errors
- [x] `dotnet test tests/Mithril.Shared.Tests` — Passed: 1207, Failed: 0, Skipped: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
