### PR TITLE
feat(diagnostics): unify logs under Shell\logs\ + add clear/open buttons (#946)

### DIFF
--- a/src/Mithril.Shared/Diagnostics/DiagnosticsLogSerilog.cs
+++ b/src/Mithril.Shared/Diagnostics/DiagnosticsLogSerilog.cs
@@ -57,10 +57,20 @@ internal static class DiagnosticsLogSerilog
     public static LogEventLevel MapMel(MelLogLevel level) => Map(Map(level));
 
     /// <summary>
-    /// Renames pre-rebrand <c>gorgon-*.json</c> diagnostic files to <c>mithril-*.json</c>.
+    /// Migrates pre-rebrand log artifacts into the unified <c>logs\</c> directory:
+    /// <list type="bullet">
+    /// <item>renames pre-rebrand <c>gorgon-*.json</c> diagnostic files to <c>mithril-*-prebrand.json</c>;</item>
+    /// <item>moves the old root-level <c>boot.log</c>/<c>crash.log</c> (which used to live in the
+    /// parent <c>Shell\</c> directory) into <c>logs\</c> as <c>mithril-boot-prebrand.log</c> /
+    /// <c>mithril-crash-prebrand.log</c>, never clobbering the live <c>mithril-boot.log</c>
+    /// the current run may already have written.</item>
+    /// </list>
+    /// Idempotent and per-file fault tolerant.
     /// </summary>
     internal static void MigrateLegacyLogFiles(Action<DiagnosticLevel, string, string> write, string logDirectory)
     {
+        MigrateLegacyRootLogFiles(write, logDirectory);
+
         IEnumerable<string> legacy;
         try
         {
@@ -91,6 +101,41 @@ internal static class DiagnosticsLogSerilog
             {
                 write(DiagnosticLevel.Warn, "SerilogSink",
                     $"Failed to migrate legacy log file {src}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Moves the pre-unification root-level <c>boot.log</c> / <c>crash.log</c> (formerly written
+    /// directly under <c>Shell\</c>) into the unified <c>logs\</c> directory under a non-clashing
+    /// <c>mithril-{name}-prebrand.log</c> name. The old files used append-per-write (open/close),
+    /// so they are not locked and can be moved.
+    /// </summary>
+    private static void MigrateLegacyRootLogFiles(Action<DiagnosticLevel, string, string> write, string logDirectory)
+    {
+        var parentDir = Path.GetDirectoryName(logDirectory);
+        if (string.IsNullOrEmpty(parentDir))
+            return;
+
+        foreach (var legacyName in new[] { "boot.log", "crash.log" })
+        {
+            var src = Path.Combine(parentDir, legacyName);
+            if (!File.Exists(src))
+                continue;
+
+            try
+            {
+                var stem = Path.GetFileNameWithoutExtension(legacyName);
+                var ext = Path.GetExtension(legacyName);
+                var target = ResolveNonClashingTarget(logDirectory, stem, ext);
+                File.Move(src, target);
+                write(DiagnosticLevel.Info, "SerilogSink",
+                    $"Moved legacy log file {legacyName} -> {Path.GetFileName(target)}");
+            }
+            catch (Exception ex)
+            {
+                write(DiagnosticLevel.Warn, "SerilogSink",
+                    $"Failed to migrate legacy root log file {src}: {ex.Message}");
             }
         }
     }

--- a/src/Mithril.Shared/Diagnostics/DiagnosticsLoggerProvider.cs
+++ b/src/Mithril.Shared/Diagnostics/DiagnosticsLoggerProvider.cs
@@ -36,8 +36,14 @@ public sealed class DiagnosticsLoggerProvider : ILoggerProvider, IDiagnosticsLog
     {
         _capacity = capacity;
         Directory.CreateDirectory(logDirectory);
-        DiagnosticsLogSerilog.MigrateLegacyLogFiles(Publish, logDirectory);
+        // Create the file logger BEFORE migrating, so the migration's Publish() calls have a
+        // live _fileLogger to write to. (Publish dereferences _fileLogger unconditionally; if
+        // migration runs first and emits any Info/Warn — as the boot.log/crash.log sweep does —
+        // a null _fileLogger would throw out of this ctor and abort host build.) Migration only
+        // touches legacy gorgon-*/boot/crash files, never the live mithril-.json this logger
+        // opens, so ordering it after CreateFileLogger is safe.
         _fileLogger = DiagnosticsLogSerilog.CreateFileLogger(logDirectory, enrichers);
+        DiagnosticsLogSerilog.MigrateLegacyLogFiles(Publish, logDirectory);
     }
 
     public IObservable<DiagnosticEntry> Live => _live;

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -33,7 +33,7 @@ public static class Program
 
     private static readonly string BootLogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Mithril", "Shell", "boot.log");
+        "Mithril", "Shell", "logs", "mithril-boot.log");
 
     /// <summary>
     /// Drop-off file the second instance uses to hand an activation URI (e.g. <c>mithril://item/X</c>)
@@ -360,9 +360,9 @@ public static class Program
         {
             var dir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Mithril", "Shell");
+                "Mithril", "Shell", "logs");
             Directory.CreateDirectory(dir);
-            File.AppendAllText(Path.Combine(dir, "crash.log"),
+            File.AppendAllText(Path.Combine(dir, "mithril-crash.log"),
                 $"\n=== {DateTime.Now:s} ===\n{ex}\n");
         }
         catch { }

--- a/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
@@ -1,4 +1,10 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using Mithril.Shared.Wpf.Dialogs;
 
 namespace Mithril.Shell.ViewModels;
 
@@ -11,9 +17,17 @@ namespace Mithril.Shell.ViewModels;
 /// Hosts the Telemetry sub-section VM (<see cref="TelemetrySettingsViewModel"/>)
 /// as a composed child so the Diagnostics page renders both perf-trace
 /// controls and the OTLP export configuration in one place — see mithril#815.
+///
+/// Also hosts the log-maintenance commands (clear diagnostics logs / clear all
+/// logs / open the log folder). Files currently held open — the live
+/// <c>mithril-.json</c> (Serilog <c>shared:false</c>), <c>mithril-boot.log</c>,
+/// and an active perf session — are skipped and clear on next restart.
 /// </summary>
 public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
 {
+    private readonly IDialogService _dialogs;
+    private readonly ILogger _logger;
+
     public ShellSettings Settings { get; }
 
     /// <summary>
@@ -25,17 +39,114 @@ public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
     /// </summary>
     public TelemetrySettingsViewModel Telemetry { get; }
 
-    public DiagnosticsSettingsViewModel(ShellSettings settings, TelemetrySettingsViewModel telemetry)
+    public DiagnosticsSettingsViewModel(
+        ShellSettings settings,
+        TelemetrySettingsViewModel telemetry,
+        IDialogService dialogs,
+        ILoggerFactory loggerFactory)
     {
         Settings = settings;
         Telemetry = telemetry;
+        _dialogs = dialogs;
+        _logger = loggerFactory.CreateLogger("Diagnostics");
     }
 
     /// <summary>The folder where perf-trace sessions land. Surfaced so the
     /// settings UI can offer a "Show me" button without duplicating the
     /// path-derivation logic from <c>Program.Main</c>.</summary>
-    public string PerfDirectoryHint =>
-        System.IO.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Mithril", "Shell", "perf");
+    public string PerfDirectoryHint => PerfDirectory;
+
+    /// <summary>The unified log directory (<c>…\Mithril\Shell\logs</c>). Mirrors
+    /// <see cref="PerfDirectoryHint"/> — surfaced for display and the
+    /// "Open log directory" command.</summary>
+    public string LogDirectoryHint => LogDirectory;
+
+    private static string ShellDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Mithril", "Shell");
+
+    private static string LogDirectory => Path.Combine(ShellDirectory, "logs");
+
+    private static string PerfDirectory => Path.Combine(ShellDirectory, "perf");
+
+    /// <summary>Outcome of the most recent clear command, shown beneath the buttons.</summary>
+    [ObservableProperty]
+    private string _maintenanceStatus = string.Empty;
+
+    /// <summary>
+    /// Deletes the rolling diagnostics stream (<c>logs\mithril-*.json</c>) only.
+    /// Leaves <c>mithril-boot.log</c> / <c>mithril-crash.log</c> (different
+    /// extension) and the perf sessions untouched.
+    /// </summary>
+    [RelayCommand]
+    private void ClearMithrilLogs()
+    {
+        if (!_dialogs.Confirm(
+                "Clear Mithril logs",
+                "Delete the rolling diagnostics logs (mithril-*.json) in the log folder?\n\n" +
+                "Boot and crash logs are kept. Files currently in use stay until the next restart."))
+            return;
+
+        var result = LogDirectoryCleaner.Clean(new[]
+        {
+            new LogDirectoryCleaner.CleanTarget(LogDirectory, "mithril-*.json"),
+        });
+        ReportClean("diagnostics logs", result);
+    }
+
+    /// <summary>
+    /// Deletes everything in <c>logs\</c> (<c>*.json</c> + <c>*.log</c>) plus the
+    /// perf-session files in <c>perf\</c>. Superset of <see cref="ClearMithrilLogsCommand"/>.
+    /// Files held open are skipped.
+    /// </summary>
+    [RelayCommand]
+    private void ClearAllLogs()
+    {
+        if (!_dialogs.Confirm(
+                "Clear all logs",
+                "This removes ALL diagnostics and boot/crash logs in the log folder " +
+                "(mithril-*.json and *.log) AND every saved performance-trace session.\n\n" +
+                "Files currently in use (the active diagnostics log, the boot log, and any " +
+                "running perf session) stay until the next restart.\n\nContinue?"))
+            return;
+
+        var result = LogDirectoryCleaner.Clean(new[]
+        {
+            new LogDirectoryCleaner.CleanTarget(LogDirectory, "*.json"),
+            new LogDirectoryCleaner.CleanTarget(LogDirectory, "*.log"),
+            new LogDirectoryCleaner.CleanTarget(PerfDirectory, "*"),
+        });
+        ReportClean("all logs", result);
+    }
+
+    /// <summary>Opens the unified log directory in the OS file browser. No confirmation.</summary>
+    [RelayCommand]
+    private void OpenLogDirectory()
+    {
+        try
+        {
+            Directory.CreateDirectory(LogDirectory);
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = LogDirectory,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to open log directory {LogDirectory}", LogDirectory);
+            MaintenanceStatus = $"Could not open {LogDirectory}: {ex.Message}";
+        }
+    }
+
+    private void ReportClean(string what, LogDirectoryCleaner.CleanResult result)
+    {
+        _logger.LogInformation(
+            "Cleared {What}: {Removed} removed, {Skipped} skipped (in use)",
+            what, result.Removed, result.Skipped);
+
+        MaintenanceStatus = result.Skipped == 0
+            ? $"Removed {result.Removed} file(s)."
+            : $"Removed {result.Removed} file(s); {result.Skipped} in use (kept until restart).";
+    }
 }

--- a/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
@@ -19,9 +19,12 @@ namespace Mithril.Shell.ViewModels;
 /// controls and the OTLP export configuration in one place — see mithril#815.
 ///
 /// Also hosts the log-maintenance commands (clear diagnostics logs / clear all
-/// logs / open the log folder). Files currently held open — the live
-/// <c>mithril-.json</c> (Serilog <c>shared:false</c>), <c>mithril-boot.log</c>,
-/// and an active perf session — are skipped and clear on next restart.
+/// logs / open the log folder). The only files held open at runtime — the live
+/// diagnostics log (<c>mithril-&lt;date&gt;.json</c>, Serilog <c>shared:false</c>)
+/// and, while recording, the active perf-session file — are skipped and clear on
+/// next restart. <c>mithril-boot.log</c> is written line-by-line with
+/// <c>File.AppendAllText</c> (not held open), so it IS deleted by "Clear all
+/// logs" and simply re-created on the next launch.
 /// </summary>
 public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
 {
@@ -106,8 +109,9 @@ public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
                 "Clear all logs",
                 "This removes ALL diagnostics and boot/crash logs in the log folder " +
                 "(mithril-*.json and *.log) AND every saved performance-trace session.\n\n" +
-                "Files currently in use (the active diagnostics log, the boot log, and any " +
-                "running perf session) stay until the next restart.\n\nContinue?"))
+                "The active diagnostics log (and the perf session, if you're recording) " +
+                "is held open and stays until the next restart. The boot log is recreated " +
+                "on the next launch.\n\nContinue?"))
             return;
 
         var result = LogDirectoryCleaner.Clean(new[]

--- a/src/Mithril.Shell/ViewModels/LogDirectoryCleaner.cs
+++ b/src/Mithril.Shell/ViewModels/LogDirectoryCleaner.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mithril.Shell.ViewModels;
+
+/// <summary>
+/// Per-file deletion helper shared by the Settings → Diagnostics "Clear logs"
+/// commands. Deletes the files matched by a set of (directory, glob) pairs,
+/// skipping any file currently held open (Serilog opens the live diagnostics
+/// file with <c>shared:false</c>; <c>mithril-boot.log</c> and an active perf
+/// session may also be locked). Locked / inaccessible files are skipped
+/// individually rather than aborting the whole sweep.
+/// </summary>
+internal static class LogDirectoryCleaner
+{
+    public readonly record struct CleanResult(int Removed, int Skipped);
+
+    /// <summary>A directory + glob pattern to sweep. Missing directories are ignored.</summary>
+    public readonly record struct CleanTarget(string Directory, string Pattern);
+
+    /// <summary>
+    /// Attempts to delete every file matched by <paramref name="targets"/>. Returns the
+    /// count removed vs. skipped (locked / inaccessible). Never throws for a per-file
+    /// failure; enumeration failure of a whole directory is also swallowed (directory
+    /// simply contributes nothing).
+    /// </summary>
+    public static CleanResult Clean(IEnumerable<CleanTarget> targets)
+    {
+        var removed = 0;
+        var skipped = 0;
+
+        foreach (var target in targets)
+        {
+            IEnumerable<string> files;
+            try
+            {
+                if (!Directory.Exists(target.Directory))
+                    continue;
+                files = Directory.EnumerateFiles(target.Directory, target.Pattern, SearchOption.TopDirectoryOnly);
+            }
+            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException) { continue; }
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    File.Delete(file);
+                    removed++;
+                }
+                catch (IOException)
+                {
+                    // File is held open (e.g. the live mithril-.json, mithril-boot.log,
+                    // or an active perf session). Leave it; it clears on next restart.
+                    skipped++;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    skipped++;
+                }
+            }
+        }
+
+        return new CleanResult(removed, skipped);
+    }
+}

