### PR TITLE
fix(telemetry): derive per-signal OTLP endpoints so logs/metrics ingest (#968)

### DIFF
--- a/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
+++ b/src/Mithril.Shared.Telemetry/Hosting/TelemetryHostExtensions.cs
@@ -224,7 +224,7 @@ public static class TelemetryHostExtensions
                 {
                     tb.AddProcessor<AllowlistAndRedactionProcessor>();
                 }
-                tb.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString));
+                tb.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString, "traces"));
             })
             .WithMetrics(mb =>
             {
@@ -248,7 +248,7 @@ public static class TelemetryHostExtensions
                     });
                 }
 
-                mb.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString));
+                mb.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString, "metrics"));
             });
 
         services.AddLogging(lb =>
@@ -276,26 +276,22 @@ public static class TelemetryHostExtensions
                     o.AddProcessor(sp => sp.GetRequiredService<LogScrubbingProcessor>());
                 }
 
-                o.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString));
+                o.AddOtlpExporter(opts => ConfigureOtlp(opts, settings, headerString, "logs"));
             });
         });
 
         return services;
     }
 
+    /// <summary>The three OTLP signal sub-paths, longest-stable ordering for the strip pass.</summary>
+    private static readonly string[] SignalPaths = ["traces", "metrics", "logs"];
+
     private static void ConfigureOtlp(
         OtlpExporterOptions opts,
         TelemetrySettings settings,
-        string headerString)
+        string headerString,
+        string signal)
     {
-        if (Uri.TryCreate(settings.Endpoint, UriKind.Absolute, out var uri))
-        {
-            opts.Endpoint = uri;
-        }
-        // If parsing fails, leave the OTel default endpoint in place rather
-        // than throw at registration — the exporter will fail to connect at
-        // runtime and surface via the diagnostics log / ExporterHealthMonitor.
-
         opts.Protocol = settings.Protocol switch
         {
             OtlpProtocol.Grpc => OtlpExportProtocol.Grpc,
@@ -303,10 +299,71 @@ public static class TelemetryHostExtensions
             _ => OtlpExportProtocol.HttpProtobuf,
         };
 
+        var resolved = ResolveSignalEndpoint(settings.Endpoint, settings.Protocol, signal);
+        if (resolved is not null)
+        {
+            opts.Endpoint = resolved;
+        }
+        // If parsing fails, leave the OTel default endpoint in place rather
+        // than throw at registration — the exporter will fail to connect at
+        // runtime and surface via the diagnostics log / ExporterHealthMonitor.
+
         if (!string.IsNullOrEmpty(headerString))
         {
             opts.Headers = headerString;
         }
+    }
+
+    /// <summary>
+    /// Derive the per-signal OTLP endpoint for <paramref name="signal"/>
+    /// (<c>"traces"</c> / <c>"metrics"</c> / <c>"logs"</c>) from the single
+    /// user-configured <paramref name="endpoint"/> (mithril#968).
+    ///
+    /// <para>Mithril registers a <strong>per-signal</strong> exporter
+    /// (<c>WithTracing(… AddOtlpExporter)</c>, <c>WithMetrics(…)</c>,
+    /// <c>AddLogging(… AddOtlpExporter)</c>) and sets <c>Endpoint</c>
+    /// programmatically. The OTel SDK's <c>AppendSignalPathToEndpoint</c> is
+    /// <c>internal</c> and the <c>OtlpExporterOptions.Endpoint</c> setter forces
+    /// it to <c>false</c>, so a programmatically-set HTTP endpoint is used
+    /// <em>verbatim</em> with no automatic <c>v1/{signal}</c> append. Mithril
+    /// therefore derives the path itself: with a single <c>Endpoint</c> field,
+    /// reusing it across all three signals would POST metrics and logs to the
+    /// traces path (the default Seq layout) and they never ingest.</para>
+    ///
+    /// <para>For <see cref="OtlpProtocol.HttpProtobuf"/>: strip any existing
+    /// trailing <c>/v1/{traces|metrics|logs}</c> (so a pasted signal URL — the
+    /// common mistake — re-derives correctly per pipeline) and any trailing
+    /// slash, then append <c>/v1/{signal}</c>. For
+    /// <see cref="OtlpProtocol.Grpc"/> the endpoint is returned verbatim: gRPC
+    /// routes the signal via the service method, not a URL path.</para>
+    ///
+    /// Returns <c>null</c> when <paramref name="endpoint"/> is not an absolute
+    /// URI, so the caller leaves the OTel default endpoint in place.
+    /// </summary>
+    internal static Uri? ResolveSignalEndpoint(string? endpoint, OtlpProtocol protocol, string signal)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        if (protocol == OtlpProtocol.Grpc)
+        {
+            return uri;
+        }
+
+        var left = uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        foreach (var existing in SignalPaths)
+        {
+            var suffix = "/v1/" + existing;
+            if (left.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                left = left[..^suffix.Length];
+                break;
+            }
+        }
+
+        return new Uri(left + "/v1/" + signal, UriKind.Absolute);
     }
 
     /// <summary>

