### PR TITLE
fix(palantir): redefine drift as tailer-poll age + add WorldMode.Stalled (#856)

### DIFF
--- a/docs/design/arda/dispatch-and-composition.md
+++ b/docs/design/arda/dispatch-and-composition.md
@@ -92,6 +92,8 @@ The distinguishing question: "does more than one consumer need the *interpreted*
 
 **Migration complete:** The legacy `IPlayerLogStream` / `IChatLogStream` / `ILogStreamDriver` pipeline has been retired. All modules consume Arda domain events exclusively. The legacy pipeline's health signaling (`LogStreamAttentionSource`) has been replaced by `IWorldHealthView` in `Arda.Contracts`.
 
+**Tailer liveness — `IIngestPulse` (infra, not a domain event):** `WorldHealth.Drift` is the wall-clock age of the tailer's last poll iteration, NOT the age of the last in-stream log timestamp (#856). The signal is exposed via `IIngestPulse` in `Arda.Hosting` (read-side) and recorded by ingest poll loops via `IIngestPulseSink` in `Arda.Abstractions` (write-side, placed there so `Arda.Ingest` doesn't reference `Arda.Hosting`). The same singleton implements both. `WorldMode.Stalled` is a first-class state — "was Live, pulse has gone silent past `DriftWarningThreshold` (5s)" — distinct from `Halted` (grammar break) and `Replaying` (catching up). Critically, the pulse is NOT a domain event on `IDomainEventBus`: the bus's vocabulary stays game-domain events only. `IIngestPulse` parallels `IReplayProgress` as infra.
+
 ## State handler catalogue
 
 Arda state handlers are named by their domain (`Map`, `Inventory`, `Npc`, `Player`, `Calendar`, `ChatInventory`, `ChatSession`, `ChatLine`). No suffix — the handler IS the state owner. Each handler implements `IFrameHandler`, receives verb dispatches, owns mutable state, and emits domain events via `IDomainEventPublisher`.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -269,8 +269,28 @@ Canonical source: [`docs/world-simulator.md` migration item #13, Decisions ratif
 
 Enum on [IWorldClock](#iworldclock): `Replaying` (draining recorded frames toward the live tail) or `Live` (caught up, blocking on new frames). Each world tracks `WorldMode` independently; PlayerWorld may catch up before ChatWorld or vice versa. Transitions emit a `ModeChanged(from, to, at)` domain event on the bus.
 
-See also: [Replaying](#replaying-worldmode), [Live](#live-worldmode), [Mode == Live gate](#mode--live-gate), [ModeChanged](#modechanged).
+The legacy Arda pipeline (today's `Arda.Contracts.State.Health.WorldMode`) also exposes `Stalled` and `Halted` for tailer-health reporting in the shell health view; those are not world-sim states and don't appear in `IWorldClock`.
+
+See also: [Replaying](#replaying-worldmode), [Live](#live-worldmode), [Stalled (WorldMode)](#stalled-worldmode), [Mode == Live gate](#mode--live-gate), [ModeChanged](#modechanged).
 Canonical source: [`docs/world-simulator.md` Vocabulary, principle 12](world-simulator.md).
+
+### Stalled (WorldMode)
+
+Health-only [WorldMode](#worldmode) state on `Arda.Contracts.State.Health.WorldMode` (the shell-facing `IWorldHealthView`, **not** the world-sim `IWorldClock`). Means: was [Live](#live-worldmode), but the tailer-poll pulse has gone silent past `WorldHealth.DriftWarningThreshold` (5s). Distinct from `Halted` (grammar break stopped the driver) and `Replaying` (still catching up).
+
+Introduced in #856 alongside the redefinition of `WorldHealth.Drift` to "wall-clock − last tailer poll" (down from the old "wall-clock − last in-stream log timestamp", which false-fired on quiet chat channels). Drives the shell attention badge; `WorldHealth.AllLive` is strict and does NOT include Stalled.
+
+See also: [Tailer-poll pulse](#tailer-poll-pulse), [WorldMode](#worldmode).
+Canonical source: GitHub issue #856.
+
+### Tailer-poll pulse
+
+A per-family "the tailer just polled the log file" heartbeat, distinct from "the game wrote a log line". Exposed via `IIngestPulse` (read, in `Arda.Hosting`) and recorded by ingest poll loops via `IIngestPulseSink` (write, in `Arda.Abstractions` — placed there so `Arda.Ingest` doesn't reference `Arda.Hosting`). The same singleton implements both sides.
+
+Fires on every iteration of the live-tail loop, **including empty reads** — that's the load-bearing semantic. Does not fire during replay drain or while the chat-source is waiting for any chat file to exist. Drives `WorldHealth.Drift` and the [Stalled](#stalled-worldmode) mode transition. The pulse is **not** a domain event on `IDomainEventBus`; the bus's vocabulary stays game-domain events only.
+
+See also: [Stalled (WorldMode)](#stalled-worldmode).
+Canonical source: GitHub issue #856.
 
 ### World runtime
 

--- a/src/Arda/Arda.Abstractions/Diagnostics/IIngestPulseSink.cs
+++ b/src/Arda/Arda.Abstractions/Diagnostics/IIngestPulseSink.cs
@@ -1,0 +1,28 @@
+namespace Arda.Abstractions.Diagnostics;
+
+/// <summary>
+/// Write-side of the tailer-poll pulse signal. Implemented by Arda.Hosting,
+/// consumed by Arda.Ingest poll loops.
+/// <para>
+/// Lives in <c>Arda.Abstractions</c> rather than alongside the read-side
+/// <c>IIngestPulse</c> in Arda.Hosting because Arda.Ingest does not (and
+/// should not) reference Arda.Hosting — Hosting is the higher composition
+/// layer. Splitting the contract along read/write lines keeps the dependency
+/// direction one-way: Ingest depends on Abstractions only.
+/// </para>
+/// </summary>
+public interface IIngestPulseSink
+{
+    /// <summary>
+    /// Records that the tailer for <paramref name="family"/> just completed a
+    /// poll iteration of its live-tail loop, regardless of whether new bytes
+    /// were available. Acts as a liveness heartbeat for the tailer itself —
+    /// distinct from "the game wrote a log line" (which is a downstream
+    /// domain event, not a tailer-health signal).
+    /// </summary>
+    /// <param name="family">Which log family's tailer just polled.</param>
+    /// <param name="polledAt">Wall-clock time of the poll.</param>
+    /// <param name="bytesRead">Number of bytes read in this poll (0 for empty reads).</param>
+    /// <param name="linesEmitted">Number of <c>LogLine</c>s yielded from this poll.</param>
+    void RecordPoll(LogFamily family, System.DateTimeOffset polledAt, int bytesRead, int linesEmitted);
+}

--- a/src/Arda/Arda.Abstractions/Diagnostics/IIngestPulseSink.cs
+++ b/src/Arda/Arda.Abstractions/Diagnostics/IIngestPulseSink.cs
@@ -22,7 +22,6 @@ public interface IIngestPulseSink
     /// </summary>
     /// <param name="family">Which log family's tailer just polled.</param>
     /// <param name="polledAt">Wall-clock time of the poll.</param>
-    /// <param name="bytesRead">Number of bytes read in this poll (0 for empty reads).</param>
     /// <param name="linesEmitted">Number of <c>LogLine</c>s yielded from this poll.</param>
-    void RecordPoll(LogFamily family, System.DateTimeOffset polledAt, int bytesRead, int linesEmitted);
+    void RecordPoll(LogFamily family, System.DateTimeOffset polledAt, int linesEmitted);
 }

--- a/src/Arda/Arda.Abstractions/Diagnostics/LogFamily.cs
+++ b/src/Arda/Arda.Abstractions/Diagnostics/LogFamily.cs
@@ -1,0 +1,21 @@
+namespace Arda.Abstractions.Diagnostics;
+
+/// <summary>
+/// Identifies which log family a tailer-poll pulse came from.
+/// <para>
+/// Placed in <c>Arda.Abstractions</c> so the producer (Arda.Ingest, which
+/// records pulses via <see cref="IIngestPulseSink"/>) and the consumer
+/// (Arda.Hosting's <c>IIngestPulse</c>) can share the vocabulary without
+/// either project taking a hard reference on the other. Arda.Hosting owns
+/// the read-side interface because that's where the singleton is composed;
+/// Arda.Ingest only sees the write-side sink.
+/// </para>
+/// </summary>
+public enum LogFamily
+{
+    /// <summary>The Player.log family (Player.log + Player-prev.log).</summary>
+    Player,
+
+    /// <summary>The chat family (ChatLogs/Chat-yy-mm-dd.log).</summary>
+    Chat
+}

--- a/src/Arda/Arda.Contracts/State/Health/IWorldHealthView.cs
+++ b/src/Arda/Arda.Contracts/State/Health/IWorldHealthView.cs
@@ -13,7 +13,13 @@ public interface IWorldHealthView
     /// <summary>Health snapshot for the Chat log driver.</summary>
     WorldHealth Chat { get; }
 
-    /// <summary>True when both drivers are in <see cref="WorldMode.Live"/>.</summary>
+    /// <summary>
+    /// True iff both drivers are in <see cref="WorldMode.Live"/> exactly.
+    /// <see cref="WorldMode.Stalled"/> does NOT count — a stall is a soft
+    /// liveness warning, not "live and healthy". Modules continue to gate
+    /// activation on <c>IReplayProgress.ReplayComplete</c> (not AllLive)
+    /// so a transient stall doesn't pull them offline.
+    /// </summary>
     bool AllLive { get; }
 
     /// <summary>

--- a/src/Arda/Arda.Contracts/State/Health/WorldHealth.cs
+++ b/src/Arda/Arda.Contracts/State/Health/WorldHealth.cs
@@ -1,17 +1,34 @@
 namespace Arda.Contracts.State.Health;
 
 /// <summary>
-/// Per-driver health snapshot: current timestamp from the log stream,
-/// frame count, replay/live mode, and drift from wall-clock.
+/// Per-driver health snapshot.
+/// <para>
+/// <see cref="Drift"/> is the wall-clock age of the tailer's last poll —
+/// "when did this tailer last look at the file". This is distinct from
+/// <see cref="LastLogTimestamp"/>, which is the most recent in-stream
+/// timestamp emitted as a domain event. The two diverge whenever the game
+/// produces no log lines (AFK, quiet chat channel, off-hours) — drift stays
+/// near zero because the tailer keeps polling, while LastLogTimestamp lags.
+/// </para>
+/// <para>
+/// Issue #856 redefined Drift away from "now − LastLogTimestamp" because
+/// the old metric false-fired on quiet chat channels: an inactive channel
+/// produces no chat events, so the chat tailer looked broken to consumers.
+/// The new metric is bounded by the poll interval and means "the polling
+/// loop has stopped" — a real liveness signal.
+/// </para>
 /// </summary>
 public sealed record WorldHealth(
-    DateTimeOffset? LastTimestamp,
+    DateTimeOffset? LastLogTimestamp,
     long FrameCount,
     WorldMode Mode,
     TimeSpan Drift)
 {
     /// <summary>
-    /// Drift beyond this threshold in Live mode indicates tailing is falling behind.
+    /// Drift beyond this threshold in <see cref="WorldMode.Live"/> means
+    /// the tailer's poll loop has gone silent for longer than expected and
+    /// the driver flips to <see cref="WorldMode.Stalled"/>. Default poll
+    /// interval is ~250–500ms so 5s is ~10 missed polls.
     /// </summary>
     public static readonly TimeSpan DriftWarningThreshold = TimeSpan.FromSeconds(5);
 }
@@ -22,8 +39,16 @@ public enum WorldMode
     /// <summary>Processing historical log lines from before Mithril started.</summary>
     Replaying,
 
-    /// <summary>Caught up; tailing live log output.</summary>
+    /// <summary>Caught up; tailing live log output; pulse observed within threshold.</summary>
     Live,
+
+    /// <summary>
+    /// Was <see cref="Live"/>; tailer-poll pulse has gone silent past
+    /// <see cref="WorldHealth.DriftWarningThreshold"/>. The polling loop
+    /// appears to have stopped — distinct from <see cref="Halted"/> (grammar
+    /// break) and <see cref="Replaying"/> (still catching up).
+    /// </summary>
+    Stalled,
 
     /// <summary>
     /// Halted on a <c>GrammarException</c>. The driver has stopped consuming;

--- a/src/Arda/Arda.Hosting/ArdaServiceCollectionExtensions.cs
+++ b/src/Arda/Arda.Hosting/ArdaServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Arda.Abstractions.Diagnostics;
 using Arda.Contracts;
 using Arda.Dispatch;
 using Arda.Hosting.Internal;
@@ -27,18 +28,21 @@ public static class ArdaServiceCollectionExtensions
         var chatDir = options.ChatLogDirectory
             ?? Path.Combine(options.LogDirectory, "ChatLogs");
 
-        // Ingest sources (L0/L1)
+        // Ingest sources (L0/L1) — pulse sink threads through so live-tail
+        // poll iterations feed WorldHealth drift (#856).
         services.AddSingleton(sp => new PlayerLogSource(
             options.LogDirectory,
             sp.GetService<TimeProvider>() ?? TimeProvider.System,
             pollInterval,
-            sp.GetService<ILoggerFactory>()?.CreateLogger("Arda.Player")));
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Arda.Player"),
+            sp.GetRequiredService<IIngestPulseSink>()));
 
         services.AddSingleton(sp => new ChatLogSource(
             chatDir,
             sp.GetService<TimeProvider>() ?? TimeProvider.System,
             pollInterval,
-            sp.GetService<ILoggerFactory>()?.CreateLogger("Arda.Chat")));
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Arda.Chat"),
+            sp.GetRequiredService<IIngestPulseSink>()));
 
         // Event bus (shared across both driver families). The composite interface
         // (IDomainEventBus, internal to Arda.Dispatch) is intentionally not
@@ -65,6 +69,13 @@ public static class ArdaServiceCollectionExtensions
         services.AddSingleton(sp =>
             new ReplayProgress(sp.GetService<ILogger<ReplayProgress>>()));
         services.AddSingleton<IReplayProgress>(sp => sp.GetRequiredService<ReplayProgress>());
+
+        // Tailer-poll pulse (#856): one singleton implements both read and
+        // write sides. Ingest sources write via IIngestPulseSink (in
+        // Arda.Abstractions); WorldHealthView reads via IIngestPulse (here).
+        services.AddSingleton<IngestPulse>();
+        services.AddSingleton<IIngestPulse>(sp => sp.GetRequiredService<IngestPulse>());
+        services.AddSingleton<IIngestPulseSink>(sp => sp.GetRequiredService<IngestPulse>());
 
         // Background services (L2 drivers)
         services.AddHostedService<PlayerWorldService>();

--- a/src/Arda/Arda.Hosting/IIngestPulse.cs
+++ b/src/Arda/Arda.Hosting/IIngestPulse.cs
@@ -1,0 +1,42 @@
+using Arda.Abstractions.Diagnostics;
+
+namespace Arda.Hosting;
+
+/// <summary>
+/// Read-side of the tailer-poll pulse signal. Reports when each log-family
+/// tailer last completed a poll iteration of its live-tail loop, distinct
+/// from when the game last wrote a log line. Drives "is the tailer
+/// running?" liveness in <see cref="Arda.Contracts.State.Health.WorldHealth"/>.
+/// <para>
+/// Read-side lives in Arda.Hosting because the singleton implementation is
+/// composed here. The write-side (<see cref="IIngestPulseSink"/>) lives in
+/// Arda.Abstractions so Arda.Ingest can record pulses without taking a
+/// dependency on Arda.Hosting. The same singleton implements both sides.
+/// </para>
+/// </summary>
+public interface IIngestPulse
+{
+    /// <summary>
+    /// Wall-clock time of the most recent poll for the family, or null if
+    /// that family hasn't polled yet (e.g. still resolving session start,
+    /// no chat file present on disk yet).
+    /// </summary>
+    DateTimeOffset? LastPoll(LogFamily family);
+
+    /// <summary>
+    /// Fires after every poll iteration for any family. Consumers that derive
+    /// "stalled" state should recompute it inside this handler — pulses from
+    /// either family are the natural revaluation cadence.
+    /// </summary>
+    event EventHandler<IngestPulseEventArgs>? Pulsed;
+}
+
+/// <summary>
+/// Payload for <see cref="IIngestPulse.Pulsed"/>. Intentionally a struct so
+/// the publisher doesn't allocate per poll on hot ingest paths.
+/// </summary>
+public readonly record struct IngestPulseEventArgs(
+    LogFamily Family,
+    DateTimeOffset PolledAt,
+    int BytesRead,
+    int LinesEmitted);

--- a/src/Arda/Arda.Hosting/IIngestPulse.cs
+++ b/src/Arda/Arda.Hosting/IIngestPulse.cs
@@ -38,5 +38,4 @@ public interface IIngestPulse
 public readonly record struct IngestPulseEventArgs(
     LogFamily Family,
     DateTimeOffset PolledAt,
-    int BytesRead,
     int LinesEmitted);

--- a/src/Arda/Arda.Hosting/Internal/IngestPulse.cs
+++ b/src/Arda/Arda.Hosting/Internal/IngestPulse.cs
@@ -1,0 +1,55 @@
+using Arda.Abstractions.Diagnostics;
+
+namespace Arda.Hosting.Internal;
+
+/// <summary>
+/// Default <see cref="IIngestPulse"/> + <see cref="IIngestPulseSink"/>
+/// implementation. Shared singleton — Arda.Ingest writes via the sink,
+/// <c>WorldHealthView</c> reads via the pulse and subscribes to
+/// <see cref="Pulsed"/> for stall detection.
+/// <para>
+/// Per-family <c>LastPoll</c> is stored in <see cref="Volatile.Read"/> /
+/// <see cref="Volatile.Write"/>-style fields; reads are lock-free. The event
+/// fires synchronously from the writer's thread (the ingest poll loop), so
+/// subscribers must avoid blocking work in the handler.
+/// </para>
+/// </summary>
+internal sealed class IngestPulse : IIngestPulse, IIngestPulseSink
+{
+    private readonly object _gate = new();
+    private DateTimeOffset? _playerLastPoll;
+    private DateTimeOffset? _chatLastPoll;
+
+    public DateTimeOffset? LastPoll(LogFamily family)
+    {
+        lock (_gate)
+        {
+            return family switch
+            {
+                LogFamily.Player => _playerLastPoll,
+                LogFamily.Chat => _chatLastPoll,
+                _ => null,
+            };
+        }
+    }
+
+    public event EventHandler<IngestPulseEventArgs>? Pulsed;
+
+    public void RecordPoll(LogFamily family, DateTimeOffset polledAt, int bytesRead, int linesEmitted)
+    {
+        lock (_gate)
+        {
+            switch (family)
+            {
+                case LogFamily.Player:
+                    _playerLastPoll = polledAt;
+                    break;
+                case LogFamily.Chat:
+                    _chatLastPoll = polledAt;
+                    break;
+            }
+        }
+
+        Pulsed?.Invoke(this, new IngestPulseEventArgs(family, polledAt, bytesRead, linesEmitted));
+    }
+}

--- a/src/Arda/Arda.Hosting/Internal/IngestPulse.cs
+++ b/src/Arda/Arda.Hosting/Internal/IngestPulse.cs
@@ -8,10 +8,11 @@ namespace Arda.Hosting.Internal;
 /// <c>WorldHealthView</c> reads via the pulse and subscribes to
 /// <see cref="Pulsed"/> for stall detection.
 /// <para>
-/// Per-family <c>LastPoll</c> is stored in <see cref="Volatile.Read"/> /
-/// <see cref="Volatile.Write"/>-style fields; reads are lock-free. The event
-/// fires synchronously from the writer's thread (the ingest poll loop), so
-/// subscribers must avoid blocking work in the handler.
+/// Per-family <c>LastPoll</c> reads and writes are serialized through a single
+/// <c>lock</c> so the read-side snapshot is internally consistent; the lock is
+/// uncontended in practice (one writer per family, occasional reader). The
+/// event fires synchronously from the writer's thread (the ingest poll loop),
+/// so subscribers must avoid blocking work in the handler.
 /// </para>
 /// </summary>
 internal sealed class IngestPulse : IIngestPulse, IIngestPulseSink
@@ -35,7 +36,7 @@ internal sealed class IngestPulse : IIngestPulse, IIngestPulseSink
 
     public event EventHandler<IngestPulseEventArgs>? Pulsed;
 
-    public void RecordPoll(LogFamily family, DateTimeOffset polledAt, int bytesRead, int linesEmitted)
+    public void RecordPoll(LogFamily family, DateTimeOffset polledAt, int linesEmitted)
     {
         lock (_gate)
         {
@@ -50,6 +51,6 @@ internal sealed class IngestPulse : IIngestPulse, IIngestPulseSink
             }
         }
 
-        Pulsed?.Invoke(this, new IngestPulseEventArgs(family, polledAt, bytesRead, linesEmitted));
+        Pulsed?.Invoke(this, new IngestPulseEventArgs(family, polledAt, linesEmitted));
     }
 }

--- a/src/Arda/Arda.Ingest/Coordinator/ChatLogSource.cs
+++ b/src/Arda/Arda.Ingest/Coordinator/ChatLogSource.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using Arda.Abstractions.Diagnostics;
 using Arda.Abstractions.Logs;
 using Arda.Ingest.Classification;
 using Arda.Ingest.Clock;
@@ -21,6 +22,7 @@ internal sealed class ChatLogSource : ILogLineSource
     private readonly BatchProcessor _processor;
     private readonly TimeSpan _pollInterval;
     private readonly ILogger? _logger;
+    private readonly IIngestPulseSink? _pulseSink;
 
     private bool _reachedLive;
     private bool _warnedMissingDir;
@@ -29,7 +31,8 @@ internal sealed class ChatLogSource : ILogLineSource
         string chatLogDirectory,
         TimeProvider time,
         TimeSpan? pollInterval = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        IIngestPulseSink? pulseSink = null)
     {
         _chatLogDirectory = chatLogDirectory ?? throw new ArgumentNullException(nameof(chatLogDirectory));
         _time = time ?? throw new ArgumentNullException(nameof(time));
@@ -37,6 +40,7 @@ internal sealed class ChatLogSource : ILogLineSource
         _processor = new BatchProcessor(new LineClassifier(_clock), time);
         _pollInterval = pollInterval ?? TimeSpan.FromMilliseconds(500);
         _logger = logger;
+        _pulseSink = pulseSink;
     }
 
     /// <inheritdoc/>
@@ -103,6 +107,18 @@ internal sealed class ChatLogSource : ILogLineSource
                 _reachedLive = true;
                 _logger?.LogInformation("Chat log reached live (IsReplay=false)");
             }
