### PR TITLE
fix(map-calibration): per-attempt icon-template provider for first-session solve (#949)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -28,6 +28,14 @@ namespace Mithril.MapCalibration.Capture;
 /// the sidecar once to populate the cache, then retry the provider. If still
 /// null, fail-soft with a "preparing map assets…" reason (no texture → no
 /// detections → gate rejects → safe-degrade).</para>
+///
+/// <para><b>Icon-template policy (#949).</b> Icon templates resolve from
+/// <see cref="IIconTemplateProvider"/> <i>per attempt</i> (it re-reads the cache
+/// each call — the icon analogue of the base-texture provider). On an empty set and
+/// when an <see cref="IAssetExtractor"/> is wired, the sidecar's <c>--icons</c> mode
+/// is demand-triggered once to populate the cache, then the set is re-resolved — so
+/// first-session calibration succeeds on a fresh icon cache without a restart. A
+/// still-empty set fails soft: no typed detections → the gate rejects.</para>
 /// </summary>
 public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
 {
@@ -48,7 +56,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     private readonly IBaseTextureProvider _baseTextures;
     private readonly IAreaReferenceProvider _references;
     private readonly IMapCalibrationSolver _solver;
-    private readonly IconTemplateSet _templates;
+    private readonly IIconTemplateProvider _iconTemplates;
     private readonly IMapCalibrationService _calibrationService;
     private readonly ILogger? _logger;
 
@@ -69,7 +77,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         IBaseTextureProvider baseTextures,
         IAreaReferenceProvider references,
         IMapCalibrationSolver solver,
-        IconTemplateSet templates,
+        IIconTemplateProvider iconTemplates,
         IMapCalibrationService calibrationService,
         ILogger? logger,
         IAssetExtractor? assetExtractor = null,
@@ -85,7 +93,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         _baseTextures = baseTextures;
         _references = references;
         _solver = solver;
-        _templates = templates;
+        _iconTemplates = iconTemplates;
         _calibrationService = calibrationService;
         _logger = logger;
         _assetExtractor = assetExtractor;
@@ -138,11 +146,18 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
 
         var references = _references.ForArea(area);
 
+        // Resolve icon templates per attempt (#949). On a fresh icon cache the
+        // provider returns Empty; if a sidecar is wired, demand-trigger its --icons
+        // mode ONCE to populate the cache, then re-resolve — so first-session
+        // calibration works without a restart. Fail-soft: still-Empty → no typed
+        // detections → the gate rejects → safe-degrade.
+        var templates = await EnsureIconTemplatesAsync(ct).ConfigureAwait(false);
+
         var request = new DetectionRequest(
             Screenshot: gray,
             BaseTexture: baseTexture,
             MapRect: mapRect,
-            Templates: _templates,
+            Templates: templates,
             RimMask: RimMaskMode.DeviationFlood,
             LowNcc: LowNcc,
             TypeFloor: TypeFloor,
@@ -226,6 +241,52 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
                 area);
         }
         return retried;
+    }
+
+    /// <summary>
+    /// #949 policy (icon analogue of <see cref="ResolveBaseTextureAsync"/>). Resolve
+    /// the icon-template set from the per-attempt <see cref="IIconTemplateProvider"/>;
+    /// on an empty set, optionally demand-trigger the sidecar's <c>--icons</c> mode
+    /// once to populate the cache, then re-resolve. Fail-soft to whatever the
+    /// provider returns (Empty included) on any path — never throws into the engine.
+    /// </summary>
+    private async Task<IconTemplateSet> EnsureIconTemplatesAsync(CancellationToken ct)
+    {
+        var templates = _iconTemplates.GetTemplates();
+        if (templates.Templates.Count > 0) return templates;
+
+        if (_assetExtractor is null || _gameConfig is null
+            || string.IsNullOrWhiteSpace(_gameConfig.GameRoot) || string.IsNullOrWhiteSpace(_assetCacheDir))
+        {
+            return templates; // no extractor wired → safe-degrade (Empty → gate rejects)
+        }
+
+        _logger?.LogInformation("Icon-template cache empty; invoking asset-extractor sidecar (--icons) on demand.");
+        try
+        {
+            var request = new ExtractRequest(
+                InstallRoot: _gameConfig.GameRoot,
+                OutDir: _assetCacheDir!,
+                Kind: ExtractKind.Icons,
+                AreaKey: null,
+                ExpectPgVersion: _pgVersion);
+            var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);
+            if (!extract.Ok)
+            {
+                _logger?.LogWarning(
+                    "Asset-extractor sidecar (--icons) failed (exit {Exit}): {Error}. Safe-degrade (no icon detections).",
+                    extract.ExitCode, extract.Error);
+                return templates;
+            }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Asset-extractor sidecar (--icons) threw. Safe-degrade (no icon detections).");
+            return templates;
+        }
+
+        return _iconTemplates.GetTemplates(); // re-resolve after populate
     }
 
     private AutoCalibrationOutcome Fail(string area, string reason)

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -129,7 +129,7 @@ public static partial class CaptureServiceCollectionExtensions
             sp.GetRequiredService<IBaseTextureProvider>(),
             sp.GetRequiredService<IAreaReferenceProvider>(),
             sp.GetRequiredService<IMapCalibrationSolver>(),
