### PR TITLE
feat(map-calibration): add capture→refine→solve trace spans (#914)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Arda.World.Player;
 using Microsoft.Extensions.Logging;
 using Mithril.MapCalibration.Detection;
+using Mithril.Shared.Diagnostics.Telemetry;
 using Mithril.Shared.Game;
 using Mithril.Shared.MapCalibration;
 
@@ -122,6 +123,13 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     {
         ct.ThrowIfCancellationRequested();
 
+        // Per-attempt trace span (#914). Null when no listener is attached (no OTLP
+        // export / no perf-recording), so this is zero-overhead when off. Child
+        // capture/refine/solve spans nest under it → a Seq waterfall showing which
+        // step is slow (the brute-force refine, until #966). Per-candidate refine
+        // spans live deeper (MapRectLocator, in the Shared-free core) — deferred to #966.
+        using var attempt = MithrilActivitySources.MapCalibration.StartActivity("calibration.attempt");
+
         var area = _areaState.CurrentArea;
         if (string.IsNullOrWhiteSpace(area))
         {
@@ -142,10 +150,18 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             return Fail(area, "no map bbox set — use the draw-map-bbox hotkey first");
         }
 
+        attempt?.SetTag("map.area", area);
         _logger?.LogInformation(
             "Auto-calibration {Area}: capturing map region {Width}x{Height} at ({X},{Y})…",
             area, bbox.Value.Width, bbox.Value.Height, bbox.Value.X, bbox.Value.Y);
-        var gray = await _capture.CaptureMapAsync(bbox.Value, ct).ConfigureAwait(false);
+        GrayImage? gray;
+        using (var captureAct = MithrilActivitySources.MapCalibration.StartActivity("calibration.capture"))
+        {
+            captureAct?.SetTag("bbox.width", bbox.Value.Width);
+            captureAct?.SetTag("bbox.height", bbox.Value.Height);
+            gray = await _capture.CaptureMapAsync(bbox.Value, ct).ConfigureAwait(false);
+            captureAct?.SetTag("capture.ok", gray is not null);
+        }
         if (gray is null)
         {
             return Fail(area, "map capture failed or was rejected (black / wrong-size frame)");
@@ -167,7 +183,12 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         _logger?.LogInformation(
             "Auto-calibration {Area}: locating the map within the captured frame (texture registration)…", area);
         var refineStart = Stopwatch.GetTimestamp();
-        var mapRect = _refiner.Refine(gray, baseTexture, RefineMinScore);
+        MapRect? mapRect;
+        using (var refineAct = MithrilActivitySources.MapCalibration.StartActivity("calibration.refine"))
+        {
+            mapRect = _refiner.Refine(gray, baseTexture, RefineMinScore);
+            refineAct?.SetTag("map.located", mapRect is not null);
+        }
         if (mapRect is null)
         {
             return Fail(area, "couldn't locate the map in the captured frame — zoom the in-game map all the way out");
@@ -204,7 +225,19 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             "Auto-calibration {Area}: running detect→solve ({TemplateCount} icon template(s), {ReferenceCount} reference(s))…",
             area, templates.Templates.Count, references.Count);
         var solveStart = Stopwatch.GetTimestamp();
-        var result = _solver.Solve(request, references);
+        CalibrationSolveResult result;
+        using (var solveAct = MithrilActivitySources.MapCalibration.StartActivity("calibration.solve"))
+        {
+            solveAct?.SetTag("templates", templates.Templates.Count);
+            solveAct?.SetTag("references", references.Count);
+            result = _solver.Solve(request, references);
+            solveAct?.SetTag("solve.inliers", result.InlierCount);
+            solveAct?.SetTag("solve.calibrated", result.Calibration is not null);
+            if (result.Calibration is not null)
+            {
+                solveAct?.SetTag("solve.residual_px", result.Calibration.ResidualPixels);
+            }
+        }
         _logger?.LogInformation(
             "Auto-calibration {Area}: solve finished in {ElapsedMs:0} ms (calibration {HasCalibration}, {Inliers} inlier(s)).",
             area, Stopwatch.GetElapsedTime(solveStart).TotalMilliseconds, result.Calibration is not null, result.InlierCount);

--- a/src/Mithril.Shared/Diagnostics/Telemetry/MithrilActivitySources.cs
+++ b/src/Mithril.Shared/Diagnostics/Telemetry/MithrilActivitySources.cs
@@ -32,6 +32,9 @@ public static class MithrilActivitySources
     /// <summary>Mithril.Overlay window lifecycle, device reset, per-area projection start (#835).</summary>
     public static readonly ActivitySource Overlay = new("Mithril.Overlay");
 
+    /// <summary>Map auto-calibration capture pipeline: per-attempt capture → refine → solve timing (#914).</summary>
+    public static readonly ActivitySource MapCalibration = new("Mithril.MapCalibration.Capture");
+
     // Arda pipeline sources live in Arda.Abstractions.Diagnostics.ArdaActivitySources
     // because Arda projects can't take a dependency on Mithril.Shared. Both catalogs
     // share the "Mithril." prefix below so listeners receive both uniformly.


### PR DESCRIPTION
## What

Adds OpenTelemetry trace spans to the map auto-calibration attempt: a parent `calibration.attempt` span with child `calibration.capture` / `calibration.refine` / `calibration.solve` spans, under a new `Mithril.MapCalibration.Capture` `ActivitySource`.

## Why

The calibration engine emitted only `ILogger` logs — **no spans or metrics**. With OTLP export enabled (e.g. to a local Seq), the overlay / reference / module subsystems show up as traces, but a calibration attempt is invisible in the trace view. The #963 breadcrumb logs answer "what happened" in the file; spans answer "how long did each step take / where is it" as a **Seq waterfall** — and route to the `/v1/traces` endpoint that's already working (logs/metrics currently mis-route to the traces path — separate issue).

## What it does

Per attempt, you get a nested trace:

```
calibration.attempt           (map.area)
├─ calibration.capture        (bbox.width, bbox.height, capture.ok)
├─ calibration.refine         (map.located)        ← the long bar today (brute-force NCC, #966)
└─ calibration.solve          (templates, references, solve.inliers, solve.calibrated, solve.residual_px)
```

The `calibration.refine` span immediately shows it's the slow step; once #966 (downsample) lands, the bar collapses to milliseconds.

## Scope / safety

- **Zero-overhead when off:** no listener attached → `StartActivity` returns `null`, so every `SetTag` and the `using` scope are no-ops (the standard ambient-Activity contract).
- New `ActivitySource` named `Mithril.MapCalibration.Capture`, added to the canonical `MithrilActivitySources` catalog (not `new`'d at the call site, per CLAUDE.md). Caught by the existing `AddSource("Mithril.*")` and the perf-recorder listener.
- **Note:** spans export on span *completion*, so a multi-minute `refine` only appears once it finishes — for live mid-refine progress the per-candidate **logs** are the right tool, which lives deeper in the Shared-free detection core (`MapRectLocator`) and is deferred to #966.

## Verification

- `dotnet build` (worktree): 0 warnings, 0 errors.
- `Mithril.MapCalibration.Capture.Tests`: **100/100**.
- `Mithril.Shared.Tests` PerfTracer byte-parity: **8/8** (new source doesn't disturb the perf-recorder format).

Related: #914 (engine), #938 (live verify), #963 (breadcrumb logs), #966 (refine perf — the long span).

— drafted by Claude (Opus 4.8), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
