### PR TITLE
feat(map-calibration): log per-step progress + timing through the calibration solve

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -141,25 +142,43 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             return Fail(area, "no map bbox set — use the draw-map-bbox hotkey first");
         }
 
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: capturing map region {Width}x{Height} at ({X},{Y})…",
+            area, bbox.Value.Width, bbox.Value.Height, bbox.Value.X, bbox.Value.Y);
         var gray = await _capture.CaptureMapAsync(bbox.Value, ct).ConfigureAwait(false);
         if (gray is null)
         {
             return Fail(area, "map capture failed or was rejected (black / wrong-size frame)");
         }
 
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: captured {Width}x{Height} frame; resolving base texture…",
+            area, gray.Width, gray.Height);
         var baseTexture = await ResolveBaseTextureAsync(area, ct).ConfigureAwait(false);
         if (baseTexture is null)
         {
             return Fail(area, "preparing map assets… (base texture unavailable — no detections possible)");
         }
 
+        // Texture-registration refine — a synchronous NCC pass over the base
+        // texture that can take a noticeable moment on a cold call. Bracket it
+        // with before/after + timing so a slow or stalled refine is visible (the
+        // attempt previously went dark after "Loaded base texture …").
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: locating the map within the captured frame (texture registration)…", area);
+        var refineStart = Stopwatch.GetTimestamp();
         var mapRect = _refiner.Refine(gray, baseTexture, RefineMinScore);
         if (mapRect is null)
         {
             return Fail(area, "couldn't locate the map in the captured frame — zoom the in-game map all the way out");
         }
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: map sub-rect located ({MapRect}) in {ElapsedMs:0} ms.",
+            area, mapRect, Stopwatch.GetElapsedTime(refineStart).TotalMilliseconds);
 
         var references = _references.ForArea(area);
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: {ReferenceCount} landmark reference(s) for this area.", area, references.Count);
 
         // Resolve icon templates per attempt (#949). On a fresh icon cache the
         // provider returns Empty; if a sidecar is wired, demand-trigger its --icons
@@ -181,7 +200,14 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             RenderSizePx = RenderSizePx,
         };
 
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: running detect→solve ({TemplateCount} icon template(s), {ReferenceCount} reference(s))…",
+            area, templates.Templates.Count, references.Count);
+        var solveStart = Stopwatch.GetTimestamp();
         var result = _solver.Solve(request, references);
+        _logger?.LogInformation(
+            "Auto-calibration {Area}: solve finished in {ElapsedMs:0} ms (calibration {HasCalibration}, {Inliers} inlier(s)).",
+            area, Stopwatch.GetElapsedTime(solveStart).TotalMilliseconds, result.Calibration is not null, result.InlierCount);
         if (result.Calibration is null)
         {
             var reason = result.RejectReason ?? "no geometrically-consistent fit";


### PR DESCRIPTION
## What

Adds `Information`-level progress + timing logging through the auto-calibration solve path (`AutoCalibrationEngine.TryCalibrateCurrentAreaAsync`).

## Why

The engine logged its fail branches and the final persist/reject, but the **happy path between `"Loaded base texture …"` and the solve result was completely silent**. `Refine` (a synchronous NCC texture-registration pass over the 2048×2033 base texture) and the detector (run for both orientations) are heavy synchronous steps with no log before them — so a slow or stalled pass is indistinguishable from a hang, and the user can't tell whether calibration is progressing.

Reported live: *"I can't tell if calibration succeeded or not — the last message I see is the texture was loaded."* Confirmed in the diagnostic logs (`mithril-20260601.json`): every attempt goes dark right after the base-texture line.

## What it does

A calibration attempt now emits a breadcrumb trail:

```
… : capturing map region 1266x1053 at (55,43)…
… : captured 1266x1053 frame; resolving base texture…
Loaded base texture for AreaEltibule (2048x2033) … pixelSha256 verified.   (existing)
… : locating the map within the captured frame (texture registration)…
… : map sub-rect located (MapRect { … }) in 1840 ms.
… : 37 landmark reference(s) for this area.
… : 0 icon template(s) available; running detect→solve…
… : solve finished in 920 ms (calibration False, 0 inlier(s)).
Auto-calibration rejected for AreaEltibule: … (existing)
```

Wherever the trail stops is the stall; the two `… in N ms` timings turn "is it stuck?" into a number, and the icon/reference counts distinguish a content-level reject (`0` detections) from a real hang. Leading suspect for the reported stall is `Refine` — it's the first heavy step after the base-texture line and previously had no log before it.

## Scope / safety

- **Logging only** — no control-flow or return-value change. `_logger?.` null-safe throughout.
- Unblocks the **#938** live manual-verify run (lets the human see where an attempt stops). Does **not** touch the #941 status-chip surfacing (separate UX work).

## Verification

- `dotnet build` (worktree project): 0 warnings, 0 errors.
- `Mithril.MapCalibration.Capture.Tests`: **100/100 passed**.

Related: #914 (engine), #938 (live manual-verify), #941 (status surface — separate).

— drafted by Claude (Opus 4.8), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