+
+            // Pulse on every live-tail iteration including empty reads — the
+            // load-bearing signal for WorldHealth drift (#856). A quiet chat
+            // channel produces zero domain events but the tailer is still
+            // running its poll loop normally; that's "live", not "stalled".
+            // (Not pulsed before the file even existed — see the
+            // files.Length == 0 waiting loop above. Per #856 design lock #2.)
+            _pulseSink?.RecordPoll(
+                LogFamily.Chat,
+                _time.GetUtcNow(),
+                bytesRead: 0,
+                linesEmitted: results?.Count ?? 0);
 
             if (results is null)
             {

--- a/src/Arda/Arda.Ingest/Coordinator/ChatLogSource.cs
+++ b/src/Arda/Arda.Ingest/Coordinator/ChatLogSource.cs
@@ -117,7 +117,6 @@ internal sealed class ChatLogSource : ILogLineSource
             _pulseSink?.RecordPoll(
                 LogFamily.Chat,
                 _time.GetUtcNow(),
-                bytesRead: 0,
                 linesEmitted: results?.Count ?? 0);
 
             if (results is null)

--- a/src/Arda/Arda.Ingest/Coordinator/PlayerLogSource.cs
+++ b/src/Arda/Arda.Ingest/Coordinator/PlayerLogSource.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Arda.Abstractions.Diagnostics;
 using Arda.Abstractions.Logs;
 using Arda.Ingest.Classification;
 using Arda.Ingest.Clock;
@@ -37,6 +38,7 @@ internal sealed class PlayerLogSource : ILogLineSource
     private readonly BatchProcessor _processor;
     private readonly TimeSpan _pollInterval;
     private readonly ILogger? _logger;
+    private readonly IIngestPulseSink? _pulseSink;
 
     private bool _reachedLive;
     private bool _warnedMissingLog;
@@ -45,7 +47,8 @@ internal sealed class PlayerLogSource : ILogLineSource
         string logDirectory,
         TimeProvider time,
         TimeSpan? pollInterval = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        IIngestPulseSink? pulseSink = null)
     {
         _logDirectory = logDirectory ?? throw new ArgumentNullException(nameof(logDirectory));
         _time = time ?? throw new ArgumentNullException(nameof(time));
@@ -53,6 +56,7 @@ internal sealed class PlayerLogSource : ILogLineSource
         _processor = new BatchProcessor(new LineClassifier(_clock), time);
         _pollInterval = pollInterval ?? TimeSpan.FromMilliseconds(250);
         _logger = logger;
+        _pulseSink = pulseSink;
     }
 
     /// <inheritdoc/>
