### PR TITLE
refactor(map-calibration): consolidate overlay position onto the shell capture rect (#957)

### DIFF
--- a/src/Legolas.Module/Controls/CaptureRectWindowBinder.cs
+++ b/src/Legolas.Module/Controls/CaptureRectWindowBinder.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration;
+
+namespace Legolas.Controls;
+
+/// <summary>
+/// #957 one-rect binder. Positions a WPF window from the shell-persisted map-capture
+/// rect (<see cref="IMapCaptureRectStore"/>, physical px) and writes the window's
+/// drags/resizes back to the same store, so the overlay frame and the BitBlt capture
+/// frame are a single source of truth (spec §7 / #940). Replaces
+/// <see cref="WindowLayoutBinder"/> for the survey map overlay; the latter stays for
+/// the inventory/calibration overlays, which keep their Legolas-owned
+/// <c>WindowLayout</c>.
+///
+/// <para><b>DIU ↔ physical.</b> The store holds <i>physical</i> desktop pixels;
+/// <c>Window.Left/Top/Width/Height</c> are <i>DIUs</i>. Conversion uses the window's
+/// own live <c>TransformToDevice</c> at apply/write time (<see cref="CaptureRectMath"/>),
+/// the same single-window-scale model the snip uses — exact for single-/uniform-DPI,
+/// #938 best-effort for mixed-DPI multi-monitor.</para>
+///
+/// <para><b>No feedback loop, no write storms.</b> Pushing the store value into the
+/// window is fenced by <see cref="BinderState._applying"/> so it doesn't bounce back
+/// as a write; write-back is debounced (a drag fires <c>LocationChanged</c> per tick,
+/// and the store flushes to disk synchronously) and additionally skipped when the
+/// computed rect already equals the stored one — which also absorbs WPF's deferred
+/// <c>SizeChanged</c> after a programmatic resize.</para>
+/// </summary>
+public static class CaptureRectWindowBinder
+{
+    // ShellMapCaptureRectStore.Set flushes to disk synchronously; coalesce a drag's
+    // burst of LocationChanged/SizeChanged into one write after the gesture settles.
+    private static readonly TimeSpan WritebackDebounce = TimeSpan.FromMilliseconds(400);
+
+    public static void Bind(Window window, IMapCaptureRectStore store, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+        ArgumentNullException.ThrowIfNull(store);
+
+        var state = new BinderState(window, store, logger);
+
+        // Conversion needs the window's device transform, which exists only once the
+        // HwndSource is up. Apply now if it already is; otherwise defer to realize.
+        if (System.Windows.PresentationSource.FromVisual(window) is not null)
+            state.ApplyFromStore();
+        else
+            window.SourceInitialized += (_, _) => state.ApplyFromStore();
+
+        window.LocationChanged += (_, _) => state.OnWindowChanged();
+        window.SizeChanged += (_, _) => state.OnWindowChanged();
+    }
+
+    private sealed class BinderState
+    {
+        private readonly Window _window;
+        private readonly IMapCaptureRectStore _store;
+        private readonly ILogger? _logger;
+        private readonly DispatcherTimer _writebackTimer;
+        // True while we push the stored rect INTO the window, so the synchronous
+        // LocationChanged/SizeChanged don't immediately schedule a write-back.
+        private bool _applying;
+
+        public BinderState(Window window, IMapCaptureRectStore store, ILogger? logger)
+        {
+            _window = window;
+            _store = store;
+            _logger = logger;
+            _writebackTimer = new DispatcherTimer(DispatcherPriority.Background, window.Dispatcher)
+            {
+                Interval = WritebackDebounce,
+            };
+            _writebackTimer.Tick += (_, _) => { _writebackTimer.Stop(); WriteBack(); };
+        }
+
+        /// <summary>Position the window from the stored physical rect. No-op when the
+        /// store is unset (window keeps its XAML default) or the transform isn't live.</summary>
+        public void ApplyFromStore()
+        {
+            CaptureRect? stored;
+            try { stored = _store.Get(); }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Reading the capture rect to position the overlay failed; leaving the window at its current place.");
+                return;
+            }
+            if (stored is not { } rect || rect.IsEmpty) return;
+
+            if (!TryGetScale(out var sx, out var sy)) return;
+            var (left, top, width, height) = CaptureRectMath.PhysicalToDiu(rect, sx, sy);
+            if (width <= 0 || height <= 0) return;
+
+            _applying = true;
+            try
+            {
+                _window.Left = left;
+                _window.Top = top;
+                _window.Width = width;
+                _window.Height = height;
+            }
+            finally
+            {
+                _applying = false;
+            }
+        }
+
+        public void OnWindowChanged()
+        {
+            if (_applying) return;                                   // our own ApplyFromStore
+            if (_window.WindowState != WindowState.Normal) return;   // min/maximised are ephemeral
+            // Debounce: the last change of a drag/resize gesture wins.
+            _writebackTimer.Stop();
+            _writebackTimer.Start();
+        }
+
+        /// <summary>Persist the window's current frame as physical px — skipping the
+        /// disk write when nothing actually changed (also absorbs the deferred
+        /// SizeChanged WPF raises after <see cref="ApplyFromStore"/>'s programmatic
+        /// resize, since that recomputes the already-stored rect).</summary>
+        private void WriteBack()
+        {
+            if (_window.WindowState != WindowState.Normal) return;
+            if (!TryGetScale(out var sx, out var sy)) return;
+
+            var physical = CaptureRectMath.DiuToPhysical(
+                _window.Left, _window.Top, _window.ActualWidth, _window.ActualHeight, sx, sy);
+            if (physical.IsEmpty) return;
+
+            try
+            {
+                if (_store.Get() == physical) return; // unchanged — no redundant flush
+                _store.Set(physical);
+            }
+            catch (Exception ex)
+            {
+                // Persisting the overlay position is best-effort: this runs on the UI
+                // dispatcher (a window event), so a settings-IO failure must not throw
+                // into the message loop and crash the overlay (#957 fail-soft). The
+                // in-memory window position is unaffected; the next gesture retries.
+                _logger?.LogWarning(ex, "Persisting the overlay capture rect failed; the position applies to this session only.");
+            }
+        }
+
+        private bool TryGetScale(out double scaleX, out double scaleY)
+        {
+            scaleX = scaleY = 0;
+            var source = System.Windows.PresentationSource.FromVisual(_window);
+            var m = source?.CompositionTarget?.TransformToDevice;
+            if (m is not { } t || t.M11 <= 0 || t.M22 <= 0) return false;
+            scaleX = t.M11;
+            scaleY = t.M22;
+            return true;
+        }
+    }
+}

--- a/src/Legolas.Module/Diagnostics/SurveyPerfHarness.cs
+++ b/src/Legolas.Module/Diagnostics/SurveyPerfHarness.cs
@@ -3,6 +3,7 @@ using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.Services;
 using Legolas.ViewModels;
+using Mithril.MapCalibration;
 
 namespace Legolas.Diagnostics;
 
@@ -28,19 +29,32 @@ public sealed class SurveyPerfHarness
     private readonly MapOverlayViewModel _mapVm;
     private readonly LegolasSettings _settings;
     private readonly FrameTimeLogger _logger;
