### PR TITLE
fix(map-calibration): resolve Steam install dir for the asset-extractor sidecar, not GameRoot (#959)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -195,7 +195,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         if (tex is not null) return tex;
 
         if (_assetExtractor is null || _gameConfig is null
-            || string.IsNullOrWhiteSpace(_gameConfig.GameRoot) || string.IsNullOrWhiteSpace(_assetCacheDir))
+            || string.IsNullOrWhiteSpace(_gameConfig.InstallRoot) || string.IsNullOrWhiteSpace(_assetCacheDir))
         {
             return null; // no extractor wired → safe-degrade (caller surfaces "preparing map assets…")
         }
@@ -204,7 +204,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         try
         {
             var request = new ExtractRequest(
-                InstallRoot: _gameConfig.GameRoot,
+                InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Texture,
                 AreaKey: area,
@@ -256,7 +256,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         if (templates.Templates.Count > 0) return templates;
 
         if (_assetExtractor is null || _gameConfig is null
-            || string.IsNullOrWhiteSpace(_gameConfig.GameRoot) || string.IsNullOrWhiteSpace(_assetCacheDir))
+            || string.IsNullOrWhiteSpace(_gameConfig.InstallRoot) || string.IsNullOrWhiteSpace(_assetCacheDir))
         {
             return templates; // no extractor wired → safe-degrade (Empty → gate rejects)
         }
@@ -265,7 +265,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         try
         {
             var request = new ExtractRequest(
-                InstallRoot: _gameConfig.GameRoot,
+                InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Icons,
                 AreaKey: null,

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -183,7 +183,7 @@ public static partial class CaptureServiceCollectionExtensions
         // cache per attempt, a same-session populate takes effect immediately — the
         // engine's own --icons demand-trigger (EnsureIconTemplatesAsync) is the
         // correctness backstop, and this warm-up is the latency optimisation.
-        // Fail-soft: no exe / GameRoot empty / non-zero exit → no icons, no throw.
+        // Fail-soft: no exe / InstallRoot empty / non-zero exit → no icons, no throw.
         services.AddSingleton<IconTemplateBootstrap>(sp => new IconTemplateBootstrap(
             sp.GetRequiredService<IAssetExtractor>(),
             sp.GetRequiredService<GameConfig>(),

--- a/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
+++ b/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
@@ -26,7 +26,7 @@ namespace Mithril.MapCalibration.Capture;
 /// Failure is irrelevant to startup — it's a cache warm-up.</para>
 ///
 /// <para><b>Fail-soft (preserved end-to-end).</b> No exe / empty
-/// <see cref="GameConfig.GameRoot"/> / non-zero exit / timeout / crash → no icons,
+/// <see cref="GameConfig.InstallRoot"/> / non-zero exit / timeout / crash → no icons,
 /// no throw, no crash. The bootstrap is skipped entirely when the cache is already
 /// populated (manifest present) so it runs at most once per fresh cache.</para>
 /// </summary>
@@ -85,10 +85,10 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
     /// </summary>
     internal async Task<bool> RunOnceAsync(CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(_gameConfig.GameRoot))
+        if (string.IsNullOrWhiteSpace(_gameConfig.InstallRoot))
         {
             _logger.LogInformation(
-                "Icon-template bootstrap skipped: PG install root not configured (GameConfig.GameRoot empty). Safe-degrade.");
+                "Icon-template bootstrap skipped: PG install root not configured (GameConfig.InstallRoot empty). Safe-degrade.");
             return false;
         }
 
@@ -110,7 +110,7 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
         try
         {
             var request = new ExtractRequest(
-                InstallRoot: _gameConfig.GameRoot,
+                InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir,
                 Kind: ExtractKind.Icons,
                 AreaKey: null,

--- a/src/Mithril.Shared/Game/GameConfig.cs
+++ b/src/Mithril.Shared/Game/GameConfig.cs
@@ -13,6 +13,23 @@ public sealed class GameConfig : INotifyPropertyChanged
         set => Set(ref _gameRoot, value);
     }
 
+    /// <summary>
+    /// The PG Unity/Steam <b>install</b> directory (e.g.
+    /// <c>…\steamapps\common\Project Gorgon</c>, which contains
+    /// <c>WindowsPlayer_Data\StreamingAssets</c>). This is what the map-calibration
+    /// asset-extractor sidecar reads as its <c>--install</c> root. Distinct from
+    /// <see cref="GameRoot"/>, which is the LocalLow <i>data</i> dir (Player.log,
+    /// ChatLogs, Reports). Deliberately does NOT participate in the
+    /// <see cref="PlayerLogPath"/>/<see cref="ChatLogDirectory"/>/<see cref="ReportsDirectory"/>
+    /// recomputation — those stay GameRoot-only.
+    /// </summary>
+    private string _installRoot = "";
+    public string InstallRoot
+    {
+        get => _installRoot;
+        set => Set(ref _installRoot, value);
+    }
+
     private double _pollIntervalSeconds = 1.0;
     public double PollIntervalSeconds
     {

--- a/src/Mithril.Shared/Game/GameLocator.cs
+++ b/src/Mithril.Shared/Game/GameLocator.cs
@@ -1,9 +1,14 @@
 using System.IO;
+using System.Text;
+using Microsoft.Win32;
 
 namespace Mithril.Shared.Game;
 
 public static class GameLocator
 {
+    /// <summary>PG ships as Steam AppID 342940.</summary>
+    private const int PgAppId = 342940;
+
     public static string? AutoDetectGameRoot()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -12,5 +17,193 @@ public static class GameLocator
             Directory.GetParent(appData)?.FullName ?? "",
             "LocalLow", "Elder Game", "Project Gorgon");
         return Directory.Exists(candidate) ? candidate : null;
+    }
+
+    /// <summary>
+    /// Fail-soft auto-detection of the PG Unity/Steam <b>install</b> directory
+    /// (e.g. <c>…\steamapps\common\Project Gorgon</c>) — the dir the asset-extractor
+    /// sidecar reads via its <c>--install</c> root. This is distinct from
+    /// <see cref="AutoDetectGameRoot"/>, which returns the LocalLow <i>data</i> dir
+    /// (Player.log etc.). PG is Steam-only on Windows, so detection is Steam-only.
+    ///
+    /// <para>Ported from <c>tools/Mithril.MapCalibration.Tools.Common/SteamInstall.cs</c>,
+    /// but adapted to be <b>fail-soft</b>: every failure (no Steam, no
+    /// <c>libraryfolders.vdf</c>, PG not found, path missing, registry/IO exception)
+    /// returns <see langword="null"/>. It NEVER throws — the whole body is guarded.</para>
+    /// </summary>
+    public static string? AutoDetectInstallRoot()
+    {
+        try
+        {
+            var steamRoot = FindSteamRoot();
+            if (steamRoot is null) return null;
+
+            var vdfPath = Path.Combine(steamRoot, "steamapps", "libraryfolders.vdf");
+            if (!File.Exists(vdfPath)) return null;
+
+            var libraryRoots = ParseLibraryRoots(File.ReadAllText(vdfPath));
+            return ResolvePgInstall(libraryRoots);
+        }
+        catch
+        {
+            // Any unexpected registry / IO / parse failure → safe-degrade to null.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fail-soft Steam-root lookup via the registry. Tries <c>HKCU\Software\Valve\Steam</c>
+    /// (<c>SteamPath</c>, <c>/</c>→<c>\</c> normalised) first, then the 32-bit view of
+    /// <c>HKLM\SOFTWARE\Valve\Steam</c> (<c>InstallPath</c> — the WOW6432Node equivalent).
+    /// Returns <see langword="null"/> on any miss or exception.
+    /// </summary>
+    private static string? FindSteamRoot()
+    {
+        try
+        {
+            using var cu = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam");
+            if (cu?.GetValue("SteamPath") is string cp)
+            {
+                cp = cp.Replace('/', '\\');
+                if (Directory.Exists(cp)) return cp;
+            }
+        }
+        catch { /* fall through to HKLM */ }
+
+        try
+        {
+            using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+            using var key = hklm.OpenSubKey(@"SOFTWARE\Valve\Steam");
+            if (key?.GetValue("InstallPath") is string p && Directory.Exists(p))
+            {
+                return p;
+            }
+        }
+        catch { /* return null below */ }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parse a <c>libraryfolders.vdf</c> document into the list of Steam library
+    /// roots whose <c>apps</c> block lists PG's appid (<see cref="PgAppId"/>). Pure —
+    /// no filesystem or registry access — so it is unit-testable from a sample vdf
+    /// string. Order is preserved (first matching library wins downstream).
+    /// </summary>
+    internal static List<string> ParseLibraryRoots(string vdfText)
+    {
+        var result = new List<string>();
+        var tokens = TokenizeVdf(vdfText);
+        int i = 0;
+        while (i < tokens.Count && tokens[i] != "{") i++;
+        if (i == tokens.Count) return result;
+        i++;
+        while (i < tokens.Count && tokens[i] != "}")
+        {
+            i++; // skip the library index key (e.g. "0")
+            if (i >= tokens.Count || tokens[i] != "{") break;
+            i++;
+            string? path = null;
+            var appIds = new HashSet<int>();
+            while (i < tokens.Count && tokens[i] != "}")
+            {
+                var k = tokens[i++];
+                if (i >= tokens.Count) break;
+                if (k == "path")
+                {
+                    path = tokens[i++];
+                }
+                else if (k == "apps" && tokens[i] == "{")
+                {
+                    i++;
+                    while (i < tokens.Count && tokens[i] != "}")
+                    {
+                        var appKey = tokens[i++];
+                        if (i >= tokens.Count) break;
+                        i++; // skip the app's value
+                        if (int.TryParse(appKey, out var id)) appIds.Add(id);
+                    }
+                    if (i < tokens.Count) i++;
+                }
+                else if (tokens[i] == "{")
+                {
+                    int depth = 1; i++;
+                    while (i < tokens.Count && depth > 0)
+                    {
+                        if (tokens[i] == "{") depth++;
+                        else if (tokens[i] == "}") depth--;
+                        i++;
+                    }
+                }
+                else
+                {
+                    i++;
+                }
+            }
+            if (i < tokens.Count) i++;
+            if (path is not null && appIds.Contains(PgAppId))
+            {
+                result.Add(path);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Given candidate Steam library roots, return the first verified PG install dir
+    /// (<c>&lt;lib&gt;\steamapps\common\Project Gorgon</c>) — verified by the existence
+    /// of <c>WindowsPlayer_Data\StreamingAssets\aa\StandaloneWindows64</c> under it
+    /// (the StreamingAssets path is the proof; the appid match upstream is only a
+    /// hint). Returns the install dir, not the StreamingAssets subdir, because the
+    /// sidecar's <c>--install</c> root expects the install root. Returns
+    /// <see langword="null"/> when no candidate verifies.
+    /// </summary>
+    internal static string? ResolvePgInstall(IEnumerable<string> libraryRoots)
+    {
+        foreach (var lib in libraryRoots)
+        {
+            if (string.IsNullOrWhiteSpace(lib)) continue;
+            var install = Path.Combine(lib, "steamapps", "common", "Project Gorgon");
+            var streamingAssets = Path.Combine(
+                install, "WindowsPlayer_Data", "StreamingAssets", "aa", "StandaloneWindows64");
+            if (Directory.Exists(streamingAssets)) return install;
+        }
+        return null;
+    }
+
+    /// <summary>Minimal Valve KeyValues tokenizer (quoted strings + braces). Lifted
+    /// from the tools <c>SteamInstall</c> so the vdf parse stays byte-identical.</summary>
+    private static List<string> TokenizeVdf(string text)
+    {
+        var t = new List<string>();
+        int i = 0;
+        while (i < text.Length)
+        {
+            var c = text[i];
+            if (char.IsWhiteSpace(c)) { i++; continue; }
+            if (c == '{' || c == '}') { t.Add(c.ToString()); i++; continue; }
+            if (c == '"')
+            {
+                i++;
+                var sb = new StringBuilder();
+                while (i < text.Length && text[i] != '"')
+                {
+                    if (text[i] == '\\' && i + 1 < text.Length)
+                    {
+                        var esc = text[i + 1];
+                        sb.Append(esc switch { 'n' => '\n', 't' => '\t', '\\' => '\\', '"' => '"', _ => esc });
+                        i += 2;
+                    }
+                    else { sb.Append(text[i]); i++; }
+                }
+                t.Add(sb.ToString());
+                if (i < text.Length) i++;
+                continue;
+            }
+            var start = i;
+            while (i < text.Length && !char.IsWhiteSpace(text[i]) && text[i] != '{' && text[i] != '}') i++;
+            t.Add(text[start..i]);
+        }
+        return t;
     }
 }

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -149,6 +149,22 @@ public static class Program
             if (string.IsNullOrEmpty(shellSettings.GameRoot))
                 shellSettings.GameRoot = GameLocator.AutoDetectGameRoot() ?? "";
 
+            // #959: the asset-extractor sidecar needs the Steam INSTALL dir
+            // (…\steamapps\common\Project Gorgon — contains WindowsPlayer_Data),
+            // which is distinct from GameRoot (the LocalLow data dir). Auto-detect
+            // Steam-only + fail-soft when unset; a manual override always wins. Persist
+            // only when detection actually filled it in (skip a redundant save when it
+            // returns null and the value stays "").
+            if (string.IsNullOrEmpty(shellSettings.InstallRoot))
+            {
+                var detectedInstall = GameLocator.AutoDetectInstallRoot();
+                if (!string.IsNullOrEmpty(detectedInstall))
+                {
+                    shellSettings.InstallRoot = detectedInstall;
+                    shellStore.SaveAsync(shellSettings).GetAwaiter().GetResult();
+                }
+            }
+
             // #919 one-time cross-file carry-over: GameProcessName +
             // CalibrationGoodResidualPx moved from LegolasSettings (legolas.json)
             // to the shared shell store. Per-file Migrate can't cross files, so
@@ -174,6 +190,7 @@ public static class Program
             var gameConfig = new GameConfig
             {
                 GameRoot = shellSettings.GameRoot,
+                InstallRoot = shellSettings.InstallRoot,
                 GameProcessName = shellSettings.GameProcessName,
                 CalibrationGoodResidualPx = shellSettings.CalibrationGoodResidualPx,
             };
@@ -183,6 +200,9 @@ public static class Program
                 {
                     case nameof(GameConfig.GameRoot):
                         shellSettings.GameRoot = gameConfig.GameRoot;
+                        break;
+                    case nameof(GameConfig.InstallRoot):
+                        shellSettings.InstallRoot = gameConfig.InstallRoot;
                         break;
                     case nameof(GameConfig.GameProcessName):
                         shellSettings.GameProcessName = gameConfig.GameProcessName;

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -30,6 +30,18 @@ public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPers
     public string GameRoot { get => _gameRoot; set => Set(ref _gameRoot, value); }
 
     /// <summary>
+    /// The PG Unity/Steam <b>install</b> directory (Steam
+    /// <c>…\steamapps\common\Project Gorgon</c>, contains <c>WindowsPlayer_Data</c>),
+    /// consumed by the map-calibration asset-extractor sidecar. Distinct from
+    /// <see cref="GameRoot"/> (the LocalLow data dir). Auto-detected when empty
+    /// (<see cref="Mithril.Shared.Game.GameLocator.AutoDetectInstallRoot"/>); a manual
+    /// override always wins. Purely additive field → no schema bump needed (missing
+    /// key → "" on load).
+    /// </summary>
+    private string _installRoot = "";
+    public string InstallRoot { get => _installRoot; set => Set(ref _installRoot, value); }
+
+    /// <summary>
     /// Case-insensitive substring matched against the foreground window's
     /// process name to decide whether the game is in focus. Relocated here from
     /// <c>LegolasSettings</c> (#919) so the shared map-calibration capture engine

--- a/src/Mithril.Shell/ViewModels/GameConfigViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/GameConfigViewModel.cs
@@ -15,12 +15,14 @@ public sealed partial class GameConfigViewModel : ObservableObject
     {
         _config = config;
         _gameRoot = config.GameRoot;
+        _installRoot = config.InstallRoot;
         _pollSeconds = config.PollIntervalSeconds;
         _gameProcessName = config.GameProcessName;
         _calibrationGoodResidualPx = config.CalibrationGoodResidualPx;
     }
 
     [ObservableProperty] private string _gameRoot;
+    [ObservableProperty] private string _installRoot;
     [ObservableProperty] private double _pollSeconds;
     [ObservableProperty] private string _gameProcessName;
     [ObservableProperty] private double _calibrationGoodResidualPx;
@@ -35,6 +37,8 @@ public sealed partial class GameConfigViewModel : ObservableObject
         _config.GameRoot = value;
         OnPropertyChanged(nameof(PlayerLogPath));
     }
+
+    partial void OnInstallRootChanged(string value) => _config.InstallRoot = value;
 
     partial void OnPollSecondsChanged(double value) => _config.PollIntervalSeconds = value;
 
@@ -57,6 +61,23 @@ public sealed partial class GameConfigViewModel : ObservableObject
     {
         var detected = GameLocator.AutoDetectGameRoot();
         if (detected is not null) GameRoot = detected;
+    }
+
+    [RelayCommand]
+    private void BrowseInstall()
+    {
+        var dlg = new OpenFolderDialog
+        {
+            Title = "Select Project Gorgon install folder (the Steam one containing WindowsPlayer_Data)",
+        };
+        if (dlg.ShowDialog() == true) InstallRoot = dlg.FolderName;
+    }
+
+    [RelayCommand]
+    private void AutoDetectInstall()
+    {
+        var detected = GameLocator.AutoDetectInstallRoot();
+        if (detected is not null) InstallRoot = detected;
     }
 
     /// <summary>

--- a/src/Mithril.Shell/Views/GameConfigView.xaml
+++ b/src/Mithril.Shell/Views/GameConfigView.xaml
@@ -22,6 +22,17 @@
         <TextBlock Text="Resolved Player.log" Foreground="#88FFFFFF" Margin="0,16,0,4"/>
         <TextBlock Text="{Binding PlayerLogPath}" FontFamily="{DynamicResource AppMonoFontFamily}" Foreground="#FFE8E8E8"/>
 
+        <!-- #959: the map-calibration asset-extractor sidecar reads the Steam INSTALL
+             dir (contains WindowsPlayer_Data), which is distinct from the LocalLow data
+             dir above. Auto-detected from Steam; override only if detection misses. -->
+        <TextBlock Text="Project Gorgon install folder (Steam — contains WindowsPlayer_Data; auto-detected, override only if needed)"
+                   Foreground="#88FFFFFF" TextWrapping="Wrap" Margin="0,16,0,4"/>
+        <DockPanel LastChildFill="True">
+            <Button DockPanel.Dock="Right" Content="Browse…" Padding="10,4" Margin="6,0,0,0" Command="{Binding BrowseInstallCommand}"/>
+            <Button DockPanel.Dock="Right" Content="Auto-detect" Padding="10,4" Margin="6,0,0,0" Command="{Binding AutoDetectInstallCommand}"/>
+            <TextBox Text="{Binding InstallRoot, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"/>
+        </DockPanel>
+
         <TextBlock Text="Poll interval (seconds)" Foreground="#88FFFFFF" Margin="0,16,0,4"/>
         <TextBox Text="{Binding PollSeconds, UpdateSourceTrigger=PropertyChanged}" Padding="6,4" Width="100" HorizontalAlignment="Left"/>
 

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -97,7 +97,7 @@ public sealed class AutoCalibrationEngineTests
     [Fact]
     public async Task Empty_icons_with_sidecar_wired_demand_triggers_icons_once_then_re_resolves()
     {
-        // Empty icon cache + a wired extractor + GameRoot/cacheDir set → the engine
+        // Empty icon cache + a wired extractor + InstallRoot/cacheDir set → the engine
         // invokes --icons once and re-resolves the provider in the SAME attempt.
         var icons = new FakeIconTemplateProvider(IconTemplateSet.Empty);
         var extractor = new RecordingAssetExtractor(); // success, no artifacts
@@ -105,7 +105,7 @@ public sealed class AutoCalibrationEngineTests
         {
             IconProvider = icons,
             Extractor = extractor,
-            GameConfig = new GameConfig { GameRoot = @"C:\PG" },
+            GameConfig = new GameConfig { InstallRoot = @"C:\PG" },
             AssetCacheDir = @"C:\cache",
         };
 
@@ -126,7 +126,7 @@ public sealed class AutoCalibrationEngineTests
         {
             IconProvider = icons,
             Extractor = extractor,
-            GameConfig = new GameConfig { GameRoot = @"C:\PG" },
+            GameConfig = new GameConfig { InstallRoot = @"C:\PG" },
             AssetCacheDir = @"C:\cache",
         };
 
@@ -139,7 +139,7 @@ public sealed class AutoCalibrationEngineTests
     [Fact]
     public async Task Empty_icons_without_a_wired_extractor_fails_soft_no_trigger()
     {
-        // No extractor / no GameRoot → safe-degrade: still solves (base texture fine),
+        // No extractor / no InstallRoot → safe-degrade: still solves (base texture fine),
         // just with an empty template set; never throws.
         var icons = new FakeIconTemplateProvider(IconTemplateSet.Empty);
         var h = new EngineHarness { IconProvider = icons }; // Extractor null by default
@@ -171,7 +171,7 @@ public sealed class AutoCalibrationEngineTests
             new FakeCalibrationService(),
             logger: null,
             assetExtractor: new ThrowingAssetExtractor(),
-            gameConfig: new GameConfig { GameRoot = @"C:\PG" },
+            gameConfig: new GameConfig { InstallRoot = @"C:\PG" },
             assetCacheDir: @"C:\cache");
 
         var act = async () => await engine.TryCalibrateCurrentAreaAsync(default);

--- a/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
@@ -12,8 +12,9 @@ namespace Mithril.MapCalibration.Capture.Tests;
 /// <summary>
 /// #945 Gap 3: the icon-template bootstrap's decision logic, tested headless over a
 /// fake <see cref="IAssetExtractor"/> + a temp cache dir (no real exe). Covers the
-/// four gates: empty cache + GameRoot set → invokes <c>--icons</c>; cache already
-/// populated → skips; GameRoot empty → skips; extractor failure/throw → no throw.
+/// four gates: empty cache + InstallRoot set → invokes <c>--icons</c>; cache already
+/// populated → skips; InstallRoot empty → skips; extractor failure/throw → no throw.
+/// (#959: the gate keys off the Steam <c>InstallRoot</c>, not the data-dir GameRoot.)
 /// </summary>
 public sealed class IconTemplateBootstrapTests : IDisposable
 {
@@ -30,9 +31,9 @@ public sealed class IconTemplateBootstrapTests : IDisposable
         try { Directory.Delete(_cacheDir, recursive: true); } catch { /* best effort */ }
     }
 
-    private IconTemplateBootstrap Build(IAssetExtractor extractor, string gameRoot, string? cacheDir = null) =>
+    private IconTemplateBootstrap Build(IAssetExtractor extractor, string installRoot, string? cacheDir = null) =>
         new(extractor,
-            new GameConfig { GameRoot = gameRoot },
+            new GameConfig { InstallRoot = installRoot },
             cacheDir ?? _cacheDir,
             pgVersion: null,
             NullLogger.Instance);
@@ -48,10 +49,10 @@ public sealed class IconTemplateBootstrapTests : IDisposable
     }
 
     [Fact]
-    public async Task Empty_cache_with_game_root_invokes_icons_extraction()
+    public async Task Empty_cache_with_install_root_invokes_icons_extraction()
     {
         var extractor = new RecordingAssetExtractor();
-        var sut = Build(extractor, gameRoot: @"C:\Games\PG");
+        var sut = Build(extractor, installRoot: @"C:\Games\PG");
 
         var invoked = await sut.RunOnceAsync(CancellationToken.None);
 
@@ -69,7 +70,7 @@ public sealed class IconTemplateBootstrapTests : IDisposable
     {
         WritePopulatedManifest();
         var extractor = new RecordingAssetExtractor();
-        var sut = Build(extractor, gameRoot: @"C:\Games\PG");
+        var sut = Build(extractor, installRoot: @"C:\Games\PG");
 
         var invoked = await sut.RunOnceAsync(CancellationToken.None);
 
@@ -78,10 +79,10 @@ public sealed class IconTemplateBootstrapTests : IDisposable
     }
 
     [Fact]
-    public async Task Empty_game_root_does_not_invoke()
+    public async Task Empty_install_root_does_not_invoke()
     {
         var extractor = new RecordingAssetExtractor();
-        var sut = Build(extractor, gameRoot: "");
+        var sut = Build(extractor, installRoot: "");
 
         var invoked = await sut.RunOnceAsync(CancellationToken.None);
 
@@ -94,7 +95,7 @@ public sealed class IconTemplateBootstrapTests : IDisposable
     {
         var failing = new RecordingAssetExtractor(
             new ExtractResult(false, ProcessAssetExtractor.ExitMissingExe, Array.Empty<ExtractedArtifact>(), "no exe"));
-        var sut = Build(failing, gameRoot: @"C:\Games\PG");
+        var sut = Build(failing, installRoot: @"C:\Games\PG");
 
         var invoked = await sut.RunOnceAsync(CancellationToken.None);
 
@@ -107,7 +108,7 @@ public sealed class IconTemplateBootstrapTests : IDisposable
     [Fact]
     public async Task Extractor_throwing_is_swallowed_fail_soft()
     {
-        var sut = Build(new ThrowingAssetExtractor(), gameRoot: @"C:\Games\PG");
+        var sut = Build(new ThrowingAssetExtractor(), installRoot: @"C:\Games\PG");
 
         var act = async () => await sut.RunOnceAsync(CancellationToken.None);
 

--- a/tests/Mithril.Shared.Tests/Game/GameConfigSettingsTests.cs
+++ b/tests/Mithril.Shared.Tests/Game/GameConfigSettingsTests.cs
@@ -94,4 +94,52 @@ public sealed class GameConfigSettingsTests
 
         changed.Should().Contain(nameof(GameConfig.CalibrationGoodResidualPx));
     }
+
+    // #959: InstallRoot = the Steam install dir consumed by the asset-extractor
+    // sidecar, distinct from GameRoot (the LocalLow data dir).
+    [Fact]
+    public void InstallRoot_default_is_empty()
+        => new GameConfig().InstallRoot.Should().BeEmpty();
+
+    [Fact]
+    public void InstallRoot_does_not_affect_data_dir_paths()
+    {
+        // InstallRoot must NOT participate in the Player.log/ChatLogs/Reports
+        // recomputation — those stay GameRoot-only.
+        var c = new GameConfig
+        {
+            GameRoot = @"C:\Data\PG",
+            InstallRoot = @"D:\Steam\common\Project Gorgon",
+        };
+
+        c.PlayerLogPath.Should().Be(@"C:\Data\PG\Player.log");
+        c.ChatLogDirectory.Should().Be(@"C:\Data\PG\ChatLogs");
+        c.ReportsDirectory.Should().Be(@"C:\Data\PG\Reports");
+    }
+
+    [Fact]
+    public void InstallRoot_raises_PropertyChanged_on_change()
+    {
+        var c = new GameConfig();
+        var changed = new List<string?>();
+        c.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        c.InstallRoot = @"D:\Steam\common\Project Gorgon";
+
+        changed.Should().Contain(nameof(GameConfig.InstallRoot));
+    }
+
+    [Fact]
+    public void InstallRoot_change_does_not_raise_data_dir_path_changes()
+    {
+        var c = new GameConfig { GameRoot = @"C:\Data\PG" };
+        var changed = new List<string?>();
+        c.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        c.InstallRoot = @"D:\Steam\common\Project Gorgon";
+
+        changed.Should().NotContain(nameof(GameConfig.PlayerLogPath));
+        changed.Should().NotContain(nameof(GameConfig.ChatLogDirectory));
+        changed.Should().NotContain(nameof(GameConfig.ReportsDirectory));
+    }
 }

--- a/tests/Mithril.Shared.Tests/Game/GameLocatorInstallRootTests.cs
+++ b/tests/Mithril.Shared.Tests/Game/GameLocatorInstallRootTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Game;
+
+/// <summary>
+/// #959: <see cref="GameLocator.AutoDetectInstallRoot"/> resolves the Steam INSTALL
+/// dir for the asset-extractor sidecar. These tests exercise the two pure helpers
+/// (<c>ParseLibraryRoots</c> over a sample <c>libraryfolders.vdf</c> string, and
+/// <c>ResolvePgInstall</c> against a temp-dir tree) so we cover the logic without
+/// touching the live registry/Steam. The public entry point stays fail-soft.
+/// </summary>
+public sealed class GameLocatorInstallRootTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public GameLocatorInstallRootTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "mithril-gamelocator-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static string Vdf(string lib0, string lib1) =>
+        "\"libraryfolders\"\n{\n" +
+        "  \"0\"\n  {\n" +
+        $"    \"path\"\t\t\"{lib0.Replace("\\", "\\\\")}\"\n" +
+        "    \"apps\"\n    {\n      \"228980\"\t\"100\"\n    }\n  }\n" +
+        "  \"1\"\n  {\n" +
+        $"    \"path\"\t\t\"{lib1.Replace("\\", "\\\\")}\"\n" +
+        "    \"apps\"\n    {\n      \"342940\"\t\"5000\"\n      \"413150\"\t\"200\"\n    }\n  }\n" +
+        "}\n";
+
+    private string MakePgTree(string libRoot)
+    {
+        var install = Path.Combine(libRoot, "steamapps", "common", "Project Gorgon");
+        var streamingAssets = Path.Combine(
+            install, "WindowsPlayer_Data", "StreamingAssets", "aa", "StandaloneWindows64");
+        Directory.CreateDirectory(streamingAssets);
+        return install;
+    }
+
+    [Fact]
+    public void ParseLibraryRoots_returns_only_libraries_listing_pg_appid()
+    {
+        var libWithoutPg = @"D:\SteamLibraryA";
+        var libWithPg = @"E:\SteamLibraryB";
+
+        var roots = GameLocator.ParseLibraryRoots(Vdf(libWithoutPg, libWithPg));
+
+        roots.Should().ContainSingle().Which.Should().Be(libWithPg);
+    }
+
+    [Fact]
+    public void ResolvePgInstall_returns_install_dir_when_streaming_assets_present()
+    {
+        var lib = Path.Combine(_tempRoot, "lib");
+        var expectedInstall = MakePgTree(lib);
+
+        var resolved = GameLocator.ResolvePgInstall(new[] { lib });
+
+        resolved.Should().Be(expectedInstall);
+    }
+
+    [Fact]
+    public void ResolvePgInstall_returns_null_when_streaming_assets_absent()
+    {
+        // A library root with the common\Project Gorgon dir but WITHOUT the
+        // StreamingAssets proof should NOT verify.
+        var lib = Path.Combine(_tempRoot, "lib");
+        Directory.CreateDirectory(Path.Combine(lib, "steamapps", "common", "Project Gorgon"));
+
+        GameLocator.ResolvePgInstall(new[] { lib }).Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolvePgInstall_returns_null_for_empty_candidate_set()
+        => GameLocator.ResolvePgInstall(System.Array.Empty<string>()).Should().BeNull();
+
+    [Fact]
+    public void ResolvePgInstall_picks_first_verified_library()
+    {
+        var libBad = Path.Combine(_tempRoot, "bad"); // no tree
+        var libGood = Path.Combine(_tempRoot, "good");
+        var expectedInstall = MakePgTree(libGood);
+
+        var resolved = GameLocator.ResolvePgInstall(new List<string> { libBad, libGood });
+
+        resolved.Should().Be(expectedInstall);
+    }
+
+    [Fact]
+    public void ParseLibraryRoots_on_garbage_returns_empty_not_throw()
+        => GameLocator.ParseLibraryRoots("not a vdf {{{ \"").Should().BeEmpty();
+}

--- a/tests/Mithril.Shell.Tests/ShellSettingsVersioningTests.cs
+++ b/tests/Mithril.Shell.Tests/ShellSettingsVersioningTests.cs
@@ -53,4 +53,31 @@ public sealed class ShellSettingsVersioningTests
 
         written.Should().Contain($"\"schemaVersion\": {ShellSettings.CurrentVersion}");
     }
+
+    [Fact]
+    public void Install_root_round_trips_through_json()
+    {
+        // #959: InstallRoot is an additive field (no schema bump). It must persist
+        // and reload distinctly from GameRoot (data dir vs install dir).
+        var written = JsonSerializer.Serialize(
+            new ShellSettings { GameRoot = @"C:\Data\PG", InstallRoot = @"D:\Steam\common\Project Gorgon" },
+            ShellSettingsJsonContext.Default.ShellSettings);
+
+        var loaded = JsonSerializer.Deserialize(
+            written, ShellSettingsJsonContext.Default.ShellSettings)!;
+
+        loaded.InstallRoot.Should().Be(@"D:\Steam\common\Project Gorgon");
+        loaded.GameRoot.Should().Be(@"C:\Data\PG");
+    }
+
+    [Fact]
+    public void Install_root_defaults_to_empty_when_absent_from_legacy_json()
+    {
+        // A pre-#959 shell.json has no installRoot key → "" on load (additive field).
+        var loaded = JsonSerializer.Deserialize(
+            """{ "gameRoot": "C:/PG" }""",
+            ShellSettingsJsonContext.Default.ShellSettings)!;
+
+        loaded.InstallRoot.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## What & why

Closes the successful-solve half of #938. Map auto-calibration handed the asset-extractor sidecar `GameConfig.GameRoot` (the LocalLow **data** dir) as its `--install` root, but the sidecar needs the Unity **install** dir (`…\steamapps\common\Project Gorgon`, containing `WindowsPlayer_Data\StreamingAssets\aa\StandaloneWindows64`). Result was `exit 4: Addressables bundle dir not found`. `GameRoot` and the install dir are different directories.

## Change

- **`GameLocator.AutoDetectInstallRoot()`** — fail-soft Steam-only detection: registry (`HKCU\Software\Valve\Steam\SteamPath` → `HKLM` 32-bit-view `InstallPath`) → parse `libraryfolders.vdf` for appid **342940** → verify by the `WindowsPlayer_Data\StreamingAssets\aa\StandaloneWindows64` path existing. Ported from the proven `tools/…/SteamInstall.cs` vdf parser, but adapted to **never throw** (returns `null` on any failure). Pure `ParseLibraryRoots`/`ResolvePgInstall` helpers are unit-tested.
- **`GameConfig.InstallRoot` + `ShellSettings.InstallRoot`** — new additive fields (no schema bump, no migration). `InstallRoot` is the install dir the sidecar reads; it deliberately does **not** drive `PlayerLogPath`/`ChatLogDirectory`/`ReportsDirectory` — those stay `GameRoot`-only.
- **Program.cs** — auto-detect the install dir when unset (persist only when detection fills it), seed `GameConfig`, and sync edits back to `ShellSettings` (mirrors the `GameRoot` wiring).
- **Engine + bootstrap** — `AutoCalibrationEngine` (texture + both icon paths) and `IconTemplateBootstrap` now pass `InstallRoot` (not `GameRoot`) as `ExtractRequest.InstallRoot`; fail-soft gates and the misleading "install root" wording updated.
- **Settings UI** — a manual install-folder override (Browse… + Auto-detect) in the Game Configuration tab as an edge-case safety net.

## Invariants held

- `GameRoot`'s data-dir role (Player.log/ChatLogs/Reports + `AddArda` tailing) is untouched — pinned by a new test.
- Fail-soft preserved end-to-end: detection failure / missing install dir → no extraction → gate rejects → "preparing map assets…", never a throw.
- #921 decoder-free `src/**` stays green (path/config only; no decoder added).

## Verification

Independently on the branch: `dotnet build Mithril.slnx` clean (0 warnings/0 errors); `MapCalibration.Capture.Tests` 100, `Shared.Tests` 1222 (incl. `ShippedGraphDecoderFreeTests`), `Shell.Tests` 78, `MapCalibration.Tests` 95 — all pass.

**Live manual verification against a running PG + Steam install is owed under #938** (human-gated; not automatable here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
