### PR TITLE
fix(map-calibration): wire IAssetExtractor + icon-cache bootstrap so the sidecar runs (#945)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -165,6 +165,22 @@ public static partial class CaptureServiceCollectionExtensions
             sp.GetRequiredService<ILoggerFactory>().CreateLogger("Mithril.MapCalibration.Capture.Trigger")));
         services.AddHostedService(sp => sp.GetRequiredService<AutoCalibrationTrigger>());
 
+        // #945 Gap 3: one-time icon-template cache bootstrap. The engine's cache-miss
+        // path only requests per-area textures, so nothing ever runs the sidecar's
+        // --icons mode and IconTemplateSet stays Empty. This hosted service runs
+        // --icons once on startup when the icon cache isn't yet populated. NEXT-LAUNCH
+        // semantics by design: IconTemplateSet is resolved once at startup (when the
+        // hosted services are constructed), so the populated cache takes in-memory
+        // effect on the SUBSEQUENT launch — see IconTemplateBootstrap's class doc.
+        // Fail-soft: no exe / GameRoot empty / non-zero exit → no icons, no throw.
+        services.AddSingleton<IconTemplateBootstrap>(sp => new IconTemplateBootstrap(
+            sp.GetRequiredService<IAssetExtractor>(),
+            sp.GetRequiredService<GameConfig>(),
+            assetCacheDir,
+            pgVersion,
+            sp.GetRequiredService<ILoggerFactory>().CreateLogger("Mithril.MapCalibration.Capture.IconBootstrap")));
+        services.AddHostedService(sp => sp.GetRequiredService<IconTemplateBootstrap>());
+
         return services;
     }
 

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,6 +18,27 @@ namespace Mithril.MapCalibration.Capture.DependencyInjection;
 /// </summary>
 public static partial class CaptureServiceCollectionExtensions
 {
+    /// <summary>
+    /// File name of the out-of-process asset-extractor sidecar (issue #931), as
+    /// produced by <c>tools/Mithril.AssetExtractor</c>'s
+    /// <c>&lt;AssemblyName&gt;mithril-asset-extract&lt;/AssemblyName&gt;</c> and
+    /// published next to <c>Mithril.exe</c> in both pack variants
+    /// (<c>release.yml</c> "Publish asset-extractor sidecar"). Resolved at runtime
+    /// relative to <see cref="AppContext.BaseDirectory"/> (the install dir holding
+    /// the shell). Exposed so the wiring test can assert the same path the
+    /// registration builds.
+    /// </summary>
+    public const string AssetExtractorExeName = "mithril-asset-extract.exe";
+
+    /// <summary>
+    /// Hard upper bound on a single sidecar run. The sidecar decodes one area's
+    /// base texture or the full icon set from the on-disk PG bundles; on a healthy
+    /// install both complete in a couple of seconds, but a cold disk / large bundle
+    /// / contended IO can stretch that. 60s is generous headroom that still kills a
+    /// genuinely hung child (the timeout fail-softs to "no texture" → gate rejects).
+    /// </summary>
+    private static readonly TimeSpan AssetExtractorTimeout = TimeSpan.FromSeconds(60);
+
     /// <summary>
     /// Wire the auto-capture pipeline. <paramref name="assetCacheDir"/> is the
     /// out-of-process asset-extractor sidecar cache the #931 base-texture +
@@ -80,6 +103,21 @@ public static partial class CaptureServiceCollectionExtensions
             sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
             sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.References")));
         services.AddSingleton<IMapCalibrationSolver, MapCalibrationSolveEngineAdapter>();
+
+        // #945 Gap 1: the out-of-process asset-extractor sidecar adapter the engine
+        // invokes on a base-texture cache-miss (AutoCalibrationEngine resolves this
+        // via the optional sp.GetService<IAssetExtractor>() below — it returned null
+        // until this registration existed, so the cache never populated). Registered
+        // BEFORE the engine for logical ordering (DI lambdas are lazy, so strict
+        // order isn't required for correctness). BCL-only (System.Diagnostics.Process)
+        // — the decoder stays out-of-process (#921), the only link is the process
+        // boundary. Registered UNCONDITIONALLY (no File.Exists gate): when the exe is
+        // absent (dev/F5), ProcessAssetExtractor.ExtractAsync fail-softs with
+        // ExitMissingExe rather than throwing, so the graph stays deterministic.
+        services.AddSingleton<IAssetExtractor>(sp => new ProcessAssetExtractor(
+            exePath: Path.Combine(AppContext.BaseDirectory, AssetExtractorExeName),
+            timeout: AssetExtractorTimeout,
+            logger: sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.AssetExtractor")));
 
         // The orchestrator. Resolved as both the concrete type (for the hotkey +
         // DI test) and the narrow IAutoCalibrationRunner seam.

--- a/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
+++ b/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Mithril.MapCalibration.Detection;

--- a/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
+++ b/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Detection;
+using Mithril.Shared.Game;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// #945 Gap 3 — one-time icon-template cache bootstrap. The engine's
+/// base-texture cache-miss path only ever requests <see cref="ExtractKind.Texture"/>
+/// (per-area); nothing requests <see cref="ExtractKind.Icons"/>, so the icon cache
+/// stays empty and <see cref="IconTemplateSet"/> loads as
+/// <see cref="IconTemplateSet.Empty"/> forever — icon detections never happen. This
+/// hosted service runs the sidecar's <c>--icons</c> mode once, on startup, when the
+/// icon cache is not yet populated, so the manifest+blob land on disk.
+///
+/// <para><b>Trigger semantics — NEXT-LAUNCH (option b, by design).</b>
+/// <see cref="IconTemplateSet"/> is resolved <i>once, eagerly</i> by the
+/// <c>AddSingleton&lt;IconTemplateSet&gt;</c> lambda in
+/// <c>AddMithrilMapCalibrationEngine</c> (via
+/// <c>BundledIconTemplateLoader.LoadFromDirectory</c>). All hosted services —
+/// including this one and <see cref="AutoCalibrationTrigger"/> — are <i>constructed</i>
+/// when the host materialises the <c>IEnumerable&lt;IHostedService&gt;</c> at
+/// startup, and constructing <see cref="AutoCalibrationTrigger"/> resolves
+/// <c>IAutoCalibrationRunner</c> → <see cref="AutoCalibrationEngine"/> →
+/// <see cref="IconTemplateSet"/>. So by the time this service's
+/// <see cref="StartAsync"/> can finish populating the cache, the
+/// <see cref="IconTemplateSet"/> singleton may already have been resolved as
+/// <see cref="IconTemplateSet.Empty"/>. We therefore deliberately do NOT try to
+/// guarantee same-session in-memory effect (that would require a fragile
+/// construction-ordering assumption or a reload-aware template holder). Instead:
+/// <b>this run populates the cache; the next app launch loads the populated cache
+/// into <see cref="IconTemplateSet"/>.</b> Acceptance "icon templates populate via
+/// the --icons trigger" is satisfied at the <i>cache</i> level on this run, with the
+/// in-memory icon-detection effect taking hold on the subsequent launch.</para>
+///
+/// <para><b>Fire-and-forget StartAsync.</b> The extraction runs on a background task
+/// so it never blocks host startup (the sidecar can take seconds on a cold disk).
+/// Failure is irrelevant to startup — it's a cache warm-up.</para>
+///
+/// <para><b>Fail-soft (preserved end-to-end).</b> No exe / empty
+/// <see cref="GameConfig.GameRoot"/> / non-zero exit / timeout / crash → no icons,
+/// no throw, no crash. The bootstrap is skipped entirely when the cache is already
+/// populated (manifest present) so it runs at most once per fresh cache.</para>
+/// </summary>
+public sealed class IconTemplateBootstrap : IHostedService, IDisposable
+{
+    private readonly IAssetExtractor _extractor;
+    private readonly GameConfig _gameConfig;
+    private readonly string _assetCacheDir;
+    private readonly string? _pgVersion;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _cts = new();
+
+    private Task? _bootstrap;
+
+    public IconTemplateBootstrap(
+        IAssetExtractor extractor,
+        GameConfig gameConfig,
+        string assetCacheDir,
+        string? pgVersion,
+        ILogger logger)
+    {
+        _extractor = extractor;
+        _gameConfig = gameConfig;
+        _assetCacheDir = assetCacheDir;
+        _pgVersion = pgVersion;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Fire-and-forget: warming the icon cache must not block host startup. Run
+        // under a private CTS (not the startup token, which signals startup-abort and
+        // doesn't fire on shutdown) so StopAsync can cancel an in-flight extraction.
+        _bootstrap = Task.Run(() => RunOnceAsync(_cts.Token), _cts.Token);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Best-effort: cancel an in-flight extraction and wait briefly for it to
+        // unwind so we don't leave a dangling child past host shutdown. Any fault /
+        // cancellation is swallowed — RunOnceAsync is already fail-soft.
+        _cts.Cancel();
+        if (_bootstrap is { } b)
+        {
+            try { await b.WaitAsync(cancellationToken).ConfigureAwait(false); }
+            catch { /* cancelled / faulted / shutdown-token tripped — nothing to do */ }
+        }
+    }
+
+    /// <summary>
+    /// The bootstrap decision + extraction, extracted for unit testing. Decides
+    /// whether to invoke the sidecar's <c>--icons</c> mode and, if so, runs it
+    /// fail-soft. Returns <c>true</c> iff the sidecar was invoked (regardless of
+    /// the sidecar's own success/failure), <c>false</c> when skipped by a gate.
+    /// </summary>
+    internal async Task<bool> RunOnceAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(_gameConfig.GameRoot))
+        {
+            _logger.LogInformation(
+                "Icon-template bootstrap skipped: PG install root not configured (GameConfig.GameRoot empty). Safe-degrade.");
+            return false;
+        }
+
+        // Already populated? The manifest's presence is the populated-cache signal
+        // (IconTemplateCache reads the sidecar's icon-templates.json). Re-running the
+        // sidecar on every launch would be wasted IO + a pointless child process.
+        if (IconTemplateCache.IsPopulated(_assetCacheDir, _logger))
+        {
+            _logger.LogInformation(
+                "Icon-template cache already populated at {CacheDir}; skipping --icons bootstrap.", _assetCacheDir);
+            return false;
+        }
+
+        _logger.LogInformation(
+            "Icon-template cache empty at {CacheDir}; invoking asset-extractor sidecar (--icons). "
+            + "Icons take effect on the next app launch (the IconTemplateSet singleton is loaded once at startup).",
+            _assetCacheDir);
+
+        try
+        {
+            var request = new ExtractRequest(
+                InstallRoot: _gameConfig.GameRoot,
+                OutDir: _assetCacheDir,
+                Kind: ExtractKind.Icons,
+                AreaKey: null,
+                ExpectPgVersion: _pgVersion);
+            var result = await _extractor.ExtractAsync(request, ct).ConfigureAwait(false);
+            if (result.Ok)
+            {
+                _logger.LogInformation(
+                    "Icon-template bootstrap populated the cache ({Count} artifact(s)); icons engage on next launch.",
+                    result.Artifacts.Count);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Icon-template bootstrap: sidecar failed (exit {Exit}): {Error}. Icons stay disabled (safe-degrade).",
+                    result.ExitCode, result.Error);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Icon-template bootstrap cancelled (host shutdown).");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Icon-template bootstrap threw; icons stay disabled (safe-degrade).");
+        }
+
+        return true;
+    }
+
+    public void Dispose() => _cts.Dispose();
+}