--- a/src/Mithril.Shared.Telemetry/Settings/TelemetrySettings.cs
+++ b/src/Mithril.Shared.Telemetry/Settings/TelemetrySettings.cs
@@ -46,7 +46,17 @@ public sealed class TelemetrySettings : INotifyPropertyChanged, IVersionedState<
     private bool _enableOtlpExport;
     public bool EnableOtlpExport { get => _enableOtlpExport; set => Set(ref _enableOtlpExport, value); }
 
-    private string _endpoint = "http://localhost:5341/ingest/otlp/v1/traces";
+    private string _endpoint = "http://localhost:5341/ingest/otlp";
+    /// <summary>
+    /// Base OTLP endpoint. The exporter derives the per-signal path
+    /// (<c>v1/traces</c> / <c>v1/metrics</c> / <c>v1/logs</c>) from this for each
+    /// signal, so paste the <strong>base</strong> (e.g.
+    /// <c>http://localhost:5341/ingest/otlp</c>), not a signal-specific URL. A
+    /// pasted <c>…/v1/traces</c> is tolerated — the trailing signal path is
+    /// stripped and re-derived per signal so metrics/logs still route correctly
+    /// (mithril#968). For gRPC the value is used verbatim (the signal is carried
+    /// by the gRPC method, not the path).
+    /// </summary>
     public string Endpoint { get => _endpoint; set => Set(ref _endpoint, value); }
 
     private OtlpProtocol _protocol = OtlpProtocol.HttpProtobuf;

--- a/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
+++ b/src/Mithril.Shell/Views/TelemetrySettingsControl.xaml
@@ -80,8 +80,10 @@
                        FontWeight="SemiBold" Margin="0,4,0,4"/>
             <TextBox Text="{Binding Settings.Endpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      Background="#FF252525" Foreground="#FFE8E8E8" BorderBrush="#44FFFFFF"
-                     Padding="6,4" Margin="0,0,0,12"
-                     ToolTip="Restart required to apply. OTel SDK 1.15.x captures the endpoint in the exporter at provider build; live swap needs a provider rebuild (tracked in follow-up)."/>
+                     Padding="6,4" Margin="0,0,0,2"
+                     ToolTip="Restart required to apply. Paste the BASE OTLP endpoint (e.g. http://localhost:5341/ingest/otlp) — each signal's v1/{traces,metrics,logs} path is derived from it. A pasted …/v1/traces is tolerated. For gRPC the value is used verbatim. OTel SDK 1.15.x captures the endpoint at provider build; live swap needs a provider rebuild (tracked in follow-up)."/>
+            <TextBlock Text="Base endpoint, e.g. http://localhost:5341/ingest/otlp — the v1/{traces,metrics,logs} path is appended per signal."
+                       Foreground="#66FFFFFF" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,12"/>
 
             <!-- Protocol. Restart-required for the same reason as Endpoint:
                  the protocol selects the exporter transport at provider build. -->