--- a/src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml
+++ b/src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml
@@ -54,6 +54,44 @@
                        FontSize="{DynamicResource AppFontSizeHint}"
                        Text="Changes preview live. Settings persist on shutdown."/>
 
+            <!-- Log maintenance -->
+            <Border Margin="0,24,0,0" Padding="0,16,0,0" BorderThickness="0,1,0,0" BorderBrush="#22FFFFFF">
+                <StackPanel>
+                    <TextBlock Text="Logs" Foreground="#88FFFFFF" Margin="0,0,0,4" FontWeight="SemiBold"/>
+                    <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8"
+                               Text="All Mithril logs live in one folder. 'Clear Mithril logs' removes only the rolling diagnostics JSON; 'Clear all logs' also removes boot/crash logs and saved performance-trace sessions. Files in use stay until restart."/>
+
+                    <TextBlock TextWrapping="Wrap" Foreground="#66FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"
+                               Text="Log folder:"/>
+                    <TextBlock TextWrapping="Wrap" Foreground="#AAFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               FontFamily="Consolas, Cascadia Mono"
+                               Text="{Binding LogDirectoryHint}" Margin="0,0,0,12"/>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <Button Content="Clear Mithril logs" Padding="10,4" Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                ToolTip="Delete the rolling diagnostics logs (mithril-*.json). Files in use stay until restart."
+                                Command="{Binding ClearMithrilLogsCommand}"/>
+                        <Button Content="Clear all logs" Padding="10,4" Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                ToolTip="Delete all logs (diagnostics, boot, crash) and saved perf-trace sessions. Files in use stay until restart."
+                                Command="{Binding ClearAllLogsCommand}"/>
+                        <Button Content="Open log directory" Padding="10,4"
+                                VerticalAlignment="Center"
+                                ToolTip="Open the log folder in File Explorer."
+                                Command="{Binding OpenLogDirectoryCommand}"/>
+                    </StackPanel>
+
+                    <TextBlock TextWrapping="Wrap" Foreground="#AAD4A847"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Text="{Binding MaintenanceStatus}"
+                               Visibility="{Binding MaintenanceStatus, Converter={StaticResource NullOrEmptyToVis}}"/>
+                </StackPanel>
+            </Border>
+
             <!-- Telemetry export (OTLP) sub-section. The VM is always registered
                  (ShellComposition adds fallback scrubber-graph singletons when
                  OTLP export is off), so this expander is always available — letting

