### PR TITLE
feat(map-calibration): wire #966 capture-frame dump to a Settings → Diagnostics toggle

### DIFF
--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -83,6 +83,16 @@ public static class ShellComposition
     public static IServiceCollection AddMithrilShell(
         this IServiceCollection services, ShellCompositionOptions o)
     {
+        // #966 Task-3 capture-frame dump toggle. Seed the Capture project's
+        // CaptureDiagnosticsOptions singleton from the persisted ShellSettings flags
+        // and keep it live by mirroring PropertyChanged onto the mutable POCO (the
+        // GameConfig precedent in Program.cs). Registered BELOW (before
+        // AddMithrilMapCalibrationCapture) so this AddSingleton wins over that call's
+        // TryAddSingleton(new CaptureDiagnosticsOptions()). Process-lifetime
+        // subscription (never unsubscribed) — both instances live for the whole
+        // process, same as the GameConfig mirror; no disposal ceremony needed.
+        var captureDiag = MirrorCaptureDiagnostics(o.ShellSettings);
+
         services
             .AddMithrilSettings<UserPreferences>(o.PreferencesPath, UserPreferencesJsonContext.Default.UserPreferences)
             .AddSingleton<ISettingsStore<ShellSettings>>(o.ShellStore)
@@ -118,6 +128,11 @@ public static class ShellComposition
                 sp.GetRequiredService<ShellSettings>(),
                 sp.GetRequiredService<ISettingsStore<ShellSettings>>(),
                 sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.Shell.MapCaptureRect")))
+            // #966 Task 3: seed + live-mirror the capture-frame-dump toggle (see
+            // MirrorCaptureDiagnostics above). Registered BEFORE
+            // AddMithrilMapCalibrationCapture so this concrete instance wins over
+            // that call's TryAddSingleton(new CaptureDiagnosticsOptions()).
+            .AddSingleton(captureDiag)
             // #914 PR-2: map auto-capture pipeline (OS capture + trigger +
             // persistence). Registered AFTER AddMithrilOverlay (consumes
             // IOverlayWindow) and AFTER AddMithrilMapCalibration (consumes
@@ -263,5 +278,37 @@ public static class ShellComposition
         services.AddHostedService(sp => sp.GetRequiredService<SessionAgreementComposer>());
 
         return services;
+    }
+
+    /// <summary>
+    /// Builds the live <see cref="Mithril.MapCalibration.Capture.CaptureDiagnosticsOptions"/>
+    /// singleton seeded from the persisted <see cref="ShellSettings"/> capture-dump
+    /// flags, then mirrors subsequent <see cref="ShellSettings.PropertyChanged"/>
+    /// edits onto the mutable POCO so a Settings → Diagnostics checkbox flip takes
+    /// effect at runtime without re-resolving the graph (#966 Task 3). Mirrors the
+    /// GameConfig live-POCO precedent in <c>Program.Main</c>. The subscription is
+    /// process-lifetime (never detached) — both objects live for the whole process.
+    /// </summary>
+    internal static Mithril.MapCalibration.Capture.CaptureDiagnosticsOptions
+        MirrorCaptureDiagnostics(ShellSettings settings)
+    {
+        var captureDiag = new Mithril.MapCalibration.Capture.CaptureDiagnosticsOptions
+        {
+            DumpCaptureFrames = settings.DumpCalibrationCaptureFrames,
+            DumpGrayFrames = settings.DumpCalibrationGrayFrames,
+        };
+        settings.PropertyChanged += (_, e) =>
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(ShellSettings.DumpCalibrationCaptureFrames):
+                    captureDiag.DumpCaptureFrames = settings.DumpCalibrationCaptureFrames;
+                    break;
+                case nameof(ShellSettings.DumpCalibrationGrayFrames):
+                    captureDiag.DumpGrayFrames = settings.DumpCalibrationGrayFrames;
+                    break;
+            }
+        };
+        return captureDiag;
     }
 }

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -92,6 +92,25 @@ public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPers
     private bool _autoStartPerfTrace;
     public bool AutoStartPerfTrace { get => _autoStartPerfTrace; set => Set(ref _autoStartPerfTrace, value); }
 