--- a/src/Mithril.MapCalibration/Detection/IconTemplateCache.cs
+++ b/src/Mithril.MapCalibration/Detection/IconTemplateCache.cs
@@ -14,11 +14,12 @@ namespace Mithril.MapCalibration.Detection;
 public static class IconTemplateCache
 {
     /// <summary>
-    /// True iff <paramref name="cacheDir"/> holds a readable, non-empty icon-template
-    /// manifest — i.e. the sidecar's <c>--icons</c> mode has already populated it.
-    /// Used to make the bootstrap run at most once per fresh cache (don't re-launch
-    /// the sidecar on every app start). Fail-soft: any read/parse error reads as
-    /// "not populated".
+    /// True iff <paramref name="cacheDir"/> holds a readable icon-template manifest
+    /// with a recorded pixel hash — i.e. the sidecar's <c>--icons</c> mode has already
+    /// run. This is a "has the sidecar produced a manifest yet?" gate, not a validation
+    /// of icon count or manifest contents. Used to make the bootstrap run at most once
+    /// per fresh cache (don't re-launch the sidecar on every app start). Fail-soft: any
+    /// read/parse error reads as "not populated".
     /// </summary>
     public static bool IsPopulated(string cacheDir, ILogger? logger = null) =>
         BundledIconTemplateLoader.ManifestPixelSha256(cacheDir, logger) is not null;

--- a/src/Mithril.MapCalibration/Detection/IconTemplateCache.cs
+++ b/src/Mithril.MapCalibration/Detection/IconTemplateCache.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Detection.Internal;
+
+namespace Mithril.MapCalibration.Detection;
+
+/// <summary>
+/// Public probe over the on-disk icon-template cache the out-of-process
+/// asset-extractor sidecar populates (issue #931). Lets a consumer (the #945
+/// icon-template bootstrap in the Capture layer) ask "is the icon cache already
+/// populated?" without taking a dependency on the internal manifest filename /
+/// loader. The cache format itself (manifest + blob) stays owned by
+/// <see cref="Internal.BundledIconTemplateLoader"/>.
+/// </summary>
+public static class IconTemplateCache
+{
+    /// <summary>
+    /// True iff <paramref name="cacheDir"/> holds a readable, non-empty icon-template
+    /// manifest — i.e. the sidecar's <c>--icons</c> mode has already populated it.
+    /// Used to make the bootstrap run at most once per fresh cache (don't re-launch
+    /// the sidecar on every app start). Fail-soft: any read/parse error reads as
+    /// "not populated".
+    /// </summary>
+    public static bool IsPopulated(string cacheDir, ILogger? logger = null) =>
+        BundledIconTemplateLoader.ManifestPixelSha256(cacheDir, logger) is not null;
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -1,12 +1,14 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Arda.Contracts;
 using Arda.World.Player;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Mithril.MapCalibration.Capture.DependencyInjection;
 using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.MapCalibration.Detection;
 using Mithril.Overlay;
 using Mithril.Shared.Game;
 using Mithril.Shared.Hotkeys;
@@ -29,8 +31,72 @@ public sealed class CaptureDependencyInjectionTests
     [Fact]
     public void Auto_capture_pipeline_resolves_from_a_built_provider()
     {
+        using var provider = BuildProvider(out _);
+
+        provider.GetRequiredService<AutoCalibrationEngine>().Should().NotBeNull();
+
+        var hotkeys = provider.GetServices<IHotkeyCommand>().ToList();
+        hotkeys.Should().Contain(h => h.Id == "mapcalibration.capture");
+        hotkeys.Should().Contain(h => h.Id == "mapcalibration.draw_bbox");
+
+        // The GameConfig-wired gate must win over the engine's default gate
+        // (last-registration-wins): a residual of 9.5 exceeds the configured 9.0.
+        var gate = provider.GetRequiredService<Detection.ICalibrationConfidenceGate>();
+        gate.Accept(new AreaCalibration(1, 0, 0, 0, 8, 9.5), 8, out _).Should().BeFalse();
+
+        provider.GetRequiredService<AutoCalibrationTrigger>().Should().NotBeNull();
+        provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .Should().Contain(s => s is AutoCalibrationTrigger);
+    }
+
+    /// <summary>
+    /// #945 Gap 1: the asset-extractor sidecar adapter is registered, so a
+    /// base-texture cache-miss in <see cref="AutoCalibrationEngine"/> can actually
+    /// invoke the sidecar (previously <c>GetService&lt;IAssetExtractor&gt;()</c>
+    /// returned null and the cache-miss path short-circuited, so the cache never
+    /// populated). It registers unconditionally (no File.Exists gate): the
+    /// fail-soft when the exe is absent lives in <see cref="ProcessAssetExtractor"/>.
+    /// </summary>
+    [Fact]
+    public void IAssetExtractor_is_registered_as_the_process_sidecar_adapter()
+    {
+        using var provider = BuildProvider(out _);
+
+        var extractor = provider.GetRequiredService<IAssetExtractor>();
+        extractor.Should().BeOfType<ProcessAssetExtractor>();
+    }
+
+    /// <summary>
+    /// #945 Gap 1: the engine actually receives the registered extractor (not the
+    /// optional <c>null</c> default). The engine resolves it the identical way the
+    /// DI lambda does (<c>sp.GetService&lt;IAssetExtractor&gt;()</c>), so asserting
+    /// the private field is non-null proves the cache-miss → sidecar path is live.
+    /// Reflection is used here deliberately: there is no public accessor for the
+    /// optional collaborator and a wiring test wants to prove the field, not behaviour.
+    /// </summary>
+    [Fact]
+    public void Engine_receives_the_registered_asset_extractor()
+    {
+        using var provider = BuildProvider(out _);
+
+        var engine = provider.GetRequiredService<AutoCalibrationEngine>();
+        var field = typeof(AutoCalibrationEngine)
+            .GetField("_assetExtractor", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull("the engine holds the optional sidecar extractor in a private field");
+        field!.GetValue(engine).Should().BeOfType<ProcessAssetExtractor>();
+    }
+
+    /// <summary>
+    /// Builds the full capture graph with faked cross-cutting collaborators, the
+    /// same shape the shell composes (<see cref="ShellComposition"/> calls
+    /// <c>AddMithrilMapCalibrationCapture(assetCacheDir)</c> with the real
+    /// single-arg signature). <c>ValidateOnBuild</c> catches a singleton cycle
+    /// (memory: di_cycle_invisible_to_unit_tests).
+    /// </summary>
+    private static ServiceProvider BuildProvider(out string assetCacheDir)
+    {
         var settingsDir = Path.Combine(Path.GetTempPath(), "mithril-capture-di-" + Guid.NewGuid());
-        var assetCacheDir = Path.Combine(settingsDir, "assets");
+        assetCacheDir = Path.Combine(settingsDir, "assets");
 
         var services = new ServiceCollection();
 
@@ -47,27 +113,14 @@ public sealed class CaptureDependencyInjectionTests
         services.AddSingleton<IReferenceDataService>(new FakeAreaReferenceData());
         services.AddSingleton<IMapCalibrationService>(new FakeCalibrationService());
 
-        services.AddMithrilMapCalibrationCapture(settingsDir, assetCacheDir);
+        // The live single-arg signature is (assetCacheDir, pgVersion = null). Passing
+        // just the cache dir mirrors ShellComposition.AddMithrilMapCalibrationCapture.
+        services.AddMithrilMapCalibrationCapture(assetCacheDir);
 
-        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        return services.BuildServiceProvider(new ServiceProviderOptions
         {
             ValidateOnBuild = true,
             ValidateScopes = true,
         });
-
-        provider.GetRequiredService<AutoCalibrationEngine>().Should().NotBeNull();
-
-        var hotkeys = provider.GetServices<IHotkeyCommand>().ToList();
-        hotkeys.Should().Contain(h => h.Id == "mapcalibration.capture");
-        hotkeys.Should().Contain(h => h.Id == "mapcalibration.draw_bbox");
-
-        // The GameConfig-wired gate must win over the engine's default gate
-        // (last-registration-wins): a residual of 9.5 exceeds the configured 9.0.
-        var gate = provider.GetRequiredService<Detection.ICalibrationConfidenceGate>();
-        gate.Accept(new AreaCalibration(1, 0, 0, 0, 8, 9.5), 8, out _).Should().BeFalse();
-
-        provider.GetRequiredService<AutoCalibrationTrigger>().Should().NotBeNull();
-        provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
-            .Should().Contain(s => s is AutoCalibrationTrigger);
     }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Arda.Contracts;
 using Arda.World.Player;
@@ -47,6 +45,12 @@ public sealed class CaptureDependencyInjectionTests
         provider.GetRequiredService<AutoCalibrationTrigger>().Should().NotBeNull();
         provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
             .Should().Contain(s => s is AutoCalibrationTrigger);
+
+        // #945 Gap 3: the one-time icon-template bootstrap is also a hosted service.
+        // Asserts the AddHostedService line survives (guards a future regression that
+        // drops it, leaving IconTemplateSet permanently Empty).
+        provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .Should().Contain(s => s is IconTemplateBootstrap);
     }
 
     /// <summary>

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading;
-using System.Threading.Tasks;
 using Arda.Contracts;
 using Arda.World.Player;
 using Mithril.MapCalibration;

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -99,6 +99,33 @@ internal sealed class SpySolver : IMapCalibrationSolver
     }
 }
 