+    // #957: the overlay frame is the shell capture rect now (MapOverlay retired).
+    private readonly IMapCaptureRectStore _captureRectStore;
 
     public SurveyPerfHarness(
         SessionState session,
         SurveyFlowController surveyFlow,
         MapOverlayViewModel mapVm,
         LegolasSettings settings,
-        FrameTimeLogger logger)
+        FrameTimeLogger logger,
+        IMapCaptureRectStore captureRectStore)
     {
         _session = session;
         _surveyFlow = surveyFlow;
         _mapVm = mapVm;
         _settings = settings;
         _logger = logger;
+        _captureRectStore = captureRectStore;
+    }
+
+    // Current map-overlay frame size as a rough origin/metadata for the synthetic
+    // load. Sourced from the one-rect capture store (physical px — exact magnitude
+    // is irrelevant here, just a valid centre), falling back to 800×600 when unset.
+    private (double Width, double Height) CurrentMapSize()
+    {
+        var rect = _captureRectStore.Get() ?? default;
+        return (rect.Width > 0 ? rect.Width : 800, rect.Height > 0 ? rect.Height : 600);
     }
 
     public bool IsRunning { get; private set; }
@@ -185,8 +199,7 @@ public sealed class SurveyPerfHarness
         // (the user may have resized it). Width/Height fall back if the
         // settings layout hasn't hydrated yet — irrelevant for the synthetic
         // load, just need a valid origin.
-        var w = _settings.MapOverlay.Width > 0 ? _settings.MapOverlay.Width : 800;
-        var h = _settings.MapOverlay.Height > 0 ? _settings.MapOverlay.Height : 600;
+        var (w, h) = CurrentMapSize();
         var centre = new PixelPoint(w / 2, h / 2);
 
         // #454: pins are absolute now — inject them directly at pixel
@@ -208,14 +221,18 @@ public sealed class SurveyPerfHarness
         }
     }
 
-    private FrameRunConfig SnapshotConfig(int pinCount, string fsmState) => new(
-        PinCount: pinCount,
-        ActiveTreatment: _settings.ActivePinStyle.Treatment.ToString(),
-        AllowsTransparency: true, // MapOverlayView XAML hard-sets this; recorded for the report
-        ClickThroughMap: _settings.ClickThroughMap,
-        ShowBearingWedges: _session.ShowBearingWedges,
-        ShowRouteLines: _session.ShowRouteLines,
-        MapWidth: _settings.MapOverlay.Width,
-        MapHeight: _settings.MapOverlay.Height,
-        FsmState: fsmState);
+    private FrameRunConfig SnapshotConfig(int pinCount, string fsmState)
+    {
+        var (mapWidth, mapHeight) = CurrentMapSize();
+        return new(
+            PinCount: pinCount,
+            ActiveTreatment: _settings.ActivePinStyle.Treatment.ToString(),
+            AllowsTransparency: true, // MapOverlayView XAML hard-sets this; recorded for the report
+            ClickThroughMap: _settings.ClickThroughMap,
+            ShowBearingWedges: _session.ShowBearingWedges,
+            ShowRouteLines: _session.ShowRouteLines,
+            MapWidth: mapWidth,
+            MapHeight: mapHeight,
+            FsmState: fsmState);
+    }
 }

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -5,7 +5,7 @@ namespace Legolas.Domain;
 
 public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<LegolasSettings>
 {
-    public const int Version = 5;
+    public const int Version = 6;
     public static int CurrentVersion => Version;
 
     /// <summary>
@@ -41,6 +41,17 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     /// customised value isn't lost) lives in <c>GameConfigCarryOver</c> at the
     /// shell composition root, because a per-file <see cref="Migrate"/> cannot
     /// reach across into <c>shell.json</c>.
+    ///
+    /// v5 → v6 (#957) retires <c>MapOverlay</c>: the survey overlay window's frame
+    /// is now the one shell-persisted map-capture rect
+    /// (<c>ShellSettings.MapCaptureBbox</c>), so the overlay reads/writes its
+    /// position through that store instead of a Legolas-owned <see cref="WindowLayout"/>.
+    /// The migration is a no-op in code (the dropped field is no longer declared, so
+    /// STJ ignores the orphaned <c>mapOverlay</c> key on load and the loader's re-save
+    /// strips it). The one-time value carry-over into <c>shell.json</c> (DIU → physical)
+    /// lives in <c>MapCaptureRectCarryOver</c> at the shell composition root, for the
+    /// same cross-file reason as the #919 carry-over above. <c>InventoryOverlay</c> /
+    /// <c>CalibrationOverlay</c> keep their <see cref="WindowLayout"/> bindings.
     /// </summary>
     public int SchemaVersion { get; set; } = 1;
 
@@ -158,7 +169,10 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     /// no area calibrated yet (the v2 default; see <see cref="SchemaVersion"/>).
     /// </summary>
     public Dictionary<string, AreaCalibration> AreaCalibrations { get; set; } = new(StringComparer.Ordinal);
-    public WindowLayout MapOverlay { get; set; } = new() { Width = 800, Height = 600 };
+    // #957: MapOverlay retired — the survey overlay window now reads/writes its
+    // frame through the one shell-persisted capture rect (ShellSettings.MapCaptureBbox,
+    // via CaptureRectWindowBinder), so capture-frame and overlay-frame are a single
+    // source of truth. Its last value migrates into shell.json (MapCaptureRectCarryOver).
     public WindowLayout InventoryOverlay { get; set; } = new() { Width = 540, Height = 440 };
     public WindowLayout CalibrationOverlay { get; set; } = new() { Width = 940, Height = 660 };
 

--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -445,6 +445,7 @@ public sealed class ToggleFrameTimeLoggerCommand : IHotkeyCommand
         }
         else
         {
+            var captureRect = _captureRectStore.Get();
             var cfg = new FrameRunConfig(
                 PinCount: _session.Surveys.Count,
                 ActiveTreatment: _settings.ActivePinStyle.Treatment.ToString(),
@@ -452,8 +453,8 @@ public sealed class ToggleFrameTimeLoggerCommand : IHotkeyCommand
                 ClickThroughMap: _settings.ClickThroughMap,
                 ShowBearingWedges: _session.ShowBearingWedges,
                 ShowRouteLines: _session.ShowRouteLines,
-                MapWidth: _captureRectStore.Get() is { Width: > 0 } wr ? wr.Width : 800,
-                MapHeight: _captureRectStore.Get() is { Height: > 0 } hr ? hr.Height : 600,
+                MapWidth: captureRect is { Width: > 0 } ? captureRect.Value.Width : 800,
+                MapHeight: captureRect is { Height: > 0 } ? captureRect.Value.Height : 600,
                 FsmState: _surveyFlow.CurrentState.ToString());
             _logger.Start("manual", cfg);
             _session.LastLogEvent = "Frame logger started — press hotkey again to stop and write report.";

--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Mithril.MapCalibration;
 using Mithril.Shared.Hotkeys;
 using Legolas.Diagnostics;
 using Legolas.Domain;
@@ -414,16 +415,20 @@ public sealed class ToggleFrameTimeLoggerCommand : IHotkeyCommand
     private readonly LegolasSettings _settings;
     private readonly SessionState _session;
     private readonly SurveyFlowController _surveyFlow;
+    // #957: the overlay frame is the shell capture rect now (MapOverlay retired).
+    private readonly IMapCaptureRectStore _captureRectStore;
     public ToggleFrameTimeLoggerCommand(
         FrameTimeLogger logger,
         LegolasSettings settings,
         SessionState session,
-        SurveyFlowController surveyFlow)
+        SurveyFlowController surveyFlow,
+        IMapCaptureRectStore captureRectStore)
     {
         _logger = logger;
         _settings = settings;
         _session = session;
         _surveyFlow = surveyFlow;
+        _captureRectStore = captureRectStore;
     }
     public string Id => "legolas.diag.frame_logger.toggle";
     public string DisplayName => "Toggle Frame-Time Logger";
