### PR TITLE
feat(map-calibration): in-app classdata.tpk download so the sidecar can decode icons/textures (#960)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -1,10 +1,12 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Arda.World.Player;
 using Microsoft.Extensions.Logging;
 using Mithril.MapCalibration.Detection;
 using Mithril.Shared.Game;
+using Mithril.Shared.MapCalibration;
 
 namespace Mithril.MapCalibration.Capture;
 
@@ -100,6 +102,19 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         _gameConfig = gameConfig;
         _assetCacheDir = assetCacheDir;
         _pgVersion = pgVersion;
+    }
+
+    /// <summary>
+    /// The downloaded <c>classdata.tpk</c> path inside the asset cache, or null when
+    /// it isn't present yet (#960). Threaded into <see cref="ExtractRequest.TpkPath"/>
+    /// so the sidecar can decode icons; when null the sidecar falls back to its old
+    /// resolution and fail-softs exactly as before.
+    /// </summary>
+    private string? ResolveTpkPath()
+    {
+        if (string.IsNullOrWhiteSpace(_assetCacheDir)) return null;
+        var tpk = Path.Combine(_assetCacheDir, ClassDataTpkProvisioner.TpkFileName);
+        return File.Exists(tpk) ? tpk : null;
     }
 
     public async Task<AutoCalibrationOutcome> TryCalibrateCurrentAreaAsync(CancellationToken ct)
@@ -208,7 +223,8 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Texture,
                 AreaKey: area,
-                ExpectPgVersion: _pgVersion);
+                ExpectPgVersion: _pgVersion,
+                TpkPath: ResolveTpkPath());
             var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);
             if (!extract.Ok)
             {
@@ -269,7 +285,8 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Icons,
                 AreaKey: null,
-                ExpectPgVersion: _pgVersion);
+                ExpectPgVersion: _pgVersion,
+                TpkPath: ResolveTpkPath());
             var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);
             if (!extract.Ok)
             {

--- a/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
+++ b/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
@@ -1,7 +1,9 @@
+using System.IO;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Mithril.MapCalibration.Detection;
 using Mithril.Shared.Game;
+using Mithril.Shared.MapCalibration;
 
 namespace Mithril.MapCalibration.Capture;
 
@@ -53,6 +55,18 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
         _assetCacheDir = assetCacheDir;
         _pgVersion = pgVersion;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// The downloaded <c>classdata.tpk</c> path inside the asset cache, or null when
+    /// it isn't present yet (#960). When null the sidecar falls back to its old
+    /// resolution and fail-softs (icons stay disabled until the user downloads it).
+    /// </summary>
+    private string? ResolveTpkPath()
+    {
+        if (string.IsNullOrWhiteSpace(_assetCacheDir)) return null;
+        var tpk = Path.Combine(_assetCacheDir, ClassDataTpkProvisioner.TpkFileName);
+        return File.Exists(tpk) ? tpk : null;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -114,7 +128,8 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
                 OutDir: _assetCacheDir,
                 Kind: ExtractKind.Icons,
                 AreaKey: null,
-                ExpectPgVersion: _pgVersion);
+                ExpectPgVersion: _pgVersion,
+                TpkPath: ResolveTpkPath());
             var result = await _extractor.ExtractAsync(request, ct).ConfigureAwait(false);
             if (result.Ok)
             {

--- a/src/Mithril.MapCalibration/Detection/IAssetExtractor.cs
+++ b/src/Mithril.MapCalibration/Detection/IAssetExtractor.cs
@@ -29,12 +29,17 @@ public interface IAssetExtractor
 /// <param name="Kind">Icons or a single area's base texture.</param>
 /// <param name="AreaKey">Required when <see cref="Kind"/> is <see cref="ExtractKind.Texture"/>.</param>
 /// <param name="ExpectPgVersion">Optional <c>--expect-pg-version</c> assertion.</param>
+/// <param name="TpkPath">Optional explicit <c>--tpk</c> path to the UABEA
+/// <c>classdata.tpk</c> the icon decoder needs (#960). When set, the sidecar
+/// prefers it over its beside-exe / repo-default resolution; when null, the
+/// sidecar falls back to its old resolution and fail-softs if none is present.</param>
 public sealed record ExtractRequest(
     string InstallRoot,
     string OutDir,
     ExtractKind Kind,
     string? AreaKey,
-    string? ExpectPgVersion);
+    string? ExpectPgVersion,
+    string? TpkPath = null);
 
 public enum ExtractKind
 {

--- a/src/Mithril.MapCalibration/Detection/ProcessAssetExtractor.cs
+++ b/src/Mithril.MapCalibration/Detection/ProcessAssetExtractor.cs
@@ -166,6 +166,11 @@ public sealed class ProcessAssetExtractor : IAssetExtractor
             psi.ArgumentList.Add("--expect-pg-version");
             psi.ArgumentList.Add(request.ExpectPgVersion);
         }
+        if (!string.IsNullOrWhiteSpace(request.TpkPath))
+        {
+            psi.ArgumentList.Add("--tpk");
+            psi.ArgumentList.Add(request.TpkPath);
+        }
         return psi;
     }
 