--- a/tests/Mithril.Shared.Tests/Diagnostics/SerilogDiagnosticsSinkMigrationTests.cs
+++ b/tests/Mithril.Shared.Tests/Diagnostics/SerilogDiagnosticsSinkMigrationTests.cs
@@ -111,4 +111,127 @@ public class DiagnosticsLogSerilogMigrationTests
         entries.Should().Contain(e =>
             e.Level == DiagnosticLevel.Warn && e.Category == "SerilogSink");
     }
+
+    /// <summary>
+    /// Creates a <c>…\Shell\logs</c> directory inside a fresh temp root and returns
+    /// the logs path. The parent (<c>…\Shell</c>) is where legacy root-level
+    /// <c>boot.log</c>/<c>crash.log</c> historically lived.
+    /// </summary>
+    private static (string Parent, string LogsDir) FreshShellWithLogs()
+    {
+        var parent = Path.Combine(Path.GetTempPath(), $"mithril-shell-{Guid.NewGuid():N}");
+        var logsDir = Path.Combine(parent, "logs");
+        Directory.CreateDirectory(logsDir);
+        return (parent, logsDir);
+    }
+
+    [Fact]
+    public void Moves_Legacy_Root_BootLog_And_CrashLog_Into_Logs_Dir()
+    {
+        var (parent, logsDir) = FreshShellWithLogs();
+        try
+        {
+            File.WriteAllText(Path.Combine(parent, "boot.log"), "boot");
+            File.WriteAllText(Path.Combine(parent, "crash.log"), "crash");
+
+            DiagnosticsLogSerilog.MigrateLegacyLogFiles((_, _, _) => { }, logsDir);
+
+            File.Exists(Path.Combine(parent, "boot.log")).Should().BeFalse();
+            File.Exists(Path.Combine(parent, "crash.log")).Should().BeFalse();
+
+            File.Exists(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().BeTrue();
+            File.Exists(Path.Combine(logsDir, "mithril-crash-prebrand.log")).Should().BeTrue();
+            File.ReadAllText(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().Be("boot");
+            File.ReadAllText(Path.Combine(logsDir, "mithril-crash-prebrand.log")).Should().Be("crash");
+        }
+        finally { Directory.Delete(parent, recursive: true); }
+    }
+
+    [Fact]
+    public void Does_Not_Clobber_Live_Mithril_BootLog()
+    {
+        var (parent, logsDir) = FreshShellWithLogs();
+        try
+        {
+            // The current run has already written the live boot log.
+            File.WriteAllText(Path.Combine(logsDir, "mithril-boot.log"), "live");
+            File.WriteAllText(Path.Combine(parent, "boot.log"), "old");
+
+            DiagnosticsLogSerilog.MigrateLegacyLogFiles((_, _, _) => { }, logsDir);
+
+            File.Exists(Path.Combine(parent, "boot.log")).Should().BeFalse();
+            File.ReadAllText(Path.Combine(logsDir, "mithril-boot.log")).Should().Be("live");
+            File.Exists(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().BeTrue();
+            File.ReadAllText(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().Be("old");
+        }
+        finally { Directory.Delete(parent, recursive: true); }
+    }
+
+    [Fact]
+    public void Disambiguates_When_Prebrand_BootLog_Target_Already_Exists()
+    {
+        var (parent, logsDir) = FreshShellWithLogs();
+        try
+        {
+            File.WriteAllText(Path.Combine(logsDir, "mithril-boot-prebrand.log"), "previous-attempt");
+            File.WriteAllText(Path.Combine(parent, "boot.log"), "old");
+
+            DiagnosticsLogSerilog.MigrateLegacyLogFiles((_, _, _) => { }, logsDir);
+
+            File.Exists(Path.Combine(parent, "boot.log")).Should().BeFalse();
+            File.ReadAllText(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().Be("previous-attempt");
+            File.Exists(Path.Combine(logsDir, "mithril-boot-prebrand_001.log")).Should().BeTrue();
+            File.ReadAllText(Path.Combine(logsDir, "mithril-boot-prebrand_001.log")).Should().Be("old");
+        }
+        finally { Directory.Delete(parent, recursive: true); }
+    }
+
+    [Fact]
+    public void Is_Idempotent_When_No_Legacy_Root_Files_Present()
+    {
+        var (parent, logsDir) = FreshShellWithLogs();
+        try
+        {
+            var entries = new List<(DiagnosticLevel Level, string Category, string Message)>();
+            void Capture(DiagnosticLevel level, string category, string message) =>
+                entries.Add((level, category, message));
+
+            DiagnosticsLogSerilog.MigrateLegacyLogFiles(Capture, logsDir);
+            DiagnosticsLogSerilog.MigrateLegacyLogFiles(Capture, logsDir);
+
+            File.Exists(Path.Combine(parent, "boot.log")).Should().BeFalse();
+            File.Exists(Path.Combine(parent, "crash.log")).Should().BeFalse();
+            entries.Should().NotContain(e => e.Level == DiagnosticLevel.Warn);
+        }
+        finally { Directory.Delete(parent, recursive: true); }
+    }
+
+    /// <summary>
+    /// Regression: the migration runs inside the <see cref="DiagnosticsLoggerProvider"/> ctor and
+    /// reports each move via <c>Publish</c>, which dereferences the Serilog file logger. If the
+    /// file logger is not yet constructed when the migration emits its first line, the ctor throws
+    /// and aborts host build. This exercises the real ctor with a legacy root <c>boot.log</c>
+    /// present (which forces a Publish during migration) and asserts it neither throws nor leaves
+    /// the legacy file behind.
+    /// </summary>
+    [Fact]
+    public void Provider_Ctor_Migrates_Root_BootLog_Without_Throwing()
+    {
+        var (parent, logsDir) = FreshShellWithLogs();
+        try
+        {
+            File.WriteAllText(Path.Combine(parent, "boot.log"), "old-boot");
+
+            var act = () =>
+            {
+                using var provider = new DiagnosticsLoggerProvider(logsDir);
+            };
+
+            act.Should().NotThrow();
+            File.Exists(Path.Combine(parent, "boot.log")).Should().BeFalse();
+            File.Exists(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().BeTrue();
+            File.ReadAllText(Path.Combine(logsDir, "mithril-boot-prebrand.log")).Should().Be("old-boot");
+        }
+        finally { Directory.Delete(parent, recursive: true); }
+    }
 }

--- a/tests/Mithril.Shell.Tests/LogDirectoryCleanerTests.cs
+++ b/tests/Mithril.Shell.Tests/LogDirectoryCleanerTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Mithril.Shell.ViewModels;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+public sealed class LogDirectoryCleanerTests
+{
+    private static string FreshDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mithril-cleaner-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Deletes_Only_Matching_Pattern()
+    {
+        var dir = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "mithril-20260101.json"), "a");
+            File.WriteAllText(Path.Combine(dir, "mithril-20260102.json"), "b");
+            File.WriteAllText(Path.Combine(dir, "mithril-boot.log"), "boot");
+            File.WriteAllText(Path.Combine(dir, "mithril-crash.log"), "crash");
+
+            var result = LogDirectoryCleaner.Clean(new[]
+            {
+                new LogDirectoryCleaner.CleanTarget(dir, "mithril-*.json"),
+            });
+
+            result.Removed.Should().Be(2);
+            result.Skipped.Should().Be(0);
+            Directory.GetFiles(dir, "*.json").Should().BeEmpty();
+            // .log files untouched
+            File.Exists(Path.Combine(dir, "mithril-boot.log")).Should().BeTrue();
+            File.Exists(Path.Combine(dir, "mithril-crash.log")).Should().BeTrue();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Deletes_All_Logs_And_Perf_Across_Multiple_Targets()
+    {
+        var logs = FreshDir();
+        var perf = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(logs, "mithril-20260101.json"), "a");
+            File.WriteAllText(Path.Combine(logs, "mithril-boot.log"), "boot");
+            File.WriteAllText(Path.Combine(logs, "mithril-crash.log"), "crash");
+            File.WriteAllText(Path.Combine(perf, "session-1.jsonl"), "p1");
+            File.WriteAllText(Path.Combine(perf, "session-2.jsonl"), "p2");
+
+            var result = LogDirectoryCleaner.Clean(new[]
+            {
+                new LogDirectoryCleaner.CleanTarget(logs, "*.json"),
+                new LogDirectoryCleaner.CleanTarget(logs, "*.log"),
+                new LogDirectoryCleaner.CleanTarget(perf, "*"),
+            });
+
+            result.Removed.Should().Be(5);
+            result.Skipped.Should().Be(0);
+            Directory.GetFiles(logs).Should().BeEmpty();
+            Directory.GetFiles(perf).Should().BeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(logs, recursive: true);
+            Directory.Delete(perf, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Skips_Locked_File_Without_Throwing()
+    {
+        var dir = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "free.json"), "x");
+            var lockedPath = Path.Combine(dir, "locked.json");
+            File.WriteAllText(lockedPath, "y");
+
+            // Hold the file open with no sharing, mirroring Serilog's shared:false handle.
+            using (var held = new FileStream(lockedPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                var result = LogDirectoryCleaner.Clean(new[]
+                {
+                    new LogDirectoryCleaner.CleanTarget(dir, "*.json"),
+                });
+
+                result.Removed.Should().Be(1);
+                result.Skipped.Should().Be(1);
+                File.Exists(Path.Combine(dir, "free.json")).Should().BeFalse();
+                File.Exists(lockedPath).Should().BeTrue();
+            }
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Missing_Directory_Contributes_Nothing()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"mithril-cleaner-missing-{Guid.NewGuid():N}");
+
+        var result = LogDirectoryCleaner.Clean(new[]
+        {
+            new LogDirectoryCleaner.CleanTarget(missing, "*"),
+        });
+
+        result.Removed.Should().Be(0);
+        result.Skipped.Should().Be(0);
+    }
+}


### PR DESCRIPTION
Closes #946.

Unifies all Mithril log files under one directory and adds log-maintenance buttons to the Diagnostics settings panel. Delivered as two commits.

## Commit 1 — Unify log files under `Shell\logs\` with a `mithril-` prefix

| Was | Becomes |
|---|---|
| `…\Shell\boot.log` | `…\Shell\logs\mithril-boot.log` |
| `…\Shell\crash.log` | `…\Shell\logs\mithril-crash.log` |
| `…\Shell\logs\mithril-<date>.json` | unchanged |

- `Program.BootLogPath` and `ShowFatal` repoint into `logs\`; their existing `Directory.CreateDirectory` calls create the dir automatically.
- `MigrateLegacyLogFiles` now sweeps the old root-level `boot.log`/`crash.log` into `logs\` as `mithril-boot-prebrand.log` / `mithril-crash-prebrand.log` via the existing non-clashing target resolver, so the live `mithril-boot.log` this run may already have written is never clobbered. Per-file try/catch, idempotent.
- **Latent bug fixed:** the provider ctor ran `MigrateLegacyLogFiles` (which `Publish`es per move) *before* constructing the Serilog file logger, so the first migration line dereferenced a null `_fileLogger` and threw out of the ctor — aborting host build. Reordered so the file logger is created first. (This was previously unexercised because no `gorgon-*` files remained to migrate; the new boot/crash sweep is the first code to `Publish` during migration.)

## Commit 2 — Three log-maintenance buttons in Settings → Diagnostics

- **Clear Mithril logs** → deletes `logs\mithril-*.json` only.
- **Clear all logs** → deletes all of `logs\` (`*.json` + `*.log`) plus `perf\*`.
- **Open log directory** → opens `logs\` in File Explorer (no prompt).

Both clear commands gate on `IDialogService.Confirm` (the "Clear all logs" prompt spells out what it removes). Deletion runs through a shared `LogDirectoryCleaner` that deletes per-file, catching `IOException`/`UnauthorizedAccessException` individually so files held open (live `mithril-.json` opened `shared:false`, `mithril-boot.log`, an active perf session) are skipped without crashing. Outcome is logged via `ILoggerFactory.CreateLogger("Diagnostics")` and shown as status text. The VM ctor gains `IDialogService` + `ILoggerFactory` (both already registered); `--selfcheck` confirms the DI graph still resolves.

## Tests
- Extended `DiagnosticsLogSerilogMigrationTests`: root boot/crash move, live `mithril-boot.log` not clobbered, `_NNN` disambiguation, idempotent-when-absent, plus a provider-ctor regression test for the null-`_fileLogger` ordering bug.
- New `LogDirectoryCleanerTests`: pattern scoping, multi-target superset, locked-file skip, missing-dir no-op.
- `dotnet build Mithril.slnx` + `dotnet test Mithril.slnx` both green (full suite).

## Verification owed / done — boot logging after relocation: **DONE**
Verified live, not just by reasoning. Launched the freshly-built shell against a real `%LocalAppData%\Mithril\Shell` that had legacy root `boot.log`/`crash.log`:
- New live `mithril-boot.log` written at the new `logs\` path ✓
- Root `boot.log` → `logs\mithril-boot-prebrand.log` (byte-exact) ✓
- Root `crash.log` → `logs\mithril-crash-prebrand.log` (byte-exact) ✓
- Shell boots without crashing (confirms the ctor-ordering fix) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