@@ -447,8 +452,8 @@ public sealed class ToggleFrameTimeLoggerCommand : IHotkeyCommand
                 ClickThroughMap: _settings.ClickThroughMap,
                 ShowBearingWedges: _session.ShowBearingWedges,
                 ShowRouteLines: _session.ShowRouteLines,
-                MapWidth: _settings.MapOverlay.Width,
-                MapHeight: _settings.MapOverlay.Height,
+                MapWidth: _captureRectStore.Get() is { Width: > 0 } wr ? wr.Width : 800,
+                MapHeight: _captureRectStore.Get() is { Height: > 0 } hr ? hr.Height : 600,
                 FsmState: _surveyFlow.CurrentState.ToString());
             _logger.Start("manual", cfg);
             _session.LastLogEvent = "Frame logger started — press hotkey again to stop and write report.";

--- a/src/Legolas.Module/Hotkeys/OverlayController.cs
+++ b/src/Legolas.Module/Hotkeys/OverlayController.cs
@@ -10,6 +10,8 @@ using Legolas.ViewModels;
 using Legolas.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration;
 using Mithril.Overlay;
 
 namespace Legolas.Hotkeys;
@@ -34,6 +36,9 @@ public sealed class OverlayController : IHostedService
     private readonly ForegroundFocusGate _focusGate;
     private readonly IOverlayWindow _overlayWindow;
     private readonly SettingsAutoSaver<LegolasSettings> _settingsSaver;
+    // #957: the survey overlay reads/writes its frame through the one shell-persisted
+    // capture rect, so capture-frame and overlay-frame are a single source of truth.
+    private readonly IMapCaptureRectStore _captureRectStore;
     private readonly CancellationTokenSource _stopCts = new();
     private Task? _activationTask;
     private bool _subscribed;
@@ -64,7 +69,8 @@ public sealed class OverlayController : IHostedService
         LegolasSettings settings,
         ForegroundFocusGate focusGate,
         IOverlayWindow overlayWindow,
-        SettingsAutoSaver<LegolasSettings> settingsSaver)
+        SettingsAutoSaver<LegolasSettings> settingsSaver,
+        IMapCaptureRectStore captureRectStore)
     {
         _services = services;
         _gates = gates;
@@ -73,6 +79,7 @@ public sealed class OverlayController : IHostedService
         _focusGate = focusGate;
         _overlayWindow = overlayWindow;
         _settingsSaver = settingsSaver;
+        _captureRectStore = captureRectStore;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -210,7 +217,14 @@ public sealed class OverlayController : IHostedService
             };
         }
 
-        WindowLayoutBinder.Bind(window, _settings.MapOverlay, _settingsSaver.Touch);
+        // #957: bind the survey overlay to the shell capture rect (physical px) — the
+        // window positions itself from it and writes drags/resizes back, so the overlay
+        // frame IS the capture frame (one-rect). Replaces the WindowLayoutBinder +
+        // LegolasSettings.MapOverlay path used by the inventory/calibration overlays.
+        CaptureRectWindowBinder.Bind(
+            window,
+            _captureRectStore,
+            _services.GetService<ILoggerFactory>()?.CreateLogger("Legolas.OverlayLayout"));
         ClickThrough.KeepTopmost(window);
 
         // #835 step 6 review iter-1 B4: wire the survey-drag + calibration-

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -91,7 +91,8 @@ public partial class MapOverlayView : Window
         // shared IOverlayWindow.Window, positioned from the shell capture rect by
         // OverlayController via CaptureRectWindowBinder. This legacy view is no longer
         // Show()n in production (#835 step 6; step 7 deletes it), so it carries no
-        // window-position binding.
+        // window-position binding. The `saver` param is consequently unused now —
+        // kept in the signature for the transient DI factory until step 7's deletion.
         Loaded += (_, _) => ApplyClickThrough();
         // Re-assert TOPMOST on every show + on a low-frequency timer while
         // visible — Loaded/Activated alone miss the Hide()/Show() cycle the

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -87,7 +87,11 @@ public partial class MapOverlayView : Window
         // assigning here guarantees the pad has its VM before any user input
         // arrives, so Command/IsChecked bindings inside the pad always work.
         OverlayNudgePad.DataContext = nudgePad;
-        WindowLayoutBinder.Bind(this, settings.MapOverlay, saver.Touch);
+        // #957: LegolasSettings.MapOverlay retired — the live survey overlay is the
+        // shared IOverlayWindow.Window, positioned from the shell capture rect by
+        // OverlayController via CaptureRectWindowBinder. This legacy view is no longer
+        // Show()n in production (#835 step 6; step 7 deletes it), so it carries no
+        // window-position binding.
         Loaded += (_, _) => ApplyClickThrough();
         // Re-assert TOPMOST on every show + on a low-frequency timer while
         // visible — Loaded/Activated alone miss the Hide()/Show() cycle the

--- a/src/Mithril.MapCalibration.Capture/IMapCaptureRegionProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/IMapCaptureRegionProvider.cs
@@ -1,8 +1,8 @@
 namespace Mithril.MapCalibration.Capture;
 
 /// <summary>
-/// Reads the single map-capture bbox (spec §7) from the SHELL-persisted capture
-/// rect (#947), converted to physical desktop pixels. The capture region is a
+/// Reads the single map-capture bbox (spec §7) from the shell-persisted capture
+/// rect (#947), already in physical desktop pixels. The capture region is a
 /// persisted desktop rectangle sourced independently of any window — see
 /// <see cref="IMapCaptureRectStore"/> for why it no longer rides the live
 /// overlay-window geometry. The auto-attempt reads <see cref="Current"/> to know

--- a/src/Mithril.MapCalibration.Capture/MapBboxDrawController.cs
+++ b/src/Mithril.MapCalibration.Capture/MapBboxDrawController.cs
@@ -23,9 +23,17 @@ namespace Mithril.MapCalibration.Capture;
 /// overlay (when realized) is kept purely for visual feedback — setting only
 /// Left/Top/Width/Height is within the allowed surface (the existing
 /// <c>WindowLayoutBinder.Apply</c> does the same); this controller does NOT mutate
-/// the overlay's Topmost/WindowStyle/AllowsTransparency/Close. The Legolas binder
-/// (→ <c>LegolasSettings.MapOverlay</c>) is untouched; full overlay-reads-shell-store
-/// consolidation is a follow-up.</para>
+/// the overlay's Topmost/WindowStyle/AllowsTransparency/Close.</para>
+///
+/// <para><b>#957 (one-rect consolidation).</b> The overlay window now reads its own
+/// position from this same <see cref="IMapCaptureRectStore"/> via
+/// <c>CaptureRectWindowBinder</c> (physical→DIU at the overlay's live device scale)
+/// and writes drags/resizes back through it — so the store is the single source of
+/// truth for both the capture frame and the overlay frame. The DIU mirror below is
+/// retained purely for <i>immediate</i> snip-time feedback when the overlay is
+/// already shown; the binder's debounced write-back then re-persists the same rect.
+/// <c>LegolasSettings.MapOverlay</c> was retired (its value migrated into the store
+/// by <c>MapCaptureRectCarryOver</c>).</para>
 ///
 /// <para>All WPF work runs on the overlay window's dispatcher (BeginDraw is
 /// invoked from <c>DrawMapBboxCommand</c>, which may run off the UI thread). The