@@ -150,6 +154,16 @@ internal sealed class PlayerLogSource : ILogLineSource
                 _reachedLive = true;
                 _logger?.LogInformation("Player log reached live (IsReplay=false)");
             }
+
+            // Pulse on every live-tail iteration, including empty reads. This is
+            // the load-bearing signal for WorldHealth drift (issue #856): "the
+            // tailer looked at the file" is distinct from "the game wrote a new
+            // line". An empty poll on an AFK character is a healthy pulse.
+            _pulseSink?.RecordPoll(
+                LogFamily.Player,
+                _time.GetUtcNow(),
+                bytesRead: 0, // batch processor doesn't expose byte counts; line count is the useful signal
+                linesEmitted: results?.Count ?? 0);
 
             if (results is null)
             {

--- a/src/Arda/Arda.Ingest/Coordinator/PlayerLogSource.cs
+++ b/src/Arda/Arda.Ingest/Coordinator/PlayerLogSource.cs
@@ -162,7 +162,6 @@ internal sealed class PlayerLogSource : ILogLineSource
             _pulseSink?.RecordPoll(
                 LogFamily.Player,
                 _time.GetUtcNow(),
-                bytesRead: 0, // batch processor doesn't expose byte counts; line count is the useful signal
                 linesEmitted: results?.Count ?? 0);
 
             if (results is null)

--- a/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
+++ b/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
@@ -1,3 +1,4 @@
+using Arda.Abstractions.Diagnostics;
 using Arda.Contracts;
 using Arda.Contracts.State.Health;
 using Arda.Dispatch;
@@ -11,13 +12,29 @@ using Microsoft.Extensions.Logging;
 namespace Mithril.Shell.DependencyInjection;
 
 /// <summary>
-/// Observes Arda pipeline health by subscribing to domain events and
-/// <see cref="IReplayProgress"/>. Derives per-driver drift (wall-clock
-/// minus last-seen log timestamp) and mode (replaying vs live).
-///
-/// <para>Implements <see cref="IAttentionSource"/> so the shell attention
-/// badge surfaces when live-mode drift exceeds a threshold — the Arda
-/// replacement for the legacy <c>LogStreamAttentionSource</c>.</para>
+/// Observes Arda pipeline health.
+/// <para>
+/// Issue #856 redefined the headline metric: <c>WorldHealth.Drift</c> is the
+/// wall-clock age of the tailer's last poll (from <see cref="IIngestPulse"/>),
+/// NOT the age of the last in-stream log timestamp. This makes drift a real
+/// tailer-liveness signal that's invariant under "the user is AFK / on a
+/// quiet chat channel". <see cref="WorldHealth.LastLogTimestamp"/> is kept
+/// as an informational field for "last X: 12m ago" UI text.
+/// </para>
+/// <para>
+/// Mode is derived lazily inside <see cref="Snapshot"/>: if grammar raised →
+/// <see cref="WorldMode.Halted"/>; else if not yet live →
+/// <see cref="WorldMode.Replaying"/>; else if poll age >
+/// <see cref="WorldHealth.DriftWarningThreshold"/> →
+/// <see cref="WorldMode.Stalled"/>; else <see cref="WorldMode.Live"/>. No
+/// timer — pulses from either family naturally re-fire
+/// <see cref="Changed"/>, which bounds detection lag to one poll interval.
+/// </para>
+/// <para>
+/// Implements <see cref="IAttentionSource"/> so the shell attention badge
+/// surfaces when a driver is <see cref="WorldMode.Stalled"/>. <see cref="WorldMode.Halted"/>
+/// has its own banner path so it does not double-count here.
+/// </para>
 /// </summary>
 internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHostedService, IDisposable
 {
@@ -25,12 +42,15 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
     private readonly IDomainEventSubscriber _bus;
     private readonly IReplayProgress _replay;
     private readonly IGrammarBreakSignal _grammarSignal;
+    private readonly IIngestPulse _pulse;
     private readonly TimeProvider _time;
     private readonly ILogger<WorldHealthView> _logger;
 
     private readonly object _gate = new();
-    private DateTimeOffset? _playerTimestamp;
-    private DateTimeOffset? _chatTimestamp;
+    private DateTimeOffset? _playerLogTimestamp;
+    private DateTimeOffset? _chatLogTimestamp;
+    private DateTimeOffset? _playerLastPoll;
+    private DateTimeOffset? _chatLastPoll;
     private long _playerFrames;
     private long _chatFrames;
     private bool _playerLive;
@@ -44,12 +64,14 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         IDomainEventSubscriber bus,
         IReplayProgress replay,
         IGrammarBreakSignal grammarSignal,
+        IIngestPulse pulse,
         ILogger<WorldHealthView> logger,
         TimeProvider? time = null)
     {
         _bus = bus;
         _replay = replay;
         _grammarSignal = grammarSignal;
+        _pulse = pulse;
         _logger = logger;
         _time = time ?? TimeProvider.System;
     }
@@ -59,7 +81,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         get
         {
             lock (_gate)
-                return Snapshot(_playerTimestamp, _playerFrames, _playerLive, _grammarSignal.IsRaised);
+                return Snapshot(_playerLogTimestamp, _playerLastPoll, _playerFrames, _playerLive, _grammarSignal.IsRaised);
         }
     }
 
@@ -68,13 +90,24 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         get
         {
             lock (_gate)
-                return Snapshot(_chatTimestamp, _chatFrames, _chatLive, _grammarSignal.IsRaised);
+                return Snapshot(_chatLogTimestamp, _chatLastPoll, _chatFrames, _chatLive, _grammarSignal.IsRaised);
         }
     }
 
     public bool AllLive
     {
-        get { lock (_gate) return _playerLive && _chatLive && !_grammarSignal.IsRaised; }
+        get
+        {
+            // Strict per design lock #9: only Live exactly counts — Stalled
+            // does NOT. Inline the Mode derivation rather than calling
+            // Snapshot twice.
+            lock (_gate)
+            {
+                if (_grammarSignal.IsRaised) return false;
+                if (!_playerLive || !_chatLive) return false;
+                return !IsStalled(_playerLastPoll) && !IsStalled(_chatLastPoll);
+            }
+        }
     }
 
     public GrammarBreak? Break
