### PR TITLE
fix(map-calibration): stage asset-extractor sidecar next to shell on local builds (#951)

### DIFF
--- a/src/Mithril.Shell/Mithril.Shell.csproj
+++ b/src/Mithril.Shell/Mithril.Shell.csproj
@@ -124,4 +124,61 @@
           DestinationFolder="$(PublishDir)modules"
           SkipUnchangedFiles="true" />
   </Target>
+
+  <!--
+    #951: stage the out-of-process asset-extractor sidecar (mithril-asset-extract.exe)
+    next to Mithril.exe on local/dev builds. The sidecar lives in
+    tools/Mithril.AssetExtractor (in Mithril.MapCalibration.Tools.slnx, NOT Mithril.slnx),
+    so a normal Shell build never produces it — yet ProcessAssetExtractor resolves it via
+    Path.Combine(AppContext.BaseDirectory, "mithril-asset-extract.exe") and fail-softs
+    ExitMissingExe when it's absent, blocking local auto-calibration testing (#938).
+
+    We publish it OUT-OF-BAND (Exec dotnet publish) and copy the single produced exe into
+    $(OutDir). This is deliberately NOT a <ProjectReference>: a reference from src/** to the
+    sidecar / Tools.Common would drag AssetsTools.NET + System.Drawing into the shipped graph
+    and trip ShippedGraphDecoderFreeTests (#921). Copy, never reference. Published
+    framework-dependent single-file (fast inner loop, one self-contained artifact, no loose
+    decoder DLLs polluting the shell output dir); release.yml keeps its own self-contained
+    single-file publish for shipped packs.
+
+    Gated off in CI (GITHUB_ACTIONS) so the test pipeline and release.yml — which has its own
+    explicit sidecar publish steps — don't double-publish. Incremental via Inputs/Outputs:
+    skipped entirely when the staged exe is newer than every sidecar source. Fail-soft: the
+    Exec is ContinueOnError so a contributor without the tools just gets no exe (safe-degrade),
+    never a broken Shell build.
+  -->
+  <!-- Gate property: distinct name from the target below by convention.
+       Override with -p:StageAssetExtractorSidecarEnabled=false. -->
+  <PropertyGroup>
+    <StageAssetExtractorSidecarEnabled Condition="'$(StageAssetExtractorSidecarEnabled)' == '' and '$(GITHUB_ACTIONS)' != 'true'">true</StageAssetExtractorSidecarEnabled>
+    <StageAssetExtractorSidecarEnabled Condition="'$(StageAssetExtractorSidecarEnabled)' == ''">false</StageAssetExtractorSidecarEnabled>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(StageAssetExtractorSidecarEnabled)' == 'true'">
+    <_AssetExtractorSrc Include="$(MSBuildThisFileDirectory)..\..\tools\Mithril.AssetExtractor\**\*.cs;$(MSBuildThisFileDirectory)..\..\tools\Mithril.AssetExtractor\*.csproj"
+                        Exclude="$(MSBuildThisFileDirectory)..\..\tools\Mithril.AssetExtractor\**\bin\**;$(MSBuildThisFileDirectory)..\..\tools\Mithril.AssetExtractor\**\obj\**" />
+    <_AssetExtractorSrc Include="$(MSBuildThisFileDirectory)..\..\tools\Mithril.MapCalibration.Tools.Common\**\*.cs;$(MSBuildThisFileDirectory)..\..\tools\Mithril.MapCalibration.Tools.Common\*.csproj"
+                        Exclude="$(MSBuildThisFileDirectory)..\..\tools\Mithril.MapCalibration.Tools.Common\**\bin\**;$(MSBuildThisFileDirectory)..\..\tools\Mithril.MapCalibration.Tools.Common\**\obj\**" />
+    <_AssetExtractorSrc Include="$(MSBuildThisFileDirectory)..\Mithril.MapCalibration\**\*.cs;$(MSBuildThisFileDirectory)..\Mithril.MapCalibration\*.csproj"
+                        Exclude="$(MSBuildThisFileDirectory)..\Mithril.MapCalibration\**\bin\**;$(MSBuildThisFileDirectory)..\Mithril.MapCalibration\**\obj\**" />
+  </ItemGroup>
+
+  <Target Name="StageAssetExtractorSidecar"
+          AfterTargets="Build"
+          Condition="'$(StageAssetExtractorSidecarEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true'"
+          Inputs="@(_AssetExtractorSrc)"
+          Outputs="$(OutDir)mithril-asset-extract.exe">
+    <Message Importance="high" Text="Staging asset-extractor sidecar (fxdep single-file) → $(OutDir)" />
+    <Exec ContinueOnError="true"
+          Command="dotnet publish &quot;$(MSBuildThisFileDirectory)..\..\tools\Mithril.AssetExtractor\Mithril.AssetExtractor.csproj&quot; -c $(Configuration) -r win-x64 --self-contained false -p:PublishSingleFile=true -o &quot;$(IntermediateOutputPath)assetextractor&quot;" />
+    <ItemGroup>
+      <_StagedSidecarExe Include="$(IntermediateOutputPath)assetextractor\mithril-asset-extract.exe" />
+    </ItemGroup>
+    <Copy Condition="'@(_StagedSidecarExe)' != ''"
+          SourceFiles="@(_StagedSidecarExe)"
+          DestinationFolder="$(OutDir)"
+          SkipUnchangedFiles="true" />
+    <Warning Condition="!Exists('$(IntermediateOutputPath)assetextractor\mithril-asset-extract.exe')"
+             Text="asset-extractor sidecar was not produced; auto-calibration will safe-degrade locally (ExitMissingExe). Build tools/Mithril.MapCalibration.Tools.slnx if you need it." />
+  </Target>
 </Project>


### PR DESCRIPTION
## What & why

Closes #951. Local/dev builds never staged `mithril-asset-extract.exe` next to the shell, so `ProcessAssetExtractor` resolved it via `AppContext.BaseDirectory`, found nothing, and fail-softed `ExitMissingExe` — auto-calibration couldn't run locally (blocking manual testing in #938). The sidecar lives in `tools/Mithril.AssetExtractor` (`Mithril.MapCalibration.Tools.slnx`, **not** `Mithril.slnx`), so a normal Shell build never built it; only `release.yml` published it into the Velopack packs.

## Change

One file: `src/Mithril.Shell/Mithril.Shell.csproj` gains a `StageAssetExtractorSidecar` target (`AfterTargets="Build"`) that publishes the sidecar **out-of-band** (`Exec dotnet publish`, framework-dependent single-file) and copies the one exe into `$(OutDir)`. Because `scripts/start.ps1` and F5 both run a Shell build, this single mechanism covers every local path — no separate start.ps1 step to drift.

- **Copy, never reference** — no `ProjectReference` from `src/**` to the sidecar / `Tools.Common`, so `AssetsTools.NET`/`System.Drawing` stay out of the shipped graph and `ShippedGraphDecoderFreeTests` (#921) stays green. Single-file publish keeps loose decoder DLLs out of the shell output dir.
- **Incremental** via `Inputs`/`Outputs` — skipped when the staged exe is newer than every sidecar source.
- **CI-gated** (`GITHUB_ACTIONS`) so the test pipeline and `release.yml` (which has its own explicit sidecar publish) don't double-publish.
- **Fail-soft** (`Exec ContinueOnError` + `<Warning>`) — a contributor without the tools built just gets no exe, never a broken Shell build.

## Verification (via `dotnet build Mithril.slnx`)

- ✅ Build green (0 errors); target runs; `mithril-asset-extract.exe` staged beside `Mithril.exe`.
- ✅ Incremental: no-change rebuild skips staging ("up-to-date"); re-stages when exe is missing or sidecar source changes.
- ✅ CI gate: `GITHUB_ACTIONS=true` → target skipped, exe not staged.
- ✅ #921 guard passes; 0 loose `AssetsTools*` / `System.Drawing.Common` DLLs in the output dir.

## Notes

- Acceptance "sidecar actually invoked at runtime (log shows success, not `ExitMissingExe`)" requires a live PG install + a cache-miss/icon-bootstrap trigger — that's the #938 manual-verify task. This PR delivers the "exe present locally" prerequisite.
- Building `Mithril.Shell.csproj` *directly* (not via the slnx) can surface a pre-existing `NETSDK1004` on `XamlResourceLint` (the lint subproject is restored as part of `Mithril.slnx`, what `scripts/start.ps1` runs — not by a direct csproj build). Unrelated to this change.

Related: #945/#948 (registration + bootstrap), #931 (sidecar), #938 (manual verify — unblocked locally), #914 (engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