--- a/src/Mithril.MapCalibration/CaptureRect.cs
+++ b/src/Mithril.MapCalibration/CaptureRect.cs
@@ -1,10 +1,16 @@
-namespace Mithril.MapCalibration.Capture;
+namespace Mithril.MapCalibration;
 
 /// <summary>
 /// A desktop-pixel rectangle: the persisted map bbox and the resolved game
 /// client rect both use it. Deliberately a plain BCL struct (no
 /// <see cref="System.Windows.Rect"/>) so it can cross into the BCL-only
 /// detection core without dragging a WPF dependency through the boundary.
+///
+/// <para>Lives in the core <c>Mithril.MapCalibration</c> assembly (moved out of
+/// <c>Mithril.MapCalibration.Capture</c> in #957) so both the windows-only Capture
+/// project and <c>Legolas.Module</c> — which references the core but not Capture —
+/// can consume the one-rect seam (<see cref="IMapCaptureRectStore"/>) without
+/// taking a dependency on the BitBlt/CsWin32 capture infra.</para>
 /// </summary>
 public readonly record struct CaptureRect(int X, int Y, int Width, int Height)
 {

--- a/src/Mithril.MapCalibration/CaptureRectMath.cs
+++ b/src/Mithril.MapCalibration/CaptureRectMath.cs
@@ -1,10 +1,10 @@
 using System;
 
-namespace Mithril.MapCalibration.Capture;
+namespace Mithril.MapCalibration;
 
 /// <summary>
-/// Pure, WPF-free conversion from device-independent (DIU/WPF) coordinates to the
-/// physical-pixel <see cref="CaptureRect"/> that <c>BitBltScreenCapture</c> reads.
+/// Pure, WPF-free conversions between device-independent (DIU/WPF) coordinates and
+/// the physical-pixel <see cref="CaptureRect"/> that <c>BitBltScreenCapture</c> reads.
 ///
 /// <para><b>Why this exists.</b> <c>BitBltScreenCapture.Capture</c> blits from
 /// <c>GetDC(NULL)</c> (the whole virtual desktop) using <c>rect.X/Y/Width/Height</c>
@@ -71,6 +71,38 @@ public static class CaptureRectMath
         if (w <= 0 || h <= 0) return default; // IsEmpty
 
         return new CaptureRect(x, y, w, h);
+    }
+
+    /// <summary>
+    /// Inverse of <see cref="DiuToPhysical"/>: convert a physical-pixel
+    /// <see cref="CaptureRect"/> back to a device-independent (DIU/WPF) rect suitable
+    /// for positioning a window via <c>Window.Left/Top/Width/Height</c> (#957 — the
+    /// overlay reads its frame from the physical-px capture store).
+    ///
+    /// <para>Unlike <see cref="DiuToPhysical"/> this does <b>not</b> round: DIU is a
+    /// fractional unit, so dividing the physical edges by the scale yields the exact
+    /// logical rect WPF expects. Round-tripping <c>physical → DIU → physical</c> at the
+    /// same scale reproduces the original integer rect (the edge-rounding in
+    /// <see cref="DiuToPhysical"/> is a no-op on already-integer device edges).</para>
+    /// </summary>
+    /// <returns>The DIU rect, or all-zero when the inputs are degenerate
+    /// (empty rect, non-finite or non-positive scale) — callers treat a zero-size
+    /// result as "nothing to apply".</returns>
+    public static (double Left, double Top, double Width, double Height) PhysicalToDiu(
+        CaptureRect rect, double dpiScaleX, double dpiScaleY)
+    {
+        if (rect.IsEmpty
+            || !IsFinite(dpiScaleX) || !IsFinite(dpiScaleY)
+            || dpiScaleX <= 0 || dpiScaleY <= 0)
+        {
+            return (0, 0, 0, 0);
+        }
+
+        double left = rect.X / dpiScaleX;
+        double top = rect.Y / dpiScaleY;
+        double width = rect.Width / dpiScaleX;
+        double height = rect.Height / dpiScaleY;
+        return (left, top, width, height);
     }
 
     private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);

--- a/src/Mithril.MapCalibration/IMapCaptureRectStore.cs
+++ b/src/Mithril.MapCalibration/IMapCaptureRectStore.cs
@@ -1,4 +1,4 @@
-namespace Mithril.MapCalibration.Capture;
+namespace Mithril.MapCalibration;
 
 /// <summary>
 /// Persisted store for the single map-capture bbox (#947), expressed as an
@@ -6,6 +6,15 @@ namespace Mithril.MapCalibration.Capture;
 /// exact frame <c>BitBltScreenCapture</c> blits from <c>GetDC(NULL)</c> (origin at
 /// the primary monitor, signed coords possible on a multi-monitor layout where a
 /// secondary screen sits left/above the primary).
+///
+/// <para><b>One-rect seam (#940/#957).</b> This is the single source of truth for
+/// both the capture frame (the BitBlt rect) and the Legolas overlay-window frame:
+/// the Capture project's region provider reads it verbatim, and the overlay window
+/// positions itself from it (converting physical→DIU at its own live device scale)
+/// and writes drags/resizes back through it. The interface lives in the core
+/// <c>Mithril.MapCalibration</c> assembly (moved out of <c>.Capture</c> in #957) so
+/// <c>Legolas.Module</c> — which references the core but not the windows-only
+/// Capture project — can consume the same store the capture path does.</para>
 ///
 /// <para><b>Why a SHELL-owned store, not the overlay window.</b> Before #947 the
 /// capture region was derived from the live overlay window's realized geometry
@@ -15,24 +24,24 @@ namespace Mithril.MapCalibration.Capture;
 /// The capture region is a <i>persisted desktop rectangle</i> independent of any
 /// window; this seam lifts it into the shell's own settings store so it survives
 /// regardless of window state. The shell backs it (it references both Legolas and
-/// this Capture project), keeping the <c>Capture ↛ Legolas.Module</c> boundary
+/// the Capture project), keeping the <c>Capture ↛ Legolas.Module</c> boundary
 /// intact.</para>
 ///
 /// <para><b>Why physical pixels (not DIUs).</b> The rect is computed once, at
 /// snip-confirm time, from the snip window's own live <c>TransformToDevice</c>
-/// scale (see <see cref="RegionSnipWindow"/>). The snip is a <i>single</i> WPF
-/// window spanning the whole virtual desktop; under PerMonitorV2 a single top-level
-/// window has ONE DPI scale and maps its entire logical surface uniformly at that
-/// scale (WPF does not per-monitor-rescale <c>GetPosition</c> within one window), so
-/// the snipped rect's physical pixels are <c>DIU · S_snip</c> uniformly. Persisting
-/// the already-resolved physical rect makes the read path frame-independent: the
-/// provider returns it verbatim with zero read-time DPI work — no monitor
-/// enumeration, no per-monitor affine map. This is correct for single-monitor and
-/// uniform-DPI multi-monitor layouts; a true mixed-DPI multi-monitor layout (the
-/// map sitting on a non-primary monitor at a different scale than the snip window's)
-/// is owed to #938 manual-verify, and a stored physical rect goes stale if the user
-/// later changes DPI/resolution (re-snip to refresh). This is no worse than the
-/// pre-#940 read-time behavior, which also keyed off a single window's scale.</para>
+/// scale. The snip is a <i>single</i> WPF window spanning the whole virtual desktop;
+/// under PerMonitorV2 a single top-level window has ONE DPI scale and maps its
+/// entire logical surface uniformly at that scale (WPF does not per-monitor-rescale
+/// <c>GetPosition</c> within one window), so the snipped rect's physical pixels are
+/// <c>DIU · S_snip</c> uniformly. Persisting the already-resolved physical rect
+/// makes the read path frame-independent: the provider returns it verbatim with
+/// zero read-time DPI work — no monitor enumeration, no per-monitor affine map. This
+/// is correct for single-monitor and uniform-DPI multi-monitor layouts; a true
+/// mixed-DPI multi-monitor layout (the map sitting on a non-primary monitor at a
+/// different scale than the snip window's) is owed to #938 manual-verify, and a
+/// stored physical rect goes stale if the user later changes DPI/resolution (re-snip
+/// to refresh). This is no worse than the pre-#940 read-time behavior, which also
+/// keyed off a single window's scale.</para>
 ///
 /// <para><b>Fail-soft.</b> <see cref="Get"/> returns <see langword="null"/> when no
 /// rect has ever been snipped — the legitimate "no bbox set" state the engine

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -7,7 +7,7 @@ using Arda.Hosting;
 using Arda.Wpf;
 using Arda.World.Chat;
 using Arda.World.Player;