@@ -106,9 +139,11 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         {
             lock (_gate)
             {
+                // Stalled is the attention-worthy state. Halted has its own
+                // banner path (design lock #10), Live/Replaying don't count.
                 var count = 0;
-                if (_playerLive && DriftExceeds(_playerTimestamp)) count++;
-                if (_chatLive && DriftExceeds(_chatTimestamp)) count++;
+                if (_playerLive && !_grammarSignal.IsRaised && IsStalled(_playerLastPoll)) count++;
+                if (_chatLive && !_grammarSignal.IsRaised && IsStalled(_chatLastPoll)) count++;
                 return count;
             }
         }
@@ -124,13 +159,20 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         _replay.PropertyChanged += OnReplayProgressChanged;
         _grammarSignal.Raised += OnGrammarBreakRaised;
         _grammarSignal.ObservedBreakChanged += OnGrammarBreakObserved;
+        _pulse.Pulsed += OnPulse;
 
         if (_replay.ReplayComplete.IsCompleted)
         {
+            // Seed each family's LastPoll to "now" on the live transition
+            // (design lock #5). The clock starts immediately; if no pulse
+            // arrives within DriftWarningThreshold the mode flips to Stalled.
+            var now = _time.GetUtcNow();
             lock (_gate)
             {
                 _playerLive = true;
                 _chatLive = true;
+                _playerLastPoll ??= _pulse.LastPoll(LogFamily.Player) ?? now;
+                _chatLastPoll ??= _pulse.LastPoll(LogFamily.Chat) ?? now;
             }
         }
 
@@ -142,6 +184,21 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         }
 
         return Task.CompletedTask;
+    }
+
+    private void OnPulse(object? sender, IngestPulseEventArgs e)
+    {
+        lock (_gate)
+        {
+            switch (e.Family)
+            {
+                case LogFamily.Player: _playerLastPoll = e.PolledAt; break;
+                case LogFamily.Chat: _chatLastPoll = e.PolledAt; break;
+            }
+        }
+        // Re-fire Changed so consumers re-derive mode; this is the only
+        // re-evaluation cadence (design lock #6 — no timer).
+        RaiseChanged();
     }
 
     private void OnGrammarBreakRaised(object? sender, EventArgs e)
@@ -170,7 +227,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
     {
         lock (_gate)
         {
-            _playerTimestamp = evt.Now;
+            _playerLogTimestamp = evt.Now;
             _playerFrames++;
         }
         RaiseChanged();
@@ -197,7 +254,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         if (ts is null) return;
         lock (_gate)
         {
-            _chatTimestamp = ts;
+            _chatLogTimestamp = ts;
             _chatFrames++;
         }
         RaiseChanged();
@@ -208,6 +265,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         bool changed = false;
         bool playerWentLive = false;
         bool chatWentLive = false;
+        var now = _time.GetUtcNow();
         lock (_gate)
         {
             if (_replay.ReplayComplete.IsCompleted)
@@ -218,6 +276,11 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
                     chatWentLive = !_chatLive;
                     _playerLive = true;
                     _chatLive = true;
+                    // Seed LastPoll on live transition (design lock #5).
+                    if (playerWentLive)
+                        _playerLastPoll ??= _pulse.LastPoll(LogFamily.Player) ?? now;
+                    if (chatWentLive)
+                        _chatLastPoll ??= _pulse.LastPoll(LogFamily.Chat) ?? now;
                     changed = true;
                 }
             }
@@ -229,6 +292,10 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
                 _chatLive = _replay.ChatProgress >= 1.0;
                 playerWentLive = _playerLive && !wasPlayerLive;
                 chatWentLive = _chatLive && !wasChatLive;
+                if (playerWentLive)
+                    _playerLastPoll ??= _pulse.LastPoll(LogFamily.Player) ?? now;
+                if (chatWentLive)
+                    _chatLastPoll ??= _pulse.LastPoll(LogFamily.Chat) ?? now;
                 changed = _playerLive != wasPlayerLive || _chatLive != wasChatLive;
             }
         }
@@ -240,53 +307,61 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         if (changed) RaiseChanged();
     }
 
-    private WorldHealth Snapshot(DateTimeOffset? ts, long frames, bool live, bool halted)
+    private WorldHealth Snapshot(DateTimeOffset? logTs, DateTimeOffset? lastPoll, long frames, bool live, bool halted)
     {
-        var drift = ts is not null
-            ? _time.GetUtcNow() - ts.Value
+        // Drift = wall-clock − last poll (#856), NOT wall-clock − last log
+        // timestamp. lastPoll being null in Live mode means "we just went
+        // live and haven't seen a pulse yet"; drift is 0 in that case.
+        var drift = lastPoll is not null
+            ? _time.GetUtcNow() - lastPoll.Value
             : TimeSpan.Zero;
         if (drift < TimeSpan.Zero) drift = TimeSpan.Zero;
 
-        var mode = halted ? WorldMode.Halted : (live ? WorldMode.Live : WorldMode.Replaying);
-        return new WorldHealth(ts, frames, mode, drift);
+        WorldMode mode;
+        if (halted) mode = WorldMode.Halted;
+        else if (!live) mode = WorldMode.Replaying;
+        else if (drift > WorldHealth.DriftWarningThreshold) mode = WorldMode.Stalled;
+        else mode = WorldMode.Live;
+
+        return new WorldHealth(logTs, frames, mode, drift);
     }
 
-    private bool DriftExceeds(DateTimeOffset? ts)
+    private bool IsStalled(DateTimeOffset? lastPoll)
     {
-        if (ts is null) return false;
-        var drift = _time.GetUtcNow() - ts.Value;
+        if (lastPoll is null) return false;
+        var drift = _time.GetUtcNow() - lastPoll.Value;
         return drift > WorldHealth.DriftWarningThreshold;
     }
 
     private void RaiseChanged()
     {
-        DateTimeOffset? playerTs;
-        DateTimeOffset? chatTs;
+        DateTimeOffset? playerLastPoll;
+        DateTimeOffset? chatLastPoll;
         bool playerLive;
         bool chatLive;
         lock (_gate)
         {
-            playerTs = _playerTimestamp;
-            chatTs = _chatTimestamp;
+            playerLastPoll = _playerLastPoll;
+            chatLastPoll = _chatLastPoll;
             playerLive = _playerLive;
             chatLive = _chatLive;
         }
 
-        LogDriftIfNeeded("Player", playerLive, playerTs);
-        LogDriftIfNeeded("Chat", chatLive, chatTs);
+        LogStallIfNeeded("Player", playerLive, playerLastPoll);
+        LogStallIfNeeded("Chat", chatLive, chatLastPoll);
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
-    private void LogDriftIfNeeded(string family, bool live, DateTimeOffset? lastTimestamp)
+    private void LogStallIfNeeded(string family, bool live, DateTimeOffset? lastPoll)
     {
-        if (!live || lastTimestamp is null) return;
-        var drift = _time.GetUtcNow() - lastTimestamp.Value;
+        if (!live || lastPoll is null) return;
+        var drift = _time.GetUtcNow() - lastPoll.Value;
         if (drift <= WorldHealth.DriftWarningThreshold) return;
         _logger.LogWarning(
-            "Pipeline drift for {Family}: {DriftSeconds:F0}s since last log timestamp {LastTimestamp}",
+            "Pipeline stall for {Family}: {DriftSeconds:F0}s since last tailer poll {LastPoll}",
             family,
             drift.TotalSeconds,
-            lastTimestamp);
+            lastPoll);
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
@@ -302,6 +377,7 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         _replay.PropertyChanged -= OnReplayProgressChanged;
         _grammarSignal.Raised -= OnGrammarBreakRaised;
         _grammarSignal.ObservedBreakChanged -= OnGrammarBreakObserved;
+        _pulse.Pulsed -= OnPulse;
         foreach (var sub in _subscriptions) sub.Dispose();
         _subscriptions.Clear();
     }

--- a/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
+++ b/src/Mithril.Shell/DependencyInjection/WorldHealthView.cs
@@ -5,6 +5,7 @@ using Arda.Dispatch;
 using Arda.Hosting;
 using Arda.World.Chat.Events;
 using Arda.World.Player.Events;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -45,6 +46,8 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
     private readonly IIngestPulse _pulse;
     private readonly TimeProvider _time;
     private readonly ILogger<WorldHealthView> _logger;
+    private readonly ThrottledWarn _playerStallWarn;
+    private readonly ThrottledWarn _chatStallWarn;
 
     private readonly object _gate = new();
     private DateTimeOffset? _playerLogTimestamp;
@@ -74,6 +77,12 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
         _pulse = pulse;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        // Per-family ThrottledWarn so a player stall doesn't suppress a chat
+        // stall warning. OnPulse fires every ~250–500 ms in the healthy case;
+        // once a family is past DriftWarningThreshold the LogWarning would
+        // otherwise emit per pulse interval until recovery.
+        _playerStallWarn = new ThrottledWarn(_logger, "WorldHealthView", time: _time);
+        _chatStallWarn = new ThrottledWarn(_logger, "WorldHealthView", time: _time);
     }
 
     public WorldHealth Player
@@ -347,21 +356,26 @@ internal sealed class WorldHealthView : IWorldHealthView, IAttentionSource, IHos
             chatLive = _chatLive;
         }
 