+    /// <summary>When true, the map-calibration capture seam dumps each successfully
+    /// validated <b>color</b> capture frame to a PNG under
+    /// <c>%LocalAppData%/Mithril/diagnostics/calibration/</c> (mirrors
+    /// <c>CaptureDiagnosticsOptions.DumpCaptureFrames</c>, #966 Task 3). Off by
+    /// default — a debug aid for investigating a slow/stalled refine, leaving the
+    /// exact pixels the solve engine was handed on disk to inspect. Purely additive
+    /// field → no schema bump (missing key → false on load).</summary>
+    private bool _dumpCalibrationCaptureFrames;
+    public bool DumpCalibrationCaptureFrames { get => _dumpCalibrationCaptureFrames; set => Set(ref _dumpCalibrationCaptureFrames, value); }
+
+    /// <summary>When true (and <see cref="DumpCalibrationCaptureFrames"/> is on),
+    /// also dump the derived <b>grayscale</b> frame alongside the color one to
+    /// <c>%LocalAppData%/Mithril/diagnostics/calibration/</c> (mirrors
+    /// <c>CaptureDiagnosticsOptions.DumpGrayFrames</c>) — catches a <c>ToGray</c>
+    /// bug a color-only dump would hide. Off by default; purely additive field →
+    /// no schema bump (missing key → false on load).</summary>
+    private bool _dumpCalibrationGrayFrames;
+    public bool DumpCalibrationGrayFrames { get => _dumpCalibrationGrayFrames; set => Set(ref _dumpCalibrationGrayFrames, value); }
+
     private string _uiFontFamily = "Segoe UI";
     public string UiFontFamily { get => _uiFontFamily; set => Set(ref _uiFontFamily, value); }
 

--- a/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
@@ -64,6 +64,11 @@ public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
     /// "Open log directory" command.</summary>
     public string LogDirectoryHint => LogDirectory;
 
+    /// <summary>The folder where map-calibration capture-frame dumps land when the
+    /// dump toggle (#966 Task 3) is on. Surfaced read-only so the settings UI can
+    /// show the path without duplicating <c>CaptureFrameDumper</c>'s derivation.</summary>
+    public string CalibrationDumpDirectoryHint => CalibrationDumpDirectory;
+
     private static string ShellDirectory => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Mithril", "Shell");
@@ -71,6 +76,12 @@ public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
     private static string LogDirectory => Path.Combine(ShellDirectory, "logs");
 
     private static string PerfDirectory => Path.Combine(ShellDirectory, "perf");
+
+    /// <summary>Mirrors <c>CaptureFrameDumper</c>'s output directory
+    /// (<c>%LocalAppData%\Mithril\diagnostics\calibration</c>) for display.</summary>
+    private static string CalibrationDumpDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Mithril", "diagnostics", "calibration");
 
     /// <summary>Outcome of the most recent clear command, shown beneath the buttons.</summary>
     [ObservableProperty]

--- a/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs
@@ -4,6 +4,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Capture;
 using Mithril.Shared.Wpf.Dialogs;
 
 namespace Mithril.Shell.ViewModels;
@@ -65,9 +66,10 @@ public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
     public string LogDirectoryHint => LogDirectory;
 
     /// <summary>The folder where map-calibration capture-frame dumps land when the
-    /// dump toggle (#966 Task 3) is on. Surfaced read-only so the settings UI can
-    /// show the path without duplicating <c>CaptureFrameDumper</c>'s derivation.</summary>
-    public string CalibrationDumpDirectoryHint => CalibrationDumpDirectory;
+    /// dump toggle (#966 Task 3) is on. Surfaced read-only by delegating to
+    /// <see cref="CaptureFrameDumper.DumpDirectory"/> — the single source of truth for
+    /// the path — so the displayed hint can never drift from where dumps are written.</summary>
+    public string CalibrationDumpDirectoryHint => CaptureFrameDumper.DumpDirectory;
 
     private static string ShellDirectory => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -76,12 +78,6 @@ public sealed partial class DiagnosticsSettingsViewModel : ObservableObject
     private static string LogDirectory => Path.Combine(ShellDirectory, "logs");
 
     private static string PerfDirectory => Path.Combine(ShellDirectory, "perf");
-
-    /// <summary>Mirrors <c>CaptureFrameDumper</c>'s output directory
-    /// (<c>%LocalAppData%\Mithril\diagnostics\calibration</c>) for display.</summary>
-    private static string CalibrationDumpDirectory => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Mithril", "diagnostics", "calibration");
 
     /// <summary>Outcome of the most recent clear command, shown beneath the buttons.</summary>
     [ObservableProperty]