--- a/tests/Mithril.Shared.Telemetry.Tests/Hosting/OtlpSignalEndpointTests.cs
+++ b/tests/Mithril.Shared.Telemetry.Tests/Hosting/OtlpSignalEndpointTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Mithril.Shared.Telemetry.Hosting;
+using Mithril.Shared.Telemetry.Settings;
+using Xunit;
+
+namespace Mithril.Shared.Telemetry.Tests.Hosting;
+
+/// <summary>
+/// mithril#968 — the OTLP exporter must route each signal to its own
+/// <c>v1/{traces|metrics|logs}</c> path. The per-signal <c>AddOtlpExporter</c>
+/// path Mithril uses takes the configured endpoint <em>verbatim</em> (the SDK's
+/// <c>AppendSignalPathToEndpoint</c> is internal and forced off once
+/// <c>Endpoint</c> is set programmatically), so Mithril derives the path itself.
+/// </summary>
+public class OtlpSignalEndpointTests
+{
+    [Theory]
+    [InlineData("traces", "http://localhost:5341/ingest/otlp/v1/traces")]
+    [InlineData("metrics", "http://localhost:5341/ingest/otlp/v1/metrics")]
+    [InlineData("logs", "http://localhost:5341/ingest/otlp/v1/logs")]
+    public void Base_endpoint_gets_per_signal_path_appended(string signal, string expected)
+    {
+        var resolved = TelemetryHostExtensions.ResolveSignalEndpoint(
+            "http://localhost:5341/ingest/otlp", OtlpProtocol.HttpProtobuf, signal);
+
+        resolved!.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("traces", "http://localhost:5341/ingest/otlp/v1/traces")]
+    [InlineData("metrics", "http://localhost:5341/ingest/otlp/v1/metrics")]
+    [InlineData("logs", "http://localhost:5341/ingest/otlp/v1/logs")]
+    public void Pasted_traces_url_is_re_derived_per_signal(string signal, string expected)
+    {
+        // The common Seq mistake: the user pastes the traces URL into the single
+        // Endpoint field. metrics/logs must NOT inherit the /v1/traces path.
+        var resolved = TelemetryHostExtensions.ResolveSignalEndpoint(
+            "http://localhost:5341/ingest/otlp/v1/traces", OtlpProtocol.HttpProtobuf, signal);
+
+        resolved!.ToString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void Any_pasted_signal_path_is_stripped_before_re_deriving()
+    {
+        // A pasted metrics or logs URL re-derives just like a pasted traces URL.
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+                "http://localhost:5341/ingest/otlp/v1/metrics", OtlpProtocol.HttpProtobuf, "traces")!
+            .ToString().Should().Be("http://localhost:5341/ingest/otlp/v1/traces");
+
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+                "http://localhost:5341/ingest/otlp/v1/logs", OtlpProtocol.HttpProtobuf, "logs")!
+            .ToString().Should().Be("http://localhost:5341/ingest/otlp/v1/logs");
+    }
+
+    [Fact]
+    public void Trailing_slash_on_base_is_tolerated()
+    {
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+                "http://localhost:5341/ingest/otlp/", OtlpProtocol.HttpProtobuf, "logs")!
+            .ToString().Should().Be("http://localhost:5341/ingest/otlp/v1/logs");
+    }
+
+    [Fact]
+    public void Existing_signal_path_strip_is_case_insensitive()
+    {
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+                "http://localhost:5341/ingest/otlp/v1/TRACES", OtlpProtocol.HttpProtobuf, "metrics")!
+            .ToString().Should().Be("http://localhost:5341/ingest/otlp/v1/metrics");
+    }
+
+    [Fact]
+    public void Root_endpoint_gets_signal_path()
+    {
+        // The OTLP/HTTP default-style endpoint with no ingest sub-path.
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+                "http://localhost:4318", OtlpProtocol.HttpProtobuf, "traces")!
+            .ToString().Should().Be("http://localhost:4318/v1/traces");
+    }
+
+    [Theory]
+    [InlineData("traces")]
+    [InlineData("metrics")]
+    [InlineData("logs")]
+    public void Grpc_endpoint_is_used_verbatim(string signal)
+    {
+        // gRPC routes the signal via the service method, not a URL path. The
+        // endpoint must be used as-is for every signal — appending /v1/{signal}
+        // would break gRPC export.
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+                "http://localhost:4317", OtlpProtocol.Grpc, signal)!
+            .ToString().Should().Be("http://localhost:4317/");
+    }
+
+    [Fact]
+    public void Unparseable_endpoint_returns_null_so_caller_keeps_the_sdk_default()
+    {
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+            "not a url", OtlpProtocol.HttpProtobuf, "traces").Should().BeNull();
+        TelemetryHostExtensions.ResolveSignalEndpoint(
+            null, OtlpProtocol.HttpProtobuf, "traces").Should().BeNull();
+    }
+}