-        LogStallIfNeeded("Player", playerLive, playerLastPoll);
-        LogStallIfNeeded("Chat", chatLive, chatLastPoll);
+        LogStallIfNeeded("Player", playerLive, playerLastPoll, _playerStallWarn);
+        LogStallIfNeeded("Chat", chatLive, chatLastPoll, _chatStallWarn);
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
-    private void LogStallIfNeeded(string family, bool live, DateTimeOffset? lastPoll)
+    private void LogStallIfNeeded(string family, bool live, DateTimeOffset? lastPoll, ThrottledWarn warn)
     {
+        // Halted has its own banner path (design lock #10) and the Count
+        // property already suppresses the attention badge while halted; do not
+        // also emit a "stall" warning per pulse for a state that's already
+        // visibly surfaced elsewhere.
+        if (_grammarSignal.IsRaised) return;
         if (!live || lastPoll is null) return;
         var drift = _time.GetUtcNow() - lastPoll.Value;
         if (drift <= WorldHealth.DriftWarningThreshold) return;
-        _logger.LogWarning(
-            "Pipeline stall for {Family}: {DriftSeconds:F0}s since last tailer poll {LastPoll}",
-            family,
-            drift.TotalSeconds,
-            lastPoll);
+        // OnPulse runs every ~250–500 ms; route through ThrottledWarn so a
+        // sustained stall produces one log per window with a "+N suppressed"
+        // rollup instead of one per pulse (CLAUDE.md: hot ingest paths).
+        warn.Warn(
+            $"Pipeline stall for {family}: {drift.TotalSeconds:F0}s since last tailer poll {lastPoll:o}");
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/Mithril.Shell/ViewModels/ShellViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/ShellViewModel.cs
@@ -198,13 +198,16 @@ public sealed partial class ShellViewModel : ObservableObject
         var chat = _health.Chat;
         var brk = _health.Break;
 
-        PipelineModeText = _health.IsHalted ? "HALTED" : (_health.AllLive ? "LIVE" : "REPLAY");
+        // Pipeline mode-text reflects the worst of the two drivers (#856):
+        // HALTED beats STALLED beats REPLAY beats LIVE.
+        PipelineModeText = ComputePipelineModeText(player.Mode, chat.Mode, _health.AllLive);
         PlayerDriftText = FormatDrift(player);
         ChatDriftText = FormatDrift(chat);
-        IsHealthDegraded = _health.AllLive &&
-            (player.Drift > WorldHealth.DriftWarningThreshold || chat.Drift > WorldHealth.DriftWarningThreshold);
-        HealthTooltip = $"Player: {player.Mode} · {player.FrameCount:N0} frames · drift {player.Drift.TotalSeconds:0.0}s\n" +
-                        $"Chat: {chat.Mode} · {chat.FrameCount:N0} frames · drift {chat.Drift.TotalSeconds:0.0}s";
+        // Stall is the attention-worthy state for the badge — Halted has its
+        // own banner path, so it doesn't double-count here.
+        IsHealthDegraded = player.Mode == WorldMode.Stalled || chat.Mode == WorldMode.Stalled;
+        HealthTooltip = $"Player: {player.Mode} · {player.FrameCount:N0} frames · poll age {player.Drift.TotalSeconds:0.0}s\n" +
+                        $"Chat: {chat.Mode} · {chat.FrameCount:N0} frames · poll age {chat.Drift.TotalSeconds:0.0}s";
 
         IsHalted = _health.IsHalted;
         IsTolerantBreakActive = _health.IsTolerantBreakActive;
@@ -214,9 +217,18 @@ public sealed partial class ShellViewModel : ObservableObject
         HaltBannerHint = brk?.ParserHint ?? "";
     }
 
+    private static string ComputePipelineModeText(WorldMode player, WorldMode chat, bool allLive)
+    {
+        if (player == WorldMode.Halted || chat == WorldMode.Halted) return "HALTED";
+        if (player == WorldMode.Stalled || chat == WorldMode.Stalled) return "STALLED";
+        if (allLive) return "LIVE";
+        return "REPLAY";
+    }
+
     private static string FormatDrift(WorldHealth h)
     {
-        if (h.LastTimestamp is null) return "—";
+        // Drift is tailer-poll age (#856) — always meaningful once a family
+        // is live, regardless of whether a log line has arrived.
         var d = h.Drift;
         return d.TotalSeconds < 2 ? "<2s" : $"{d.TotalSeconds:0}s";
     }

--- a/src/Palantir.Module/ViewModels/WorldHealthViewModel.cs
+++ b/src/Palantir.Module/ViewModels/WorldHealthViewModel.cs
@@ -9,6 +9,12 @@ namespace Palantir.ViewModels;
 /// rows showing mode, frame count, drift, and liveness. The health view fires
 /// <see cref="IWorldHealthView.Changed"/> on the Arda dispatch thread, so
 /// every handler marshals through <see cref="_dispatch"/>.
+/// <para>
+/// Issue #856: row colour/icon binds to <see cref="WorldMode"/> directly
+/// rather than a derived "degraded" boolean — Stalled is now a first-class
+/// mode and Halted has its own state, so a single bool can't represent the
+/// row's attention level cleanly.
+/// </para>
 /// </summary>
 public sealed partial class WorldHealthViewModel : ObservableObject, IDisposable
 {
@@ -16,17 +22,17 @@ public sealed partial class WorldHealthViewModel : ObservableObject, IDisposable
     private readonly Action<Action> _dispatch;
     private bool _disposed;
 
-    [ObservableProperty] private string _playerMode = "—";
+    [ObservableProperty] private WorldMode _playerMode;
+    [ObservableProperty] private string _playerModeText = "—";
     [ObservableProperty] private string _playerFrames = "0";
     [ObservableProperty] private string _playerDrift = "—";
-    [ObservableProperty] private string _playerTimestamp = "—";
-    [ObservableProperty] private bool _playerDegraded;
+    [ObservableProperty] private string _playerLastLog = "—";
 
-    [ObservableProperty] private string _chatMode = "—";
+    [ObservableProperty] private WorldMode _chatMode;
+    [ObservableProperty] private string _chatModeText = "—";
     [ObservableProperty] private string _chatFrames = "0";
     [ObservableProperty] private string _chatDrift = "—";
-    [ObservableProperty] private string _chatTimestamp = "—";
-    [ObservableProperty] private bool _chatDegraded;
+    [ObservableProperty] private string _chatLastLog = "—";
 
     [ObservableProperty] private bool _allLive;
     [ObservableProperty] private string _overallStatus = "Waiting for data…";
@@ -52,28 +58,37 @@ public sealed partial class WorldHealthViewModel : ObservableObject, IDisposable
         var p = _health.Player;
         var c = _health.Chat;
 
-        PlayerMode = p.Mode.ToString();
+        PlayerMode = p.Mode;
+        PlayerModeText = p.Mode.ToString();
         PlayerFrames = p.FrameCount.ToString("N0", CultureInfo.CurrentCulture);
         PlayerDrift = FormatDrift(p);
-        PlayerTimestamp = FormatTimestamp(p.LastTimestamp);
-        PlayerDegraded = p.Mode == WorldMode.Live && p.Drift > WorldHealth.DriftWarningThreshold;
+        PlayerLastLog = FormatTimestamp(p.LastLogTimestamp);
 
-        ChatMode = c.Mode.ToString();
+        ChatMode = c.Mode;
+        ChatModeText = c.Mode.ToString();
         ChatFrames = c.FrameCount.ToString("N0", CultureInfo.CurrentCulture);
         ChatDrift = FormatDrift(c);
-        ChatTimestamp = FormatTimestamp(c.LastTimestamp);
-        ChatDegraded = c.Mode == WorldMode.Live && c.Drift > WorldHealth.DriftWarningThreshold;
+        ChatLastLog = FormatTimestamp(c.LastLogTimestamp);
 
         AllLive = _health.AllLive;
-        OverallStatus = _health.AllLive
-            ? (PlayerDegraded || ChatDegraded ? "Live — drift warning" : "Live — healthy")
-            : "Replaying log history…";
+        OverallStatus = ComputeOverall(p.Mode, c.Mode, _health.AllLive, _health.IsHalted);
+    }
+
+    private static string ComputeOverall(WorldMode player, WorldMode chat, bool allLive, bool isHalted)
+    {
+        if (isHalted) return "Halted — grammar break";
+        if (player == WorldMode.Stalled || chat == WorldMode.Stalled)
+            return "Tailer stalled";
+        if (allLive) return "Live — healthy";
+        return "Replaying log history…";
     }
 
     private static string FormatDrift(WorldHealth h)
     {
-        if (h.LastTimestamp is null) return "—";
         var d = h.Drift;
+        // Drift is tailer-poll age — meaningful from the moment a family
+        // goes live, regardless of whether a log line has arrived. The old
+        // "no timestamp → '—'" guard no longer applies.
         if (d.TotalSeconds < 1) return "<1s";
         if (d.TotalMinutes < 1) return $"{d.TotalSeconds:0.0}s";
         return $"{d.TotalMinutes:0.0}m";

--- a/src/Palantir.Module/Views/WorldHealthView.xaml
+++ b/src/Palantir.Module/Views/WorldHealthView.xaml
@@ -27,11 +27,11 @@
             <TextBlock TextWrapping="Wrap" Foreground="#AAFFFFFF"
                        FontSize="{DynamicResource AppFontSizeHint}"
                        Margin="0,0,0,16">
-                Live Arda pipeline health: per-driver mode (replaying vs live),
-                frame count, last-seen log timestamp, and wall-clock drift.
-                Drift is the gap between the log timestamp Arda last processed
-                and the current wall-clock — a growing drift in Live mode means
-                tailing is falling behind.
+                Live Arda pipeline health: per-driver mode (replaying / live /
+                stalled / halted), frame count, last-seen log timestamp, and
+                wall-clock drift. Drift is the gap between the wall-clock and
+                the tailer's last poll iteration — a growing drift means the
+                polling loop has stopped, not that the user is quiet.
             </TextBlock>
 
             <!-- Overall status -->
@@ -71,7 +71,7 @@
                         <TextBlock DockPanel.Dock="Left" Text="Mode"
                                    Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
                         <TextBlock HorizontalAlignment="Right"
-                                   Text="{Binding PlayerMode}"
+                                   Text="{Binding PlayerModeText}"
                                    Foreground="#FFFFFFFF" FontWeight="SemiBold"/>
                     </DockPanel>
                     <DockPanel Margin="0,0,0,6">
@@ -83,20 +83,33 @@
                                    Foreground="#FFFFFFFF"/>
                     </DockPanel>
                     <DockPanel Margin="0,0,0,6">
-                        <TextBlock DockPanel.Dock="Left" Text="Last timestamp (UTC)"
+                        <TextBlock DockPanel.Dock="Left" Text="Last log timestamp (UTC)"
                                    Foreground="#88FFFFFF" VerticalAlignment="Center"/>
                         <TextBlock HorizontalAlignment="Right"
-                                   Text="{Binding PlayerTimestamp}"
+                                   Text="{Binding PlayerLastLog}"
                                    FontFamily="{DynamicResource AppMonoFontFamily}"
                                    Foreground="#88FFFFFF"/>
                     </DockPanel>
                     <DockPanel>
-                        <TextBlock DockPanel.Dock="Left" Text="Wall-clock drift"
+                        <TextBlock DockPanel.Dock="Left" Text="Tailer-poll age"
                                    Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
                         <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                             <Ellipse Width="8" Height="8" Fill="#FFE04545"
-                                     VerticalAlignment="Center" Margin="0,0,6,0"
-                                     Visibility="{Binding PlayerDegraded, Converter={StaticResource BoolToVis}}"/>
+                                     VerticalAlignment="Center" Margin="0,0,6,0">
+                                <Ellipse.Style>
+                                    <Style TargetType="Ellipse">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding PlayerMode}" Value="Stalled">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding PlayerMode}" Value="Halted">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Ellipse.Style>
+                            </Ellipse>
                             <TextBlock Text="{Binding PlayerDrift}"
                                        FontFamily="{DynamicResource AppMonoFontFamily}"
                                        Foreground="#FFFFFFFF" FontWeight="SemiBold"/>
