### PR TITLE
fix(arda): anchor Player.log clock to correct UTC date (#942)

### DIFF
--- a/src/Arda/Arda.Ingest/Clock/PlayerLogClock.cs
+++ b/src/Arda/Arda.Ingest/Clock/PlayerLogClock.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Arda.Ingest.Clock;
 
 /// <summary>
@@ -27,6 +29,13 @@ internal sealed class PlayerLogClock : ILogSourceClock
     private TimeSpan? _prevTimeOfDay;
 
     internal const int PrefixLength = 11; // "[HH:MM:SS] "
+
+    // Slack allowed between the last line's time-of-day and the file mtime before
+    // the mtime-fallback decides the line belongs to the previous day. Live-log
+    // buffering can leave the newest line a few seconds ahead of a lagging mtime;
+    // a genuine prior-day last line sits many hours ahead, so an hour cleanly
+    // separates the two cases (#942).
+    private static readonly TimeSpan MtimeRollbackTolerance = TimeSpan.FromHours(1);
 
     public PlayerLogClock(TimeProvider time)
     {
@@ -127,9 +136,15 @@ internal sealed class PlayerLogClock : ILogSourceClock
         var mtime = mtimeUtcAccessor();
         var mtimeDate = DateOnly.FromDateTime(mtime);
 
-        // If the last line's time-of-day is past the mtime's time-of-day,
-        // the file was last written on the prior day relative to the last line.
-        if (lastTimeOfDay.Value > mtime.TimeOfDay)
+        // Place the last line's time-of-day on the mtime's date. The last line
+        // cannot have been written meaningfully *after* the file's last-write-
+        // time, so if that candidate lands beyond mtime by more than a small
+        // tolerance the file rolled past midnight before its final flush and the
+        // line belongs to the previous day. A bare time-of-day ">" comparison
+        // misfires on a live log whose newest buffered line is a few seconds
+        // ahead of a lagging mtime, rolling the whole anchor back a day (#942).
+        var candidate = mtimeDate.ToDateTime(TimeOnly.FromTimeSpan(lastTimeOfDay.Value));
+        if (candidate - mtime > MtimeRollbackTolerance)
             mtimeDate = mtimeDate.AddDays(-1);
 
         _currentUtcDate = mtimeDate.AddDays(-midnightRollovers);
@@ -149,6 +164,11 @@ internal sealed class PlayerLogClock : ILogSourceClock
     private const string BannerMarker = "Logged in as character ";
     private const string TimeMarker = "Time UTC=";
 
+    // The game emits the login instant via invariant-culture DateTime.ToString():
+    // "MM/dd/yyyy HH:mm:ss" (slashes, month-first), e.g.
+    //   Time UTC=05/31/2026 12:55:00. Timezone Offset 01:00:00
+    private const string BannerDateTimeFormat = "MM/dd/yyyy HH:mm:ss";
+
     /// <inheritdoc/>
     public void TryConsumeBanner(ReadOnlySpan<char> line)
     {
@@ -163,27 +183,21 @@ internal sealed class PlayerLogClock : ILogSourceClock
         if (timeIdx < 0) return;
 
         var stamp = body[(timeIdx + TimeMarker.Length)..];
-        // Expecting "YYYY-MM-DD HH:MM:SS" — strip a trailing period/dot.
-        if (stamp.Length >= 1 && stamp[^1] == '.') stamp = stamp[..^1];
-        if (stamp.Length < 19) return;
-        if (stamp[4] != '-' || stamp[7] != '-' || stamp[10] != ' ' ||
-            stamp[13] != ':' || stamp[16] != ':') return;
+        // Take the fixed-width "MM/dd/yyyy HH:mm:ss" datetime prefix; the banner
+        // continues with ". Timezone Offset ..." which we ignore here (Time UTC=
+        // is already UTC, so Player.log anchors with a zero offset).
+        if (stamp.Length < BannerDateTimeFormat.Length) return;
+        var dateTime = stamp[..BannerDateTimeFormat.Length];
 
-        if (!int.TryParse(stamp[..4], out var year) ||
-            !int.TryParse(stamp[5..7], out var month) ||
-            !int.TryParse(stamp[8..10], out var day) ||
-            !int.TryParse(stamp[11..13], out var hour) ||
-            !int.TryParse(stamp[14..16], out var minute) ||
-            !int.TryParse(stamp[17..19], out var second)) return;
-
-        if (month is < 1 or > 12 || day is < 1 or > 31 ||
-            hour > 23 || minute > 59 || second > 59) return;
+        if (!DateTime.TryParseExact(dateTime, BannerDateTimeFormat,
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var utc))
+            return;
 
         // A new banner crosses a session boundary — reset rollover tracking
         // before re-anchoring so the next line doesn't trigger a false
         // midnight advance against the prior session's last time-of-day.
         Reset();
-        AnchorToDate(new DateOnly(year, month, day), new TimeSpan(hour, minute, second));
+        AnchorToDate(DateOnly.FromDateTime(utc), utc.TimeOfDay);
     }
 
     /// <summary>

--- a/src/Arda/Arda.Ingest/Coordinator/BatchProcessor.cs
+++ b/src/Arda/Arda.Ingest/Coordinator/BatchProcessor.cs
@@ -54,7 +54,7 @@ internal sealed class BatchProcessor
         {
             // Pre-scan: a session banner anywhere in the batch can override
             // the date/timezone state (e.g. Player.log "Logged in as ...
-            // Time UTC=YYYY-MM-DD HH:MM:SS"). Must run BEFORE EnsureAnchored
+            // Time UTC=MM/dd/yyyy HH:mm:ss"). Must run BEFORE EnsureAnchored
             // so banner wins over mtime fallback, and BEFORE classification
             // so the FIRST classified line is stamped against the banner.
             for (var i = 0; i < batch.LineCount; i++)

--- a/tests/Arda.Ingest.Tests/BatchProcessorTests.cs
+++ b/tests/Arda.Ingest.Tests/BatchProcessorTests.cs
@@ -138,7 +138,7 @@ public class BatchProcessorTests : IDisposable
     public void ProcessBatch_BannerInBatch_AnchorsAgainstBannerNotMtime()
     {
         File.WriteAllText(_tempFile,
-            "[14:30:05] Logged in as character Bob. Time UTC=2026-01-15 14:30:05\n" +
+            "[14:30:05] Logged in as character Bob. Time UTC=01/15/2026 14:30:05. Timezone Offset 00:00:00\n" +
             "[14:30:06] LocalPlayer: ProcessAddItem(1)\n");
         // Mtime is wildly different from the banner — banner must win.
         File.SetLastWriteTimeUtc(_tempFile, new DateTime(2027, 6, 1, 0, 0, 0, DateTimeKind.Utc));

--- a/tests/Arda.Ingest.Tests/PlayerLogClockTests.cs
+++ b/tests/Arda.Ingest.Tests/PlayerLogClockTests.cs
@@ -54,8 +54,10 @@ public class PlayerLogClockTests
     {
         var clock = new PlayerLogClock(TimeProvider.System);
 
+        // Real game format: invariant-culture MM/dd/yyyy HH:mm:ss (slashes,
+        // month-first), followed by ". Timezone Offset ...".
         clock.TryConsumeBanner(
-            "[14:30:05] Logged in as character Bob. Time UTC=2026-01-15 14:30:05".AsSpan());
+            "[14:30:05] Logged in as character Bob. Time UTC=01/15/2026 14:30:05. Timezone Offset 00:00:00".AsSpan());
 
         var result = clock.TryParse("[14:30:06] LocalPlayer: action".AsSpan());
 
@@ -66,17 +68,36 @@ public class PlayerLogClockTests
     }
 
     [Fact]
+    public void TryConsumeBanner_CapturedRealBanner_AnchorsToCorrectDate()
+    {
+        var clock = new PlayerLogClock(TimeProvider.System);
+
+        // Verbatim line captured from a live Player.log (issue #942).
+        clock.TryConsumeBanner(
+            "[12:55:00] Logged in as character Emraell. Time UTC=05/31/2026 12:55:00. Timezone Offset 01:00:00".AsSpan());
+
+        var result = clock.TryParse("[12:55:01] LocalPlayer: action".AsSpan());
+
+        result.HasTimestamp.Should().BeTrue();
+        result.Timestamp!.Value.Year.Should().Be(2026);
+        result.Timestamp!.Value.Month.Should().Be(5);
+        result.Timestamp!.Value.Day.Should().Be(31);
+        result.Timestamp!.Value.Offset.Should().Be(TimeSpan.Zero,
+            "Time UTC= is already UTC; the trailing Timezone Offset applies to chat-local conversion, not Player.log");
+    }
+
+    [Fact]
     public void TryConsumeBanner_NewBannerResetsDate_NoFalseMidnightAdvance()
     {
         var clock = new PlayerLogClock(TimeProvider.System);
 
         clock.TryConsumeBanner(
-            "[14:30:05] Logged in as character Bob. Time UTC=2026-01-15 14:30:05".AsSpan());
+            "[14:30:05] Logged in as character Bob. Time UTC=01/15/2026 14:30:05. Timezone Offset 00:00:00".AsSpan());
         clock.TryParse("[14:30:06] line".AsSpan());
 
         // Re-login: a new banner with an earlier time-of-day on a new date.
         clock.TryConsumeBanner(
-            "[10:00:00] Logged in as character Bob. Time UTC=2026-01-20 10:00:00".AsSpan());
+            "[10:00:00] Logged in as character Bob. Time UTC=01/20/2026 10:00:00. Timezone Offset 00:00:00".AsSpan());
 
         var result = clock.TryParse("[10:00:01] post-relogin".AsSpan());
 
@@ -85,6 +106,58 @@ public class PlayerLogClockTests
         result.Timestamp!.Value.Month.Should().Be(1);
         result.Timestamp!.Value.Day.Should().Be(20,
             "Reset() inside TryConsumeBanner clears _prevTimeOfDay so the earlier HH:MM:SS does not trigger a phantom midnight advance");
+    }
+
+    [Fact]
+    public void EnsureAnchored_LiveLogLastLineAheadOfMtime_DoesNotRollBackADay()
+    {
+        var clock = new PlayerLogClock(TimeProvider.System);
+        var (buffer, lines) = BuildBatch("[12:56:20] first", "[12:56:30] last");
+
+        // Live log: the newest buffered line (12:56:30) is a few seconds ahead
+        // of the file's recorded last-write-time (12:56:25). This must NOT roll
+        // the anchor date back a full day (issue #942, root cause #2).
+        var mtime = new DateTime(2026, 5, 31, 12, 56, 25, DateTimeKind.Utc);
+
+        clock.EnsureAnchored(lines, buffer, () => mtime);
+
+        var result = clock.TryParse("[12:56:31] next".AsSpan());
+
+        result.HasTimestamp.Should().BeTrue();
+        result.Timestamp!.Value.Date.Should().Be(new DateTime(2026, 5, 31),
+            "a live-log last line marginally ahead of the file mtime must not subtract a whole day");
+    }
+
+    [Fact]
+    public void EnsureAnchored_LastLineGenuinelyPriorDay_RollsBackADay()
+    {
+        var clock = new PlayerLogClock(TimeProvider.System);
+        // Last log line late at night; file not written again until well into
+        // the next morning (mtime). The line genuinely belongs to the prior day.
+        var (buffer, lines) = BuildBatch("[23:55:00] late night line");
+        var mtime = new DateTime(2026, 5, 31, 06, 00, 00, DateTimeKind.Utc);
+
+        clock.EnsureAnchored(lines, buffer, () => mtime);
+
+        var result = clock.TryParse("[23:55:01] next".AsSpan());
+
+        result.HasTimestamp.Should().BeTrue();
+        result.Timestamp!.Value.Date.Should().Be(new DateTime(2026, 5, 30),
+            "a last line hours ahead of the mtime time-of-day genuinely belongs to the previous day");
+    }
+
+    private static (char[] buffer, (int Start, int Length)[] lines) BuildBatch(params string[] textLines)
+    {
+        var sb = new System.Text.StringBuilder();
+        var spans = new (int Start, int Length)[textLines.Length];
+        for (var i = 0; i < textLines.Length; i++)
+        {
+            var start = sb.Length;
+            sb.Append(textLines[i]);
+            spans[i] = (start, textLines[i].Length);
+        }
+
+        return (sb.ToString().ToCharArray(), spans);
     }
 
     [Fact]

--- a/tests/Arda.Ingest.Tests/PlayerLogClockTests.cs
+++ b/tests/Arda.Ingest.Tests/PlayerLogClockTests.cs
@@ -70,7 +70,12 @@ public class PlayerLogClockTests
     [Fact]
     public void TryConsumeBanner_CapturedRealBanner_AnchorsToCorrectDate()
     {
-        var clock = new PlayerLogClock(TimeProvider.System);
+        // "now" is deliberately a far-off date so that if banner parsing ever
+        // silently breaks, the wall-clock fallback in TryParse would surface a
+        // 2099 date — keeping this verbatim-capture assertion load-bearing on
+        // any calendar day, not just the day the line was captured (05/31).
+        var clock = new PlayerLogClock(new FixedUtcTimeProvider(
+            new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero)));
 
         // Verbatim line captured from a live Player.log (issue #942).
         clock.TryConsumeBanner(
@@ -158,6 +163,11 @@ public class PlayerLogClockTests
         }
 
         return (sb.ToString().ToCharArray(), spans);
+    }
+
+    private sealed class FixedUtcTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #942.