--- a/src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml
+++ b/src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml
@@ -50,6 +50,33 @@
                        FontSize="{DynamicResource AppFontSizeHint}" Margin="0,8,0,4"
                        Text="Bind a hotkey to 'Toggle perf-trace recording' under Hotkeys settings to start/stop a session on demand. The status bar shows a red REC dot while a session is active."/>
 
+            <!-- Map-calibration capture diagnostics (#966 Task 3) -->
+            <Border Margin="0,24,0,0" Padding="0,16,0,0" BorderThickness="0,1,0,0" BorderBrush="#22FFFFFF">
+                <StackPanel>
+                    <TextBlock Text="Map-calibration capture frames" Foreground="#88FFFFFF" Margin="0,0,0,4" FontWeight="SemiBold"/>
+                    <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8"
+                               Text="Dumps each successfully captured map frame to a PNG so you can inspect the exact pixels the auto-calibration solve was handed. A debug aid for investigating a slow or stalled solve — leave off otherwise."/>
+
+                    <CheckBox Content="Dump calibration capture frames (PNG)"
+                              IsChecked="{Binding Settings.DumpCalibrationCaptureFrames, Mode=TwoWay}"
+                              Foreground="#FFE8E8E8" Margin="0,0,0,8"/>
+
+                    <CheckBox Content="…also dump the derived grayscale frame"
+                              IsChecked="{Binding Settings.DumpCalibrationGrayFrames, Mode=TwoWay}"
+                              IsEnabled="{Binding Settings.DumpCalibrationCaptureFrames}"
+                              Foreground="#FFE8E8E8" Margin="0,0,0,16"/>
+
+                    <TextBlock TextWrapping="Wrap" Foreground="#66FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"
+                               Text="Frames land in:"/>
+                    <TextBlock TextWrapping="Wrap" Foreground="#AAFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               FontFamily="Consolas, Cascadia Mono"
+                               Text="{Binding CalibrationDumpDirectoryHint}" Margin="0,0,0,4"/>
+                </StackPanel>
+            </Border>
+
             <TextBlock Margin="0,24,0,0" TextWrapping="Wrap" Foreground="#66FFFFFF"
                        FontSize="{DynamicResource AppFontSizeHint}"
                        Text="Changes preview live. Settings persist on shutdown."/>

--- a/tests/Mithril.Shell.Tests/CaptureDiagnosticsMirrorTests.cs
+++ b/tests/Mithril.Shell.Tests/CaptureDiagnosticsMirrorTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Capture;
+using Mithril.Shell.DependencyInjection;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #966 Task 3: the Settings → Diagnostics capture-frame-dump checkboxes flip
+/// <see cref="ShellSettings.DumpCalibrationCaptureFrames"/> /
+/// <see cref="ShellSettings.DumpCalibrationGrayFrames"/>, which must mirror onto the
+/// live <see cref="CaptureDiagnosticsOptions"/> singleton the capture seam reads —
+/// without re-resolving the DI graph. Exercises the exact seed + PropertyChanged
+/// wiring <c>ShellComposition</c> registers (<see cref="ShellComposition.MirrorCaptureDiagnostics"/>).
+/// </summary>
+public sealed class CaptureDiagnosticsMirrorTests
+{
+    [Fact]
+    public void Seeds_the_options_from_current_settings()
+    {
+        var settings = new ShellSettings
+        {
+            DumpCalibrationCaptureFrames = true,
+            DumpCalibrationGrayFrames = true,
+        };
+
+        var options = ShellComposition.MirrorCaptureDiagnostics(settings);
+
+        options.DumpCaptureFrames.Should().BeTrue();
+        options.DumpGrayFrames.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Defaults_are_off_when_settings_are_off()
+    {
+        var options = ShellComposition.MirrorCaptureDiagnostics(new ShellSettings());
+
+        options.DumpCaptureFrames.Should().BeFalse();
+        options.DumpGrayFrames.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Flipping_the_color_dump_setting_mirrors_onto_the_singleton()
+    {
+        var settings = new ShellSettings();
+        var options = ShellComposition.MirrorCaptureDiagnostics(settings);
+
+        settings.DumpCalibrationCaptureFrames = true;
+        options.DumpCaptureFrames.Should().BeTrue("flipping the setting must mirror live onto the options POCO");
+
+        settings.DumpCalibrationCaptureFrames = false;
+        options.DumpCaptureFrames.Should().BeFalse("turning the setting back off must mirror too");
+    }
+
+    [Fact]
+    public void Flipping_the_gray_dump_setting_mirrors_onto_the_singleton()
+    {
+        var settings = new ShellSettings();
+        var options = ShellComposition.MirrorCaptureDiagnostics(settings);
+
+        settings.DumpCalibrationGrayFrames = true;
+        options.DumpGrayFrames.Should().BeTrue();
+
+        settings.DumpCalibrationGrayFrames = false;
+        options.DumpGrayFrames.Should().BeFalse();
+    }
+}

--- a/tests/Mithril.Shell.Tests/ShellSettingsVersioningTests.cs
+++ b/tests/Mithril.Shell.Tests/ShellSettingsVersioningTests.cs
@@ -80,4 +80,33 @@ public sealed class ShellSettingsVersioningTests
 
         loaded.InstallRoot.Should().BeEmpty();
     }
+
+    [Fact]
+    public void Calibration_dump_flags_round_trip_through_json()
+    {
+        // #966 Task 3: the capture-frame-dump toggles are additive bool fields (no
+        // schema bump). They must persist and reload with the values intact.
+        var written = JsonSerializer.Serialize(
+            new ShellSettings { DumpCalibrationCaptureFrames = true, DumpCalibrationGrayFrames = true },
+            ShellSettingsJsonContext.Default.ShellSettings);
+
+        var loaded = JsonSerializer.Deserialize(
+            written, ShellSettingsJsonContext.Default.ShellSettings)!;
+
+        loaded.DumpCalibrationCaptureFrames.Should().BeTrue();
+        loaded.DumpCalibrationGrayFrames.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Calibration_dump_flags_default_to_false_when_absent_from_legacy_json()
+    {
+        // A shell.json predating #966 Task 3 has neither key → false on load
+        // (additive bool fields), so the dump stays off until the user opts in.
+        var loaded = JsonSerializer.Deserialize(
+            """{ "gameRoot": "C:/PG" }""",
+            ShellSettingsJsonContext.Default.ShellSettings)!;
+
+        loaded.DumpCalibrationCaptureFrames.Should().BeFalse();
+        loaded.DumpCalibrationGrayFrames.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## What

Wires the #966 Task-3 capture-frame dump to a persisted **Settings → Diagnostics** toggle.

Issue #966 Task 3 (merged in #972) added a color capture-frame PNG dump behind `CaptureDiagnosticsOptions.DumpCaptureFrames`, but the flag was a bare DI singleton with **no way to turn it on** — no settings, no UI. This adds persisted `ShellSettings` flags surfaced as checkboxes so a user/dev can flip the dump on without recompiling, and it survives restarts.

## Changes

- **`src/Mithril.Shell/ShellSettings.cs`** — adds two additive `bool` flags following the perf-trace bool precedent:
  - `DumpCalibrationCaptureFrames` (primary, color dump)
  - `DumpCalibrationGrayFrames` (secondary, derived grayscale; mirrors `CaptureDiagnosticsOptions.DumpGrayFrames`)
  Purely additive → **no schema bump** (`Version` stays 1; missing key → `false`).
- **`src/Mithril.Shell/DependencyInjection/ShellComposition.cs`** — seeds a `CaptureDiagnosticsOptions` singleton from the persisted settings and live-mirrors `ShellSettings.PropertyChanged` onto the mutable POCO (the `GameConfig` precedent in `Program.cs`). Registered **before** `AddMithrilMapCalibrationCapture` so this concrete instance wins over that call's `TryAddSingleton(new CaptureDiagnosticsOptions())`. Mirror logic extracted to an `internal MirrorCaptureDiagnostics` helper for testability.
- **`src/Mithril.Shell/Views/DiagnosticsSettingsView.xaml`** — adds a "Map-calibration capture frames" group: primary checkbox + gray checkbox gated under it (`IsEnabled` bound to the primary), explicit `Mode=TwoWay` on the `IsChecked` bindings (per `docs/wpf-gotchas.md`), and a directory hint.
- **`src/Mithril.Shell/ViewModels/DiagnosticsSettingsViewModel.cs`** — adds read-only `CalibrationDumpDirectoryHint` mirroring `CaptureFrameDumper`'s output dir (`%LocalAppData%\Mithril\diagnostics\calibration`).
- **Tests** — JSON round-trip (set + legacy-absent → false) and the seed/live-mirror wiring.

## Verification

- `dotnet build Mithril.slnx` — clean, 0 warnings (warnings-as-errors).
- `dotnet test Mithril.slnx` — green across all projects.
- No `System.Drawing.Common` / `AssetsTools` deps added (no new package references at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