@@ -115,7 +128,7 @@
                         <TextBlock DockPanel.Dock="Left" Text="Mode"
                                    Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
                         <TextBlock HorizontalAlignment="Right"
-                                   Text="{Binding ChatMode}"
+                                   Text="{Binding ChatModeText}"
                                    Foreground="#FFFFFFFF" FontWeight="SemiBold"/>
                     </DockPanel>
                     <DockPanel Margin="0,0,0,6">
@@ -127,20 +140,33 @@
                                    Foreground="#FFFFFFFF"/>
                     </DockPanel>
                     <DockPanel Margin="0,0,0,6">
-                        <TextBlock DockPanel.Dock="Left" Text="Last timestamp (UTC)"
+                        <TextBlock DockPanel.Dock="Left" Text="Last log timestamp (UTC)"
                                    Foreground="#88FFFFFF" VerticalAlignment="Center"/>
                         <TextBlock HorizontalAlignment="Right"
-                                   Text="{Binding ChatTimestamp}"
+                                   Text="{Binding ChatLastLog}"
                                    FontFamily="{DynamicResource AppMonoFontFamily}"
                                    Foreground="#88FFFFFF"/>
                     </DockPanel>
                     <DockPanel>
-                        <TextBlock DockPanel.Dock="Left" Text="Wall-clock drift"
+                        <TextBlock DockPanel.Dock="Left" Text="Tailer-poll age"
                                    Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
                         <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                             <Ellipse Width="8" Height="8" Fill="#FFE04545"
-                                     VerticalAlignment="Center" Margin="0,0,6,0"
-                                     Visibility="{Binding ChatDegraded, Converter={StaticResource BoolToVis}}"/>
+                                     VerticalAlignment="Center" Margin="0,0,6,0">
+                                <Ellipse.Style>
+                                    <Style TargetType="Ellipse">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ChatMode}" Value="Stalled">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ChatMode}" Value="Halted">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Ellipse.Style>
+                            </Ellipse>
                             <TextBlock Text="{Binding ChatDrift}"
                                        FontFamily="{DynamicResource AppMonoFontFamily}"
                                        Foreground="#FFFFFFFF" FontWeight="SemiBold"/>

--- a/tests/Arda.Ingest.Tests/IngestPulseTests.cs
+++ b/tests/Arda.Ingest.Tests/IngestPulseTests.cs
@@ -34,9 +34,9 @@ public sealed class IngestPulseTests : IDisposable
     private sealed class RecordingSink : IIngestPulseSink
     {
         private readonly object _gate = new();
-        private readonly List<(LogFamily Family, DateTimeOffset At, int Bytes, int Lines)> _entries = [];
+        private readonly List<(LogFamily Family, DateTimeOffset At, int Lines)> _entries = [];
 
-        public IReadOnlyList<(LogFamily Family, DateTimeOffset At, int Bytes, int Lines)> Snapshot()
+        public IReadOnlyList<(LogFamily Family, DateTimeOffset At, int Lines)> Snapshot()
         {
             lock (_gate) return [.. _entries];
         }
@@ -51,9 +51,9 @@ public sealed class IngestPulseTests : IDisposable
             lock (_gate) return _entries.Count(e => e.Family == family && e.Lines == 0);
         }
 
-        public void RecordPoll(LogFamily family, DateTimeOffset polledAt, int bytesRead, int linesEmitted)
+        public void RecordPoll(LogFamily family, DateTimeOffset polledAt, int linesEmitted)
         {
-            lock (_gate) _entries.Add((family, polledAt, bytesRead, linesEmitted));
+            lock (_gate) _entries.Add((family, polledAt, linesEmitted));
         }
     }
 

--- a/tests/Arda.Ingest.Tests/IngestPulseTests.cs
+++ b/tests/Arda.Ingest.Tests/IngestPulseTests.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics;
+using Arda.Abstractions.Diagnostics;
+using Arda.Ingest.Coordinator;
+using FluentAssertions;
+using Xunit;
+
+namespace Arda.Ingest.Tests;
+
+/// <summary>
+/// Verifies that the live-tail poll loop in <see cref="PlayerLogSource"/> /
+/// <see cref="ChatLogSource"/> records a pulse on every iteration including
+/// empty reads — the load-bearing behaviour for issue #856 (drift defined as
+/// "tailer-poll age", not "domain-event arrival age").
+/// </summary>
+public sealed class IngestPulseTests : IDisposable
+{
+    private readonly string _logDir;
+
+    public IngestPulseTests()
+    {
+        _logDir = Path.Combine(Path.GetTempPath(), "ArdaIngestPulseTests-" + Guid.NewGuid());
+        Directory.CreateDirectory(_logDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_logDir))
+        {
+            try { Directory.Delete(_logDir, recursive: true); }
+            catch { /* test cleanup best-effort */ }
+        }
+    }
+
+    private sealed class RecordingSink : IIngestPulseSink
+    {
+        private readonly object _gate = new();
+        private readonly List<(LogFamily Family, DateTimeOffset At, int Bytes, int Lines)> _entries = [];
+
+        public IReadOnlyList<(LogFamily Family, DateTimeOffset At, int Bytes, int Lines)> Snapshot()
+        {
+            lock (_gate) return [.. _entries];
+        }
+
+        public int CountFor(LogFamily family)
+        {
+            lock (_gate) return _entries.Count(e => e.Family == family);
+        }
+
+        public int EmptyPollsFor(LogFamily family)
+        {
+            lock (_gate) return _entries.Count(e => e.Family == family && e.Lines == 0);
+        }
+
+        public void RecordPoll(LogFamily family, DateTimeOffset polledAt, int bytesRead, int linesEmitted)
+        {
+            lock (_gate) _entries.Add((family, polledAt, bytesRead, linesEmitted));
+        }
+    }
+
+    [Fact]
+    public async Task PlayerLogSource_PulsesOnEveryLiveTailPoll_IncludingEmptyReads()
+    {
+        var playerLog = Path.Combine(_logDir, "Player.log");
+        File.WriteAllText(playerLog, "[10:00:00] Initial line\n");
+
+        var sink = new RecordingSink();
+        var source = new PlayerLogSource(
+            _logDir,
+            TimeProvider.System,
+            pollInterval: TimeSpan.FromMilliseconds(20),
+            logger: null,
+            pulseSink: sink);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var consumer = Task.Run(async () =>
+        {
+            await foreach (var _ in source.Lines(cts.Token)) { /* drain */ }
+        }, cts.Token);
+
+        // Wait long enough for several empty polls past the initial drain.
+        await WaitFor(() => sink.EmptyPollsFor(LogFamily.Player) >= 3, cts.Token);
+
+        cts.Cancel();
+        try { await consumer; } catch (OperationCanceledException) { }
+
+        sink.CountFor(LogFamily.Player).Should().BeGreaterThanOrEqualTo(3,
+            "the live-tail poll loop pulses every iteration even on empty reads");
+        sink.EmptyPollsFor(LogFamily.Player).Should().BeGreaterThan(0,
+            "drift must be measurable when the file is quiet");
+    }
+
+    [Fact]
+    public async Task ChatLogSource_DoesNotPulse_WhenNoChatFileExists()
+    {
+        // No chat file created — source sits in the file-resolution wait loop.
+        var sink = new RecordingSink();
+        var source = new ChatLogSource(
+            _logDir,
+            TimeProvider.System,
+            pollInterval: TimeSpan.FromMilliseconds(20),
+            logger: null,
+            pulseSink: sink);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        var consumer = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var _ in source.Lines(cts.Token)) { /* drain */ }
+            }
+            catch (OperationCanceledException) { }
+        }, CancellationToken.None);
+
+        await Task.Delay(250, CancellationToken.None);
+        cts.Cancel();
+        try { await consumer; } catch (OperationCanceledException) { }
+
+        sink.CountFor(LogFamily.Chat).Should().Be(0,
+            "design lock: do not pulse before a file even exists — that's not 'tailer healthy', " +
+            "that's 'waiting for setup'");
+    }
+
+    [Fact]
+    public async Task ChatLogSource_PulsesOnLiveTailPoll_OnceFileExists()
+    {
+        var chatFile = Path.Combine(_logDir, $"Chat-{DateTime.UtcNow:yy-MM-dd}.log");
+        File.WriteAllText(chatFile, "[10:00:00] Initial\n");
+
+        var sink = new RecordingSink();
+        var source = new ChatLogSource(
+            _logDir,
+            TimeProvider.System,
+            pollInterval: TimeSpan.FromMilliseconds(20),
+            logger: null,
+            pulseSink: sink);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var consumer = Task.Run(async () =>
+        {
+            await foreach (var _ in source.Lines(cts.Token)) { /* drain */ }
+        }, cts.Token);
+
+        await WaitFor(() => sink.EmptyPollsFor(LogFamily.Chat) >= 3, cts.Token);
+
+        cts.Cancel();
+        try { await consumer; } catch (OperationCanceledException) { }
+
+        sink.CountFor(LogFamily.Chat).Should().BeGreaterThanOrEqualTo(3);
+        sink.EmptyPollsFor(LogFamily.Chat).Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task PlayerLogSource_WorksWithNullSink()
+    {
+        // Pulse sink is optional — older shells and bare unit tests must still work.
+        var playerLog = Path.Combine(_logDir, "Player.log");
+        File.WriteAllText(playerLog, "[10:00:00] Hello\n");
+
+        var source = new PlayerLogSource(
+            _logDir,
+            TimeProvider.System,
+            pollInterval: TimeSpan.FromMilliseconds(20),
+            logger: null,
+            pulseSink: null);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var consumer = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var _ in source.Lines(cts.Token)) { /* drain */ }
+            }
+            catch (OperationCanceledException) { }
+        }, CancellationToken.None);
+
+        await consumer; // no exception
+    }
+
+    private static async Task WaitFor(Func<bool> predicate, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (sw.Elapsed > TimeSpan.FromSeconds(4))
+                throw new TimeoutException("Condition not met within 4s");
+            await Task.Delay(20, ct);
+        }
+    }
+}