## Problem

`PlayerLogClock` anchored Player.log lines to the **wrong UTC date** (one day behind), producing a steady **~86,400 s (24 h)** "drift" in the shell status bar / Palantir World Health while the game was **live and connected**. Diagnosed from a real session log — the time-of-day tracked wall-clock live and the offset was correct (`+00:00`); only the **date** was stale (`05/30` while it was `05/31`).

## Root causes

1. **Banner format mismatch (primary).** `TryConsumeBanner` expected `YYYY-MM-DD HH:MM:SS` (dashes), but the game emits the login banner via invariant-culture `DateTime.ToString()` — `MM/dd/yyyy HH:mm:ss` (slashes, month-first):
   ```
   [12:55:00] Logged in as character Emraell. Time UTC=05/31/2026 12:55:00. Timezone Offset 01:00:00
   ```
   The structural check failed at `stamp[4]`, silently discarding the authoritative date anchor. Now parsed via `DateTime.TryParseExact` against the real format.

2. **mtime fallback off-by-one (secondary).** With the banner gone, the fallback's bare `lastTimeOfDay > mtime.TimeOfDay` check subtracted a whole day whenever a live log's newest buffered line was a few seconds ahead of a lagging mtime. Now compares the candidate datetime against mtime with a **1 h tolerance** — live-log lag no longer rolls back a day, while a genuine prior-day last line (hours ahead) still does.

## Why tests didn't catch it

`PlayerLogClockTests` and `BatchProcessorTests` fed the dashes format the game never emits — green tests, broken reality. Updated to the **captured real banner line**.

## Tests

- `TryConsumeBanner` parses the real `MM/dd/yyyy HH:mm:ss` slash format → anchors to the correct date (RED before fix).
- Captured verbatim banner regression test.
- `EnsureAnchored`: live-log last line a few seconds ahead of mtime → date **not** rolled back a day (RED before fix); genuine prior-day last line (hours ahead) → still rolls back.
- `BatchProcessorTests` banner-wins-over-mtime (mtime forced to 2027, asserts banner's 2026) — end-to-end proof the banner is now consumed.

Full solution build clean (warnings-as-errors); Arda.Ingest (53), Arda.Hosting replay-determinism (13), Samwise world-clock determinism (3) all green.

## Verification owed

Re-run against live PG and confirm the status-bar Player drift sits at <2 s (matching Chat), not ~86,400 s.