+/// <summary>
+/// Records each <see cref="IAssetExtractor.ExtractAsync"/> call and returns a
+/// configurable canned result, so the icon bootstrap's decision logic can be
+/// tested headless (no real exe). Defaults to a success with no artifacts.
+/// </summary>
+internal sealed class RecordingAssetExtractor : IAssetExtractor
+{
+    private readonly ExtractResult _result;
+    public RecordingAssetExtractor(ExtractResult? result = null) =>
+        _result = result ?? new ExtractResult(true, 0, Array.Empty<ExtractedArtifact>(), null);
+
+    public List<ExtractRequest> Calls { get; } = new();
+
+    public Task<ExtractResult> ExtractAsync(ExtractRequest request, CancellationToken ct)
+    {
+        Calls.Add(request);
+        return Task.FromResult(_result);
+    }
+}
+
+/// <summary>An extractor whose ExtractAsync throws — proves the bootstrap fail-softs.</summary>
+internal sealed class ThrowingAssetExtractor : IAssetExtractor
+{
+    public Task<ExtractResult> ExtractAsync(ExtractRequest request, CancellationToken ct) =>
+        throw new InvalidOperationException("boom");
+}
+
 internal sealed class FakeCalibrationService : IMapCalibrationService
 {
     private readonly Dictionary<string, AreaCalibration> _prior = new(StringComparer.Ordinal);

--- a/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
@@ -1,8 +1,4 @@
-using System;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Mithril.MapCalibration.Capture;

--- a/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mithril.MapCalibration.Capture;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.MapCalibration.Detection;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// #945 Gap 3: the icon-template bootstrap's decision logic, tested headless over a
+/// fake <see cref="IAssetExtractor"/> + a temp cache dir (no real exe). Covers the
+/// four gates: empty cache + GameRoot set → invokes <c>--icons</c>; cache already
+/// populated → skips; GameRoot empty → skips; extractor failure/throw → no throw.
+/// </summary>
+public sealed class IconTemplateBootstrapTests : IDisposable
+{
+    private readonly string _cacheDir;
+
+    public IconTemplateBootstrapTests()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), "mithril-iconboot-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_cacheDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_cacheDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private IconTemplateBootstrap Build(IAssetExtractor extractor, string gameRoot, string? cacheDir = null) =>
+        new(extractor,
+            new GameConfig { GameRoot = gameRoot },
+            cacheDir ?? _cacheDir,
+            pgVersion: null,
+            NullLogger.Instance);
+
+    private void WritePopulatedManifest()
+    {
+        // A minimal valid manifest (camelCase, schema-versioned, non-empty Icons +
+        // pixelSha256) is all IconTemplateCache.IsPopulated needs to read "populated".
+        var json =
+            "{\"schemaVersion\":1,\"pixelSha256\":\"deadbeef\"," +
+            "\"icons\":[{\"name\":\"x\",\"landmarkType\":\"Cave\",\"pivotX\":0,\"pivotY\":0,\"width\":1,\"height\":1}]}";
+        File.WriteAllText(Path.Combine(_cacheDir, "icon-templates.json"), json);
+    }
+
+    [Fact]
+    public async Task Empty_cache_with_game_root_invokes_icons_extraction()
+    {
+        var extractor = new RecordingAssetExtractor();
+        var sut = Build(extractor, gameRoot: @"C:\Games\PG");
+
+        var invoked = await sut.RunOnceAsync(CancellationToken.None);
+
+        invoked.Should().BeTrue();
+        extractor.Calls.Should().ContainSingle();
+        var call = extractor.Calls.Single();
+        call.Kind.Should().Be(ExtractKind.Icons);
+        call.InstallRoot.Should().Be(@"C:\Games\PG");
+        call.OutDir.Should().Be(_cacheDir);
+        call.AreaKey.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Already_populated_cache_does_not_invoke()
+    {
+        WritePopulatedManifest();
+        var extractor = new RecordingAssetExtractor();
+        var sut = Build(extractor, gameRoot: @"C:\Games\PG");
+
+        var invoked = await sut.RunOnceAsync(CancellationToken.None);
+
+        invoked.Should().BeFalse();
+        extractor.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Empty_game_root_does_not_invoke()
+    {
+        var extractor = new RecordingAssetExtractor();
+        var sut = Build(extractor, gameRoot: "");
+
+        var invoked = await sut.RunOnceAsync(CancellationToken.None);
+
+        invoked.Should().BeFalse();
+        extractor.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Extractor_failure_does_not_throw()
+    {
+        var failing = new RecordingAssetExtractor(
+            new ExtractResult(false, ProcessAssetExtractor.ExitMissingExe, Array.Empty<ExtractedArtifact>(), "no exe"));
+        var sut = Build(failing, gameRoot: @"C:\Games\PG");
+
+        var invoked = await sut.RunOnceAsync(CancellationToken.None);
+
+        // The sidecar WAS invoked (it's the gate that decides invocation, not the
+        // sidecar's success); the failure is swallowed fail-soft.
+        invoked.Should().BeTrue();
+        failing.Calls.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Extractor_throwing_is_swallowed_fail_soft()
+    {
+        var sut = Build(new ThrowingAssetExtractor(), gameRoot: @"C:\Games\PG");
+
+        var act = async () => await sut.RunOnceAsync(CancellationToken.None);
+
+        // The throw is caught inside RunOnceAsync; it still reports "invoked".
+        (await act.Should().NotThrowAsync()).Which.Should().BeTrue();
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Mithril.MapCalibration.Detection;
 using Xunit;

--- a/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
@@ -137,6 +137,29 @@ public sealed class ProcessAssetExtractorTests : IDisposable
     }
 
     [Fact]
+    public async Task Sidecar_resolved_beside_the_host_fail_softs_when_absent()
+    {
+        // #945 Gap 1/2 contract: the Capture DI registers the extractor with
+        // exePath = Path.Combine(AppContext.BaseDirectory, "mithril-asset-extract.exe").
+        // In dev/F5 (and this test host) the sidecar isn't published beside the
+        // binary, so that path doesn't exist. The registration is unconditional
+        // (no File.Exists gate) precisely because this path fail-softs: assert it
+        // returns ExitMissingExe and does NOT throw, so the DI graph stays
+        // deterministic and the engine safe-degrades ("preparing map assets…").
+        var exePath = Path.Combine(AppContext.BaseDirectory, "mithril-asset-extract.exe");
+        File.Exists(exePath).Should().BeFalse("the sidecar isn't published beside the test host");
+
+        var sut = new ProcessAssetExtractor(exePath, TimeSpan.FromSeconds(5),
+            launcher: (_, _) => throw new InvalidOperationException("launcher must not run when the exe is absent"));
+
+        var result = await sut.ExtractAsync(
+            new ExtractRequest("C:/PG", "C:/cache", ExtractKind.Texture, "AreaSerbule", null), CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.ExitCode.Should().Be(ProcessAssetExtractor.ExitMissingExe);
+    }
+
+    [Fact]
     public async Task Caller_cancellation_propagates_as_OperationCanceled()
     {
         using var cts = new CancellationTokenSource();


### PR DESCRIPTION
## What this fixes

Map auto-calibration could never populate its asset cache, so a solve could never succeed (no icon templates / no base texture → no detections → confidence gate rejects). Three wiring gaps from #945, all fail-soft-preserving:

### Gap 1 — `IAssetExtractor` was never registered (the core fix)
`AutoCalibrationEngine` already invokes `_assetExtractor.ExtractAsync(...)` on a base-texture cache-miss, and the Capture DI already resolved `assetExtractor: sp.GetService<IAssetExtractor>()` — but **nothing registered it**, so it resolved `null` and the cache-miss path short-circuited.

Now `AddMithrilMapCalibrationCapture` registers `ProcessAssetExtractor`:
- exe resolved next to the shell via `Path.Combine(AppContext.BaseDirectory, "mithril-asset-extract.exe")` (a named `const AssetExtractorExeName`, matching the `tools/Mithril.AssetExtractor` `AssemblyName`).
- 60s timeout (justified in a comment: one area's texture / the full icon set decodes in seconds on a healthy install; 60s is headroom that still kills a hung child).
- Registered **unconditionally** — `ProcessAssetExtractor.ExtractAsync` already fail-softs with `ExitMissingExe` when the exe is absent (dev/F5), so no `File.Exists` gate; keeps the DI graph deterministic.
- BCL-only (`System.Diagnostics.Process`); the decoder stays out-of-process (#921). No new `src/** → tools/` reference.

Also reconciled the stale two-arg `AddMithrilMapCalibrationCapture(settingsDir, assetCacheDir)` DI-test call with the live `(assetCacheDir, pgVersion = null)` signature (it was silently passing `settingsDir` as the cache dir and `assetCacheDir` as the pg-version).

### Gap 3 — icon `--icons` bootstrap
The engine's cache-miss path only requests `ExtractKind.Texture` (per-area), so the sidecar's `--icons` mode was never invoked and `IconTemplateSet` stayed `Empty`. Added `IconTemplateBootstrap`, a hosted service that runs `--icons` once on startup when the icon cache isn't yet populated.

**Design choice: NEXT-LAUNCH semantics (option b), chosen deliberately.**
`IconTemplateSet` is resolved **once, eagerly**, by the `AddSingleton<IconTemplateSet>` lambda. All hosted services are *constructed* when the host materializes the `IEnumerable<IHostedService>` at startup, and constructing `AutoCalibrationTrigger` resolves `IAutoCalibrationRunner → AutoCalibrationEngine → IconTemplateSet`. So a cache populated by this service's `StartAsync` may land *after* `IconTemplateSet` was already resolved as `Empty`. Rather than depend on a fragile hosted-service **construction-ordering** assumption (option a) or add a reload-aware template holder (option c), the bootstrap **populates the cache on this run; the populated cache loads into `IconTemplateSet` on the next launch.** Acceptance "icon templates populate via the `--icons` trigger" is satisfied at the *cache* level on this run, with the in-memory icon-detection effect taking hold on the subsequent launch. This is documented loudly in the class doc, the DI registration comment, and the startup log line.

Gates: runs iff `GameConfig.GameRoot` is non-empty AND the icon manifest is absent (via new public `IconTemplateCache.IsPopulated`, a thin facade over the internal manifest probe so the Capture layer doesn't depend on the internal loader/filename). Fire-and-forget `StartAsync` (never blocks host startup); `StopAsync` cancels + best-effort awaits the in-flight run. Fail-soft: no exe / empty GameRoot / non-zero exit / timeout / throw → no icons, no throw.

### Gap 2 — sidecar bundling: verified, no change
`release.yml` already publishes `tools/Mithril.AssetExtractor` (`AssemblyName = mithril-asset-extract` → `mithril-asset-extract.exe`) into **both** `publish/selfcontained` and `publish/fxdep` (steps "Publish asset-extractor sidecar (selfcontained)" / "(fxdep)"), each **before** that dir's `vpk pack --packDir`. vpk sweeps the pack dir flat, so the exe lands next to `Mithril.exe`, and `AppContext.BaseDirectory` at runtime is the install dir holding the shell. No defect found → **release.yml unchanged.**

## Tests
- `CaptureDependencyInjectionTests`:
  - fixed stale two-arg call → live single-arg signature.
  - `IAssetExtractor_is_registered_as_the_process_sidecar_adapter` — resolves non-null, is `ProcessAssetExtractor`.
  - `Engine_receives_the_registered_asset_extractor` — reflection over the engine's private `_assetExtractor` proves it's wired (not the optional `null` default).
- `ProcessAssetExtractorTests.Sidecar_resolved_beside_the_host_fail_softs_when_absent` — `AppContext.BaseDirectory` + exe name → `ExitMissingExe`, no throw.
- `IconTemplateBootstrapTests` (5): empty cache + GameRoot → invokes `Kind=Icons` with the right args; already-populated → skips; empty GameRoot → skips; extractor failure → no throw; extractor throw → swallowed.

Build: `dotnet build Mithril.slnx` clean (0 warnings, warnings-as-errors). `dotnet test Mithril.slnx`: all map-calibration projects green (Capture 78, MapCalibration 90, Shell 54, Legolas 528, Overlay 46). Two intermittent failures observed on full-suite runs (`Mithril.Shared.Tests` icon-CDN-preload progress race; `Samwise.Tests`) are pre-existing environmental flakes — both pass in isolation and on re-run, neither touches code in this PR (cross-assembly FileIO/parallel races documented in `release.yml`).

## Manual verify owed
The actual sidecar launch + cache population + a real solve can only be verified against a **live PG install** (the asset-decode path is intentionally un-CI'd, consistent with the offline tools). Owed: confirm on a real install that a base-texture cache-miss logs `"invoking asset-extractor sidecar"`, the sidecar runs and writes a hash-verified texture, the icon bootstrap populates `icon-templates.{json,bin}`, and (next launch) `IconTemplateSet` loads non-empty and a calibration solves. Tracked alongside #938.

Closes #945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