--- a/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
+++ b/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
@@ -70,10 +70,10 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
 
         public event EventHandler<IngestPulseEventArgs>? Pulsed;
 
-        public void Pulse(LogFamily family, DateTimeOffset at, int bytes = 0, int lines = 0)
+        public void Pulse(LogFamily family, DateTimeOffset at, int lines = 0)
         {
             _last[family] = at;
-            Pulsed?.Invoke(this, new IngestPulseEventArgs(family, at, bytes, lines));
+            Pulsed?.Invoke(this, new IngestPulseEventArgs(family, at, lines));
         }
     }
 

--- a/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
+++ b/tests/Mithril.Shell.Tests/WorldHealthViewTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Arda.Abstractions.Diagnostics;
 using Arda.Abstractions.Logs;
 using Arda.Contracts;
 using Arda.Contracts.State.Health;
@@ -19,11 +20,14 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     private readonly FakeReplayProgress _replay = new();
     private readonly FakeTimeProvider _time = new();
     private readonly FakeGrammarBreakSignal _grammarSignal = new();
+    private readonly FakeIngestPulse _pulse = new();
     private readonly WorldHealthView _view;
 
     public WorldHealthViewTests()
     {
-        _view = new WorldHealthView(_bus, _replay, _grammarSignal, NullLogger<WorldHealthView>.Instance, _time);
+        _view = new WorldHealthView(
+            _bus, _replay, _grammarSignal, _pulse,
+            NullLogger<WorldHealthView>.Instance, _time);
     }
 
     private sealed class FakeGrammarBreakSignal : IGrammarBreakSignal
@@ -53,6 +57,26 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    /// Test double for <see cref="IIngestPulse"/>. <see cref="Pulse"/> drives
+    /// the WorldHealthView the way the real ingest poll loop would.
+    /// </summary>
+    private sealed class FakeIngestPulse : IIngestPulse
+    {
+        private readonly Dictionary<LogFamily, DateTimeOffset> _last = new();
+
+        public DateTimeOffset? LastPoll(LogFamily family) =>
+            _last.TryGetValue(family, out var v) ? v : null;
+
+        public event EventHandler<IngestPulseEventArgs>? Pulsed;
+
+        public void Pulse(LogFamily family, DateTimeOffset at, int bytes = 0, int lines = 0)
+        {
+            _last[family] = at;
+            Pulsed?.Invoke(this, new IngestPulseEventArgs(family, at, bytes, lines));
+        }
+    }
+
     public Task InitializeAsync() => _view.StartAsync(CancellationToken.None);
     public Task DisposeAsync() { _view.Dispose(); return Task.CompletedTask; }
 
@@ -68,7 +92,7 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     }
 
     [Fact]
-    public void CalendarTimeAdvanced_IncrementsPlayerFramesAndTimestamp()
+    public void CalendarTimeAdvanced_IncrementsPlayerFramesAndLogTimestamp()
     {
         var ts = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
         _time.SetUtcNow(ts);
@@ -76,11 +100,13 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
         _bus.Publish(new CalendarTimeAdvanced(ts, Meta(ts)));
 
         _view.Player.FrameCount.Should().Be(1);
-        _view.Player.LastTimestamp.Should().Be(ts);
+        // LastLogTimestamp is informational (when did the GAME write a line),
+        // distinct from drift (when did the TAILER last poll).
+        _view.Player.LastLogTimestamp.Should().Be(ts);
     }
 
     [Fact]
-    public void ChatEvent_IncrementsFramesAndTimestamp()
+    public void ChatEvent_IncrementsFramesAndLogTimestamp()
     {
         var ts = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
         _time.SetUtcNow(ts);
@@ -88,7 +114,7 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
         _bus.Publish(new PlayerChatLine("Global", "Test", "Hello".AsMemory(), Meta(ts)));
 
         _view.Chat.FrameCount.Should().Be(1);
-        _view.Chat.LastTimestamp.Should().Be(ts);
+        _view.Chat.LastLogTimestamp.Should().Be(ts);
     }
 
     [Fact]
@@ -99,12 +125,17 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
         _bus.Publish(new PlayerChatLine("Global", "Test", "Hello".AsMemory(), nullMeta));
 
         _view.Chat.FrameCount.Should().Be(0);
-        _view.Chat.LastTimestamp.Should().BeNull();
+        _view.Chat.LastLogTimestamp.Should().BeNull();
     }
 
     [Fact]
     public void ReplayComplete_TransitionsBothToLive()
     {
+        // After ReplayComplete the view seeds LastPoll to "now", so without
+        // any time advance the drivers are Live (within threshold).
+        var now = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(now);
+
         _replay.Complete();
 
         _view.AllLive.Should().BeTrue();
@@ -113,13 +144,15 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     }
 
     [Fact]
-    public void DriftCalculation_ReturnsNonNegative()
+    public void DriftCalculation_AfterPulse_ReturnsWallClockMinusPoll()
     {
-        var logTs = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
-        var wallClock = logTs.AddSeconds(3);
-        _time.SetUtcNow(wallClock);
+        var pollAt = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(pollAt);
+        _replay.Complete();
+        _pulse.Pulse(LogFamily.Player, pollAt);
 
-        _bus.Publish(new CalendarTimeAdvanced(logTs, Meta(logTs)));
+        // 3s pass with no further pulse.
+        _time.SetUtcNow(pollAt.AddSeconds(3));
 
         _view.Player.Drift.Should().Be(TimeSpan.FromSeconds(3));
     }
@@ -127,11 +160,13 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     [Fact]
     public void DriftCalculation_NegativeDrift_ClampedToZero()
     {
-        var logTs = new DateTimeOffset(2026, 5, 25, 12, 0, 5, TimeSpan.Zero);
-        var wallClock = logTs.AddSeconds(-2);
-        _time.SetUtcNow(wallClock);
+        var pollAt = new DateTimeOffset(2026, 5, 25, 12, 0, 5, TimeSpan.Zero);
+        _time.SetUtcNow(pollAt);
+        _replay.Complete();
+        _pulse.Pulse(LogFamily.Player, pollAt);
 
-        _bus.Publish(new CalendarTimeAdvanced(logTs, Meta(logTs)));
+        // Wall clock travels backward (test clock manipulation).
+        _time.SetUtcNow(pollAt.AddSeconds(-2));
 
         _view.Player.Drift.Should().Be(TimeSpan.Zero);
     }
