### PR TITLE
fix(map-calibration): unify landmark-type vocabulary so detect→solve pairs (#974)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
@@ -15,32 +15,27 @@ namespace Mithril.MapCalibration.Capture;
 /// whose <see cref="Npc.AreaName"/> matches the area.
 ///
 /// <para>Each source is mapped to a <see cref="LandmarkReference"/> whose
-/// <c>Type</c> is one of the four template/solver tokens
-/// (<c>landmark_telepad</c> / <c>landmark_medipillar</c> / <c>landmark_portal</c>
-/// / <c>landmark_npc</c>) the detector pairs against. World coords are parsed
+/// <c>Type</c> is the <b>raw PG landmark type</b> — the canonical vocabulary
+/// (<c>Portal</c> / <c>MeditationPillar</c> / <c>TeleportationPlatform</c> /
+/// <c>Npc</c>, see <see cref="CanonicalLandmarkTypes"/>) the detector also keys
+/// its <see cref="IconTemplate.LandmarkType"/> detections by, so the
+/// type-constrained RANSAC solver can pair them with an Ordinal type match
+/// (mithril#974). The <c>landmark_*</c> sprite strings are template <i>names</i>
+/// (<see cref="LandmarkReference.Name"/>), never types. World coords are parsed
 /// from the <c>"x:N y:N z:N"</c> position string (the live <c>landmarks.json</c> /
 /// <c>npcs.json</c> shape — memory <c>pg_reference_coords_are_world_frame</c>).</para>
 /// </summary>
 public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
 {
-    // Verification owed (#914): confirm the Landmark.Type → template-token mapping
-    // against live landmarks.json. Confirmed against v470 corpus on 2026-05-31:
-    // Type ∈ { Portal, MeditationPillar, TeleportationPlatform } — every landmark
-    // carries exactly one of these. The four template tokens come from
-    // IconTemplateExtractor's canonical pairing (tools/Mithril.MapCalibration.Tools.Common):
-    //   Portal → landmark_portal, MeditationPillar → landmark_medipillar,
-    //   TeleportationPlatform → landmark_telepad, (NPCs) → landmark_npc.
-    // Any future/unmapped Type is WARNED and dropped (no silent coercion to a
-    // wrong token, which would mispair a detection and corrupt the solve).
-    private static readonly IReadOnlyDictionary<string, string> LandmarkTypeToToken =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["Portal"] = "landmark_portal",
-            ["MeditationPillar"] = "landmark_medipillar",
-            ["TeleportationPlatform"] = "landmark_telepad",
-        };
-
-    private const string NpcToken = "landmark_npc";
+    // The canonical raw-PG landmark types we accept from landmarks.json. Confirmed
+    // against the v470 corpus on 2026-05-31: Type ∈ { Portal, MeditationPillar,
+    // TeleportationPlatform } — every landmark carries exactly one of these. NPCs
+    // are emitted with the CanonicalLandmarkTypes.Npc type. The vocabulary lives
+    // in CanonicalLandmarkTypes so detection-side (IconTemplate.LandmarkType) and
+    // reference-side keys never diverge again (mithril#974). Any future/unmapped
+    // Type is WARNED and dropped (no silent coercion to a wrong type, which would
+    // mispair a detection and corrupt the solve).
+    private static readonly IReadOnlySet<string> KnownLandmarkTypes = CanonicalLandmarkTypes.LandmarkTypes;
 
     private readonly IReferenceDataService _refData;
     private readonly ILogger? _logger;
@@ -67,19 +62,21 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
             foreach (var lm in landmarks)
             {
                 if (lm is null || string.IsNullOrEmpty(lm.Type)) continue;
-                if (!LandmarkTypeToToken.TryGetValue(lm.Type, out var token))
+                if (!KnownLandmarkTypes.Contains(lm.Type))
                 {
                     // No silent drop: surface the unmapped type so an uncovered
                     // landmark category is visible (verification-owed follow-up).
                     _logger?.LogWarning(
-                        "Unmapped landmark Type {Type} in area {Area} (landmark {Name}); dropped — no template token. " +
-                        "Verification owed (#914): confirm Landmark.Type → template-token mapping vs live landmarks.json.",
+                        "Unmapped landmark Type {Type} in area {Area} (landmark {Name}); dropped — not a canonical landmark type. " +
+                        "Verification owed (#914): confirm Landmark.Type vocabulary vs live landmarks.json + the icon-template manifest.",
                         lm.Type, areaKey, lm.Name);
                     continue;
                 }
                 if (TryParseWorld(lm.Loc, out var world))
                 {
-                    result.Add(new LandmarkReference(token, lm.Name ?? lm.Type, world));
+                    // Emit the raw PG type verbatim — the same vocabulary the
+                    // detector keys IconTemplate.LandmarkType by (mithril#974).
+                    result.Add(new LandmarkReference(lm.Type, lm.Name ?? lm.Type, world));
                 }
                 else
                 {
@@ -94,7 +91,7 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
             if (!string.Equals(npc.AreaName, areaKey, StringComparison.Ordinal)) continue;
             if (TryParseWorld(npc.Pos, out var world))
             {
-                result.Add(new LandmarkReference(NpcToken, npc.Name ?? "NPC", world));
+                result.Add(new LandmarkReference(CanonicalLandmarkTypes.Npc, npc.Name ?? "NPC", world));
             }
             else
             {

--- a/src/Mithril.MapCalibration/Detection/CanonicalLandmarkTypes.cs
+++ b/src/Mithril.MapCalibration/Detection/CanonicalLandmarkTypes.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+
+namespace Mithril.MapCalibration.Detection;
+
+/// <summary>
+/// The single source of truth for the landmark-type vocabulary the calibration
+/// detect→solve pipeline pairs on. These are the <b>raw PG type</b> strings —
+/// the same values that appear in landmarks.json (<c>Landmark.Type</c>), in the
+/// bundled icon-template manifest's <c>landmarkType</c> field (which the loader
+/// surfaces as <see cref="IconTemplate.LandmarkType"/>), and that the solver
+/// matches with an <see cref="System.StringComparison.Ordinal"/> equality.
+///
+/// <para>Both sides of the correspondence — detection type-keys
+/// (<see cref="IconTemplate.LandmarkType"/>) and reference type-keys
+/// (<see cref="LandmarkReference.Type"/>) — MUST speak this vocabulary, or the
+/// type-constrained RANSAC pool is empty and every solve rejects with 0 inliers
+/// (mithril#974). The provider's allowlist consumes
+/// <see cref="LandmarkTypes"/> so the vocabulary lives in exactly one place.</para>
+/// </summary>
+public static class CanonicalLandmarkTypes
+{
+    /// <summary>Portal landmark type (landmarks.json).</summary>
+    public const string Portal = "Portal";
+
+    /// <summary>Meditation-pillar landmark type (landmarks.json).</summary>
+    public const string MeditationPillar = "MeditationPillar";
+
+    /// <summary>Teleportation-platform landmark type (landmarks.json).</summary>
+    public const string TeleportationPlatform = "TeleportationPlatform";
+
+    /// <summary>NPC type — NPCs come from npcs.json, not landmarks.json, but pair like a landmark.</summary>
+    public const string Npc = "Npc";
+
+    /// <summary>
+    /// The three types sourced from <c>landmarks.json</c> (excludes <see cref="Npc"/>),
+    /// used as the provider's landmark allowlist.
+    /// </summary>
+    public static readonly IReadOnlySet<string> LandmarkTypes =
+        new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            Portal,
+            MeditationPillar,
+            TeleportationPlatform,
+        };
+
+    /// <summary>Every canonical type the solver pairs on (the three landmark types + <see cref="Npc"/>).</summary>
+    public static readonly IReadOnlySet<string> All =
+        new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            Portal,
+            MeditationPillar,
+            TeleportationPlatform,
+            Npc,
+        };
+}

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace Mithril.MapCalibration.Detection;
@@ -44,6 +45,7 @@ public sealed class MapCalibrationSolveEngine
             var req = request with { BaseTexture = texture };
 
             var detections = _detector.Detect(req);
+            LogDetectSummary(rotate180, detections, references);
             var (cal, inliers) = TypeAwareRansacSolver.Solve(ToMutable(detections), references, request.MapRect);
 
             if (cal is null)
@@ -82,6 +84,47 @@ public sealed class MapCalibrationSolveEngine
         var rejected = bestRejected ?? new CalibrationSolveResult(null, 0, "no detections");
         _logger?.LogInformation("Auto-calibration rejected: {Reason}.", rejected.RejectReason);
         return rejected;
+    }
+
+    /// <summary>
+    /// Per-orientation detect summary: typed detection total + per-type breakdown
+    /// and the reference per-type breakdown, plus a targeted Warning when the two
+    /// type-key sets are disjoint (the mithril#974 failure mode: a detection-side
+    /// IconTemplate.LandmarkType vocabulary that doesn't overlap the reference-side
+    /// LandmarkReference.Type vocabulary → 0 correspondences possible). Cheap: at
+    /// most one Information line + (rarely) one Warning per orientation, ≤ 2 each
+    /// per solve attempt.
+    /// </summary>
+    private void LogDetectSummary(
+        bool rotate180,
+        IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> detections,
+        IReadOnlyList<LandmarkReference> references)
+    {
+        if (_logger is null) return;
+
+        var detTotal = detections.Sum(kv => kv.Value.Count);
+        var detBreakdown = string.Join(" ", detections
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => $"{kv.Key}={kv.Value.Count}"));
+        var refBreakdown = string.Join(" ", references
+            .GroupBy(r => r.Type, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => $"{g.Key}={g.Count()}"));
+
+        _logger.LogInformation(
+            "Detect (rotate180={Rotate180}): {DetTotal} typed detections [{DetBreakdown}]; references [{RefBreakdown}].",
+            rotate180, detTotal, detBreakdown, refBreakdown);
+
+        var detKeys = new HashSet<string>(detections.Keys, StringComparer.Ordinal);
+        var refKeys = new HashSet<string>(references.Select(r => r.Type), StringComparer.Ordinal);
+        if (detKeys.Count > 0 && refKeys.Count > 0 && !detKeys.Overlaps(refKeys))
+        {
+            _logger.LogWarning(
+                "Detection type-keys [{DetKeys}] and reference type-keys [{RefKeys}] are disjoint — "
+                + "0 correspondences possible; likely an icon-template ↔ reference type-vocabulary mismatch.",
+                string.Join(",", detKeys.OrderBy(k => k, StringComparer.Ordinal)),
+                string.Join(",", refKeys.OrderBy(k => k, StringComparer.Ordinal)));
+        }
     }
 
     private static IReadOnlyDictionary<string, List<TypedDetection>> ToMutable(

--- a/tests/Mithril.MapCalibration.Capture.Tests/AreaReferenceProviderTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AreaReferenceProviderTests.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using FluentAssertions;
 using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.MapCalibration.Detection;
 using Mithril.Reference.Models.Misc;
 using Xunit;
 
@@ -25,10 +27,13 @@ public sealed class AreaReferenceProviderTests
 
         var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
 
-        refs.Should().Contain(r => r.Type == "landmark_portal" && r.World.X == 10 && r.World.Z == -20);
-        refs.Should().Contain(r => r.Type == "landmark_medipillar");
-        refs.Should().Contain(r => r.Type == "landmark_telepad");
-        refs.Should().Contain(r => r.Type == "landmark_npc" && r.Name == "Marna" && r.World.X == 30 && r.World.Z == 40);
+        // mithril#974: Type carries the raw PG vocabulary (the same the detector
+        // keys IconTemplate.LandmarkType by); the landmark_* sprite strings are
+        // template NAMES, never types.
+        refs.Should().Contain(r => r.Type == "Portal" && r.World.X == 10 && r.World.Z == -20);
+        refs.Should().Contain(r => r.Type == "MeditationPillar");
+        refs.Should().Contain(r => r.Type == "TeleportationPlatform");
+        refs.Should().Contain(r => r.Type == "Npc" && r.Name == "Marna" && r.World.X == 30 && r.World.Z == 40);
     }
 
     [Fact]