### PR DESCRIPTION
Fixes #968.

## Problem

The OTLP exporter reused a single `Endpoint` across all three signals, so any endpoint carrying a signal-specific path (the default Seq layout) routed **logs and metrics to the wrong ingestion path**. With `…/ingest/otlp/v1/traces` configured: traces ingest, but metrics and logs POST to `/v1/traces` and never ingest — which is why the #963 calibration breadcrumb logs were invisible in Seq even with OTLP export on.

## Why not `UseOtlpExporter()`

The issue's preferred option was migrating to the cross-cutting `UseOtlpExporter()` for its auto-append. It's viable but comes out behind here, for reasons independent of security:

1. **No public header-capable overload.** OTel 1.15.3 exposes only two public overloads — `UseOtlpExporter()` (env-vars only) and `UseOtlpExporter(OtlpExportProtocol, Uri baseUrl)` (no headers). The header/`IConfiguration`/`OtlpExporterBuilder` overloads are `internal`, and `OtlpExporterBuilderOptions` is `internal` (no `services.Configure` back door). So with auth headers in play (Seq/Honeycomb keys, via the DPAPI `HeaderValueProtection` path) we couldn't use the typed `(protocol, baseUrl)` overload at all — endpoint, protocol, and headers would all have to be marshalled through `OTEL_EXPORTER_OTLP_*` env strings and the parameterless overload. Not simpler than the typed `opts` we already set.
2. **Auto-append doesn't tolerate the paste the issue is about.** `UseOtlpExporter`'s appender takes a base and appends `v1/{signal}`; a pasted `…/ingest/otlp/v1/traces` (the exact #968 mistake) becomes `…/v1/traces/v1/metrics`. `ResolveSignalEndpoint` strips the trailing signal path first, as the issue explicitly asked.
3. **Logs convergence unverified.** The logs exporter is wired via `AddLogging(… AddOpenTelemetry)`, not `WithLogging`, so migration would need to prove `UseOtlpExporter` attaches to that provider.

The only thing migration buys — auto-append from a base — the 15-line tested helper already does, and more robustly against the real-world paste.

## Fix (issue Option 1, surgical)

`ResolveSignalEndpoint(endpoint, protocol, signal)` derives the path itself:
- **HttpProtobuf**: strip any trailing `/v1/{traces,metrics,logs}` (tolerating the common "pasted the traces URL" mistake), strip a trailing slash, then append `/v1/{signal}`.
- **gRPC**: returned verbatim — the signal rides the gRPC service method, not a URL path.
- Unparseable endpoint → `null`, so the caller keeps the OTel default (unchanged behavior).

All existing wiring (headers, protocol, the three per-pipeline scrubbers, `TrustEndpoint` gating) is untouched. The default endpoint and the settings-UI help/tooltip now document the **base** form (`http://localhost:5341/ingest/otlp`).

## Tests

- New `OtlpSignalEndpointTests` (14 cases): base → per-signal append, pasted-signal-URL re-derivation, trailing slash, case-insensitive strip, root endpoint, gRPC verbatim, null on unparseable.
- Full `Mithril.Shared.Telemetry.Tests` suite green (107 passed). Shell builds + XAML lint passes.

## Verification owed

Routing is unit-verified by URL derivation. A live-Seq end-to-end check (traces + logs + metrics all land after the change) is still owed — I don't have a Seq instance wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