@@ -139,32 +174,103 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
     [Fact]
     public void AttentionCount_ZeroWhenReplaying()
     {
-        var logTs = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
-        _time.SetUtcNow(logTs.AddSeconds(10));
-        _bus.Publish(new CalendarTimeAdvanced(logTs, Meta(logTs)));
+        var pollAt = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(pollAt.AddSeconds(10));
+        _pulse.Pulse(LogFamily.Player, pollAt);
 
-        _view.Count.Should().Be(0, "drift threshold only applies in Live mode");
+        _view.Count.Should().Be(0, "stall threshold only applies in Live mode");
     }
 
     [Fact]
     public void AttentionCount_IncreasesWhenLiveDriftExceedsThreshold()
     {
+        var pollAt = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(pollAt);
         _replay.Complete();
-        var logTs = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
-        _time.SetUtcNow(logTs.AddSeconds(6));
-        _bus.Publish(new CalendarTimeAdvanced(logTs, Meta(logTs)));
+        _pulse.Pulse(LogFamily.Player, pollAt);
+        _pulse.Pulse(LogFamily.Chat, pollAt);
 
-        _view.Count.Should().Be(1, "player is live with drift > 5s");
+        // 6s pass with no further pulse.
+        _time.SetUtcNow(pollAt.AddSeconds(6));
+
+        _view.Count.Should().Be(2, "both drivers are live with poll age > 5s");
     }
 
     [Fact]
     public void AttentionCount_ZeroWhenDriftBelowThreshold()
     {
+        var pollAt = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(pollAt);
         _replay.Complete();
-        var logTs = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
-        _time.SetUtcNow(logTs.AddSeconds(2));
-        _bus.Publish(new CalendarTimeAdvanced(logTs, Meta(logTs)));
+        _pulse.Pulse(LogFamily.Player, pollAt);
+        _pulse.Pulse(LogFamily.Chat, pollAt);
 
+        _time.SetUtcNow(pollAt.AddSeconds(2));
+
+        _view.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The headline #856 scenario: a quiet chat channel produces zero
+    /// PlayerChatLine events. The chat tailer keeps polling; pulse keeps the
+    /// chat row Live; the attention badge stays at 0.
+    /// </summary>
+    [Fact]
+    public void QuietChatChannel_StaysLive_NoAttention()
+    {
+        var t0 = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(t0);
+        _replay.Complete();
+        _pulse.Pulse(LogFamily.Player, t0);
+        _pulse.Pulse(LogFamily.Chat, t0);
+
+        // 30 seconds pass. Player has CalendarTimeAdvanced firing every second,
+        // chat has NO events at all. Both tailers keep polling.
+        for (var s = 1; s <= 30; s++)
+        {
+            var t = t0.AddSeconds(s);
+            _time.SetUtcNow(t);
+            _bus.Publish(new CalendarTimeAdvanced(t, Meta(t)));
+            _pulse.Pulse(LogFamily.Player, t);
+            _pulse.Pulse(LogFamily.Chat, t);
+        }
+
+        _view.Chat.Mode.Should().Be(WorldMode.Live,
+            "the chat tailer's poll loop is healthy — silence on the channel is not a fault");
+        _view.Player.Mode.Should().Be(WorldMode.Live);
+        _view.AllLive.Should().BeTrue();
+        _view.Count.Should().Be(0, "no false-fire on inactive chat (the #856 fix)");
+    }
+
+    /// <summary>
+    /// The new Stalled mode: live, then no pulse for > threshold, then a
+    /// fresh pulse arrives and the driver returns to Live.
+    /// </summary>
+    [Fact]
+    public void StalledMode_LiveToStalledToLive()
+    {
+        var t0 = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
+        _time.SetUtcNow(t0);
+        _replay.Complete();
+        _pulse.Pulse(LogFamily.Player, t0);
+        _pulse.Pulse(LogFamily.Chat, t0);
+        _view.Player.Mode.Should().Be(WorldMode.Live);
+
+        // 6s pass with no pulse → stalled.
+        _time.SetUtcNow(t0.AddSeconds(6));
+        _view.Player.Mode.Should().Be(WorldMode.Stalled);
+        _view.Chat.Mode.Should().Be(WorldMode.Stalled);
+        _view.AllLive.Should().BeFalse("Stalled does not count as Live (design lock #9)");
+        _view.Count.Should().Be(2);
+
+        // Fresh pulse → back to Live.
+        var t6 = t0.AddSeconds(6);
+        _pulse.Pulse(LogFamily.Player, t6);
+        _pulse.Pulse(LogFamily.Chat, t6);
+
+        _view.Player.Mode.Should().Be(WorldMode.Live);
+        _view.Chat.Mode.Should().Be(WorldMode.Live);
+        _view.AllLive.Should().BeTrue();
         _view.Count.Should().Be(0);
     }
 
@@ -177,6 +283,18 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
         var ts = new DateTimeOffset(2026, 5, 25, 12, 0, 0, TimeSpan.Zero);
         _time.SetUtcNow(ts);
         _bus.Publish(new CalendarTimeAdvanced(ts, Meta(ts)));
+
+        fired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ChangedEvent_FiresOnPulse()
+    {
+        // Pulse is now the primary stall-detection cadence (design lock #6).
+        var fired = false;
+        _view.Changed += (_, _) => fired = true;
+
+        _pulse.Pulse(LogFamily.Player, DateTimeOffset.UtcNow);
 
         fired.Should().BeTrue();
     }
@@ -255,6 +373,17 @@ public sealed class WorldHealthViewTests : IAsyncLifetime
         _bus.Publish(new CalendarTimeAdvanced(ts, Meta(ts)));
 
         _view.Player.FrameCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromPulse()
+    {
+        _view.Dispose();
+
+        // Pulse after dispose should not throw — verifies we removed the
+        // handler so a long-lived IIngestPulse doesn't pin a disposed view.
+        var act = () => _pulse.Pulse(LogFamily.Player, DateTimeOffset.UtcNow);
+        act.Should().NotThrow();
     }
 
     // ── Test infrastructure ───────────────────────────────────────────────

--- a/tests/Palantir.Tests/WorldHealthViewModelTests.cs
+++ b/tests/Palantir.Tests/WorldHealthViewModelTests.cs
@@ -1,0 +1,117 @@
+using Arda.Contracts.State.Health;
+using FluentAssertions;
+using Palantir.ViewModels;
+using Xunit;
+
+namespace Palantir.Tests;
+
+/// <summary>
+/// Pins the per-mode overall-status copy and per-row mode-text mapping for
+/// the Palantir World Health detail page after #856 reshaped the bindings
+/// (was: PlayerDegraded/ChatDegraded booleans; now: Mode-driven).
+/// </summary>
+public sealed class WorldHealthViewModelTests
+{
+    private sealed class FakeHealth : IWorldHealthView
+    {
+        public WorldHealth Player { get; set; } = new(null, 0, WorldMode.Replaying, TimeSpan.Zero);
+        public WorldHealth Chat { get; set; } = new(null, 0, WorldMode.Replaying, TimeSpan.Zero);
+        public bool AllLive { get; set; }
+        public GrammarBreak? Break { get; set; }
+        public bool IsHalted { get; set; }
+        public bool IsTolerantBreakActive { get; set; }
+        public int ObservedBreakCount { get; set; }
+
+        public event EventHandler? Changed;
+
+        public void RaiseChanged() => Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static Action<Action> Synchronous() => a => a();
+
+    [Fact]
+    public void BothLive_OverallStatusIsHealthy()
+    {
+        var health = new FakeHealth
+        {
+            Player = new(null, 100, WorldMode.Live, TimeSpan.FromSeconds(1)),
+            Chat = new(null, 50, WorldMode.Live, TimeSpan.FromSeconds(1)),
+            AllLive = true,
+        };
+
+        var vm = new WorldHealthViewModel(health, Synchronous());
+
+        vm.OverallStatus.Should().Be("Live — healthy");
+        vm.PlayerMode.Should().Be(WorldMode.Live);
+        vm.ChatMode.Should().Be(WorldMode.Live);
+        vm.AllLive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OneStalled_OverallStatusIsTailerStalled()
+    {
+        var health = new FakeHealth
+        {
+            Player = new(null, 100, WorldMode.Live, TimeSpan.FromSeconds(1)),
+            Chat = new(null, 50, WorldMode.Stalled, TimeSpan.FromSeconds(10)),
+            AllLive = false, // Stalled does NOT count as live (design lock #9)
+        };
+
+        var vm = new WorldHealthViewModel(health, Synchronous());
+
+        vm.OverallStatus.Should().Be("Tailer stalled");
+        vm.ChatMode.Should().Be(WorldMode.Stalled);
+        vm.AllLive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Halted_OverallStatusIsHaltedRegardlessOfOtherDriver()
+    {
+        var health = new FakeHealth
+        {
+            Player = new(null, 100, WorldMode.Halted, TimeSpan.Zero),
+            Chat = new(null, 50, WorldMode.Halted, TimeSpan.Zero),
+            IsHalted = true,
+        };
+
+        var vm = new WorldHealthViewModel(health, Synchronous());
+
+        vm.OverallStatus.Should().Be("Halted — grammar break");
+        vm.PlayerMode.Should().Be(WorldMode.Halted);
+    }
+
+    [Fact]
+    public void Replaying_OverallStatusIsReplaying()
+    {
+        var vm = new WorldHealthViewModel(new FakeHealth(), Synchronous());
+
+        vm.OverallStatus.Should().Be("Replaying log history…");
+    }
+
+    [Fact]
+    public void ChangedEvent_RefreshesProperties()
+    {
+        var health = new FakeHealth();
+        var vm = new WorldHealthViewModel(health, Synchronous());
+        vm.PlayerMode.Should().Be(WorldMode.Replaying);
+
+        health.Player = new(null, 100, WorldMode.Live, TimeSpan.FromSeconds(1));
+        health.AllLive = false; // Chat still Replaying
+        health.RaiseChanged();
+
+        vm.PlayerMode.Should().Be(WorldMode.Live);
+    }
+
+    [Fact]
+    public void Dispose_DetachesFromHealth()
+    {
+        var health = new FakeHealth();
+        var vm = new WorldHealthViewModel(health, Synchronous());
+
+        vm.Dispose();
+        health.Player = new(null, 100, WorldMode.Stalled, TimeSpan.FromSeconds(10));
+        health.RaiseChanged();
+
+        vm.PlayerMode.Should().Be(WorldMode.Replaying, "disposed VM stops updating");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #856. World Health view was false-firing a drift warning on inactive chat channels because `WorldHealth.Drift` was defined as `now − LastTimestamp` where `LastTimestamp` was the most recent in-stream log timestamp. Quiet guild/trade chat made the tailer look broken even though the tailer itself was healthy.

- Redefine `WorldHealth.Drift` to mean **"wall-clock age of the tailer's last poll iteration"**, recorded via a new `IIngestPulse` signal.
- Add `WorldMode.Stalled` as a first-class state for "was Live, pulse has gone silent past `DriftWarningThreshold` (5s)".
- Rename `WorldHealth.LastTimestamp` → `LastLogTimestamp` (informational only; powers "last log: 12m ago" UI text, not drift).
- `Arda.Contracts.State.Health.WorldMode.Stalled` is inserted between `Live` and `Halted`; `AllLive` is strict — Stalled does NOT count (locked design decision #9).

## Design notes

The pulse is infra, not a domain event on `IDomainEventBus` (the bus stays game-domain only — locked design decision #1, #11). The contract is split along read/write to keep the dependency direction one-way:

- `IIngestPulseSink` + `LogFamily` live in `Arda.Abstractions` so `Arda.Ingest` can record pulses without depending on the higher composition layer.
- `IIngestPulse` + `IngestPulseEventArgs` live in `Arda.Hosting` where the singleton is composed.
- Same singleton (`Arda.Hosting.Internal.IngestPulse`) implements both.

This judgment call resolves the cross-project dependency ambiguity the spec flagged (the issue placed both interfaces in `Arda.Hosting`, but ingest sources can't reference Hosting). Brief comments at each interface explain the placement.

Pulses fire on every iteration of the live-tail loop **including empty reads** (load-bearing — the whole point is "we looked, file was silent"). Pulses do NOT fire during the Phase-1 prev-replay drain, the rotation drain inner loop, or while the chat source is waiting for any chat file to exist (design lock #2).

Stall detection is lazy — recomputed inside `Snapshot()` and on every `RaiseChanged()` (which fires on pulse from any family). No timer; detection lag is bounded by the next pulse, ~250–500ms (design lock #6).

## Test plan

- [x] `dotnet build Mithril.slnx` — green, 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — all tests pass except a pre-existing flake in `Mithril.MapCalibration.Capture.Tests.TextureRegistrationRefinerTests.Refine_through_the_seam_downsamples_at_live_resolution` (10s perf-budget timing flake from PR #972 / issue #966, unrelated to this change — passes on rerun in isolation).
- [x] New `tests/Arda.Ingest.Tests/IngestPulseTests.cs` (4 tests) — empty-read pulses fire, no pulse before chat file exists, null sink is safe.
- [x] Rewritten `tests/Mithril.Shell.Tests/WorldHealthViewTests.cs` — drives drift via `IIngestPulse` instead of `CalendarTimeAdvanced`; adds `QuietChatChannel_StaysLive_NoAttention` (the #856 headline scenario) and `StalledMode_LiveToStalledToLive`.
- [x] New `tests/Palantir.Tests/WorldHealthViewModelTests.cs` (6 tests) — pins per-mode overall-status copy + Mode-driven binding.
- [ ] Manual: run the shell with a real Player.log + idle ChatLogs; confirm Chat row stays Live indefinitely on a silent chat. (Owed by shepherd / on merge.)
- [ ] Manual stall sim: pause Mithril at a breakpoint inside the poll loop for >5s, confirm row flips to Stalled, then resume and confirm it flips back to Live. (Owed by shepherd / on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)