@@ -42,7 +47,7 @@ public sealed class AreaReferenceProviderTests
 
         var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
 
-        refs.Should().ContainSingle(r => r.Type == "landmark_portal");
+        refs.Should().ContainSingle(r => r.Type == "Portal");
         refs.Should().OnlyContain(r => r.Name == "Good");
     }
 
@@ -62,4 +67,24 @@ public sealed class AreaReferenceProviderTests
     [Fact]
     public void Unknown_area_yields_empty()
         => new ReferenceDataAreaReferenceProvider(new FakeAreaReferenceData()).ForArea("AreaNope").Should().BeEmpty();
+
+    [Fact]
+    public void Emitted_types_are_a_subset_of_the_canonical_vocabulary()
+    {
+        // mithril#974 seam guard: every reference Type the provider emits must be
+        // in CanonicalLandmarkTypes.All — the same vocabulary the detector keys
+        // IconTemplate.LandmarkType by — so the type-constrained solver can pair
+        // them. A stray landmark_* token here would re-open the 0-inliers bug.
+        var refData = new FakeAreaReferenceData()
+            .WithLandmarks("AreaSerbule",
+                new Landmark { Name = "P", Loc = "x:1 y:0 z:1", Type = "Portal" },
+                new Landmark { Name = "M", Loc = "x:2 y:0 z:2", Type = "MeditationPillar" },
+                new Landmark { Name = "T", Loc = "x:3 y:0 z:3", Type = "TeleportationPlatform" })
+            .WithNpc("AreaSerbule", "Marna", pos: "x:4 y:0 z:4");
+
+        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
+
+        refs.Select(r => r.Type).Distinct().Should().OnlyContain(t => CanonicalLandmarkTypes.All.Contains(t));
+        refs.Should().NotBeEmpty();
+    }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/ReferenceProviderSolverSeamTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/ReferenceProviderSolverSeamTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.MapCalibration.Detection;
+using Mithril.Reference.Models.Misc;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// mithril#974 cross-component seam test — the test that would have caught the
+/// bug. It joins the PRODUCTION reference vocabulary (built via
+/// <see cref="ReferenceDataAreaReferenceProvider"/>) to the DETECTION vocabulary
+/// (detections keyed by the bundled icon-template manifest's <c>landmarkType</c>,
+/// i.e. <see cref="CanonicalLandmarkTypes"/>) and runs both through the real
+/// <see cref="TypeAwareRansacSolver"/>. The pre-fix provider emitted
+/// <c>landmark_*</c> tokens that were Ordinal-disjoint from the detection keys,
+/// so the type-constrained pool was empty and the solver returned 0 inliers /
+/// null. Post-fix the vocabularies match and the synthetic fixture cold-solves.
+/// </summary>
+public sealed class ReferenceProviderSolverSeamTests
+{
+    // Ground-truth world (X,Z) -> texture-pixel transform.
+    private static readonly AreaCalibration Truth = new(
+        Scale: 1.2, RotationRadians: 0.35, OriginX: 400.0, OriginY: 300.0,
+        ReferenceCount: 0, ResidualPixels: 0.0)
+    { MirrorNorth = false, CalibrationZoom = 1.0 };
+
+    // Texture 800x600 at native scale, screenshot padded by (50, 80): so
+    // texture-pixel == screenshot-pixel - origin.
+    private static readonly MapRect Rect = new(
+        OriginX: 50, OriginY: 80, Width: 800, Height: 600, TextureWidth: 800, TextureHeight: 600);
+
+    // (PG type, name, worldX, worldZ). NPCs are emitted by the provider from
+    // npcs.json; the rest from landmarks.json.
+    private static readonly (string Type, string Name, double X, double Z)[] Points =
+    [
+        ("Portal", "Serbule Portal", -50.0, 80.0),
+        ("Portal", "South Portal", 75.0, -40.0),
+        ("TeleportationPlatform", "Telepad", 100.0, 20.0),
+        ("MeditationPillar", "Pillar", 0.0, -10.0),
+        ("Npc", "Marna", 40.0, 60.0),
+        ("Npc", "Joeh", -30.0, -55.0),
+    ];
+
+    [Fact]
+    public void Provider_vocabulary_pairs_with_manifest_detection_vocabulary()
+    {
+        // Build the area reference set through the PRODUCTION provider.
+        var fake = new FakeAreaReferenceData()
+            .WithLandmarks("AreaSerbule",
+                Points.Where(p => p.Type != CanonicalLandmarkTypes.Npc)
+                    .Select(p => new Landmark
+                    {
+                        Name = p.Name,
+                        Type = p.Type,
+                        Loc = $"x:{p.X.ToString(System.Globalization.CultureInfo.InvariantCulture)} y:0 " +
+                              $"z:{p.Z.ToString(System.Globalization.CultureInfo.InvariantCulture)}",
+                    })
+                    .ToArray());
+        foreach (var npc in Points.Where(p => p.Type == CanonicalLandmarkTypes.Npc))
+        {
+            fake.WithNpc("AreaSerbule", npc.Name,
+                pos: $"x:{npc.X.ToString(System.Globalization.CultureInfo.InvariantCulture)} y:0 " +
+                     $"z:{npc.Z.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        }
+
+        var refs = new ReferenceDataAreaReferenceProvider(fake).ForArea("AreaSerbule");
+        refs.Should().HaveCount(Points.Length);
+        // Provider speaks the canonical vocabulary…
+        refs.Select(r => r.Type).Distinct().Should().OnlyContain(t => CanonicalLandmarkTypes.All.Contains(t));
+
+        // …and the detector keys detections by IconTemplate.LandmarkType — the
+        // SAME vocabulary. Synthesise detections by projecting each ref's world
+        // coord through Truth into screenshot space, keyed by its PG type.
+        var detections = new Dictionary<string, List<TypedDetection>>(StringComparer.Ordinal);
+        foreach (var p in Points)
+        {
+            var tex = Truth.WorldToWindow(new WorldCoord(p.X, 0, p.Z));
+            var det = new TypedDetection(p.Type, p.Name, tex.X + Rect.OriginX, tex.Y + Rect.OriginY, Score: 0.9);
+            if (!detections.TryGetValue(p.Type, out var list)) { list = new(); detections[p.Type] = list; }
+            list.Add(det);
+        }
+
+        var (cal, inliers) = TypeAwareRansacSolver.Solve(detections, refs.ToList(), Rect);
+
+        cal.Should().NotBeNull("the provider + detection vocabularies must overlap so the type-constrained pool is non-empty (mithril#974)");
+        inliers.Should().NotBeEmpty();
+        inliers.Count.Should().BeGreaterThanOrEqualTo(4);
+        Math.Abs(cal!.Scale - Truth.Scale).Should().BeLessThan(0.05);
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/Detection/BundledIconTemplateLoaderTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/BundledIconTemplateLoaderTests.cs
@@ -97,6 +97,24 @@ public sealed class BundledIconTemplateLoaderTests : IDisposable
     }
 
     [Fact]
+    public void CanonicalLandmarkTypes_All_matches_the_manifest_landmarkType_value_set()
+    {
+        // mithril#974 parity guard: the CanonicalLandmarkTypes vocabulary the
+        // reference provider emits MUST equal the icon-template manifest's
+        // landmarkType value set (the detection-side keys), casing exact —
+        // otherwise the type-constrained solver pool is empty and every solve
+        // rejects with 0 inliers.
+        WriteCacheFixture(FourLandmarks);
+
+        var set = BundledIconTemplateLoader.LoadFromDirectory(_dir, logger: null);
+        var manifestTypes = set.Templates.Select(t => t.LandmarkType).ToHashSet(StringComparer.Ordinal);
+
+        manifestTypes.Should().BeEquivalentTo(CanonicalLandmarkTypes.All);
+        // Casing-exact: no Ordinal-mismatched member sneaks in.
+        manifestTypes.Should().OnlyContain(t => CanonicalLandmarkTypes.All.Contains(t));
+    }
+
+    [Fact]
     public void Every_template_has_positive_dims_and_matching_buffer_lengths()
     {
         WriteCacheFixture(FourLandmarks);

--- a/tests/Mithril.MapCalibration.Tests/Detection/MapCalibrationSolveEngineLoggingTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/MapCalibrationSolveEngineLoggingTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+/// <summary>
+/// mithril#974 detect-stage diagnostics: the engine emits a per-orientation
+/// detect summary and a targeted Warning when the detection type-key set and the
+/// reference type-key set are disjoint (the failure mode where the icon-template
+/// and reference vocabularies don't overlap → 0 correspondences possible).
+/// </summary>
+public sealed class MapCalibrationSolveEngineLoggingTests
+{
+    [Fact]
+    public void Warns_when_detection_and_reference_vocabularies_are_disjoint()
+    {
+        // Detections keyed by a vocabulary the refs DON'T use → disjoint.
+        var detector = new FixedDetector(new Dictionary<string, IReadOnlyList<TypedDetection>>(StringComparer.Ordinal)
+        {
+            ["landmark_portal"] = new[] { new TypedDetection("landmark_portal", "icon", 10, 10, 0.9) },
+        });
+        var refs = new List<LandmarkReference>
+        {
+            new("Portal", "Serbule Portal", new WorldCoord(1, 0, 2)),
+        };
+
+        var logger = new CapturingLogger();
+        var engine = new MapCalibrationSolveEngine(detector, new AlwaysRejectGate(), logger);
+
+        engine.Solve(BuildRequest(), refs);
+
+        logger.Warnings.Should().Contain(m =>
+            m.Contains("disjoint") && m.Contains("0 correspondences possible"));
+    }
+
+    [Fact]
+    public void Does_not_warn_when_vocabularies_overlap()
+    {
+        // Detections + refs share the canonical "Portal" key → overlap, no warning.
+        var detector = new FixedDetector(new Dictionary<string, IReadOnlyList<TypedDetection>>(StringComparer.Ordinal)
+        {
+            ["Portal"] = new[] { new TypedDetection("Portal", "icon", 10, 10, 0.9) },
+        });
+        var refs = new List<LandmarkReference>
+        {
+            new("Portal", "Serbule Portal", new WorldCoord(1, 0, 2)),
+        };
+
+        var logger = new CapturingLogger();
+        var engine = new MapCalibrationSolveEngine(detector, new AlwaysRejectGate(), logger);
+
+        engine.Solve(BuildRequest(), refs);
+
+        logger.Warnings.Should().NotContain(m => m.Contains("disjoint"));
+        // The per-orientation detect summary still fires (Information).
+        logger.Infos.Should().Contain(m => m.Contains("typed detections"));
+    }
+
+    private static DetectionRequest BuildRequest()
+    {
+        var img = new GrayImage(8, 8, new byte[64]);
+        var rect = new MapRect(0, 0, 8, 8, 8, 8);
+        return new DetectionRequest(img, img, rect, IconTemplateSet.Empty, RimMaskMode.None,
+            LowNcc: 0.5, TypeFloor: 0.45,
+            BlobOptions: new BlobOptions(MinArea: 8, MaxIconArea: 1500, MinSolidity: 0.25, MaxAspect: 3.5, MinPeak: 0.5));
+    }
+
+    /// <summary>Detector that ignores the request and returns a fixed detection map.</summary>
+    private sealed class FixedDetector : ICalibrationDetector
+    {
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> _result;
+        public FixedDetector(IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> result) => _result = result;
+        public IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> Detect(DetectionRequest request) => _result;
+    }
+
+    private sealed class AlwaysRejectGate : ICalibrationConfidenceGate
+    {
+        public bool Accept(AreaCalibration solve, int inlierCount, out string? rejectReason)
+        {
+            rejectReason = "test-reject";
+            return false;
+        }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = new();
+        public List<string> Infos { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var msg = formatter(state, exception);
+            if (logLevel == LogLevel.Warning) Warnings.Add(msg);
+            else if (logLevel == LogLevel.Information) Infos.Add(msg);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tools/Mithril.MapCalibration.Tools.Common/IconTemplateEmitter.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/IconTemplateEmitter.cs
@@ -30,10 +30,10 @@ public static class IconTemplateEmitter
     // IconTemplateExtractor.LandmarkIcons). Name → (LandmarkType, synthetic dims).
     private static readonly (string Name, string LandmarkType, int W, int H)[] Landmarks =
     [
-        ("landmark_telepad", "TeleportationPlatform", 28, 22),
-        ("landmark_medipillar", "MeditationPillar", 18, 40),
-        ("landmark_portal", "Portal", 24, 32),
-        ("landmark_npc", "Npc", 17, 16),
+        ("landmark_telepad", CanonicalLandmarkTypes.TeleportationPlatform, 28, 22),
+        ("landmark_medipillar", CanonicalLandmarkTypes.MeditationPillar, 18, 40),
+        ("landmark_portal", CanonicalLandmarkTypes.Portal, 24, 32),
+        ("landmark_npc", CanonicalLandmarkTypes.Npc, 17, 16),
     ];
 
     private sealed record Decoded(string Name, string LandmarkType, double PivotX, double PivotY, int W, int H, byte[] Gray, byte[] Alpha);

--- a/tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/IconTemplateExtractor.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using AssetsTools.NET.Texture;
+using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibration.Common;
 
@@ -41,10 +42,10 @@ public static class IconTemplateExtractor
     // discriminator (or "Player"/"Pet" for the player-self pins).
     private static readonly (string TextureName, string LandmarkType)[] LandmarkIcons =
     [
-        ("landmark_telepad", "TeleportationPlatform"),
-        ("landmark_medipillar", "MeditationPillar"),
-        ("landmark_portal", "Portal"),
-        ("landmark_npc", "Npc"),
+        ("landmark_telepad", CanonicalLandmarkTypes.TeleportationPlatform),
+        ("landmark_medipillar", CanonicalLandmarkTypes.MeditationPillar),
+        ("landmark_portal", CanonicalLandmarkTypes.Portal),
+        ("landmark_npc", CanonicalLandmarkTypes.Npc),
         // landmark_star is generic waypoint; skip for v1 — no Type to match on.
     ];
 
@@ -147,6 +148,13 @@ public static class IconTemplateExtractor
             }
             else if (PlayerPinPrefixes.Any(p => name.StartsWith(p, StringComparison.Ordinal)))
             {
+                // "Player" is intentionally NOT a CanonicalLandmarkTypes member.
+                // Player-self pins have no reference source (they appear in neither
+                // landmarks.json nor npcs.json), so a "Player" detection simply
+                // contributes nothing to the type-constrained pairing pool — its
+                // absence from CanonicalLandmarkTypes.All is by-design, not the
+                // detect↔reference vocabulary divergence #974 guards against.
+                // (PlayerPinPrefixes is currently empty, so this branch is dead.)
                 landmarkType = "Player";
             }
             else

--- a/tools/Mithril.MapCalibration.Tools.Common/NpcsReader.cs
+++ b/tools/Mithril.MapCalibration.Tools.Common/NpcsReader.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Mithril.MapCalibration;
+using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibration.Common;
 
@@ -39,7 +40,7 @@ public static class NpcsReader
             var world = WorldCoord.TryParse(posStr);
             if (world is null) continue;
             var name = v.TryGetProperty("Name", out var nameProp) ? nameProp.GetString() ?? entry.Name : entry.Name;
-            list.Add(new LandmarkRef("Npc", name, world.Value));
+            list.Add(new LandmarkRef(CanonicalLandmarkTypes.Npc, name, world.Value));
         }
         return list;
     }


### PR DESCRIPTION
## What

Fixes #974. Auto-calibration's `detect→solve` rejected every real solve with `0 inliers / "no geometrically-consistent fit"` — the live-run blocker behind #938.

Root cause: detections and references spoke **different landmark-type vocabularies**, and `TypeAwareRansacSolver.RansacAssign` pairs them with an `Ordinal`-equal type match. Detections key on the raw PG type from the icon-template manifest (`Npc`, `Portal`, `MeditationPillar`, `TeleportationPlatform`), but `ReferenceDataAreaReferenceProvider` translated those into sprite tokens (`landmark_npc`, `landmark_portal`, …). `"landmark_npc" != "Npc"` → empty pool → guaranteed 0 inliers. The `landmark_*` strings are sprite **names**, not types.

## Why this fix

Canonical vocabulary = the **raw PG type**. The provider now speaks it:

- `ReferenceDataAreaReferenceProvider` emits `lm.Type` verbatim for landmarks and `CanonicalLandmarkTypes.Npc` for NPCs. Warn-and-drop for unmapped landmark types and the unparseable-coords aggregated warning are preserved.
- New `CanonicalLandmarkTypes` (`src/Mithril.MapCalibration/Detection/`) is the single source of truth for the four type strings + an `All`/landmark-only set; the provider's allowlist consumes it so the vocabulary lives in one place.
- `MapCalibrationSolveEngine.Solve` now logs a per-orientation detect summary (typed-detection + reference per-type breakdowns) and a targeted `Warning` when the detection and reference type-key sets are **disjoint** ("0 correspondences possible; likely an icon-template ↔ reference type-vocabulary mismatch") — so this failure mode is loud next time.

No `landmark_*` string is used as a `LandmarkReference.Type` anywhere in `src/` after this change.

## Tests

- Flipped `AreaReferenceProviderTests` to the raw PG vocabulary (`Portal`/`MeditationPillar`/`TeleportationPlatform`/`Npc`); kept the malformed-loc-skip and unmapped-type-drop tests.
- **Cross-component seam test** (`ReferenceProviderSolverSeamTests`, in `.Capture.Tests`) — the test that would have caught the bug: builds refs via the production provider + detections keyed by the manifest vocabulary, runs them through `TypeAwareRansacSolver.Solve`, and asserts a non-empty correspondence pool / non-null calibration.
- Parity test: `CanonicalLandmarkTypes.All` equals the bundled icon-template manifest's `LandmarkType` value set, casing exact.
- Logging tests: the disjoint-vocab `Warning` fires when detection/reference type-keys don't overlap and does not when they do.

### Verification

- `dotnet build Mithril.slnx` → green (warnings-as-errors).
- `dotnet test tests/Mithril.MapCalibration.Tests` → 104/104 green.
- `dotnet test tests/Mithril.MapCalibration.Capture.Tests` → 107/107 green (stable across 3 reruns).
- Full `dotnet test Mithril.slnx` showed two failures (one in `.Capture.Tests`, one in `Mithril.Shared.Tests` which this PR doesn't touch); both projects pass cleanly in isolation — concurrent-execution flakes, not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