-using Mithril.MapCalibration.Capture;
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture.DependencyInjection;
 using Mithril.MapCalibration.DependencyInjection;
 using Mithril.Overlay.DependencyInjection;

--- a/src/Mithril.Shell/MapCaptureRectCarryOver.cs
+++ b/src/Mithril.Shell/MapCaptureRectCarryOver.cs
@@ -1,0 +1,115 @@
+using System.IO;
+using System.Text.Json;
+using Mithril.MapCalibration;
+
+namespace Mithril.Shell;
+
+/// <summary>
+/// One-time composition-root carry-over (#957) of the retired
+/// <c>LegolasSettings.MapOverlay</c> (the overlay window's persisted position, DIUs,
+/// in <c>legolas/settings.json</c>) into <see cref="ShellSettings.MapCaptureBbox"/>
+/// (the one-rect capture frame, physical px, in <c>shell.json</c>).
+///
+/// <para><b>Why a cross-file carry-over (mirrors <see cref="GameConfigCarryOver"/>,
+/// #919).</b> The value moves <em>between files</em> and <em>between units</em>
+/// (DIU → physical), so a per-file <c>IVersionedState.Migrate</c> can reach neither
+/// across files nor at the right unit. We read the pre-retirement <c>mapOverlay</c>
+/// rect straight out of the raw <c>legolas/settings.json</c> on disk (the key
+/// persists there for upgrading users even though <c>LegolasSettings</c> no longer
+/// declares the field) and seed the shell store <strong>only when the shell rect is
+/// still unset</strong> (<see cref="ShellSettings.MapCaptureBbox"/> is
+/// <see langword="null"/>). That makes it idempotent: once the user has snipped or
+/// dragged (shell rect non-null) we never clobber it, and on a fresh install with no
+/// legolas file it is a no-op.</para>
+///
+/// <para><b>Why this matters.</b> #947 shipped <see cref="ShellSettings.MapCaptureBbox"/>
+/// null-default, so an upgrading user's last overlay-derived capture region was
+/// already reset to "no bbox". Recovering it from the still-persisted overlay
+/// position restores the one-rect for upgraders instead of forcing a re-snip.</para>
+///
+/// <para><b>DPI.</b> DIU → physical needs a device scale. At bootstrap no overlay
+/// window exists, so the caller supplies the system/primary DPI scale — exact for
+/// the supported single-/uniform-DPI case; a true mixed-DPI multi-monitor layout is
+/// #938 best-effort (the seeded rect may be off-scale; the user re-snips to correct).</para>
+/// </summary>
+public static class MapCaptureRectCarryOver
+{
+    // The retired LegolasSettings.MapOverlay factory default (its initializer was
+    // `new() { Width = 800, Height = 600 }`, over WindowLayout's Left=100/Top=100).
+    // A persisted rect still equal to this means the user never positioned the
+    // overlay, so there is no meaningful frame to migrate — leave the shell rect
+    // unset and let the user snip fresh.
+    internal const double DefaultLeft = 100;
+    internal const double DefaultTop = 100;
+    internal const double DefaultWidth = 800;
+    internal const double DefaultHeight = 600;
+
+    /// <summary>
+    /// Mutates <paramref name="shell"/> in place. Safe to call on every startup; only
+    /// the first run (shell rect still null + a non-default legolas overlay rect)
+    /// changes anything.
+    /// </summary>
+    /// <param name="legolasSettingsPath">Path to the module's <c>settings.json</c>.</param>
+    /// <param name="shell">The loaded shared shell settings.</param>
+    /// <param name="dpiScale">System/primary device scale (1.0 at 100%, 1.5 at 150%)
+    /// used to convert the legacy DIU rect to physical pixels.</param>
+    /// <returns><c>true</c> if the bbox was carried over (so the caller can persist).</returns>
+    public static bool Apply(string legolasSettingsPath, ShellSettings shell, double dpiScale)
+    {
+        ArgumentNullException.ThrowIfNull(shell);
+        if (shell.MapCaptureBbox is not null) return false; // already set — never clobber
+        if (string.IsNullOrEmpty(legolasSettingsPath) || !File.Exists(legolasSettingsPath))
+            return false;
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(legolasSettingsPath));
+            root = doc.RootElement.Clone(); // survive the using-block dispose
+        }
+        catch
+        {
+            // Corrupt / unreadable legolas settings — nothing to carry. The module's
+            // own loader will surface any real problem.
+            return false;
+        }
+
+        if (root.ValueKind != JsonValueKind.Object
+            || !root.TryGetProperty("mapOverlay", out var overlay)
+            || overlay.ValueKind != JsonValueKind.Object)
+            return false;
+
+        if (!TryGetNumber(overlay, "left", out var left)
+            || !TryGetNumber(overlay, "top", out var top)
+            || !TryGetNumber(overlay, "width", out var width)
+            || !TryGetNumber(overlay, "height", out var height))
+            return false;
+
+        if (width <= 0 || height <= 0) return false; // degenerate — nothing to capture
+
+        // Untouched factory default → no meaningful frame to migrate.
+        if (left == DefaultLeft && top == DefaultTop
+            && width == DefaultWidth && height == DefaultHeight)
+            return false;
+
+        var physical = CaptureRectMath.DiuToPhysical(left, top, width, height, dpiScale, dpiScale);
+        if (physical.IsEmpty) return false;
+
+        shell.MapCaptureBbox = new MapCaptureBbox
+        {
+            Left = physical.X,
+            Top = physical.Y,
+            Width = physical.Width,
+            Height = physical.Height,
+        };
+        return true;
+    }
+
+    private static bool TryGetNumber(JsonElement obj, string name, out double value)
+    {
+        value = 0;
+        return obj.TryGetProperty(name, out var el)
+            && el.ValueKind == JsonValueKind.Number
+            && el.TryGetDouble(out value);
+    }
+}

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -43,6 +43,20 @@ public static class Program
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Mithril", "Shell", "activation.uri");
 