-            sp.GetRequiredService<IconTemplateSet>(),
+            sp.GetRequiredService<IIconTemplateProvider>(),
             sp.GetRequiredService<IMapCalibrationService>(),
             sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.Engine"),
             assetExtractor: sp.GetService<IAssetExtractor>(),
@@ -164,13 +164,13 @@ public static partial class CaptureServiceCollectionExtensions
             sp.GetRequiredService<ILoggerFactory>().CreateLogger("Mithril.MapCalibration.Capture.Trigger")));
         services.AddHostedService(sp => sp.GetRequiredService<AutoCalibrationTrigger>());
 
-        // #945 Gap 3: one-time icon-template cache bootstrap. The engine's cache-miss
-        // path only requests per-area textures, so nothing ever runs the sidecar's
-        // --icons mode and IconTemplateSet stays Empty. This hosted service runs
-        // --icons once on startup when the icon cache isn't yet populated. NEXT-LAUNCH
-        // semantics by design: IconTemplateSet is resolved once at startup (when the
-        // hosted services are constructed), so the populated cache takes in-memory
-        // effect on the SUBSEQUENT launch — see IconTemplateBootstrap's class doc.
+        // #945 Gap 3 / #949: non-blocking icon-template cache warm-up. Runs the
+        // sidecar's --icons mode once on startup when the icon cache isn't yet
+        // populated, so the common case has icons ready before the first attempt (no
+        // first-attempt latency). Since #949 made IIconTemplateProvider re-read the
+        // cache per attempt, a same-session populate takes effect immediately — the
+        // engine's own --icons demand-trigger (EnsureIconTemplatesAsync) is the
+        // correctness backstop, and this warm-up is the latency optimisation.
         // Fail-soft: no exe / GameRoot empty / non-zero exit → no icons, no throw.
         services.AddSingleton<IconTemplateBootstrap>(sp => new IconTemplateBootstrap(
             sp.GetRequiredService<IAssetExtractor>(),

--- a/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
+++ b/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
@@ -6,33 +6,20 @@ using Mithril.Shared.Game;
 namespace Mithril.MapCalibration.Capture;
 
 /// <summary>
-/// #945 Gap 3 — one-time icon-template cache bootstrap. The engine's
+/// #945 Gap 3 — non-blocking icon-template cache warm-up. The engine's
 /// base-texture cache-miss path only ever requests <see cref="ExtractKind.Texture"/>
-/// (per-area); nothing requests <see cref="ExtractKind.Icons"/>, so the icon cache
-/// stays empty and <see cref="IconTemplateSet"/> loads as
-/// <see cref="IconTemplateSet.Empty"/> forever — icon detections never happen. This
-/// hosted service runs the sidecar's <c>--icons</c> mode once, on startup, when the
-/// icon cache is not yet populated, so the manifest+blob land on disk.
+/// (per-area); on a fresh install the icon cache starts empty. This hosted service
+/// runs the sidecar's <c>--icons</c> mode once, on startup, when the icon cache is
+/// not yet populated, so the manifest+blob land on disk before the first
+/// calibration attempt.
 ///
-/// <para><b>Trigger semantics — NEXT-LAUNCH (option b, by design).</b>
-/// <see cref="IconTemplateSet"/> is resolved <i>once, eagerly</i> by the
-/// <c>AddSingleton&lt;IconTemplateSet&gt;</c> lambda in
-/// <c>AddMithrilMapCalibrationEngine</c> (via
-/// <c>BundledIconTemplateLoader.LoadFromDirectory</c>). All hosted services —
-/// including this one and <see cref="AutoCalibrationTrigger"/> — are <i>constructed</i>
-/// when the host materialises the <c>IEnumerable&lt;IHostedService&gt;</c> at
-/// startup, and constructing <see cref="AutoCalibrationTrigger"/> resolves
-/// <c>IAutoCalibrationRunner</c> → <see cref="AutoCalibrationEngine"/> →
-/// <see cref="IconTemplateSet"/>. So by the time this service's
-/// <see cref="StartAsync"/> can finish populating the cache, the
-/// <see cref="IconTemplateSet"/> singleton may already have been resolved as
-/// <see cref="IconTemplateSet.Empty"/>. We therefore deliberately do NOT try to
-/// guarantee same-session in-memory effect (that would require a fragile
-/// construction-ordering assumption or a reload-aware template holder). Instead:
-/// <b>this run populates the cache; the next app launch loads the populated cache
-/// into <see cref="IconTemplateSet"/>.</b> Acceptance "icon templates populate via
-/// the --icons trigger" is satisfied at the <i>cache</i> level on this run, with the
-/// in-memory icon-detection effect taking hold on the subsequent launch.</para>
+/// <para><b>Same-session effect (#949).</b> Icon templates resolve via the
+/// per-attempt <see cref="IIconTemplateProvider"/> (it re-reads the cache on every
+/// attempt), so a populate from this warm-up takes effect on the very next attempt
+/// — no app restart. This warm-up is therefore a <i>latency optimisation</i> (have
+/// icons ready before the first attempt), and the engine's own <c>--icons</c>
+/// demand-trigger (<c>AutoCalibrationEngine.EnsureIconTemplatesAsync</c>) is the
+/// correctness backstop if the warm-up hasn't finished by the first attempt.</para>
 ///
 /// <para><b>Fire-and-forget StartAsync.</b> The extraction runs on a background task
 /// so it never blocks host startup (the sidecar can take seconds on a cold disk).
@@ -116,8 +103,8 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
         }
 
         _logger.LogInformation(
-            "Icon-template cache empty at {CacheDir}; invoking asset-extractor sidecar (--icons). "
-            + "Icons take effect on the next app launch (the IconTemplateSet singleton is loaded once at startup).",
+            "Icon-template cache empty at {CacheDir}; invoking asset-extractor sidecar (--icons) warm-up. "
+            + "Icons engage on the next calibration attempt (IIconTemplateProvider re-reads the cache per attempt).",
             _assetCacheDir);
 
         try
@@ -132,7 +119,7 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
             if (result.Ok)
             {
                 _logger.LogInformation(
-                    "Icon-template bootstrap populated the cache ({Count} artifact(s)); icons engage on next launch.",
+                    "Icon-template bootstrap populated the cache ({Count} artifact(s)); icons engage on the next calibration attempt.",
                     result.Artifacts.Count);
             }
             else

--- a/src/Mithril.MapCalibration/DependencyInjection/MapCalibrationServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration/DependencyInjection/MapCalibrationServiceCollectionExtensions.cs
@@ -65,20 +65,26 @@ public static class MapCalibrationServiceCollectionExtensions
     /// <see cref="ICalibrationDetector"/>, the
     /// <see cref="ICalibrationConfidenceGate"/>, the
     /// <see cref="MapCalibrationSolveEngine"/>, the
-    /// <see cref="IconTemplateSet"/> (loaded once from the asset cache dir via
-    /// <c>BundledIconTemplateLoader.LoadFromDirectory</c>), and an
-    /// <see cref="IBaseTextureProvider"/> over the same cache. Independent of
+    /// <see cref="IIconTemplateProvider"/> (a per-attempt
+    /// <see cref="Internal.CachedIconTemplateProvider"/> over the asset cache dir),
+    /// and an <see cref="IBaseTextureProvider"/> over the same cache. Independent of
     /// <see cref="AddMithrilMapCalibration"/> (the persistence registration) —
     /// register either or both.
     ///
     /// <para><b>#931:</b> the icon templates + base textures are no longer shipped
     /// as embedded PG art; the out-of-process asset-extractor sidecar populates
     /// <paramref name="assetCacheDir"/> at runtime and these loaders read it
-    /// BCL-only. When the dir is absent/empty the registrations yield
-    /// <see cref="IconTemplateSet.Empty"/> / a null-returning base-texture
-    /// provider — the intended fail-soft (no detections → gate rejects →
+    /// BCL-only. When the dir is absent/empty the provider yields
+    /// <see cref="IconTemplateSet.Empty"/> / the base-texture provider returns
+    /// null — the intended fail-soft (no detections → gate rejects →
     /// safe-degrade). The optional <paramref name="pgVersion"/> keys the
     /// canonical-hash gate that guards base textures.</para>
+    ///
+    /// <para><b>#949:</b> the icon templates resolve via a <i>per-attempt</i>
+    /// provider (re-reads the cache each call), not an eager singleton, so a
+    /// same-session populate (the engine's <c>--icons</c> demand-trigger or the
+    /// startup warm-up) engages on the next attempt — first-session calibration no
+    /// longer needs a restart.</para>
     /// </summary>
     public static IServiceCollection AddMithrilMapCalibrationEngine(
         this IServiceCollection services,
@@ -88,8 +94,8 @@ public static class MapCalibrationServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace(assetCacheDir))
             throw new ArgumentException("assetCacheDir required", nameof(assetCacheDir));
 
-        services.AddSingleton<IconTemplateSet>(sp =>
-            BundledIconTemplateLoader.LoadFromDirectory(
+        services.AddSingleton<IIconTemplateProvider>(sp =>
+            new CachedIconTemplateProvider(
                 assetCacheDir,
                 sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Templates")));
         services.AddSingleton<IBaseTextureProvider>(sp =>

--- a/src/Mithril.MapCalibration/Detection/IIconTemplateProvider.cs
+++ b/src/Mithril.MapCalibration/Detection/IIconTemplateProvider.cs
@@ -1,0 +1,32 @@
+namespace Mithril.MapCalibration.Detection;
+
+/// <summary>
+/// Supplies the decoded <see cref="IconTemplateSet"/> the detector matches against,
+/// resolved <i>per attempt</i> rather than once eagerly. This is the icon analogue
+/// of <see cref="IBaseTextureProvider"/>: an implementation re-reads the on-disk
+/// cache the out-of-process asset-extractor sidecar (issue #931) populates, so a
+/// same-session populate (e.g. the engine's <c>--icons</c> demand-trigger or the
+/// startup warm-up) takes effect on the very next attempt — no app restart needed.
+/// Decoder-free at this seam: an implementation reads a pre-decoded manifest+blob
+/// cache BCL-only; no image decoder ever enters the app graph.
+///
+/// <para><b>#949 motivation.</b> The previous design resolved
+/// <see cref="IconTemplateSet"/> as an eager singleton, captured before the icon
+/// cache was populated — so the first session always saw
+/// <see cref="IconTemplateSet.Empty"/> (zero typed detections → the confidence gate
+/// rejected → the user had to restart). This provider closes that gap by deferring
+/// the load to attempt time.</para>
+///
+/// <para><b>Fail-soft:</b> returns <see cref="IconTemplateSet.Empty"/> on any miss
+/// (no cache, missing file, hash mismatch, truncation, exception). Empty templates
+/// → no typed detections → the confidence gate rejects → safe-degrade, never a
+/// silent wrong calibration and never a throw into the engine.</para>
+/// </summary>
+public interface IIconTemplateProvider
+{
+    /// <summary>
+    /// The current icon-template set, re-read from the cache, or
+    /// <see cref="IconTemplateSet.Empty"/> if it can't be loaded + verified.
+    /// </summary>
+    IconTemplateSet GetTemplates();
+}

--- a/src/Mithril.MapCalibration/Detection/Internal/CachedIconTemplateProvider.cs
+++ b/src/Mithril.MapCalibration/Detection/Internal/CachedIconTemplateProvider.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Mithril.MapCalibration.Detection.Internal;
+
+/// <summary>
+/// Per-attempt <see cref="IIconTemplateProvider"/> over the on-disk icon-template
+/// cache the out-of-process asset-extractor sidecar (issue #931) populates. The
+/// icon analogue of <see cref="CachedBaseTextureProvider"/>: each
+/// <see cref="GetTemplates"/> reflects whatever is on disk now, so a same-session
+/// populate (the engine's <c>--icons</c> demand-trigger, or the startup warm-up)
+/// engages on the very next attempt — no app restart (#949).
+///
+/// <para><b>Caching.</b> Decompressing + parsing the icon blob on every attempt is
+/// wasteful, so the loaded set is memoised keyed by the manifest's
+/// <c>pixelSha256</c> (<see cref="BundledIconTemplateLoader.ManifestPixelSha256"/>,
+/// a cheap manifest-only read). The set is reloaded when that hash changes <i>or</i>
+/// when the previously-cached set was <see cref="IconTemplateSet.Empty"/> — so a
+/// fresh same-session populate (cache went empty → populated) is always picked up
+/// even if the manifest read transiently raced the blob write.</para>
+///
+/// <para><b>Fail-soft:</b> any miss/exception → <see cref="IconTemplateSet.Empty"/>
+/// (never throws into the engine). Empty templates → no typed detections → the
+/// confidence gate rejects → safe-degrade.</para>
+/// </summary>
+internal sealed class CachedIconTemplateProvider : IIconTemplateProvider
+{
+    private readonly string _cacheDir;
+    private readonly ILogger? _logger;
+    private readonly object _gate = new();
+
+    // Memoised load. _cachedHash is the manifest pixelSha256 the cached set was
+    // loaded from; null means "nothing loaded yet". Guarded by _gate.
+    private IconTemplateSet? _cached;
+    private string? _cachedHash;
+
+    /// <param name="cacheDir">Directory holding <c>icon-templates.{json,bin}</c>.</param>
+    public CachedIconTemplateProvider(string cacheDir, ILogger? logger = null)
+    {
+        _cacheDir = cacheDir;
+        _logger = logger;
+    }
+
+    public IconTemplateSet GetTemplates()
+    {
+        try
+        {
+            var currentHash = BundledIconTemplateLoader.ManifestPixelSha256(_cacheDir, _logger);
+
+            lock (_gate)
+            {
+                // Reload when: nothing cached yet, the manifest hash changed, OR the
+                // cached set was Empty (so a same-session populate is picked up — a
+                // populated cache after an Empty load must re-read regardless of hash).
+                bool stale =
+                    _cached is null
+                    || _cached.Templates.Count == 0
+                    || !string.Equals(_cachedHash, currentHash, StringComparison.OrdinalIgnoreCase);
+
+                if (stale)
+                {
+                    _cached = BundledIconTemplateLoader.LoadFromDirectory(_cacheDir, _logger);
+                    _cachedHash = currentHash;
+                }
+
+                return _cached ?? IconTemplateSet.Empty;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Defensive: the loader is itself fail-soft, but the manifest probe could
+            // throw on an exotic IO fault. Never let that reach the engine.
+            _logger?.LogWarning(ex, "Icon-template provider threw resolving {CacheDir}; returning Empty (safe-degrade).", _cacheDir);
+            return IconTemplateSet.Empty;
+        }
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture.Tests.Fixtures;
 using Mithril.MapCalibration.Detection;
+using Mithril.Shared.Game;
 using Xunit;
 
 namespace Mithril.MapCalibration.Capture.Tests;
@@ -91,7 +92,99 @@ public sealed class AutoCalibrationEngineTests
         h.Solver.Called.Should().BeFalse("no base texture → never reach the solver");
     }
 
+    // ── #949: same-session icon-template demand-trigger ──────────────────────
+
+    [Fact]
+    public async Task Empty_icons_with_sidecar_wired_demand_triggers_icons_once_then_re_resolves()
+    {
+        // Empty icon cache + a wired extractor + GameRoot/cacheDir set → the engine
+        // invokes --icons once and re-resolves the provider in the SAME attempt.
+        var icons = new FakeIconTemplateProvider(IconTemplateSet.Empty);
+        var extractor = new RecordingAssetExtractor(); // success, no artifacts
+        var h = new EngineHarness
+        {
+            IconProvider = icons,
+            Extractor = extractor,
+            GameConfig = new GameConfig { GameRoot = @"C:\PG" },
+            AssetCacheDir = @"C:\cache",
+        };
+
+        await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        extractor.Calls.Should().ContainSingle()
+            .Which.Kind.Should().Be(ExtractKind.Icons);
+        // GetTemplates() is called once before the trigger and once after (re-resolve).
+        icons.Calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Populated_icons_do_not_demand_trigger_the_sidecar()
+    {
+        var icons = new FakeIconTemplateProvider(OneTemplate());
+        var extractor = new RecordingAssetExtractor();
+        var h = new EngineHarness
+        {
+            IconProvider = icons,
+            Extractor = extractor,
+            GameConfig = new GameConfig { GameRoot = @"C:\PG" },
+            AssetCacheDir = @"C:\cache",
+        };
+
+        await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        extractor.Calls.Should().BeEmpty("templates were already present — no --icons run");
+        icons.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Empty_icons_without_a_wired_extractor_fails_soft_no_trigger()
+    {
+        // No extractor / no GameRoot → safe-degrade: still solves (base texture fine),
+        // just with an empty template set; never throws.
+        var icons = new FakeIconTemplateProvider(IconTemplateSet.Empty);
+        var h = new EngineHarness { IconProvider = icons }; // Extractor null by default
+
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Should().NotBeNull();
+        h.Solver.Called.Should().BeTrue("an empty icon set is not a hard stop — the gate decides");
+        icons.Calls.Should().Be(1, "no extractor → no re-resolve");
+    }
+
+    [Fact]
+    public async Task Sidecar_throwing_on_icons_fails_soft_without_throwing()
+    {
+        var icons = new FakeIconTemplateProvider(IconTemplateSet.Empty);
+
+        // Build an engine with a throwing extractor directly to prove fail-soft.
+        var solver = new SpySolver(new CalibrationSolveResult(new AreaCalibration(1, 0, 0, 0, 6, 0.5), 6, null));
+        var engine = new AutoCalibrationEngine(
+            new FakeAreaState(Area),
+            new FakeWindowLocator(new GameWindow(1, new CaptureRect(0, 0, 1920, 1080))),
+            new FakeRegionProvider(new CaptureRect(0, 0, 64, 64)),
+            new SpyCapture(new GrayImage(64, 64, new byte[64 * 64])),
+            new FakeRefiner(new MapRect(0, 0, 64, 64, 64, 64)),
+            new FakeBaseTextureProvider(new GrayImage(64, 64, new byte[64 * 64])),
+            new FakeAreaRefs(new[] { new LandmarkReference("landmark_npc", "x", new WorldCoord(1, 0, 1)) }),
+            solver,
+            icons,
+            new FakeCalibrationService(),
+            logger: null,
+            assetExtractor: new ThrowingAssetExtractor(),
+            gameConfig: new GameConfig { GameRoot = @"C:\PG" },
+            assetCacheDir: @"C:\cache");
+
+        var act = async () => await engine.TryCalibrateCurrentAreaAsync(default);
+        await act.Should().NotThrowAsync();
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static IconTemplateSet OneTemplate() => new(new[]
+    {
+        new IconTemplate("landmark_npc", "Npc", 0.5, 0.5,
+            new GrayImage(2, 2, new byte[4]), new GrayImage(2, 2, new byte[4])),
+    });
 
     private static CalibrationSolveResult Accepted(double residual, int inliers) =>
         new(new AreaCalibration(1.2, 0.1, 100, 100, inliers, residual), inliers, null);
@@ -115,6 +208,15 @@ public sealed class AutoCalibrationEngineTests
         public CalibrationSolveResult Solve { get; init; } = new(new AreaCalibration(1, 0, 0, 0, 6, 0.5), 6, null);
         public FakeCalibrationService Service { get; init; } = new();
 
+        // #949: icon templates resolve per attempt via IIconTemplateProvider.
+        public FakeIconTemplateProvider IconProvider { get; init; } = new();
+
+        // Optional sidecar wiring for the same-session --icons demand-trigger path.
+        // Leave null (default) to model "no extractor wired" (the unit-branch shape).
+        public RecordingAssetExtractor? Extractor { get; init; }
+        public GameConfig? GameConfig { get; init; }
+        public string? AssetCacheDir { get; init; }
+
         public SpyCapture Capture { get; } = new(new GrayImage(64, 64, new byte[64 * 64]));
         public SpySolver Solver { get; private set; } = null!;
 
@@ -130,9 +232,12 @@ public sealed class AutoCalibrationEngineTests
                 new FakeBaseTextureProvider(BaseTexture),
                 new FakeAreaRefs(new[] { new LandmarkReference("landmark_npc", "x", new WorldCoord(1, 0, 1)) }),
                 Solver,
-                IconTemplateSet.Empty,
+                IconProvider,
                 Service,
-                logger: null);
+                logger: null,
+                assetExtractor: Extractor,
+                gameConfig: GameConfig,
+                assetCacheDir: AssetCacheDir);
         }
     }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -91,6 +91,27 @@ public sealed class CaptureDependencyInjectionTests
     }
 
     /// <summary>
+    /// #949: the per-attempt icon-template provider is registered (not the old eager
+    /// <c>IconTemplateSet</c> singleton) and the engine consumes it. Resolving an
+    /// empty cache yields an empty set (the intended fail-soft).
+    /// </summary>
+    [Fact]
+    public void Icon_template_provider_is_registered_and_resolves_empty_over_an_empty_cache()
+    {
+        using var provider = BuildProvider(out _);
+
+        var iconProvider = provider.GetRequiredService<IIconTemplateProvider>();
+        iconProvider.Should().NotBeNull();
+        iconProvider.GetTemplates().Templates.Should().BeEmpty("the temp asset cache is empty in this test");
+
+        var engine = provider.GetRequiredService<AutoCalibrationEngine>();
+        var field = typeof(AutoCalibrationEngine)
+            .GetField("_iconTemplates", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull("the engine holds the icon-template provider in a private field");
+        field!.GetValue(engine).Should().BeSameAs(iconProvider, "the engine consumes the registered provider");
+    }
+
+    /// <summary>
     /// Builds the full capture graph with faked cross-cutting collaborators, the
     /// same shape the shell composes (<see cref="ShellComposition"/> calls
     /// <c>AddMithrilMapCalibrationCapture(assetCacheDir)</c> with the real

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -76,6 +76,24 @@ internal sealed class FakeBaseTextureProvider : IBaseTextureProvider
     public GrayImage? TryGetBaseTexture(string areaKey) => _tex;
 }
 
+/// <summary>
+/// Per-attempt icon-template provider fake (#949). Returns whatever set
+/// <see cref="Set"/> currently holds (default: <see cref="IconTemplateSet.Empty"/>),
+/// counts calls, and can flip its set to a populated one to model a same-session
+/// populate (e.g. after the engine's <c>--icons</c> demand-trigger).
+/// </summary>
+internal sealed class FakeIconTemplateProvider : IIconTemplateProvider
+{
+    public FakeIconTemplateProvider(IconTemplateSet? set = null) => Set = set ?? IconTemplateSet.Empty;
+    public IconTemplateSet Set { get; set; }
+    public int Calls { get; private set; }
+    public IconTemplateSet GetTemplates()
+    {
+        Calls++;
+        return Set;
+    }
+}
+
 internal sealed class FakeAreaRefs : IAreaReferenceProvider
 {
     private readonly IReadOnlyList<LandmarkReference> _refs;

--- a/tests/Mithril.MapCalibration.Tests/Detection/CachedIconTemplateProviderTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/CachedIconTemplateProviderTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.MapCalibration.Detection.Internal;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+/// <summary>
+/// #949: the icon templates resolve via a per-attempt
+/// <see cref="IIconTemplateProvider"/> (re-reads the cache each call) rather than an
+/// eager singleton, so a same-session populate engages immediately — the headline
+/// acceptance criterion (first-session calibration on a fresh icon cache, no
+/// restart). These tests build the cache fixture in-test with BCL primitives only
+/// (no AssetsTools / System.Drawing — that would re-leak the decoders, #921).
+/// </summary>
+public sealed class CachedIconTemplateProviderTests : IDisposable
+{
+    private readonly string _dir;
+
+    public CachedIconTemplateProviderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "mithril949-iconprovider-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Empty_cache_dir_yields_empty_templates_safe_degrade()
+    {
+        var provider = new CachedIconTemplateProvider(_dir, logger: null);
+
+        provider.GetTemplates().Templates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Missing_cache_dir_yields_empty_templates_safe_degrade()
+    {
+        var provider = new CachedIconTemplateProvider(Path.Combine(_dir, "nope"), logger: null);
+
+        provider.GetTemplates().Templates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Same_session_populate_is_picked_up_within_one_process_lifetime()
+    {
+        // THE headline acceptance criterion (#949): a provider that first reads an
+        // empty cache must return the populated set on the NEXT call once the cache
+        // is populated — no process restart.
+        var provider = new CachedIconTemplateProvider(_dir, logger: null);
+
+        provider.GetTemplates().Templates.Should().BeEmpty("cache is empty initially");
+
+        WriteCacheFixture(FourLandmarks); // sidecar populates the cache, same session
+
+        var after = provider.GetTemplates();
+        after.Templates.Should().NotBeEmpty("the per-attempt provider re-reads the cache");
+        after.Templates.Select(t => t.LandmarkType).Distinct()
+            .Should().Contain(new[] { "TeleportationPlatform", "MeditationPillar", "Portal", "Npc" });
+    }
+
+    [Fact]
+    public void Repeated_calls_over_a_stable_cache_return_the_same_memoised_set()
+    {
+        WriteCacheFixture(FourLandmarks);
+        var provider = new CachedIconTemplateProvider(_dir, logger: null);
+
+        var a = provider.GetTemplates();
+        var b = provider.GetTemplates();
+
+        a.Templates.Should().NotBeEmpty();
+        b.Should().BeSameAs(a, "the loaded set is memoised keyed by the manifest hash (no re-decompress)");
+    }
+
+    [Fact]
+    public void Hash_mismatch_yields_empty_templates_safe_degrade()
+    {
+        WriteCacheFixture(FourLandmarks, corruptHash: true);
+        var provider = new CachedIconTemplateProvider(_dir, logger: null);
+
+        provider.GetTemplates().Templates.Should().BeEmpty();
+    }
+
+    // ── Fixture (BCL-only, mirrors BundledIconTemplateLoaderTests) ────────────
+
+    private sealed record Entry(string Name, string LandmarkType, double PivotX, double PivotY, int Width, int Height);
+
+    private void WriteCacheFixture(IReadOnlyList<Entry> entries, bool corruptHash = false)
+    {
+        using var pixelMs = new MemoryStream();
+        foreach (var e in entries)
+        {
+            int count = e.Width * e.Height;
+            for (int i = 0; i < count; i++) pixelMs.WriteByte((byte)((i * 7 + e.Width) % 256));
+            for (int i = 0; i < count; i++) pixelMs.WriteByte((byte)((i * 3 + e.Height) % 256));
+        }
+        var pixels = pixelMs.ToArray();
+        var sha = Convert.ToHexStringLower(SHA256.HashData(pixels));
+        if (corruptHash) sha = new string('0', sha.Length);
+
+        var manifest = new
+        {
+            schemaVersion = 1,
+            pixelSha256 = sha,
+            icons = entries.Select(e => new
+            {
+                name = e.Name,
+                landmarkType = e.LandmarkType,
+                pivotX = e.PivotX,
+                pivotY = e.PivotY,
+                width = e.Width,
+                height = e.Height,
+            }).ToArray(),
+        };
+        File.WriteAllText(Path.Combine(_dir, "icon-templates.json"),
+            JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }),
+            new UTF8Encoding(false));
+
+        using var fs = File.Create(Path.Combine(_dir, "icon-templates.bin"));
+        using var deflate = new DeflateStream(fs, CompressionLevel.Optimal);
+        deflate.Write(pixels, 0, pixels.Length);
+    }
+
+    private static readonly Entry[] FourLandmarks =
+    [
+        new("landmark_telepad", "TeleportationPlatform", 0.5, 0.5, 8, 6),
+        new("landmark_medipillar", "MeditationPillar", 0.5, 0.5, 6, 10),
+        new("landmark_portal", "Portal", 0.5, 0.5, 7, 9),
+        new("landmark_npc", "Npc", 0.5, 0.5, 5, 5),
+    ];
+}

--- a/tests/Mithril.MapCalibration.Tests/Detection/EngineRegistrationTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/EngineRegistrationTests.cs
@@ -26,30 +26,33 @@ public sealed class EngineRegistrationTests
         provider.GetService<MapCalibrationSolveEngine>().Should().NotBeNull();
         provider.GetService<ICalibrationDetector>().Should().BeOfType<DeviationBlobCalibrationDetector>();
         provider.GetService<ICalibrationConfidenceGate>().Should().BeOfType<CalibrationConfidenceGate>();
-        provider.GetService<IconTemplateSet>().Should().NotBeNull();
+        provider.GetService<IIconTemplateProvider>().Should().NotBeNull();
         provider.GetService<IBaseTextureProvider>().Should().NotBeNull();
     }
 
     [Fact]
-    public void Template_set_is_singleton()
+    public void Icon_template_provider_is_singleton()
     {
+        // #949: the icon templates resolve via a per-attempt provider, not an eager
+        // IconTemplateSet singleton. The provider itself is a singleton (it memoises
+        // the loaded set across attempts).
         var provider = new ServiceCollection()
             .AddMithrilMapCalibrationEngine(TempCacheDir())
             .BuildServiceProvider();
 
-        var a = provider.GetRequiredService<IconTemplateSet>();
-        var b = provider.GetRequiredService<IconTemplateSet>();
+        var a = provider.GetRequiredService<IIconTemplateProvider>();
+        var b = provider.GetRequiredService<IIconTemplateProvider>();
         a.Should().BeSameAs(b);
     }
 
     [Fact]
-    public void Absent_cache_dir_yields_empty_template_set_and_null_base_texture()
+    public void Absent_cache_dir_yields_empty_templates_and_null_base_texture()
     {
         var provider = new ServiceCollection()
             .AddMithrilMapCalibrationEngine(TempCacheDir())
             .BuildServiceProvider();
 
-        provider.GetRequiredService<IconTemplateSet>().Templates.Should().BeEmpty();
+        provider.GetRequiredService<IIconTemplateProvider>().GetTemplates().Templates.Should().BeEmpty();
         provider.GetRequiredService<IBaseTextureProvider>().TryGetBaseTexture("AreaSerbule").Should().BeNull();
     }
 


### PR DESCRIPTION
## What & why

Closes #949. Map auto-calibration couldn't solve **first-session** on a fresh icon cache — the user had to restart Mithril once before it could ever succeed.

**Root cause:** icon templates loaded *once, eagerly* as an `IconTemplateSet` singleton, resolved (as `IconTemplateSet.Empty`) before the icon cache was populated — because the DI container *constructs* every `IHostedService` (pulling `AutoCalibrationTrigger → AutoCalibrationEngine → IconTemplateSet`) before any `StartAsync` runs the `IconTemplateBootstrap` populate. Empty templates → zero typed detections in `DeviationBlobCalibrationDetector` → no type-matched correspondences → confidence gate rejects. Base textures already avoided this by loading **per-call** via `IBaseTextureProvider`.

## Change — mirror `IBaseTextureProvider` for icons

- **New `IIconTemplateProvider`** (`src/Mithril.MapCalibration/Detection/`) — `IconTemplateSet GetTemplates()`, the icon analogue of `IBaseTextureProvider`. Impl `CachedIconTemplateProvider` reads the sidecar-written manifest+blob via `BundledIconTemplateLoader`, memoised keyed by manifest `pixelSha256` (reloads on hash change OR when the cached set was `Empty`, so a same-session populate is picked up). BCL-only; fail-soft to `Empty` on any miss/throw.
- **`AutoCalibrationEngine`** takes `IIconTemplateProvider`; resolves templates **per attempt**. On an empty set with an extractor wired + `GameRoot` set, it demand-triggers the sidecar's `--icons` mode once (same fail-soft shape as the existing base-texture cache-miss path), then re-resolves before building the `DetectionRequest`. → fully same-session, no restart.
- **Registration** swaps the eager `AddSingleton<IconTemplateSet>` for `AddSingleton<IIconTemplateProvider, CachedIconTemplateProvider>`; capture wiring + engine ctor consume the provider.
- **`IconTemplateBootstrap`** kept as a non-blocking startup warm-up (no first-attempt latency in the common case) with the engine's demand-trigger as the correctness backstop; "next-launch" language dropped.
- `DetectionRequest.Templates` stays a concrete `IconTemplateSet`; the detector is unchanged (pure function over a passed-in set).

## Guardrails
- **#921 decoder-free `src/**`:** provider is BCL-only (no `AssetsTools.NET`/`System.Drawing`/`tools/` ref); `ShippedGraphDecoderFreeTests` stays green.
- **Fail-soft everywhere:** missing exe / non-zero exit / timeout / empty `GameRoot` / empty cache → `Empty` templates → gate rejects → no wrong calibration, no throw.

## Tests
- New `CachedIconTemplateProviderTests`: headline same-session test (empty → write manifest+blob → next `GetTemplates()` non-empty within one process lifetime) + empty/missing/hash-mismatch/memoisation cases.
- `AutoCalibrationEngineTests`: fake provider + 4 demand-trigger cases (triggers once + re-resolves; populated skips; no-extractor fail-soft; throwing-extractor fail-soft).
- `EngineRegistrationTests` / `CaptureDependencyInjectionTests` retargeted to `IIconTemplateProvider`.

## Verification
- `dotnet build Mithril.slnx` clean; MapCalibration + Capture test projects green; `ShippedGraphDecoderFreeTests` green. (Re-verified by the shepherd on the branch.)
- Live-PG first-session solve (real sidecar populating a real fresh cache) is owed under #938 — can't be CI'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)