--- a/src/Mithril.Shared/MapCalibration/ClassDataTpkProvisioner.cs
+++ b/src/Mithril.Shared/MapCalibration/ClassDataTpkProvisioner.cs
@@ -1,0 +1,194 @@
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Mithril.Shared.Settings;
+
+namespace Mithril.Shared.MapCalibration;
+
+/// <summary>
+/// BCL-only (HttpClient + SHA256 + File IO) provisioner for the UABEA
+/// <c>classdata.tpk</c> the asset-extractor sidecar needs (#960). No decoder /
+/// AssetsTools.NET dependency enters <c>src/**</c> — this only downloads + verifies
+/// + places the opaque artifact; the sidecar in <c>tools/</c> is the only thing
+/// that ever reads it (keeps the #921 decoder-free-graph guard green).
+/// </summary>
+public sealed class ClassDataTpkProvisioner : IClassDataTpkProvisioner
+{
+    /// <summary>
+    /// Canonical filename, shared with the engine/bootstrap so both agree on the
+    /// path inside the asset-cache dir. Never hardcode the string elsewhere.
+    /// </summary>
+    public const string TpkFileName = "classdata.tpk";
+
+    /// <summary>
+    /// UABEA master <c>ReleaseFiles/classdata.tpk</c>. Third-party; downloaded at
+    /// runtime to the user's machine only — never committed or staged (#921).
+    /// </summary>
+    public const string DownloadUrl =
+        "https://github.com/nesrak1/UABEA/raw/master/ReleaseFiles/classdata.tpk";
+
+    /// <summary>
+    /// SHA-256 of the current UABEA master <c>ReleaseFiles/classdata.tpk</c>
+    /// (verified by download during #960 implementation: 289,605 bytes, magic
+    /// <c>TPK*</c>). Tracks the upstream master artifact; update this constant (and
+    /// the size envelope below if it drifts materially) if UABEA revs the file.
+    /// </summary>
+    public const string ExpectedSha256 =
+        "129e1f80f930415db6779fe6089afa75280cb51462bcee812beab6cd81a764c6";
+
+    // Sane size envelope as a cheap pre-check before hashing. The real file is
+    // ~283 KB; allow comfortable headroom so a minor upstream rev within the
+    // pinned-SHA window still passes the floor, while an HTML redirect / error
+    // page (tiny) or a wrong artifact (huge) is rejected up front.
+    private const long DefaultMinSizeBytes = 200_000;   // ~200 KB floor
+    private const long DefaultMaxSizeBytes = 5_000_000; // ~5 MB ceiling
+
+    private readonly string _assetCacheDir;
+    private readonly HttpClient _http;
+    private readonly ILogger? _logger;
+    private readonly string _expectedSha;
+    private readonly long _minSizeBytes;
+    private readonly long _maxSizeBytes;
+
+    public ClassDataTpkProvisioner(string assetCacheDir, HttpClient http, ILogger? logger = null)
+        : this(assetCacheDir, http, ExpectedSha256, DefaultMinSizeBytes, DefaultMaxSizeBytes, logger)
+    {
+    }
+
+    /// <summary>
+    /// Test seam (<c>InternalsVisibleTo</c>): lets the unit tests drive the
+    /// happy-path placement with a controllable expected SHA / size envelope
+    /// without reproducing the real ~283 KB upstream bytes. Production always
+    /// goes through the public ctor, which pins <see cref="ExpectedSha256"/>.
+    /// </summary>
+    internal ClassDataTpkProvisioner(
+        string assetCacheDir, HttpClient http, string expectedSha,
+        long minSizeBytes, long maxSizeBytes, ILogger? logger = null)
+    {
+        _assetCacheDir = assetCacheDir;
+        _http = http;
+        _expectedSha = expectedSha;
+        _minSizeBytes = minSizeBytes;
+        _maxSizeBytes = maxSizeBytes;
+        _logger = logger;
+    }
+
+    /// <summary>The canonical on-disk path the sidecar's <c>--tpk</c> is pointed at.</summary>
+    public string TpkPath => Path.Combine(_assetCacheDir, TpkFileName);
+
+    public bool IsInstalled()
+    {
+        try
+        {
+            var path = TpkPath;
+            if (!File.Exists(path)) return false;
+            var len = new FileInfo(path).Length;
+            return len >= _minSizeBytes && len <= _maxSizeBytes;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to stat classdata.tpk at {Path}", TpkPath);
+            return false;
+        }
+    }
+
+    public async Task<TpkProvisionResult> EnsureAsync(
+        IProgress<TpkProvisionProgress>? progress, CancellationToken ct)
+    {
+        if (IsInstalled())
+        {
+            _logger?.LogInformation("classdata.tpk already present at {Path}; skipping download.", TpkPath);
+            return new TpkProvisionResult(TpkProvisionStatus.AlreadyPresent, "Already installed.");
+        }
+
+        var dest = TpkPath;
+        var tmp = dest + ".download-" + Guid.NewGuid().ToString("N") + ".partial";
+
+        try
+        {
+            Directory.CreateDirectory(_assetCacheDir);
+
+            _logger?.LogInformation("Downloading classdata.tpk from {Url}", DownloadUrl);
+
+            using (var resp = await _http.GetAsync(
+                DownloadUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false))
+            {
+                resp.EnsureSuccessStatusCode();
+
+                var total = resp.Content.Headers.ContentLength;
+                using var src = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+                using var dst = new FileStream(
+                    tmp, FileMode.Create, FileAccess.Write, FileShare.None, 64 * 1024, useAsync: true);
+
+                var buffer = new byte[64 * 1024];
+                long received = 0;
+                int read;
+                while ((read = await src.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+                {
+                    await dst.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+                    received += read;
+                    progress?.Report(new TpkProvisionProgress(received, total));
+                }
+            }
+
+            // ── Verify: size floor/ceiling, then SHA-256 against the pin. ──
+            var size = new FileInfo(tmp).Length;
+            if (size < _minSizeBytes || size > _maxSizeBytes)
+            {
+                _logger?.LogWarning(
+                    "classdata.tpk download size {Size} bytes outside expected envelope [{Min}, {Max}]; rejecting.",
+                    size, _minSizeBytes, _maxSizeBytes);
+                return Fail(tmp, $"Downloaded file size ({size:N0} bytes) is outside the expected range.");
+            }
+
+            var actualSha = await ComputeSha256Async(tmp, ct).ConfigureAwait(false);
+            if (!string.Equals(actualSha, _expectedSha, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger?.LogWarning(
+                    "classdata.tpk SHA-256 {Actual} != expected {Expected}; rejecting download.",
+                    actualSha, _expectedSha);
+                return Fail(tmp, "Downloaded file failed integrity check (SHA-256 mismatch).");
+            }
+
+            // Atomic move into place (retries through AV/indexer flake).
+            var bytes = await File.ReadAllBytesAsync(tmp, ct).ConfigureAwait(false);
+            await AtomicFile.WriteAllBytesAtomicAsync(dest, bytes, ct).ConfigureAwait(false);
+            TryDelete(tmp);
+
+            _logger?.LogInformation("classdata.tpk installed at {Path} ({Size} bytes).", dest, size);
+            return new TpkProvisionResult(TpkProvisionStatus.Downloaded, "Downloaded and verified.");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            TryDelete(tmp);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "classdata.tpk download failed; map icons stay disabled (safe-degrade).");
+            return Fail(tmp, $"Download failed: {ex.Message}");
+        }
+    }
+
+    private TpkProvisionResult Fail(string tmp, string message)
+    {
+        TryDelete(tmp);
+        return new TpkProvisionResult(TpkProvisionStatus.Failed, message);
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken ct)
+    {
+        using var sha = SHA256.Create();
+        await using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read, 64 * 1024, useAsync: true);
+        var hash = await sha.ComputeHashAsync(stream, ct).ConfigureAwait(false);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch (Exception ex) { _logger?.LogWarning(ex, "Failed to delete temp tpk {Path}", path); }
+    }
+}

--- a/src/Mithril.Shared/MapCalibration/IClassDataTpkProvisioner.cs
+++ b/src/Mithril.Shared/MapCalibration/IClassDataTpkProvisioner.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mithril.Shared.MapCalibration;
+
+/// <summary>
+/// Provisions the UABEA <c>classdata.tpk</c> (the ~283 KB Unity class-data
+/// package) the out-of-process asset-extractor sidecar needs to decode PG icon
+/// templates (#960). The artifact is third-party and is deliberately NOT bundled
+/// in the repo/release (#921 keeps <c>src/**</c> decoder-free; the <c>.tpk</c> is
+/// read only by the sidecar in <c>tools/</c>) — instead it is downloaded once, on
+/// the user's explicit click, into the always-writable Mithril asset cache
+/// (<c>%LocalAppData%/Mithril/assets/</c>), which survives Velopack app updates
+/// (the swapped <c>current\</c> exe dir does not).
+///
+/// <para><b>Fail-soft:</b> any network / IO / verify failure is logged and
+/// returned as <see cref="TpkProvisionStatus.Failed"/>; <see cref="EnsureAsync"/>
+/// never throws. When the tpk is absent the engine threads no <c>--tpk</c> and the
+/// sidecar safe-degrades exactly as it does today (no icons, calibration
+/// degrades).</para>
+/// </summary>
+public interface IClassDataTpkProvisioner
+{
+    /// <summary>
+    /// True iff a plausibly-valid <c>classdata.tpk</c> already exists at the
+    /// canonical asset-cache path (existence + a cheap size-floor check — does NOT
+    /// re-hash on every poll). Cheap enough to call from a status-binding getter.
+    /// </summary>
+    bool IsInstalled();
+
+    /// <summary>
+    /// Idempotent provisioning. If <see cref="IsInstalled"/>, returns
+    /// <see cref="TpkProvisionStatus.AlreadyPresent"/> without touching the network.
+    /// Otherwise downloads the tpk, verifies it (size floor AND SHA-256 against the
+    /// pinned constant), and atomically moves it into the canonical path. On any
+    /// failure the temp file is cleaned up and the canonical path is left untouched.
+    /// Never throws.
+    /// </summary>
+    Task<TpkProvisionResult> EnsureAsync(IProgress<TpkProvisionProgress>? progress, CancellationToken ct);
+}
+
+/// <summary>Outcome of <see cref="IClassDataTpkProvisioner.EnsureAsync"/>.</summary>
+public enum TpkProvisionStatus
+{
+    /// <summary>A valid tpk was already present; nothing was downloaded.</summary>
+    AlreadyPresent,
+
+    /// <summary>The tpk was downloaded, verified, and placed at the canonical path.</summary>
+    Downloaded,
+
+    /// <summary>Provisioning failed (network / IO / verify). No file was placed.</summary>
+    Failed,
+}
+
+/// <summary>Result record: a status plus a human-readable message for the UI.</summary>
+public sealed record TpkProvisionResult(TpkProvisionStatus Status, string Message)
+{
+    public bool Ok => Status != TpkProvisionStatus.Failed;
+}
+
+/// <summary>Coarse download-progress signal for the settings UI.</summary>
+/// <param name="BytesReceived">Bytes downloaded so far.</param>
+/// <param name="TotalBytes">Total bytes if the server reported Content-Length, else null.</param>
+public readonly record struct TpkProvisionProgress(long BytesReceived, long? TotalBytes);

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.IO;
+using System.Net.Http;
 using Arda.Abstractions.Diagnostics;
 using Arda.Composition;
 using Arda.Contracts.State.Health;
@@ -19,6 +20,7 @@ using Mithril.Shared.Diagnostics.Telemetry;
 using Mithril.Shared.Game;
 using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Icons;
+using Mithril.Shared.MapCalibration;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
@@ -123,6 +125,14 @@ public static class ShellComposition
             // override inside this call wins over the engine's default gate
             // (last-registration-wins).
             .AddMithrilMapCalibrationCapture(o.AssetCacheDir)
+            // #960: BCL-only provisioner that one-click downloads the third-party
+            // UABEA classdata.tpk into the asset cache (same dir the sidecar reads),
+            // so icon decoding can engage without bundling the artifact. Needs the
+            // shared HttpClient registered by AddMithrilReferenceData above.
+            .AddSingleton<IClassDataTpkProvisioner>(sp => new ClassDataTpkProvisioner(
+                o.AssetCacheDir,
+                sp.GetRequiredService<HttpClient>(),
+                sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Tpk")))
             .AddMithrilIcons(o.IconCacheDir)
             .AddMithrilAudio()
             .AddMithrilHotkeys()

--- a/src/Mithril.Shell/ViewModels/GameConfigViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/GameConfigViewModel.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Game;
+using Mithril.Shared.MapCalibration;
 using Microsoft.Win32;
 
 namespace Mithril.Shell.ViewModels;
@@ -10,15 +11,21 @@ namespace Mithril.Shell.ViewModels;
 public sealed partial class GameConfigViewModel : ObservableObject
 {
     private readonly GameConfig _config;
+    private readonly IClassDataTpkProvisioner? _tpkProvisioner;
 
-    public GameConfigViewModel(GameConfig config)
+    public GameConfigViewModel(GameConfig config, IClassDataTpkProvisioner? tpkProvisioner = null)
     {
         _config = config;
+        _tpkProvisioner = tpkProvisioner;
         _gameRoot = config.GameRoot;
         _installRoot = config.InstallRoot;
         _pollSeconds = config.PollIntervalSeconds;
         _gameProcessName = config.GameProcessName;
         _calibrationGoodResidualPx = config.CalibrationGoodResidualPx;
+        _tpkInstalled = _tpkProvisioner?.IsInstalled() ?? false;
+        _downloadTpkStatus = _tpkInstalled
+            ? "Map-decoder data is installed."
+            : string.Empty;
     }
 
     [ObservableProperty] private string _gameRoot;
@@ -29,6 +36,20 @@ public sealed partial class GameConfigViewModel : ObservableObject
 
     /// <summary>Status line shown after "Detect from foreground" completes.</summary>
     [ObservableProperty] private string _detectGameProcessStatus = string.Empty;
+
+    /// <summary>True when the classdata.tpk map-decoder package is present (#960).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanDownloadTpk))]
+    private bool _tpkInstalled;
+
+    /// <summary>
+    /// Drives the download button's <c>IsEnabled</c>: offer the download only when
+    /// a provisioner is wired and the tpk isn't already installed.
+    /// </summary>
+    public bool CanDownloadTpk => _tpkProvisioner is not null && !TpkInstalled;
+
+    /// <summary>Status/progress line for the map-decoder-data download.</summary>
+    [ObservableProperty] private string _downloadTpkStatus = string.Empty;
 
     public string PlayerLogPath => string.IsNullOrEmpty(GameRoot) ? "(unset)" : System.IO.Path.Combine(GameRoot, "Player.log");
 
@@ -125,6 +146,46 @@ public sealed partial class GameConfigViewModel : ObservableObject
         {
             DetectGameProcessStatus = $"Could not read process: {ex.Message}";
         }
+    }
+
+    /// <summary>
+    /// One-click download of the third-party UABEA <c>classdata.tpk</c> the
+    /// map-calibration asset-extractor sidecar needs to decode PG icons (#960).
+    /// Fail-soft: the provisioner never throws; any failure just updates the
+    /// status line and leaves icons disabled (calibration degrades as before).
+    /// </summary>
+    [RelayCommand]
+    private async Task DownloadTpkAsync()
+    {
+        if (_tpkProvisioner is null)
+        {
+            DownloadTpkStatus = "Map-decoder download is unavailable.";
+            return;
+        }
+
+        if (_tpkProvisioner.IsInstalled())
+        {
+            TpkInstalled = true;
+            DownloadTpkStatus = "Map-decoder data is already installed.";
+            return;
+        }
+
+        DownloadTpkStatus = "Downloading map-decoder data…";
+        var progress = new Progress<TpkProvisionProgress>(p =>
+        {
+            DownloadTpkStatus = p.TotalBytes is { } total && total > 0
+                ? $"Downloading map-decoder data… {p.BytesReceived * 100 / total}%"
+                : $"Downloading map-decoder data… {p.BytesReceived / 1024:N0} KB";
+        });
+
+        var result = await _tpkProvisioner.EnsureAsync(progress, CancellationToken.None);
+        TpkInstalled = _tpkProvisioner.IsInstalled();
+        DownloadTpkStatus = result.Status switch
+        {
+            TpkProvisionStatus.AlreadyPresent => "Map-decoder data is installed.",
+            TpkProvisionStatus.Downloaded => "Map-decoder data installed.",
+            _ => $"Download failed — map icons stay disabled. {result.Message}",
+        };
     }
 
     [LibraryImport("user32.dll", SetLastError = true)]

--- a/src/Mithril.Shell/Views/GameConfigView.xaml
+++ b/src/Mithril.Shell/Views/GameConfigView.xaml
@@ -33,6 +33,20 @@
             <TextBox Text="{Binding InstallRoot, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"/>
         </DockPanel>
 
+        <!-- #960: one-click download of the third-party UABEA classdata.tpk the
+             asset-extractor sidecar needs to decode map icons. Not bundled (keeps
+             the artifact out of the repo/release); downloaded to the always-writable
+             asset cache that survives app updates. Disabled once installed. -->
+        <TextBlock Text="Map-decoder data (classdata.tpk — required for map-calibration icon detection; downloaded once, ~283 KB)"
+                   Foreground="#88FFFFFF" TextWrapping="Wrap" Margin="0,16,0,4"/>
+        <StackPanel Orientation="Horizontal">
+            <Button Content="Download map-decoder data" Padding="10,4"
+                    Command="{Binding DownloadTpkCommand}"
+                    IsEnabled="{Binding CanDownloadTpk}"
+                    ToolTip="Downloads classdata.tpk (UABEA) to %LocalAppData%/Mithril/assets/ so the calibrator can decode map icons."/>
+        </StackPanel>
+        <TextBlock Text="{Binding DownloadTpkStatus}" Foreground="#88FFFFFF" TextWrapping="Wrap" Margin="0,4,0,0"/>
+
         <TextBlock Text="Poll interval (seconds)" Foreground="#88FFFFFF" Margin="0,16,0,4"/>
         <TextBox Text="{Binding PollSeconds, UpdateSourceTrigger=PropertyChanged}" Padding="6,4" Width="100" HorizontalAlignment="Left"/>
 

--- a/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
@@ -83,6 +83,45 @@ public sealed class ProcessAssetExtractorTests : IDisposable
     }
 
     [Fact]
+    public async Task Tpk_path_is_added_to_args_when_set()
+    {
+        ProcessStartInfo? captured = null;
+        var sut = new ProcessAssetExtractor(_fakeExe, TimeSpan.FromSeconds(5),
+            launcher: (psi, _) =>
+            {
+                captured = psi;
+                return Task.FromResult(new ProcessRunResult(0,
+                    "{\"status\":\"ok\",\"pgVersion\":\"1\",\"extractorVersion\":\"1\",\"artifacts\":[]}", ""));
+            });
+
+        await sut.ExtractAsync(
+            new ExtractRequest("C:/PG", "C:/cache", ExtractKind.Icons, null, null, TpkPath: "C:/cache/classdata.tpk"),
+            CancellationToken.None);
+
+        captured!.ArgumentList.Should().ContainInOrder("--tpk", "C:/cache/classdata.tpk");
+    }
+
+    [Fact]
+    public async Task Tpk_path_is_omitted_when_null()
+    {
+        ProcessStartInfo? captured = null;
+        var sut = new ProcessAssetExtractor(_fakeExe, TimeSpan.FromSeconds(5),
+            launcher: (psi, _) =>
+            {
+                captured = psi;
+                return Task.FromResult(new ProcessRunResult(0,
+                    "{\"status\":\"ok\",\"pgVersion\":\"1\",\"extractorVersion\":\"1\",\"artifacts\":[]}", ""));
+            });
+
+        // Default TpkPath = null (omitted last positional arg).
+        await sut.ExtractAsync(
+            new ExtractRequest("C:/PG", "C:/cache", ExtractKind.Icons, null, null),
+            CancellationToken.None);
+
+        captured!.ArgumentList.Should().NotContain("--tpk");
+    }
+
+    [Fact]
     public async Task Exit_code_3_maps_to_failure_mentioning_the_area_bundle()
     {
         var sut = new ProcessAssetExtractor(_fakeExe, TimeSpan.FromSeconds(5),

--- a/tests/Mithril.Shared.Tests/MapCalibration/ClassDataTpkProvisionerTests.cs
+++ b/tests/Mithril.Shared.Tests/MapCalibration/ClassDataTpkProvisionerTests.cs
@@ -1,0 +1,170 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using FluentAssertions;
+using Mithril.Shared.MapCalibration;
+using Xunit;
+
+namespace Mithril.Shared.Tests.MapCalibration;
+
+/// <summary>
+/// #960: the BCL-only <see cref="ClassDataTpkProvisioner"/> over a fake
+/// <see cref="HttpMessageHandler"/> — happy path, idempotency, and the fail-closed
+/// verify paths (size floor / SHA mismatch / network throw), each asserting the
+/// canonical file is NOT placed and the temp file is cleaned up. Never throws.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class ClassDataTpkProvisionerTests : IDisposable
+{
+    private readonly string _cacheDir;
+
+    public ClassDataTpkProvisionerTests()
+    {
+        _cacheDir = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-tpk-tests");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_cacheDir, recursive: true); } catch { }
+    }
+
+    private string TpkPath => Path.Combine(_cacheDir, ClassDataTpkProvisioner.TpkFileName);
+
+    // The provisioner pins ExpectedSha256 to the real ~283 KB upstream file, which
+    // we can't reproduce byte-for-byte in a unit test. The internal test-seam ctor
+    // (InternalsVisibleTo) lets the happy-path test supply a controllable expected
+    // SHA + size envelope so we can drive download→verify→place over a fake handler;
+    // the fail-closed tests use the production public ctor (real pinned SHA), so an
+    // arbitrary buffer correctly fails the SHA check.
+    private static byte[] PaddedBuffer(int size, byte fill)
+    {
+        var buf = new byte[size];
+        Array.Fill(buf, fill);
+        return buf;
+    }
+
+    private static HttpClient HttpReturning(byte[] body) =>
+        new(new RoutingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(body),
+        }));
+
+    private static HttpClient HttpThrowing() =>
+        new(new ThrowingHandler("network down"));
+
+    [Fact]
+    public async Task AlreadyPresent_skips_network_when_valid_tpk_exists()
+    {
+        // A file at the canonical path, above the size floor → IsInstalled() true.
+        Directory.CreateDirectory(_cacheDir);
+        File.WriteAllBytes(TpkPath, PaddedBuffer(250_000, 0x42));
+
+        var sut = new ClassDataTpkProvisioner(_cacheDir, HttpThrowing());
+
+        sut.IsInstalled().Should().BeTrue();
+
+        var result = await sut.EnsureAsync(progress: null, CancellationToken.None);
+
+        result.Status.Should().Be(TpkProvisionStatus.AlreadyPresent);
+        result.Ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Happy_path_downloads_verifies_and_places_the_file()
+    {
+        // Drive the placement path through the internal test seam: a buffer above
+        // the floor, with the expected SHA set to the buffer's own hash.
+        var body = PaddedBuffer(250_000, 0x17);
+        var sha = Convert.ToHexStringLower(SHA256.HashData(body));
+
+        var sut = new ClassDataTpkProvisioner(
+            _cacheDir, HttpReturning(body),
+            expectedSha: sha, minSizeBytes: 200_000, maxSizeBytes: 5_000_000);
+
+        var result = await sut.EnsureAsync(progress: null, CancellationToken.None);
+
+        result.Status.Should().Be(TpkProvisionStatus.Downloaded);
+        File.Exists(TpkPath).Should().BeTrue();
+        File.ReadAllBytes(TpkPath).Should().Equal(body);
+        NoTempLeftBehind();
+    }
+
+    [Fact]
+    public async Task Size_below_floor_is_rejected_and_no_file_placed()
+    {
+        var body = PaddedBuffer(1_000, 0x01); // well under the 200 KB floor
+        var sut = new ClassDataTpkProvisioner(_cacheDir, HttpReturning(body));
+
+        var result = await sut.EnsureAsync(progress: null, CancellationToken.None);
+
+        result.Status.Should().Be(TpkProvisionStatus.Failed);
+        File.Exists(TpkPath).Should().BeFalse();
+        NoTempLeftBehind();
+    }
+
+    [Fact]
+    public async Task Sha_mismatch_is_rejected_and_no_file_placed()
+    {
+        // Right size, wrong hash (the pinned SHA won't match this arbitrary buffer).
+        var body = PaddedBuffer(250_000, 0x55);
+        var sut = new ClassDataTpkProvisioner(_cacheDir, HttpReturning(body));
+
+        var result = await sut.EnsureAsync(progress: null, CancellationToken.None);
+
+        result.Status.Should().Be(TpkProvisionStatus.Failed);
+        result.Message.Should().Contain("integrity");
+        File.Exists(TpkPath).Should().BeFalse();
+        NoTempLeftBehind();
+    }
+
+    [Fact]
+    public async Task Network_exception_returns_Failed_without_throwing()
+    {
+        var sut = new ClassDataTpkProvisioner(_cacheDir, HttpThrowing());
+
+        var result = await sut.EnsureAsync(progress: null, CancellationToken.None);
+
+        result.Status.Should().Be(TpkProvisionStatus.Failed);
+        File.Exists(TpkPath).Should().BeFalse();
+        NoTempLeftBehind();
+    }
+
+    [Fact]
+    public void IsInstalled_false_for_undersized_file()
+    {
+        Directory.CreateDirectory(_cacheDir);
+        File.WriteAllBytes(TpkPath, PaddedBuffer(1_000, 0x09)); // under the floor
+
+        var sut = new ClassDataTpkProvisioner(_cacheDir, HttpThrowing());
+
+        sut.IsInstalled().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInstalled_false_when_absent()
+    {
+        var sut = new ClassDataTpkProvisioner(_cacheDir, HttpThrowing());
+        sut.IsInstalled().Should().BeFalse();
+    }
+
+    private void NoTempLeftBehind()
+    {
+        if (!Directory.Exists(_cacheDir)) return;
+        Directory.GetFiles(_cacheDir, "*.partial").Should().BeEmpty();
+        Directory.GetFiles(_cacheDir, "*.download-*").Should().BeEmpty();
+    }
+
+    private sealed class RoutingHandler(Func<HttpRequestMessage, HttpResponseMessage> route) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(route(request));
+    }
+
+    private sealed class ThrowingHandler(string message) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => throw new HttpRequestException(message);
+    }
+}

--- a/tests/Mithril.Shell.Tests/GameConfigViewModelTpkTests.cs
+++ b/tests/Mithril.Shell.Tests/GameConfigViewModelTpkTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Mithril.Shared.Game;
+using Mithril.Shared.MapCalibration;
+using Mithril.Shell.ViewModels;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #960: the Game-Configuration download button wiring — the VM reflects the
+/// provisioner's installed state, runs the download command, and updates its
+/// status + enabled-state from the result without ever throwing.
+/// </summary>
+public sealed class GameConfigViewModelTpkTests
+{
+    [Fact]
+    public void Reflects_installed_state_at_construction()
+    {
+        var vm = new GameConfigViewModel(new GameConfig(), new FakeProvisioner { Installed = true });
+
+        vm.TpkInstalled.Should().BeTrue();
+        vm.CanDownloadTpk.Should().BeFalse("an already-installed tpk needs no download");
+    }
+
+    [Fact]
+    public void Offers_download_when_not_installed()
+    {
+        var vm = new GameConfigViewModel(new GameConfig(), new FakeProvisioner { Installed = false });
+
+        vm.TpkInstalled.Should().BeFalse();
+        vm.CanDownloadTpk.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Cannot_download_without_a_provisioner()
+    {
+        var vm = new GameConfigViewModel(new GameConfig(), tpkProvisioner: null);
+
+        vm.CanDownloadTpk.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Successful_download_flips_installed_and_updates_status()
+    {
+        var prov = new FakeProvisioner
+        {
+            Installed = false,
+            Result = new TpkProvisionResult(TpkProvisionStatus.Downloaded, "Downloaded and verified."),
+            InstalledAfterEnsure = true,
+        };
+        var vm = new GameConfigViewModel(new GameConfig(), prov);
+
+        await vm.DownloadTpkCommand.ExecuteAsync(null);
+
+        vm.TpkInstalled.Should().BeTrue();
+        vm.CanDownloadTpk.Should().BeFalse();
+        vm.DownloadTpkStatus.Should().Contain("installed");
+    }
+
+    [Fact]
+    public async Task Failed_download_leaves_not_installed_and_surfaces_message()
+    {
+        var prov = new FakeProvisioner
+        {
+            Installed = false,
+            Result = new TpkProvisionResult(TpkProvisionStatus.Failed, "Download failed: network down"),
+            InstalledAfterEnsure = false,
+        };
+        var vm = new GameConfigViewModel(new GameConfig(), prov);
+
+        await vm.DownloadTpkCommand.ExecuteAsync(null);
+
+        vm.TpkInstalled.Should().BeFalse();
+        vm.CanDownloadTpk.Should().BeTrue();
+        vm.DownloadTpkStatus.Should().Contain("failed");
+    }
+
+    private sealed class FakeProvisioner : IClassDataTpkProvisioner
+    {
+        public bool Installed { get; set; }
+        public bool InstalledAfterEnsure { get; set; }
+        public TpkProvisionResult Result { get; set; } =
+            new(TpkProvisionStatus.AlreadyPresent, "Already installed.");
+
+        private bool _ensured;
+
+        public bool IsInstalled() => _ensured ? InstalledAfterEnsure : Installed;
+
+        public Task<TpkProvisionResult> EnsureAsync(
+            IProgress<TpkProvisionProgress>? progress, CancellationToken ct)
+        {
+            _ensured = true;
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/tools/Mithril.AssetExtractor/Program.cs
+++ b/tools/Mithril.AssetExtractor/Program.cs
@@ -3,7 +3,7 @@
 // pre-decoded manifest+blob cache the decoder-free app graph reads BCL-only.
 //
 // CLI:
-//   mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>]
+//   mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>] [--tpk <path>]
 //
 // Outputs: cache files on disk (existing manifest+blob format) + ONE JSON result
 // line on stdout + an exit code. stderr = human diagnostics.
@@ -103,7 +103,7 @@ namespace Mithril.Tools.AssetExtractor
             if (args.Kind == ExtractKind.Icons)
             {
                 var iconsDir = Path.Combine(args.OutDir, "icons-src");
-                IconTemplateExtractor.EnsureExtracted(args.InstallRoot, iconsDir, ResolveTpkPath());
+                IconTemplateExtractor.EnsureExtracted(args.InstallRoot, iconsDir, ResolveTpkPath(args.TpkPath));
                 var sha = IconTemplateEmitter.EmitFromIcons(iconsDir, args.OutDir, pgVersion, extractorVersion);
                 artifacts.Add(new ResultArtifact("icons", null, Path.Combine(args.OutDir, "icon-templates.json"), sha));
             }
@@ -142,11 +142,16 @@ namespace Mithril.Tools.AssetExtractor
             Console.Out.WriteLine(json);
         }
 
-        private static string ResolveTpkPath()
+        private static string ResolveTpkPath(string? explicitPath)
         {
-            // The icon extractor needs classdata.tpk. Prefer one next to the exe,
-            // then the Tools default. EnsureExtracted errors with a download URL if
-            // it's genuinely missing (→ decode-failed exit).
+            // The icon extractor needs classdata.tpk. Prefer an explicit --tpk path
+            // when the caller provided one and it exists (the app downloads the tpk
+            // to its always-writable asset cache and threads that path in — #960),
+            // then one next to the exe, then the Tools default. EnsureExtracted
+            // errors with a download URL if it's genuinely missing (→ decode-failed
+            // exit), so missing-tpk still fail-softs exactly as before.
+            if (!string.IsNullOrWhiteSpace(explicitPath) && File.Exists(explicitPath))
+                return explicitPath;
             var beside = Path.Combine(AppContext.BaseDirectory, "classdata.tpk");
             return File.Exists(beside) ? beside : RepoPaths.DefaultTpkPath();
         }
@@ -169,11 +174,11 @@ namespace Mithril.Tools.AssetExtractor
 
     internal enum ExtractKind { Icons, Texture }
 
-    internal sealed record SidecarArgs(string InstallRoot, string OutDir, ExtractKind Kind, string? AreaKey, string? ExpectPgVersion)
+    internal sealed record SidecarArgs(string InstallRoot, string OutDir, ExtractKind Kind, string? AreaKey, string? ExpectPgVersion, string? TpkPath)
     {
         public static SidecarArgs Parse(string[] args)
         {
-            string? install = null, outDir = null, area = null, expect = null;
+            string? install = null, outDir = null, area = null, expect = null, tpk = null;
             bool icons = false;
             for (int i = 0; i < args.Length; i++)
             {
@@ -184,6 +189,7 @@ namespace Mithril.Tools.AssetExtractor
                     case "--icons": icons = true; break;
                     case "--area": area = Next(args, ref i, "--area"); break;
                     case "--expect-pg-version": expect = Next(args, ref i, "--expect-pg-version"); break;
+                    case "--tpk": tpk = Next(args, ref i, "--tpk"); break;
                     default:
                         throw new UserFacingException($"unknown argument '{args[i]}'");
                 }
@@ -192,7 +198,7 @@ namespace Mithril.Tools.AssetExtractor
             if (string.IsNullOrWhiteSpace(outDir)) throw new UserFacingException("--out <cacheDir> is required");
             if (icons && area is not null) throw new UserFacingException("--icons and --area are mutually exclusive");
             if (!icons && area is null) throw new UserFacingException("one of --icons or --area <AreaKey> is required");
-            return new SidecarArgs(install, outDir, icons ? ExtractKind.Icons : ExtractKind.Texture, area, expect);
+            return new SidecarArgs(install, outDir, icons ? ExtractKind.Icons : ExtractKind.Texture, area, expect, tpk);
         }
 
         private static string Next(string[] args, ref int i, string flag)
@@ -204,7 +210,7 @@ namespace Mithril.Tools.AssetExtractor
         public static void PrintUsage()
         {
             Console.Error.WriteLine(
-                "usage: mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>]");
+                "usage: mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>] [--tpk <path>]");
         }
     }
 


### PR DESCRIPTION
## What & why

Closes the icon-templates half of #938. The asset-extractor sidecar can't decode PG icons/textures without `classdata.tpk` (the ~290 KB UABEA Unity class-data package), which isn't present → `exit 4: classdata.tpk not found` → icons stay disabled → no typed detections → no successful solve. `classdata.tpk` is third-party, so we **do not bundle it** — it's provided via a one-click in-app download (analogous to the CDN reference-data pattern), kept out of the repo/release.

## Approach B (download to the asset cache + real `--tpk`)

Chosen over "download beside the exe" because the asset cache (`%LocalAppData%/Mithril/assets/`) is always user-writable **and survives Velopack app updates** (the exe dir under `current\` is swapped on update, which would force a re-download each time).

- **`ClassDataTpkProvisioner`** (new, in `src/Mithril.Shared`, **BCL-only**: `HttpClient` + `SHA256` + file IO) — idempotent `EnsureAsync`: GET the UABEA URL → temp → **size-floor then SHA-256 verify against a pinned constant** → atomic move into `…/assets/classdata.tpk`. Fail-soft: any network/IO/verify error → `Warning` + `Failed`, never throws, temp cleaned up. `IsInstalled()` for status.
- **Sidecar `--tpk <path>`** (`tools/Mithril.AssetExtractor`) — real flag (mirrors the existing `--tpk` in `tools/MapCalibrationFromScreenshot`); `ResolveTpkPath` prefers the explicit path, else the old beside-exe → Tools-default chain (missing tpk still fail-softs as before).
- **Plumbing** — `ExtractRequest.TpkPath` (trailing optional param, existing call sites unchanged); `ProcessAssetExtractor` emits `--tpk` iff set; `AutoCalibrationEngine` (texture + both icon paths) and `IconTemplateBootstrap` set `TpkPath` to the cache file iff it exists (shared `ClassDataTpkProvisioner.TpkFileName` constant), else null.
- **UI** — a "Download map-decoder data (classdata.tpk)" button in the Game Configuration view (beside the #959 install-dir field) with progress/status and installed-state gating.

## Integrity pin (independently re-verified)

SHA-256 `129e1f80f930415db6779fe6089afa75280cb51462bcee812beab6cd81a764c6`, size 289,605 bytes, magic `TPK*` — fetched from the live UABEA master artifact and confirmed by the shepherd independently. Size envelope 200 KB–5 MB. Mismatch fails closed (no file placed; icons stay disabled) rather than installing an unexpected artifact. The constant documents that it tracks upstream master and needs updating if UABEA revs the file.

## Invariants held

- **#921 decoder-free `src/**`**: the provisioner is BCL-only; no AssetsTools.NET enters the app graph (the `.tpk` is read solely by the out-of-process sidecar). `ShippedGraphDecoderFreeTests` green.
- **Fail-soft**: no network / bad download / verify mismatch → no icons, no throw; calibration degrades exactly as today.
- **No third-party artifact** committed or staged (`git ls-files | grep .tpk` → none).

## Verification

Independently on the branch: `dotnet build Mithril.slnx` clean (0/0); `MapCalibration.Tests` 97, `MapCalibration.Capture.Tests` 100, `Shared.Tests` 1229 (incl. `ShippedGraphDecoderFreeTests`), `Shell.Tests` 83 — all pass. Provisioner tested (idempotent skip / happy path / size-mismatch / SHA-mismatch / network-fault / temp-cleanup); adapter tested for `--tpk` present+omitted.

**Live manual verification against a running PG + Steam install is owed under #938** (human-gated). With #959 (install-dir) + this PR (classdata.tpk), both known blockers for the successful-solve path are cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