+    /// <summary>System (primary-monitor) DPI scale at process start — 1.0 at 96 DPI
+    /// (100%), 1.5 at 144 (150%). Used once at bootstrap to convert the retired
+    /// overlay DIU rect to physical px (#957, <see cref="MapCaptureRectCarryOver"/>)
+    /// before any window exists. The process is PerMonitorV2-aware via the app
+    /// manifest, so this reflects the real system setting (not a flat 96).</summary>
+    private static double SystemDpiScale()
+    {
+        uint dpi = GetDpiForSystem();
+        return dpi == 0 ? 1.0 : dpi / 96.0;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForSystem();
+
     [STAThread]
     public static void Main(string[] args)
     {
@@ -119,6 +133,19 @@ public static class Program
             var shellStore = new JsonSettingsStore<ShellSettings>(
                 shellSettingsPath, ShellSettingsJsonContext.Default.ShellSettings);
             var shellSettings = shellStore.LoadAsync().GetAwaiter().GetResult();
+
+            // #957: ShellSettings became schema-versioned (#208). Mirror
+            // AddMithrilVersionedSettings — dispatch through Migrate + persist when the
+            // loaded version lags CurrentVersion (identity for v1; future bumps add
+            // upgrade logic). Done inline because the shell store is loaded by hand
+            // here, before the host is built.
+            if (shellSettings.SchemaVersion != ShellSettings.CurrentVersion)
+            {
+                shellSettings = ShellSettings.Migrate(shellSettings);
+                shellSettings.SchemaVersion = ShellSettings.CurrentVersion;
+                shellStore.SaveAsync(shellSettings).GetAwaiter().GetResult();
+            }
+
             if (string.IsNullOrEmpty(shellSettings.GameRoot))
                 shellSettings.GameRoot = GameLocator.AutoDetectGameRoot() ?? "";
 
@@ -131,6 +158,16 @@ public static class Program
             // closes. Runs before the module loads, so the shared store wins.
             var legolasSettingsPath = Path.Combine(localApp, "Mithril", "Legolas", "settings.json");
             if (GameConfigCarryOver.Apply(legolasSettingsPath, shellSettings))
+                shellStore.SaveAsync(shellSettings).GetAwaiter().GetResult();
+
+            // #957 one-time cross-file carry-over: the retired LegolasSettings.MapOverlay
+            // (overlay position, DIUs) → ShellSettings.MapCaptureBbox (the one-rect
+            // capture frame, physical px), so an upgrading user's overlay frame becomes
+            // the capture frame instead of resetting to "no bbox". Idempotent — only
+            // fires when the shell rect is still unset. DIU→physical needs a device
+            // scale and no window exists yet, so use the system/primary DPI (exact for
+            // uniform-DPI; mixed-DPI is #938 best-effort — re-snip to correct).
+            if (MapCaptureRectCarryOver.Apply(legolasSettingsPath, shellSettings, SystemDpiScale()))
                 shellStore.SaveAsync(shellSettings).GetAwaiter().GetResult();
 
             // Game config (live, observable)

--- a/src/Mithril.Shell/ShellMapCaptureRectStore.cs
+++ b/src/Mithril.Shell/ShellMapCaptureRectStore.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Logging;
-using Mithril.MapCalibration.Capture;
+using Mithril.MapCalibration;
 using Mithril.Shared.Settings;
 
 namespace Mithril.Shell;

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -6,8 +6,26 @@ using Mithril.Shared.Hotkeys;
 
 namespace Mithril.Shell;
 
-public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPersistence
+public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPersistence, IVersionedState<ShellSettings>
 {
+    /// <summary>Current persisted schema version. ShellSettings became versioned in
+    /// #957 (#208 hygiene — every persisted JSON root should carry a version). Bump
+    /// this and add upgrade logic in <see cref="Migrate"/> when a field is
+    /// renamed/retyped/removed; a purely additive field needs no bump.</summary>
+    public const int Version = 1;
+
+    /// <inheritdoc cref="IVersionedState{T}.CurrentVersion"/>
+    public static int CurrentVersion => Version;
+
+    /// <summary>Identity migrate — no breaking shape change yet. The one-time
+    /// cross-file carry-over of the retired <c>LegolasSettings.MapOverlay</c> →
+    /// <see cref="MapCaptureBbox"/> lives in <see cref="MapCaptureRectCarryOver"/>
+    /// (it needs a DPI scale a per-file migrate can't supply), not here.</summary>
+    public static ShellSettings Migrate(ShellSettings loaded) => loaded;
+
+    /// <summary>Persisted schema version of this instance (see <see cref="Version"/>).</summary>
+    public int SchemaVersion { get; set; } = Version;
+
     private string _gameRoot = "";
     public string GameRoot { get => _gameRoot; set => Set(ref _gameRoot, value); }
 

--- a/tests/Legolas.Tests/Hotkeys/OverlayControllerInputSmokeTests.cs
+++ b/tests/Legolas.Tests/Hotkeys/OverlayControllerInputSmokeTests.cs
@@ -114,7 +114,8 @@ public sealed class OverlayControllerInputSmokeTests
         var moduleGates = new Mithril.Shared.Modules.ModuleGates();
         var overlayWindow = new FakeOverlayWindow();
         var controller = new OverlayController(
-            stub, moduleGates, session, settings, focusGate: null!, overlayWindow, settingsSaver: null!);
+            stub, moduleGates, session, settings, focusGate: null!, overlayWindow,
+            settingsSaver: null!, captureRectStore: null!);
 
         // The "viewport" stands in for the shared window's ViewportRoot.
         // The TestSimulate* seams don't read its rendered surface, only

--- a/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
@@ -216,6 +216,36 @@ public class LegolasSettingsMigrationTests
     }
 
     [Fact]
+    public void V5_blob_with_mapOverlay_loads_and_drops_the_retired_key_on_save()
+    {
+        // #957: MapOverlay was retired (the survey overlay reads its frame from the
+        // shell capture rect now). A v5 blob still has the orphaned mapOverlay key;
+        // it must load without error, Migrate is a no-op for v5+, and the re-saved
+        // v6 JSON no longer carries the key (STJ ignores it on load + drops on save).
+        var v5 = """
+            {
+              "schemaVersion": 5,
+              "mapOverlay": { "left": 220, "top": 140, "width": 960, "height": 540 },
+              "pinStyle": { "outer": { "strokeColor": "#FFAA0000" } }
+            }
+            """;
+        var loaded = JsonSerializer.Deserialize(v5, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+        loaded.SchemaVersion.Should().Be(5);
+
+        var migrated = LegolasSettings.Migrate(loaded);
+        migrated.SchemaVersion = LegolasSettings.CurrentVersion;
+
+        // v5 → v6 leaves everything else untouched.
+        migrated.PinStyle.Outer.StrokeColor.Should().Be("#FFAA0000");
+
+        var written = JsonSerializer.Serialize(migrated, LegolasSettingsJsonContext.Default.LegolasSettings);
+        written.Should().NotContain("mapOverlay", "the retired field is no longer declared, so STJ drops it");
+        written.Should().Contain($"\"schemaVersion\": {LegolasSettings.CurrentVersion}");
+        // Sibling overlay layouts are unaffected by the retire.
+        written.Should().Contain("inventoryOverlay");
+    }
+
+    [Fact]
     public void MotherlodeMultiMapMode_defaults_true_and_round_trips()
     {
         // Additive (#488): a v4 blob without the key loads the true default,

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureMathTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureMathTests.cs
@@ -116,4 +116,63 @@ public sealed class CaptureMathTests
         CaptureRectMath.DiuToPhysical(-800, -100, 400, 200, 1.5, 1.5)
             .Should().Be(new CaptureRect(-1200, -150, 600, 300));
     }
+
+    // ---- #957: physical→DIU for the overlay read path ----
+    //
+    // The overlay window reads its frame from the physical-px capture store and must
+    // convert back to DIU to set Window.Left/Top/Width/Height. PhysicalToDiu is the
+    // inverse of DiuToPhysical; round-tripping at the same scale must reproduce the
+    // original integer rect (the binder positions the window where the snip framed it).
+
+    [Fact]
+    public void PhysicalToDiu_is_identity_at_100_percent()
+    {
+        CaptureRectMath.PhysicalToDiu(new CaptureRect(120, 80, 800, 600), 1.0, 1.0)
+            .Should().Be((120.0, 80.0, 800.0, 600.0));
+    }
+
+    [Theory]
+    [InlineData(1.50, 300, 150, 600, 450, 200, 100, 400, 300)]  // 150%
+    [InlineData(2.00, 200, 100, 800, 600, 100, 50, 400, 300)]   // 200%
+    public void PhysicalToDiu_divides_by_dpi(
+        double scale,
+        int px, int py, int pw, int ph,
+        double dl, double dt, double dw, double dh)
+    {
+        CaptureRectMath.PhysicalToDiu(new CaptureRect(px, py, pw, ph), scale, scale)
+            .Should().Be((dl, dt, dw, dh));
+    }
+
+    [Fact]
+    public void PhysicalToDiu_preserves_negative_virtual_origin()
+    {
+        // Secondary monitor left/above the primary: the signed origin survives the
+        // inverse scale just as it does the forward one.
+        CaptureRectMath.PhysicalToDiu(new CaptureRect(-1200, -150, 600, 300), 1.5, 1.5)
+            .Should().Be((-800.0, -100.0, 400.0, 200.0));
+    }
+
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(1.25)]
+    [InlineData(1.5)]
+    [InlineData(2.0)]
+    public void PhysicalToDiu_round_trips_back_to_the_original_physical_rect(double scale)
+    {
+        var original = new CaptureRect(150, 90, 640, 480);
+        var (l, t, w, h) = CaptureRectMath.PhysicalToDiu(original, scale, scale);
+        // DIU → physical at the same scale must reproduce the integer rect the snip
+        // framed (edge-rounding is a no-op on already-integer device edges).
+        CaptureRectMath.DiuToPhysical(l, t, w, h, scale, scale).Should().Be(original);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, 0, 1.0, 1.0)]    // empty rect
+    [InlineData(0, 0, 100, 100, 0.0, 1.0)] // bad scale
+    public void PhysicalToDiu_returns_zero_on_degenerate_input(
+        int px, int py, int pw, int ph, double sx, double sy)
+    {
+        CaptureRectMath.PhysicalToDiu(new CaptureRect(px, py, pw, ph), sx, sy)
+            .Should().Be((0.0, 0.0, 0.0, 0.0));
+    }
 }

--- a/tests/Mithril.Shell.Tests/MapCaptureRectCarryOverTests.cs
+++ b/tests/Mithril.Shell.Tests/MapCaptureRectCarryOverTests.cs
@@ -1,0 +1,151 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shell;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #957 carry-over: the retired <c>LegolasSettings.MapOverlay</c> (overlay window
+/// position, DIUs, in <c>legolas/settings.json</c>) migrates into
+/// <see cref="ShellSettings.MapCaptureBbox"/> (the one-rect capture frame, physical
+/// px) so an upgrading user's overlay frame becomes the capture frame instead of
+/// resetting to "no bbox". Pins the cross-file read, the DIU→physical conversion at
+/// a given system scale, idempotency, and the don't-clobber / default gates.
+/// </summary>
+public sealed class MapCaptureRectCarryOverTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "mithril-957-" + Guid.NewGuid().ToString("N"));
+
+    public MapCaptureRectCarryOverTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private string WriteLegolasJson(string json)
+    {
+        var path = Path.Combine(_dir, "settings.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public void Non_default_overlay_is_carried_into_an_unset_shell_at_100_percent()
+    {
+        var path = WriteLegolasJson(
+            """{ "mapOverlay": { "left": 220, "top": 140, "width": 960, "height": 540 } }""");
+        var shell = new ShellSettings();
+
+        var carried = MapCaptureRectCarryOver.Apply(path, shell, dpiScale: 1.0);
+
+        carried.Should().BeTrue();
+        shell.MapCaptureBbox.Should().NotBeNull();
+        shell.MapCaptureBbox!.Left.Should().Be(220);
+        shell.MapCaptureBbox.Top.Should().Be(140);
+        shell.MapCaptureBbox.Width.Should().Be(960);
+        shell.MapCaptureBbox.Height.Should().Be(540);
+    }
+
+    [Fact]
+    public void Overlay_is_converted_to_physical_pixels_at_a_non_100_percent_scale()
+    {
+        var path = WriteLegolasJson(
+            """{ "mapOverlay": { "left": 200, "top": 100, "width": 400, "height": 300 } }""");
+        var shell = new ShellSettings();
+
+        var carried = MapCaptureRectCarryOver.Apply(path, shell, dpiScale: 1.5);
+
+        carried.Should().BeTrue();
+        // DIU · 1.5 → physical, edge-rounded (the same math the snip uses).
+        shell.MapCaptureBbox!.Left.Should().Be(300);
+        shell.MapCaptureBbox.Top.Should().Be(150);
+        shell.MapCaptureBbox.Width.Should().Be(600);
+        shell.MapCaptureBbox.Height.Should().Be(450);
+    }
+
+    [Fact]
+    public void An_already_set_shell_rect_is_never_clobbered()
+    {
+        var path = WriteLegolasJson(
+            """{ "mapOverlay": { "left": 220, "top": 140, "width": 960, "height": 540 } }""");
+        var shell = new ShellSettings
+        {
+            MapCaptureBbox = new MapCaptureBbox { Left = 10, Top = 20, Width = 30, Height = 40 },
+        };
+
+        var carried = MapCaptureRectCarryOver.Apply(path, shell, dpiScale: 1.0);
+
+        carried.Should().BeFalse();
+        shell.MapCaptureBbox!.Left.Should().Be(10);
+        shell.MapCaptureBbox.Width.Should().Be(30);
+    }
+
+    [Fact]
+    public void Carry_over_is_idempotent_second_run_after_carrying_does_nothing()
+    {
+        var path = WriteLegolasJson(
+            """{ "mapOverlay": { "left": 220, "top": 140, "width": 960, "height": 540 } }""");
+        var shell = new ShellSettings();
+
+        MapCaptureRectCarryOver.Apply(path, shell, 1.0).Should().BeTrue();
+        // Shell rect is now set → the gate is closed.
+        MapCaptureRectCarryOver.Apply(path, shell, 1.0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Untouched_factory_default_overlay_is_not_carried()
+    {
+        // The retired MapOverlay initializer default: left=100, top=100, 800x600.
+        var path = WriteLegolasJson(
+            """{ "mapOverlay": { "left": 100, "top": 100, "width": 800, "height": 600 } }""");
+        var shell = new ShellSettings();
+
+        var carried = MapCaptureRectCarryOver.Apply(path, shell, 1.0);
+
+        carried.Should().BeFalse("an untouched default overlay is no meaningful frame to migrate");
+        shell.MapCaptureBbox.Should().BeNull();
+    }
+
+    [Fact]
+    public void Degenerate_overlay_size_is_not_carried()
+    {
+        var path = WriteLegolasJson(
+            """{ "mapOverlay": { "left": 100, "top": 100, "width": 0, "height": 600 } }""");
+        var shell = new ShellSettings();
+
+        MapCaptureRectCarryOver.Apply(path, shell, 1.0).Should().BeFalse();
+        shell.MapCaptureBbox.Should().BeNull();
+    }
+
+    [Fact]
+    public void Missing_overlay_key_is_a_no_op()
+    {
+        var path = WriteLegolasJson("""{ "clickThroughMap": true }""");
+        var shell = new ShellSettings();
+
+        MapCaptureRectCarryOver.Apply(path, shell, 1.0).Should().BeFalse();
+        shell.MapCaptureBbox.Should().BeNull();
+    }
+
+    [Fact]
+    public void Missing_legolas_file_is_a_no_op()
+    {
+        var shell = new ShellSettings();
+
+        MapCaptureRectCarryOver.Apply(Path.Combine(_dir, "nope.json"), shell, 1.0)
+            .Should().BeFalse();
+        shell.MapCaptureBbox.Should().BeNull();
+    }
+
+    [Fact]
+    public void Corrupt_legolas_file_is_a_no_op()
+    {
+        var path = WriteLegolasJson("{ not valid json");
+        var shell = new ShellSettings();
+
+        MapCaptureRectCarryOver.Apply(path, shell, 1.0).Should().BeFalse();
+        shell.MapCaptureBbox.Should().BeNull();
+    }
+}

--- a/tests/Mithril.Shell.Tests/ShellMapCaptureRectStoreTests.cs
+++ b/tests/Mithril.Shell.Tests/ShellMapCaptureRectStoreTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Mithril.MapCalibration.Capture;
+using Mithril.MapCalibration;
 using Mithril.Shared.Settings;
 using Mithril.Shell;
 using Xunit;

--- a/tests/Mithril.Shell.Tests/ShellSettingsVersioningTests.cs
+++ b/tests/Mithril.Shell.Tests/ShellSettingsVersioningTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.Shell;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #957 (#208): ShellSettings became schema-versioned. Pins the v1 invariants — a
+/// fresh instance is current, <see cref="ShellSettings.Migrate"/> is an identity
+/// passthrough, and the version round-trips through the source-gen JSON context.
+/// </summary>
+public sealed class ShellSettingsVersioningTests
+{
+    [Fact]
+    public void Current_version_is_one_and_fresh_instances_are_current()
+    {
+        ShellSettings.CurrentVersion.Should().Be(1);
+        new ShellSettings().SchemaVersion.Should().Be(ShellSettings.CurrentVersion);
+    }
+
+    [Fact]
+    public void Migrate_is_an_identity_passthrough()
+    {
+        var s = new ShellSettings { GameRoot = @"C:\Games\PG", SidebarWidth = 333 };
+
+        var migrated = ShellSettings.Migrate(s);
+
+        migrated.Should().BeSameAs(s);
+        migrated.GameRoot.Should().Be(@"C:\Games\PG");
+        migrated.SidebarWidth.Should().Be(333);
+    }
+
+    [Fact]
+    public void Legacy_unversioned_json_loads_as_current_shape()
+    {
+        // A pre-#957 shell.json never carried a schemaVersion key. STJ leaves the
+        // property at its initializer (= current), so the loader treats it as v1 (it
+        // IS the v1 shape) — no spurious migration, no throw.
+        var loaded = JsonSerializer.Deserialize(
+            """{ "gameRoot": "C:/PG", "sidebarWidth": 280 }""",
+            ShellSettingsJsonContext.Default.ShellSettings)!;
+
+        loaded.SchemaVersion.Should().Be(ShellSettings.CurrentVersion);
+        loaded.GameRoot.Should().Be("C:/PG");
+    }
+
+    [Fact]
+    public void Schema_version_round_trips_through_json()
+    {
+        var written = JsonSerializer.Serialize(
+            new ShellSettings(), ShellSettingsJsonContext.Default.ShellSettings);
+
+        written.Should().Contain($"\"schemaVersion\": {ShellSettings.CurrentVersion}");
+    }
+}


### PR DESCRIPTION
Closes #957.

## What & why
#947 lifted the map **capture** rect to a shell-owned store (`ShellSettings.MapCaptureBbox`, physical px, behind `IMapCaptureRectStore`), but the Legolas **overlay window** still positioned itself from `LegolasSettings.MapOverlay` (DIU). Two rects coincided only at snip time and diverged on drag. This consolidates the overlay onto the shell capture rect so the capture frame and the overlay frame are a single source of truth, both directions (spec §7 / #940 one-rect invariant).

## Changes
- **Seam → core.** Moved `CaptureRect` / `IMapCaptureRectStore` / `CaptureRectMath` from `Mithril.MapCalibration.Capture` to core `Mithril.MapCalibration` so `Legolas.Module` (references core, **not** the windows-only Capture project) consumes the same store the capture path does. Added `CaptureRectMath.PhysicalToDiu` for the overlay read path. `#921` decoder-free guard stays green (all BCL).
- **`CaptureRectWindowBinder`.** Positions the overlay from the store (physical→DIU at the window's own live `TransformToDevice`) on `SourceInitialized`; writes drags/resizes back (DIU→physical), debounced (the store flushes synchronously), with an `_applying` feedback fence + skip-if-unchanged guard (also absorbs WPF's deferred `SizeChanged`). Wired into the **live** `OverlayController` path — the issue cited `MapOverlayView:90`, but that view has been dead since #835 step 6.
- **Migrate, then retire `LegolasSettings.MapOverlay`.** `MapCaptureRectCarryOver` (mirrors the #919 `GameConfigCarryOver` idiom) reads the raw `mapOverlay` DIU rect from `legolas/settings.json` at bootstrap and seeds `MapCaptureBbox` (DIU→physical at system DPI), only when the shell rect is still unset — so an upgrading user's overlay frame is **recovered** rather than reset to "no bbox". Property removed; `LegolasSettings` bumped v5→v6.
- **Schema-versioned `ShellSettings`** (folded in, #208) — it previously carried **no** version. Now `IVersionedState<ShellSettings>` v1 with an identity `Migrate` + an inline migrate dispatch in `Program.cs`.
- **Doc tidy** — `IMapCaptureRegionProvider` reworded; `MapBboxDrawController` updated (the consolidation it called a follow-up is done).

## Acceptance
- [x] Overlay sits at the same rect the capture path uses, sourced from one store, both directions (snip→store+mirror, drag→store via binder write-back).
- [x] No capture↔overlay transform introduced — the DIU↔physical conversion is the sanctioned per-window scale, single store (#940).
- [x] `MapOverlay` disposition: migrated (carry-over) + retired (v5→v6) cleanly.
- [x] Stale `IMapCaptureRegionProvider` doc-comment corrected.
- [x] Build clean (warnings-as-errors); #921 guard green; fail-soft preserved.

## Tests
`CaptureRectMath.PhysicalToDiu` (round-trip/scale/sign/degenerate); 9 `MapCaptureRectCarryOver` cases (carry/clobber-guard/default-gate/idempotency/missing/corrupt); 4 `ShellSettings` versioning cases; `LegolasSettings` v5→v6 drop-`mapOverlay`-key case. Full suite green.

## Manual-verify owed (running PG, #938 class)
Snip with overlay hidden → show → overlay sits at the snipped rect; drag overlay → capture BitBlt follows; upgrade path recovers the prior `mapOverlay` frame; on a scaled (≠100% DPI) display the overlay and capture frames coincide. Mixed-DPI multi-monitor remains the #938 single-window-scale caveat.

— drafted by Claude (Opus 4.8), posted by @arthur-conde
