### PR TITLE
feat(synthesis-probe): bundle consumption + Eltibule diagnostic verdict

### DIFF
--- a/docs/superpowers/plans/2026-06-01-synthesis-probe-diagnostic.md
+++ b/docs/superpowers/plans/2026-06-01-synthesis-probe-diagnostic.md
@@ -1,0 +1,2273 @@
+# Synthesis-Probe Diagnostic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `--phase synthesis-probe` in `tools/MapCalibrationFromScreenshot` that scores the icon-likelihood-field objective `J(T) = Σ L_{type(r)}(T·r)` across five experiments (E1–E5) on the committed Frame 1 / Frame 2 fixtures, dumps CSV + PNG artifacts and OTel spans, and tells us whether to pursue the cold or hybrid synthesis solver in production.
+
+**Architecture:** Phase-additive — a new `SynthesisProbe/` subdirectory inside the existing tool project holds the field builder, J evaluator, gradient-ascent refiner, the five experiments, OTel tracer setup, and CSV/PNG output writers. A sibling test project (`MapCalibrationFromScreenshot.SynthesisProbe.Tests`) hosts xUnit/FluentAssertions tests, built outside `Mithril.slnx` (matching the parent tool's isolation). Production code under `src/Mithril.MapCalibration/**` is **not** touched in v0 — the spec is explicit.
+
+**Tech Stack:** .NET 10 / `net10.0-windows`, xUnit + FluentAssertions for tests, OpenTelemetry SDK for .NET (`OpenTelemetry`, `OpenTelemetry.Exporter.Console`, `OpenTelemetry.Exporter.OpenTelemetryProtocol`).
+
+**Spec:** [docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md](../specs/2026-06-01-synthesis-probe-diagnostic-design.md). Territory map: `scratch/auto-calibration-handoff.md`.
+
+---
+
+## File Structure
+
+### New files (tool project, `tools/MapCalibrationFromScreenshot/`)
+
+| File | Responsibility |
+|---|---|
+| `SynthesisProbe/CandidateTransform.cs` | Record of `(Scale, RotRadians, Mirror, Tx, Ty)` + `Apply(WorldCoord) → PixelPoint` that mirrors `AreaCalibration.WorldToWindow`. |
+| `SynthesisProbe/IconLikelihoodField.cs` | Builds `L_t` for one template: `D = clamp(screenshot − aligned_base, 0, 255)` then full-image alpha-masked NCC → `double[,]`. Plus `Sample(field, x, y)` with bicubic interpolation. |
+| `SynthesisProbe/JEvaluator.cs` | `Evaluate(transform, fieldsByType, refs, mapRect) → JResult { J, RefsAboveHalf, RefsOffCrop, PerRefScores }`. Owns the world→texture→crop math. |
+| `SynthesisProbe/LocalRefine.cs` | Gauss-Newton ascent on `(Scale, Tx, Ty)` over the bicubic field at a fixed `(Rot, Mirror)`. ~30 iter max, returns refined transform + final J. |
+| `SynthesisProbe/RansacSeedsCsv.cs` | Reads `label,scale,rot,ox,oy,mirror` rows from a CSV into a list of `(label, CandidateTransform)`. |
+| `SynthesisProbe/ProbeReferences.cs` | Loads area refs (landmarks + npcs) and types them with the same `LandmarkType` vocabulary the production detector uses. |
+| `SynthesisProbe/SynthesisProbeWriter.cs` | Owns the CSV stream + the field/landscape PNG writers. |
+| `SynthesisProbe/SynthesisProbeTracer.cs` | `ActivitySource MithrilToolsMapCalibrationSynthesisProbe = new("Mithril.Tools.MapCalibrationSynthesisProbe")` + `Configure(TraceConsole/Otlp option) → TracerProvider`. |
+| `SynthesisProbe/Experiments/E1_TruthScore.cs` | One `Evaluate` at `--truth-cal`. |
+| `SynthesisProbe/Experiments/E2_TranslationSweep.cs` | Sweeps `(Tx, Ty)` ±2·template_size around truth, step 1 px. Writes CSV + landscape PNG. |
+| `SynthesisProbe/Experiments/E3_ScaleSweep.cs` | Sweeps `Scale` ±25% around truth, step 1%. Writes CSV + 1-D landscape PNG. |
+| `SynthesisProbe/Experiments/E4_RansacSeedScore.cs` | Evaluates each row of `--ransac-seeds-csv`. |
+| `SynthesisProbe/Experiments/E5_ColdGrid.cs` | Cold grid over `Scale × Tx × Ty × {Rot} × {Mirror}`, takes top-8 by raw `J`, refines each with `LocalRefine`, reports best post-refine distance to truth. |
+| `SynthesisProbe/SynthesisProbePhase.cs` | Top-level: load inputs, build fields, configure tracer, run E1→E5, close tracer. |
+
+### New files (test project, `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/`)
+
+| File | Tests |
+|---|---|
+| `MapCalibrationFromScreenshot.SynthesisProbe.Tests.csproj` | Standalone csproj, references the tool and the production `Mithril.MapCalibration`. Built outside `Mithril.slnx`. |
+| `CandidateTransformTests.cs` | `Apply` matches `AreaCalibration.WorldToWindow` exactly for both mirror values and a non-zero rotation. |
+| `IconLikelihoodFieldTests.cs` | Synthetic 64×64 background, 1 known icon at (32, 32); field's argmax is at (32, 32). Bicubic `Sample` matches grid value at integer coords, interpolates smoothly at sub-pixel. |
+| `JEvaluatorTests.cs` | Synthetic 3-ref scene; `J(truth) ≫ J(random transform)`; `RefsOffCrop` correctly counts off-crop refs. |
+| `LocalRefineTests.cs` | From a 5 px offset on a synthetic gaussian-peak field, refine converges to within 0.5 px in ≤30 iter. |
+| `E5_ColdGridTests.cs` | Synthetic 3-ref scene; top-8 grid maxima after refine include a ≤5 px-of-truth entry. |
+| `SynthesisProbeTracerTests.cs` | When a listener is attached, `probe.attempt` span is emitted with expected tags. When no listener, no exception. |
+
+### Modified files
+
+- `tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj` — add `OpenTelemetry`, `OpenTelemetry.Exporter.Console`, `OpenTelemetry.Exporter.OpenTelemetryProtocol` package refs.
+- `tools/MapCalibrationFromScreenshot/CliArgs.cs` — add fields for `--truth-cal`, `--ransac-seeds-csv`, `--trace-console`, `--otlp`, plus `Phase.SynthesisProbe` enum value, parsing, help text.
+- `tools/MapCalibrationFromScreenshot/Pipeline.cs` — dispatch `Phase.SynthesisProbe` to `SynthesisProbePhase.Run(args)` before the existing full-pipeline code.
+- `tools/MapCalibrationFromScreenshot/README.md` — document `--phase synthesis-probe` at the bottom of the existing flag table.
+
+---
+
+### Task 1: Scaffold the phase, test project, and stub entry point
+
+**Files:**
+- Modify: `tools/MapCalibrationFromScreenshot/CliArgs.cs`
+- Modify: `tools/MapCalibrationFromScreenshot/Pipeline.cs`
+- Modify: `tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/MapCalibrationFromScreenshot.SynthesisProbe.Tests.csproj`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ScaffoldTests.cs`
+
+- [ ] **Step 1: Create the test csproj**
+
+```xml
+<!-- tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/MapCalibrationFromScreenshot.SynthesisProbe.Tests.csproj -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MapCalibrationFromScreenshot\MapCalibrationFromScreenshot.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+- [ ] **Step 2: Add a placeholder failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ScaffoldTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class ScaffoldTests
+{
+    [Fact]
+    public void Phase_synthesis_probe_is_a_recognized_phase_value()
+    {
+        Enum.IsDefined(typeof(Phase), Phase.SynthesisProbe).Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release
+```
+
+Expected: BUILD FAILURE — `Phase.SynthesisProbe` does not exist.
+
+- [ ] **Step 4: Add the enum value, the CLI parse case, and the help string**
+
+In `tools/MapCalibrationFromScreenshot/CliArgs.cs`, add `SynthesisProbe` to the `Phase` enum:
+
+```csharp
+internal enum Phase
+{
+    Full,
+    ExtractIcons,
+    ExtractMap,
+    SelfTest,
+    EmitTemplates,
+    SynthesisProbe,
+}
+```
+
+In the same file's `ParsePhase` switch:
+
+```csharp
+private static Phase ParsePhase(string s) => s.ToLowerInvariant() switch
+{
+    "extract-icons" => Phase.ExtractIcons,
+    "extract-map" => Phase.ExtractMap,
+    "full" => Phase.Full,
+    "self-test" => Phase.SelfTest,
+    "emit-templates" => Phase.EmitTemplates,
+    "synthesis-probe" => Phase.SynthesisProbe,
+    _ => throw new UserFacingException($"unknown phase '{s}' (extract-icons | extract-map | full | self-test | emit-templates | synthesis-probe)"),
+};
+```
+
+In the help text (`PrintUsage` modes block), append:
+
+```
+  --phase synthesis-probe       run E1-E5 icon-likelihood-field diagnostic; emits CSV + PNGs + OTel
+```
+
+- [ ] **Step 5: Create the stub phase entry**
+
+```csharp
+// tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class SynthesisProbePhase
+{
+    public static int Run(CliArgs args)
+    {
+        Console.WriteLine("[synthesis-probe] not yet implemented");
+        return 0;
+    }
+}
+```
+
+- [ ] **Step 6: Dispatch in `Pipeline.cs`**
+
+In `Pipeline.Run`, after the `SelfTest` block, add:
+
+```csharp
+if (args.Phase == Phase.SynthesisProbe)
+{
+    return SynthesisProbe.SynthesisProbePhase.Run(args);
+}
+```
+
+- [ ] **Step 7: Add OTel package refs to the tool csproj**
+
+In `tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj`, inside the existing `<ItemGroup>` with `<PackageReference>` entries:
+
+```xml
+<PackageReference Include="OpenTelemetry" Version="1.10.0" />
+<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+```
+
+- [ ] **Step 8: Run the test, verify it passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release
+```
+
+Expected: PASS — 1 test, 0 failures.
+
+- [ ] **Step 9: Verify the CLI accepts the new phase**
+
+```bash
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- --phase synthesis-probe --area AreaEltibule
+```
+
+Expected: stdout contains `[synthesis-probe] not yet implemented`, exit code 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/CliArgs.cs tools/MapCalibrationFromScreenshot/Pipeline.cs tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/
+git commit -m "feat(synthesis-probe): scaffold --phase synthesis-probe + test project"
+```
+
+---
+
+### Task 2: CandidateTransform record
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/CandidateTransform.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CandidateTransformTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// CandidateTransformTests.cs
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class CandidateTransformTests
+{
+    [Theory]
+    [InlineData(false, 0.0)]
+    [InlineData(true, 0.0)]
+    [InlineData(false, Math.PI)]
+    [InlineData(true, Math.PI)]
+    public void Apply_matches_AreaCalibration_WorldToWindow(bool mirror, double rot)
+    {
+        var t = new CandidateTransform(Scale: 0.82, RotRadians: rot, Mirror: mirror, Tx: 100.0, Ty: 200.0);
+        var cal = new AreaCalibration(0.82, rot, 100.0, 200.0, ReferenceCount: 1, ResidualPixels: 0.0) { MirrorNorth = mirror };
+        var world = new WorldCoord(50, 0, 30);
+
+        var fromCandidate = t.Apply(world);
+        var fromCalibration = cal.WorldToWindow(world);
+
+        fromCandidate.X.Should().BeApproximately(fromCalibration.X, 1e-9);
+        fromCandidate.Y.Should().BeApproximately(fromCalibration.Y, 1e-9);
+    }
+
+    [Fact]
+    public void FromAreaCalibration_copies_all_fields()
+    {
+        var cal = new AreaCalibration(0.5, Math.PI, 12.0, 34.0, 5, 0.7) { MirrorNorth = true };
+        var t = CandidateTransform.FromAreaCalibration(cal);
+
+        t.Scale.Should().Be(0.5);
+        t.RotRadians.Should().Be(Math.PI);
+        t.Mirror.Should().BeTrue();
+        t.Tx.Should().Be(12.0);
+        t.Ty.Should().Be(34.0);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~CandidateTransformTests"
+```
+
+Expected: BUILD FAILURE — `CandidateTransform` not found.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// CandidateTransform.cs
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal readonly record struct CandidateTransform(double Scale, double RotRadians, bool Mirror, double Tx, double Ty)
+{
+    public PixelPoint Apply(WorldCoord world)
+    {
+        var east = world.X;
+        var north = Mirror ? -world.Z : world.Z;
+        var cos = Math.Cos(RotRadians);
+        var sin = Math.Sin(RotRadians);
+        var rotE = east * cos + north * sin;
+        var rotN = -east * sin + north * cos;
+        return new PixelPoint(Tx + Scale * rotE, Ty - Scale * rotN);
+    }
+
+    public static CandidateTransform FromAreaCalibration(AreaCalibration cal) =>
+        new(cal.Scale, cal.RotationRadians, cal.MirrorNorth, cal.OriginX, cal.OriginY);
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~CandidateTransformTests"
+```
+
+Expected: PASS — 5 tests (4 theory rows + 1 fact), 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/CandidateTransform.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CandidateTransformTests.cs
+git commit -m "feat(synthesis-probe): add CandidateTransform mirroring AreaCalibration"
+```
+
+---
+
+### Task 3: CLI flag plumbing for --truth-cal, --ransac-seeds-csv, --trace-console, --otlp
+
+**Files:**
+- Modify: `tools/MapCalibrationFromScreenshot/CliArgs.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsSynthesisProbeTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// CliArgsSynthesisProbeTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class CliArgsSynthesisProbeTests
+{
+    [Fact]
+    public void Parses_truth_cal_five_tuple()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe",
+            "--screenshot", "x.png",
+            "--area", "AreaEltibule",
+            "--truth-cal", "0.82,0.0,100.5,200.5,false",
+        })!;
+
+        args.TruthCal.Should().NotBeNull();
+        args.TruthCal!.Value.Scale.Should().Be(0.82);
+        args.TruthCal.Value.Rot.Should().Be(0.0);
+        args.TruthCal.Value.Ox.Should().Be(100.5);
+        args.TruthCal.Value.Oy.Should().Be(200.5);
+        args.TruthCal.Value.Mirror.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parses_ransac_seeds_csv_path()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe",
+            "--screenshot", "x.png",
+            "--area", "AreaEltibule",
+            "--ransac-seeds-csv", "C:/seeds.csv",
+        })!;
+        args.RansacSeedsCsvPath.Should().Be("C:/seeds.csv");
+    }
+
+    [Fact]
+    public void Parses_trace_console_flag()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--screenshot", "x.png", "--area", "AreaEltibule",
+            "--trace-console",
+        })!;
+        args.TraceConsole.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parses_otlp_endpoint()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--screenshot", "x.png", "--area", "AreaEltibule",
+            "--otlp", "http://localhost:4317",
+        })!;
+        args.OtlpEndpoint.Should().Be("http://localhost:4317");
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Expected: BUILD FAILURE — fields `TruthCal`, `RansacSeedsCsvPath`, `TraceConsole`, `OtlpEndpoint` not on `CliArgs`.
+
+- [ ] **Step 3: Add the four fields + parsers to `CliArgs`**
+
+In `CliArgs.cs`, add to the record:
+
+```csharp
+(double Scale, double Rot, double Ox, double Oy, bool Mirror)? TruthCal,
+string? RansacSeedsCsvPath,
+bool TraceConsole,
+string? OtlpEndpoint
+```
+
+In `Parse`, add the locals (next to other parse locals):
+
+```csharp
+(double, double, double, double, bool)? truthCal = null;
+string? ransacSeedsCsv = null;
+bool traceConsole = false;
+string? otlpEndpoint = null;
+```
+
+Add the switch cases (inside the main `for (int i...)` switch, before `case "-h"`):
+
+```csharp
+case "--truth-cal":
+    truthCal = ParseSeed(Next(argv, ref i)); // same format: scale,rot,ox,oy,mirror
+    break;
+case "--ransac-seeds-csv":
+    ransacSeedsCsv = Next(argv, ref i);
+    break;
+case "--trace-console":
+    traceConsole = true;
+    break;
+case "--otlp":
+    otlpEndpoint = Next(argv, ref i);
+    break;
+```
+
+Reorder `ParseSeed` so it accepts `scale,rot,ox,oy,mirror` (the existing one takes `rot,scale,ox,oy,mirror`). Add a new helper that swaps the order, named `ParseTruthCal`:
+
+```csharp
+private static (double, double, double, double, bool) ParseTruthCal(string s)
+{
+    var parts = s.Split(',', 5);
+    if (parts.Length != 5) throw new UserFacingException($"--truth-cal wants 'scale,rot,ox,oy,mirror' (got '{s}')");
+    return (
+        double.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
+        double.Parse(parts[1].Trim(), CultureInfo.InvariantCulture),
+        double.Parse(parts[2].Trim(), CultureInfo.InvariantCulture),
+        double.Parse(parts[3].Trim(), CultureInfo.InvariantCulture),
+        bool.Parse(parts[4].Trim()));
+}
+```
+
+…and call `ParseTruthCal` (not `ParseSeed`) in the `--truth-cal` case.
+
+Pass the four new fields through to the `CliArgs` constructor at the bottom of `Parse`. Add them in the same positional order to the record header. Update help text to document the four flags under a "synthesis-probe diagnostic" section:
+
+```
+synthesis-probe diagnostic (--phase synthesis-probe):
+  --truth-cal <scale,rot,ox,oy,mirror>  known-correct calibration for E1-E5 (mirror = true|false)
+  --ransac-seeds-csv <path>             CSV of candidate calibrations to score (E4):
+                                          label,scale,rot,ox,oy,mirror
+  --trace-console                       emit OTel spans to stdout
+  --otlp <endpoint>                     emit OTel spans to the named OTLP endpoint
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~CliArgsSynthesisProbeTests"
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/CliArgs.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsSynthesisProbeTests.cs
+git commit -m "feat(synthesis-probe): parse --truth-cal, --ransac-seeds-csv, --trace-console, --otlp"
+```
+
+---
+
+### Task 4: IconLikelihoodField.Build (deviation + alpha-masked NCC)
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldBuildTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// IconLikelihoodFieldBuildTests.cs
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldBuildTests
+{
+    [Fact]
+    public void Field_peaks_at_known_icon_location()
+    {
+        // 64x64 background of gray 128.
+        const int W = 64, H = 64;
+        var screenshot = NewGray(W, H, fill: 128);
+        var baseTex = NewGray(W, H, fill: 128);
+
+        // 5x5 template: bright cross. Fully opaque alpha.
+        var template = new IconTemplate(
+            Name: "x",
+            LandmarkType: "Portal",
+            PivotX: 0.5,
+            PivotY: 0.5,
+            Width: 5,
+            Height: 5,
+            Pixels: new byte[] { 0,0,255,0,0, 0,0,255,0,0, 255,255,255,255,255, 0,0,255,0,0, 0,0,255,0,0 },
+            Alpha:  new byte[] { 0,0,255,0,0, 0,0,255,0,0, 255,255,255,255,255, 0,0,255,0,0, 0,0,255,0,0 });
+
+        // Stamp the template on the screenshot at center (32,32).
+        StampTemplate(screenshot, template, cx: 32, cy: 32);
+
+        var field = IconLikelihoodField.Build(screenshot, baseTex, template);
+
+        field.GetLength(0).Should().Be(H);
+        field.GetLength(1).Should().Be(W);
+        var (maxX, maxY) = Argmax(field);
+        maxX.Should().BeInRange(31, 33); // centered on the stamp, allowing 1 px tolerance
+        maxY.Should().BeInRange(31, 33);
+        field[maxY, maxX].Should().BeGreaterThan(0.8); // strong NCC on a clean stamp
+    }
+
+    private static GrayImage NewGray(int w, int h, byte fill)
+    {
+        var p = new byte[w * h];
+        Array.Fill(p, fill);
+        return new GrayImage(w, h, p);
+    }
+
+    private static void StampTemplate(GrayImage img, IconTemplate t, int cx, int cy)
+    {
+        int x0 = cx - t.Width / 2;
+        int y0 = cy - t.Height / 2;
+        for (int ty = 0; ty < t.Height; ty++)
+            for (int tx = 0; tx < t.Width; tx++)
+            {
+                if (t.Alpha[ty * t.Width + tx] == 0) continue;
+                int x = x0 + tx, y = y0 + ty;
+                if (x < 0 || y < 0 || x >= img.Width || y >= img.Height) continue;
+                img.Pixels[y * img.Width + x] = t.Pixels[ty * t.Width + tx];
+            }
+    }
+
+    private static (int X, int Y) Argmax(double[,] field)
+    {
+        int bestX = 0, bestY = 0;
+        double bestV = double.NegativeInfinity;
+        for (int y = 0; y < field.GetLength(0); y++)
+            for (int x = 0; x < field.GetLength(1); x++)
+                if (field[y, x] > bestV) { bestV = field[y, x]; bestX = x; bestY = y; }
+        return (bestX, bestY);
+    }
+}
+```
+
+> **Note:** `IconTemplate` lives at `src/Mithril.MapCalibration/Detection/IconTemplate.cs`. If its constructor signature differs from the above, mirror its actual shape — the synthetic stamp logic stays the same.
+
+- [ ] **Step 2: Run, verify it fails**
+
+Expected: BUILD FAILURE — `IconLikelihoodField` not found.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// IconLikelihoodField.cs
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class IconLikelihoodField
+{
+    public static double[,] Build(GrayImage screenshot, GrayImage alignedBase, IconTemplate template)
+    {
+        if (screenshot.Width != alignedBase.Width || screenshot.Height != alignedBase.Height)
+            throw new ArgumentException("screenshot and aligned base must have matching dimensions");
+
+        int w = screenshot.Width, h = screenshot.Height;
+        var deviation = new byte[w * h];
+        for (int i = 0; i < deviation.Length; i++)
+        {
+            int d = screenshot.Pixels[i] - alignedBase.Pixels[i];
+            deviation[i] = d > 0 ? (byte)Math.Min(255, d) : (byte)0;
+        }
+        var devImage = new GrayImage(w, h, deviation);
+
+        return ScoreAll(devImage, template);
+    }
+
+    /// <summary>
+    /// Whole-image alpha-masked NCC. Returns an HxW array of raw NCC scores
+    /// (no NMS, no thresholding). For each anchor (cx, cy), correlates the
+    /// alpha-opaque pixels of <paramref name="template"/> against the image
+    /// window centered on the template's pivot. Scores at positions where the
+    /// template would overhang the image edge are 0.
+    /// </summary>
+    public static double[,] ScoreAll(GrayImage image, IconTemplate template)
+    {
+        int W = image.Width, H = image.Height;
+        int tw = template.Width, th = template.Height;
+        int ax = (int)Math.Round(template.PivotX * tw);
+        int ay = (int)Math.Round(template.PivotY * th);
+
+        // Precompute template mean / variance over opaque pixels only.
+        double tSum = 0;
+        int opaqueCount = 0;
+        for (int i = 0; i < tw * th; i++)
+        {
+            if (template.Alpha[i] == 0) continue;
+            tSum += template.Pixels[i];
+            opaqueCount++;
+        }
+        if (opaqueCount == 0) return new double[H, W];
+        double tMean = tSum / opaqueCount;
+        double tVar = 0;
+        for (int i = 0; i < tw * th; i++)
+        {
+            if (template.Alpha[i] == 0) continue;
+            double d = template.Pixels[i] - tMean;
+            tVar += d * d;
+        }
+        double tStd = Math.Sqrt(tVar);
+        if (tStd < 1e-9) return new double[H, W];
+
+        var field = new double[H, W];
+        Parallel.For(0, H, cy =>
+        {
+            int y0 = cy - ay;
+            if (y0 < 0 || y0 + th > H) return;
+            for (int cx = 0; cx < W; cx++)
+            {
+                int x0 = cx - ax;
+                if (x0 < 0 || x0 + tw > W) continue;
+
+                double iSum = 0;
+                for (int ty = 0; ty < th; ty++)
+                    for (int tx = 0; tx < tw; tx++)
+                        if (template.Alpha[ty * tw + tx] != 0)
+                            iSum += image.Pixels[(y0 + ty) * W + (x0 + tx)];
+
+                double iMean = iSum / opaqueCount;
+                double iVar = 0, cov = 0;
+                for (int ty = 0; ty < th; ty++)
+                    for (int tx = 0; tx < tw; tx++)
+                    {
+                        if (template.Alpha[ty * tw + tx] == 0) continue;
+                        double di = image.Pixels[(y0 + ty) * W + (x0 + tx)] - iMean;
+                        double dt = template.Pixels[ty * tw + tx] - tMean;
+                        iVar += di * di;
+                        cov += di * dt;
+                    }
+                double iStd = Math.Sqrt(iVar);
+                field[cy, cx] = (iStd < 1e-9) ? 0.0 : cov / (iStd * tStd);
+            }
+        });
+        return field;
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~IconLikelihoodFieldBuildTests"
+```
+
+Expected: PASS — argmax within tolerance, NCC ≥ 0.8 at peak.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldBuildTests.cs
+git commit -m "feat(synthesis-probe): build per-type icon-likelihood field from screenshot deviation"
+```
+
+---
+
+### Task 5: IconLikelihoodField.Sample (bicubic)
+
+**Files:**
+- Modify: `tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldSampleTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// IconLikelihoodFieldSampleTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldSampleTests
+{
+    [Fact]
+    public void Sample_at_integer_position_returns_grid_value()
+    {
+        var field = new double[3, 3];
+        field[1, 1] = 0.7;
+        IconLikelihoodField.Sample(field, 1.0, 1.0).Should().BeApproximately(0.7, 1e-9);
+    }
+
+    [Fact]
+    public void Sample_between_grid_points_interpolates_monotonically()
+    {
+        // Linearly-rising field along x: f(x,y) = x*0.1.
+        var field = new double[3, 5];
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 5; x++)
+                field[y, x] = x * 0.1;
+
+        var s1 = IconLikelihoodField.Sample(field, 1.0, 1.0);
+        var s15 = IconLikelihoodField.Sample(field, 1.5, 1.0);
+        var s2 = IconLikelihoodField.Sample(field, 2.0, 1.0);
+
+        s15.Should().BeGreaterThan(s1);
+        s15.Should().BeLessThan(s2);
+        s15.Should().BeApproximately(0.15, 0.02);  // bicubic stays close to linear on a linear field
+    }
+
+    [Fact]
+    public void Sample_outside_field_returns_zero()
+    {
+        var field = new double[3, 3];
+        for (int y = 0; y < 3; y++) for (int x = 0; x < 3; x++) field[y, x] = 1.0;
+
+        IconLikelihoodField.Sample(field, -1.0, 1.0).Should().Be(0.0);
+        IconLikelihoodField.Sample(field, 3.5, 1.0).Should().Be(0.0);
+        IconLikelihoodField.Sample(field, 1.0, -0.5).Should().Be(0.0);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Expected: BUILD FAILURE — `Sample` method not found.
+
+- [ ] **Step 3: Implement**
+
+In `IconLikelihoodField.cs`, add:
+
+```csharp
+public static double Sample(double[,] field, double x, double y)
+{
+    int h = field.GetLength(0), w = field.GetLength(1);
+    if (x < 0 || y < 0 || x > w - 1 || y > h - 1) return 0.0;
+
+    int ix = (int)Math.Floor(x);
+    int iy = (int)Math.Floor(y);
+    double fx = x - ix;
+    double fy = y - iy;
+
+    // Cubic Hermite (Catmull-Rom-ish) over 4 samples per row, then over 4 row results.
+    double[] col = new double[4];
+    for (int j = -1; j <= 2; j++)
+    {
+        int yy = Math.Clamp(iy + j, 0, h - 1);
+        double[] row = new double[4];
+        for (int i = -1; i <= 2; i++)
+        {
+            int xx = Math.Clamp(ix + i, 0, w - 1);
+            row[i + 1] = field[yy, xx];
+        }
+        col[j + 1] = CubicHermite(row[0], row[1], row[2], row[3], fx);
+    }
+    return CubicHermite(col[0], col[1], col[2], col[3], fy);
+}
+
+private static double CubicHermite(double a, double b, double c, double d, double t)
+{
+    double a0 = -0.5 * a + 1.5 * b - 1.5 * c + 0.5 * d;
+    double a1 = a - 2.5 * b + 2.0 * c - 0.5 * d;
+    double a2 = -0.5 * a + 0.5 * c;
+    double a3 = b;
+    return ((a0 * t + a1) * t + a2) * t + a3;
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~IconLikelihoodFieldSampleTests"
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldSampleTests.cs
+git commit -m "feat(synthesis-probe): bicubic Sample over the icon-likelihood field"
+```
+
+---
+
+### Task 6: JEvaluator
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/ReferencePoint.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/JEvaluator.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/JEvaluatorTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// JEvaluatorTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class JEvaluatorTests
+{
+    [Fact]
+    public void J_is_high_when_refs_project_onto_field_peaks()
+    {
+        // Two 64x64 fields with one peak each at known crop pixels.
+        var portalField = ZerosWithPeak(64, 64, peakX: 20, peakY: 20, value: 0.95);
+        var npcField = ZerosWithPeak(64, 64, peakX: 50, peakY: 40, value: 0.92);
+        var fields = new Dictionary<string, double[,]>
+        {
+            ["Portal"] = portalField,
+            ["Npc"] = npcField,
+        };
+
+        // Two refs in world coords that land at the peaks under identity-ish transform.
+        var refs = new[]
+        {
+            new ReferencePoint("p1", "Portal", WorldX: 0, WorldZ: 0),
+            new ReferencePoint("n1", "Npc", WorldX: 30, WorldZ: -20),
+        };
+
+        // Transform: identity-ish, picking origin so world (0,0) lands at (20,20)
+        // and (30,-20) lands at (50,40). Scale = 1 px/unit, no rotation, no mirror.
+        var truth = new CandidateTransform(Scale: 1.0, RotRadians: 0.0, Mirror: false, Tx: 20.0, Ty: 20.0);
+
+        var jTruth = JEvaluator.Evaluate(truth, fields, refs);
+        jTruth.J.Should().BeGreaterThan(1.8); // sum of two ~0.9 peaks
+        jTruth.RefsAboveHalf.Should().Be(2);
+        jTruth.RefsOffCrop.Should().Be(0);
+
+        // Shift origin so refs land far off the peaks.
+        var wrong = truth with { Tx = -100.0, Ty = -100.0 };
+        var jWrong = JEvaluator.Evaluate(wrong, fields, refs);
+        jWrong.J.Should().BeLessThan(0.1);
+        jWrong.RefsOffCrop.Should().Be(2);
+    }
+
+    private static double[,] ZerosWithPeak(int w, int h, int peakX, int peakY, double value)
+    {
+        var f = new double[h, w];
+        f[peakY, peakX] = value;
+        return f;
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `JEvaluator`, `ReferencePoint`, `JResult` not found.
+
+- [ ] **Step 3: Implement ReferencePoint**
+
+```csharp
+// ReferencePoint.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal readonly record struct ReferencePoint(string Label, string LandmarkType, double WorldX, double WorldZ);
+```
+
+- [ ] **Step 4: Implement JEvaluator**
+
+```csharp
+// JEvaluator.cs
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal readonly record struct JResult(double J, int RefsAboveHalf, int RefsOffCrop, IReadOnlyList<double> PerRefScores);
+
+internal static class JEvaluator
+{
+    public static JResult Evaluate(
+        CandidateTransform t,
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs)
+    {
+        double j = 0;
+        int aboveHalf = 0;
+        int offCrop = 0;
+        var perRef = new double[refs.Count];
+
+        for (int i = 0; i < refs.Count; i++)
+        {
+            var r = refs[i];
+            if (!fieldsByType.TryGetValue(r.LandmarkType, out var field))
+            {
+                perRef[i] = 0;
+                continue;
+            }
+            var p = t.Apply(new WorldCoord(r.WorldX, 0, r.WorldZ));
+            int h = field.GetLength(0), w = field.GetLength(1);
+            if (p.X < 0 || p.Y < 0 || p.X > w - 1 || p.Y > h - 1)
+            {
+                offCrop++;
+                perRef[i] = 0;
+                continue;
+            }
+            var score = IconLikelihoodField.Sample(field, p.X, p.Y);
+            perRef[i] = score;
+            j += score;
+            if (score >= 0.5) aboveHalf++;
+        }
+
+        return new JResult(j, aboveHalf, offCrop, perRef);
+    }
+}
+```
+
+- [ ] **Step 5: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~JEvaluatorTests"
+```
+
+Expected: PASS — 1 test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/ReferencePoint.cs tools/MapCalibrationFromScreenshot/SynthesisProbe/JEvaluator.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/JEvaluatorTests.cs
+git commit -m "feat(synthesis-probe): JEvaluator sums per-ref field samples"
+```
+
+---
+
+### Task 7: SynthesisProbeWriter (CSV + field PNG + landscape PNG)
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeWriter.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeWriterTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// SynthesisProbeWriterTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class SynthesisProbeWriterTests
+{
+    [Fact]
+    public void Csv_writes_header_and_row()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-csv-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+            {
+                var t = new CandidateTransform(0.5, 0.0, false, 100, 200);
+                var jr = new JResult(J: 1.7, RefsAboveHalf: 2, RefsOffCrop: 0, PerRefScores: new[] { 0.9, 0.8 });
+                w.AppendCsvRow("E1", "truth", t, jr, dominanceVsRunnerUp: double.NaN);
+            }
+            var lines = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            lines[0].Should().Be("experiment,label,scale,rot,mirror,tx,ty,J,refs_above_0.5,dominance_vs_runner_up");
+            lines[1].Should().StartWith("E1,truth,0.5,0,false,100,200,1.7,2,");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Field_png_written_with_expected_dims()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-png-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var field = new double[10, 20];
+            field[5, 10] = 0.9;
+            w.WriteFieldPng("Portal", field);
+            File.Exists(Path.Combine(dir, "field_Portal.png")).Should().BeTrue();
+            // Just check it's a valid PNG by re-reading dimensions via System.Drawing.
+            using var img = System.Drawing.Image.FromFile(Path.Combine(dir, "field_Portal.png"));
+            img.Width.Should().Be(20);
+            img.Height.Should().Be(10);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Landscape_png_dimensions_match_input()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-land-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var landscape = new double[65, 65];
+            w.WriteLandscapePng("translation", landscape);
+            using var img = System.Drawing.Image.FromFile(Path.Combine(dir, "grid_landscape_translation.png"));
+            img.Width.Should().Be(65);
+            img.Height.Should().Be(65);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `SynthesisProbeWriter` not found.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// SynthesisProbeWriter.cs
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal sealed class SynthesisProbeWriter : IDisposable
+{
+    private readonly StreamWriter _csv;
+    private readonly string _outDir;
+
+    public SynthesisProbeWriter(string outDir)
+    {
+        Directory.CreateDirectory(outDir);
+        _outDir = outDir;
+        _csv = new StreamWriter(Path.Combine(outDir, "synthesis_probe.csv"));
+        _csv.WriteLine("experiment,label,scale,rot,mirror,tx,ty,J,refs_above_0.5,dominance_vs_runner_up");
+    }
+
+    public void AppendCsvRow(string experiment, string label, CandidateTransform t, JResult jr, double dominanceVsRunnerUp)
+    {
+        _csv.Write(experiment); _csv.Write(',');
+        _csv.Write(label); _csv.Write(',');
+        _csv.Write(t.Scale.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(t.RotRadians.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(t.Mirror ? "true" : "false"); _csv.Write(',');
+        _csv.Write(t.Tx.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(t.Ty.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(jr.J.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(jr.RefsAboveHalf.ToString(CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.WriteLine(double.IsNaN(dominanceVsRunnerUp) ? "" : dominanceVsRunnerUp.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    public void WriteFieldPng(string type, double[,] field) =>
+        WriteScalarPng(Path.Combine(_outDir, $"field_{type}.png"), field, vmin: -1.0, vmax: 1.0);
+
+    public void WriteLandscapePng(string label, double[,] landscape) =>
+        WriteScalarPng(Path.Combine(_outDir, $"grid_landscape_{label}.png"), landscape, vmin: Min(landscape), vmax: Max(landscape));
+
+    private static void WriteScalarPng(string path, double[,] field, double vmin, double vmax)
+    {
+        int h = field.GetLength(0), w = field.GetLength(1);
+        double span = (vmax - vmin) > 1e-9 ? (vmax - vmin) : 1.0;
+        using var bmp = new Bitmap(w, h, PixelFormat.Format24bppRgb);
+        var rect = new Rectangle(0, 0, w, h);
+        var data = bmp.LockBits(rect, ImageLockMode.WriteOnly, PixelFormat.Format24bppRgb);
+        try
+        {
+            int stride = data.Stride;
+            byte[] row = new byte[stride];
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    double v = (field[y, x] - vmin) / span;
+                    v = Math.Clamp(v, 0, 1);
+                    byte g = (byte)Math.Round(v * 255);
+                    row[x * 3 + 0] = g;
+                    row[x * 3 + 1] = g;
+                    row[x * 3 + 2] = g;
+                }
+                Marshal.Copy(row, 0, data.Scan0 + y * stride, stride);
+            }
+        }
+        finally { bmp.UnlockBits(data); }
+        bmp.Save(path, ImageFormat.Png);
+    }
+
+    private static double Min(double[,] f)
+    {
+        double m = double.PositiveInfinity;
+        foreach (var v in f) if (v < m) m = v;
+        return m;
+    }
+
+    private static double Max(double[,] f)
+    {
+        double m = double.NegativeInfinity;
+        foreach (var v in f) if (v > m) m = v;
+        return m;
+    }
+
+    public void Dispose() => _csv.Dispose();
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~SynthesisProbeWriterTests"
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeWriter.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeWriterTests.cs
+git commit -m "feat(synthesis-probe): CSV + field PNG + landscape PNG writers"
+```
+
+---
+
+### Task 8: SynthesisProbeTracer (OTel ActivitySource + exporters)
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeTracer.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeTracerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// SynthesisProbeTracerTests.cs
+using System.Diagnostics;
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class SynthesisProbeTracerTests
+{
+    [Fact]
+    public void ActivitySource_emits_span_when_listener_is_attached()
+    {
+        var emitted = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == SynthesisProbeTracer.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = emitted.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using (var act = SynthesisProbeTracer.Source.StartActivity("test.span"))
+        {
+            act?.SetTag("foo", "bar");
+        }
+
+        emitted.Should().ContainSingle(a => a.OperationName == "test.span");
+        emitted[0].Tags.Should().Contain(kv => kv.Key == "foo" && kv.Value == "bar");
+    }
+
+    [Fact]
+    public void No_exception_when_no_listener_attached()
+    {
+        var act = SynthesisProbeTracer.Source.StartActivity("never.listened");
+        act.Should().BeNull(); // no listener → null span, no NPE on access via `?.`
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `SynthesisProbeTracer` not found.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// SynthesisProbeTracer.cs
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class SynthesisProbeTracer
+{
+    public const string ActivitySourceName = "Mithril.Tools.MapCalibrationSynthesisProbe";
+    public static readonly ActivitySource Source = new(ActivitySourceName);
+
+    public static TracerProvider? Configure(bool traceConsole, string? otlpEndpoint)
+    {
+        if (!traceConsole && otlpEndpoint is null) return null;
+
+        var builder = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MapCalibrationSynthesisProbe"))
+            .AddSource(ActivitySourceName);
+
+        if (traceConsole) builder.AddConsoleExporter();
+        if (otlpEndpoint is not null)
+            builder.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));
+
+        return builder.Build();
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~SynthesisProbeTracerTests"
+```
+
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeTracer.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeTracerTests.cs
+git commit -m "feat(synthesis-probe): OTel ActivitySource + console/OTLP exporter selection"
+```
+
+---
+
+### Task 9: E1 (truth score) + E2 (translation sweep) + E3 (scale sweep)
+
+These three experiments all share the same fixture and writer. Grouping them keeps the plan compact without losing TDD discipline — each gets its own test, each fails before its impl lands.
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E1_TruthScore.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E2_TranslationSweep.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E3_ScaleSweep.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E1_E2_E3_Tests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// Experiments/E1_E2_E3_Tests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E1_E2_E3_Tests
+{
+    private static (IReadOnlyDictionary<string, double[,]> fields, IReadOnlyList<ReferencePoint> refs, CandidateTransform truth) SyntheticScene()
+    {
+        // 64x64 portal field with one strong peak at (20,20).
+        var portal = new double[64, 64];
+        portal[20, 20] = 0.9;
+        var refs = new[] { new ReferencePoint("p1", "Portal", WorldX: 0, WorldZ: 0) };
+        var truth = new CandidateTransform(Scale: 1.0, RotRadians: 0.0, Mirror: false, Tx: 20.0, Ty: 20.0);
+        return (new Dictionary<string, double[,]> { ["Portal"] = portal }, refs, truth);
+    }
+
+    [Fact]
+    public void E1_writes_truth_row()
+    {
+        var (fields, refs, truth) = SyntheticScene();
+        var dir = NewTempDir();
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+                E1_TruthScore.Run(fields, refs, truth, w);
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            rows.Should().Contain(r => r.StartsWith("E1,truth,"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void E2_writes_landscape_with_peak_at_truth_center()
+    {
+        var (fields, refs, truth) = SyntheticScene();
+        var dir = NewTempDir();
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+                E2_TranslationSweep.Run(fields, refs, truth, templateSizePx: 5, w);
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            rows.Where(r => r.StartsWith("E2,")).Should().NotBeEmpty();
+            File.Exists(Path.Combine(dir, "grid_landscape_translation.png")).Should().BeTrue();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void E3_writes_51_scale_rows()
+    {
+        var (fields, refs, truth) = SyntheticScene();
+        var dir = NewTempDir();
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+                E3_ScaleSweep.Run(fields, refs, truth, w);
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            rows.Count(r => r.StartsWith("E3,")).Should().Be(51);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-e123-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `E1_TruthScore`, `E2_TranslationSweep`, `E3_ScaleSweep` not found.
+
+- [ ] **Step 3: Implement E1**
+
+```csharp
+// Experiments/E1_TruthScore.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E1_TruthScore
+{
+    public static JResult Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E1");
+        var jr = JEvaluator.Evaluate(truth, fieldsByType, refs);
+        act?.SetTag("eval_count", 1);
+        act?.SetTag("J_truth", jr.J);
+        act?.SetTag("refs_above_0.5", jr.RefsAboveHalf);
+        act?.SetTag("refs_off_crop", jr.RefsOffCrop);
+        writer.AppendCsvRow("E1", "truth", truth, jr, dominanceVsRunnerUp: double.NaN);
+        return jr;
+    }
+}
+```
+
+- [ ] **Step 4: Implement E2**
+
+```csharp
+// Experiments/E2_TranslationSweep.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E2_TranslationSweep
+{
+    public static void Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        int templateSizePx,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E2");
+        int halfWindow = 2 * templateSizePx;
+        int side = halfWindow * 2 + 1;
+        var landscape = new double[side, side];
+
+        double jBest = double.NegativeInfinity;
+        int evals = 0;
+        for (int dy = -halfWindow; dy <= halfWindow; dy++)
+            for (int dx = -halfWindow; dx <= halfWindow; dx++)
+            {
+                var t = truth with { Tx = truth.Tx + dx, Ty = truth.Ty + dy };
+                var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+                landscape[dy + halfWindow, dx + halfWindow] = jr.J;
+                if (jr.J > jBest) jBest = jr.J;
+                evals++;
+                if (evals % 100 == 0)
+                    writer.AppendCsvRow("E2", $"dx={dx},dy={dy}", t, jr, dominanceVsRunnerUp: double.NaN);
+            }
+        writer.WriteLandscapePng("translation", landscape);
+
+        act?.SetTag("eval_count", evals);
+        act?.SetTag("J_best", jBest);
+        act?.SetTag("window_px", halfWindow);
+    }
+}
+```
+
+> **Note:** every 100th row is written to keep the CSV readable; the full landscape lives in the PNG. Adjust the stride if you want denser CSV coverage.
+
+- [ ] **Step 5: Implement E3**
+
+```csharp
+// Experiments/E3_ScaleSweep.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E3_ScaleSweep
+{
+    public static void Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E3");
+        double jBest = double.NegativeInfinity;
+        int evals = 0;
+        // -25% .. +25% in 1% steps = 51 samples.
+        for (int pct = -25; pct <= 25; pct++)
+        {
+            double factor = 1.0 + pct / 100.0;
+            var t = truth with { Scale = truth.Scale * factor };
+            var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+            writer.AppendCsvRow("E3", $"pct={pct}", t, jr, dominanceVsRunnerUp: double.NaN);
+            if (jr.J > jBest) jBest = jr.J;
+            evals++;
+        }
+        act?.SetTag("eval_count", evals);
+        act?.SetTag("J_best", jBest);
+    }
+}
+```
+
+- [ ] **Step 6: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~E1_E2_E3_Tests"
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/ tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/
+git commit -m "feat(synthesis-probe): experiments E1 (truth), E2 (translation sweep), E3 (scale sweep)"
+```
+
+---
+
+### Task 10: RansacSeedsCsv reader + E4 (RANSAC seed score)
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/RansacSeedsCsv.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E4_RansacSeedScore.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E4_RansacSeedScoreTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// Experiments/E4_RansacSeedScoreTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E4_RansacSeedScoreTests
+{
+    [Fact]
+    public void Reads_csv_and_scores_each_seed_with_dominance()
+    {
+        var portal = new double[64, 64];
+        portal[20, 20] = 0.9;
+        var fields = new Dictionary<string, double[,]> { ["Portal"] = portal };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var truth = new CandidateTransform(1.0, 0.0, false, 20, 20);
+
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-e4-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var csv = Path.Combine(dir, "seeds.csv");
+            File.WriteAllLines(csv, new[]
+            {
+                "label,scale,rot,ox,oy,mirror",
+                "near_truth,1.0,0.0,21,21,false",
+                "far_off,1.0,0.0,-100,-100,false",
+            });
+
+            using (var w = new SynthesisProbeWriter(dir))
+                E4_RansacSeedScore.Run(fields, refs, truth, csv, w);
+
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv")).Where(r => r.StartsWith("E4,")).ToList();
+            rows.Should().HaveCount(2);
+            // The "near_truth" row scores nonzero; "far_off" scores ~0.
+            var nearRow = rows.Single(r => r.Contains(",near_truth,"));
+            var farRow = rows.Single(r => r.Contains(",far_off,"));
+            // J column is the 8th comma-separated (idx 7).
+            double JOf(string row) => double.Parse(row.Split(',')[7], System.Globalization.CultureInfo.InvariantCulture);
+            JOf(nearRow).Should().BeGreaterThan(JOf(farRow));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `RansacSeedsCsv`, `E4_RansacSeedScore` not found.
+
+- [ ] **Step 3: Implement RansacSeedsCsv**
+
+```csharp
+// RansacSeedsCsv.cs
+using System.Globalization;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class RansacSeedsCsv
+{
+    public static List<(string Label, CandidateTransform T)> Read(string path)
+    {
+        var rows = new List<(string, CandidateTransform)>();
+        foreach (var line in File.ReadAllLines(path).Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var parts = line.Split(',', 6);
+            if (parts.Length != 6) throw new FormatException($"bad row '{line}' (want label,scale,rot,ox,oy,mirror)");
+            rows.Add((parts[0],
+                new CandidateTransform(
+                    double.Parse(parts[1], CultureInfo.InvariantCulture),
+                    double.Parse(parts[2], CultureInfo.InvariantCulture),
+                    bool.Parse(parts[5]),
+                    double.Parse(parts[3], CultureInfo.InvariantCulture),
+                    double.Parse(parts[4], CultureInfo.InvariantCulture))));
+        }
+        return rows;
+    }
+}
+```
+
+- [ ] **Step 4: Implement E4**
+
+```csharp
+// Experiments/E4_RansacSeedScore.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E4_RansacSeedScore
+{
+    public static void Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        string csvPath,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E4");
+        var seeds = RansacSeedsCsv.Read(csvPath);
+        var jTruth = JEvaluator.Evaluate(truth, fieldsByType, refs);
+        double jMaxSeed = double.NegativeInfinity;
+        foreach (var (_, t) in seeds)
+        {
+            var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+            if (jr.J > jMaxSeed) jMaxSeed = jr.J;
+        }
+        foreach (var (label, t) in seeds)
+        {
+            var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+            double dominance = jMaxSeed > 0 ? jr.J / jMaxSeed : double.NaN;
+            writer.AppendCsvRow("E4", label, t, jr, dominance);
+        }
+        act?.SetTag("eval_count", seeds.Count);
+        act?.SetTag("J_truth", jTruth.J);
+        act?.SetTag("J_max_seed", jMaxSeed);
+        act?.SetTag("dominance", jMaxSeed > 0 ? jTruth.J / jMaxSeed : double.NaN);
+    }
+}
+```
+
+- [ ] **Step 5: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~E4_RansacSeedScoreTests"
+```
+
+Expected: PASS — 1 test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/RansacSeedsCsv.cs tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E4_RansacSeedScore.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E4_RansacSeedScoreTests.cs
+git commit -m "feat(synthesis-probe): E4 scores --ransac-seeds-csv candidates against truth"
+```
+
+---
+
+### Task 11: LocalRefine (gradient ascent on bicubic field)
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/LocalRefine.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/LocalRefineTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// LocalRefineTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class LocalRefineTests
+{
+    [Fact]
+    public void Pulls_in_from_5px_offset_on_gaussian_peak()
+    {
+        // 64x64 field with a smooth gaussian peak at (32,32), sigma=3.
+        int W = 64, H = 64;
+        var f = new double[H, W];
+        for (int y = 0; y < H; y++)
+            for (int x = 0; x < W; x++)
+            {
+                double dx = x - 32, dy = y - 32;
+                f[y, x] = Math.Exp(-(dx * dx + dy * dy) / (2 * 3.0 * 3.0));
+            }
+        var fields = new Dictionary<string, double[,]> { ["Portal"] = f };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var seed = new CandidateTransform(Scale: 1.0, RotRadians: 0.0, Mirror: false, Tx: 27.0, Ty: 32.0); // 5 px off in x
+
+        var refined = LocalRefine.Run(seed, fields, refs, maxIter: 60, stepInit: 1.0);
+
+        refined.Tx.Should().BeApproximately(32.0, 0.5);
+        refined.Ty.Should().BeApproximately(32.0, 0.5);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `LocalRefine` not found.
+
+- [ ] **Step 3: Implement (coordinate-descent ascent on Tx/Ty/Scale)**
+
+```csharp
+// LocalRefine.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class LocalRefine
+{
+    /// <summary>
+    /// Hill-climbing ascent on (Tx, Ty, Scale). Uses adaptive step-halving:
+    /// at each iteration tries +step in each axis, takes the move with the
+    /// best J; halves the step when no axis improves. Holds Rot and Mirror fixed
+    /// (those are discrete branches at the grid level).
+    /// </summary>
+    public static CandidateTransform Run(
+        CandidateTransform seed,
+        IReadOnlyDictionary<string, double[,]> fields,
+        IReadOnlyList<ReferencePoint> refs,
+        int maxIter,
+        double stepInit)
+    {
+        var t = seed;
+        double bestJ = JEvaluator.Evaluate(t, fields, refs).J;
+        double stepXY = stepInit;
+        double stepScale = stepInit * Math.Max(1e-6, seed.Scale) * 0.01;
+
+        for (int iter = 0; iter < maxIter; iter++)
+        {
+            var candidates = new (CandidateTransform T, double J)[]
+            {
+                (t with { Tx = t.Tx + stepXY }, 0),
+                (t with { Tx = t.Tx - stepXY }, 0),
+                (t with { Ty = t.Ty + stepXY }, 0),
+                (t with { Ty = t.Ty - stepXY }, 0),
+                (t with { Scale = t.Scale + stepScale }, 0),
+                (t with { Scale = Math.Max(1e-6, t.Scale - stepScale) }, 0),
+            };
+            int bestI = -1;
+            double newBest = bestJ;
+            for (int i = 0; i < candidates.Length; i++)
+            {
+                var j = JEvaluator.Evaluate(candidates[i].T, fields, refs).J;
+                candidates[i] = (candidates[i].T, j);
+                if (j > newBest) { newBest = j; bestI = i; }
+            }
+            if (bestI < 0)
+            {
+                stepXY *= 0.5;
+                stepScale *= 0.5;
+                if (stepXY < 0.01 && stepScale < 1e-6) break;
+            }
+            else
+            {
+                t = candidates[bestI].T;
+                bestJ = newBest;
+            }
+        }
+        return t;
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~LocalRefineTests"
+```
+
+Expected: PASS — refined Tx within 0.5 px of 32.0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/LocalRefine.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/LocalRefineTests.cs
+git commit -m "feat(synthesis-probe): LocalRefine hill-climbing ascent on (Tx, Ty, Scale)"
+```
+
+---
+
+### Task 12: E5 (cold grid + top-8 refine)
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGridTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// Experiments/E5_ColdGridTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E5_ColdGridTests
+{
+    [Fact]
+    public void Top8_includes_a_near_truth_entry_after_refine()
+    {
+        // 128x128 portal field with a sharp peak at (64,64).
+        var f = new double[128, 128];
+        for (int y = 0; y < 128; y++)
+            for (int x = 0; x < 128; x++)
+            {
+                double dx = x - 64, dy = y - 64;
+                f[y, x] = Math.Exp(-(dx * dx + dy * dy) / (2 * 3.0 * 3.0));
+            }
+        var fields = new Dictionary<string, double[,]> { ["Portal"] = f };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var truth = new CandidateTransform(1.0, 0.0, false, 64, 64);
+
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-e5-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var report = E5_ColdGrid.Run(
+                fields, refs, truth,
+                scaleBracket: (0.5, 2.0),
+                scaleSamples: 8,
+                cropWidth: 128, cropHeight: 128,
+                gridStepPx: 8,
+                templateSizePx: 5,
+                writer: w);
+            report.BestDistanceToTruthPx.Should().BeLessThan(5.0);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `E5_ColdGrid` not found.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// Experiments/E5_ColdGrid.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal sealed record E5Report(double BestDistanceToTruthPx, double JBestAfterRefine, IReadOnlyList<(CandidateTransform T, double J, double DistanceToTruth)> Top8AfterRefine);
+
+internal static class E5_ColdGrid
+{
+    public static E5Report Run(
+        IReadOnlyDictionary<string, double[,]> fields,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        (double Min, double Max) scaleBracket,
+        int scaleSamples,
+        int cropWidth, int cropHeight,
+        int gridStepPx,
+        int templateSizePx,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E5");
+        var rots = new[] { 0.0, Math.PI };
+        var mirrors = new[] { false, true };
+
+        var scales = new double[scaleSamples];
+        for (int i = 0; i < scaleSamples; i++)
+        {
+            double frac = (double)i / (scaleSamples - 1);
+            scales[i] = scaleBracket.Min * Math.Pow(scaleBracket.Max / scaleBracket.Min, frac);
+        }
+
+        var raw = new List<(CandidateTransform T, double J)>(capacity: 4096);
+        int evals = 0;
+        foreach (var mirror in mirrors)
+            foreach (var rot in rots)
+                foreach (var scale in scales)
+                    for (int ty = gridStepPx / 2; ty < cropHeight; ty += gridStepPx)
+                        for (int tx = gridStepPx / 2; tx < cropWidth; tx += gridStepPx)
+                        {
+                            var t = new CandidateTransform(scale, rot, mirror, tx, ty);
+                            var j = JEvaluator.Evaluate(t, fields, refs).J;
+                            raw.Add((t, j));
+                            evals++;
+                        }
+
+        var top8 = raw.OrderByDescending(p => p.J).Take(8).ToArray();
+
+        var refined = new List<(CandidateTransform T, double J, double Distance)>();
+        foreach (var (t, _) in top8)
+        {
+            var rt = LocalRefine.Run(t, fields, refs, maxIter: 60, stepInit: gridStepPx);
+            var rj = JEvaluator.Evaluate(rt, fields, refs).J;
+            double dx = rt.Tx - truth.Tx, dy = rt.Ty - truth.Ty;
+            double dist = Math.Sqrt(dx * dx + dy * dy);
+            refined.Add((rt, rj, dist));
+            writer.AppendCsvRow("E5", $"refined_J={rj:0.000}", rt, JEvaluator.Evaluate(rt, fields, refs), dominanceVsRunnerUp: double.NaN);
+        }
+
+        double bestDist = refined.Min(x => x.Distance);
+        double bestJ = refined.Max(x => x.J);
+        act?.SetTag("eval_count", evals);
+        act?.SetTag("J_best_after_refine", bestJ);
+        act?.SetTag("truth_in_topk", bestDist <= 5.0);
+        act?.SetTag("best_distance_px", bestDist);
+
+        return new E5Report(bestDist, bestJ, refined);
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~E5_ColdGridTests"
+```
+
+Expected: PASS — `BestDistanceToTruthPx < 5`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGridTests.cs
+git commit -m "feat(synthesis-probe): E5 cold grid + top-8 refine + distance-to-truth report"
+```
+
+---
+
+### Task 13: ProbeReferences loader (area refs → typed ReferencePoint list)
+
+The probe needs the same 38 refs the production solver uses. The existing tool already has `LandmarksReader` and `NpcsReader` (in `Mithril.MapCalibration.Tools.Common`). We just need to map them into `ReferencePoint` with the right `LandmarkType` strings.
+
+**Files:**
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/ProbeReferences.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ProbeReferencesTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// ProbeReferencesTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class ProbeReferencesTests
+{
+    [Fact]
+    public void Loads_eltibule_refs_with_canonical_types()
+    {
+        // Use the same default paths the existing tool resolves.
+        var landmarks = ProbeReferences.DefaultLandmarksPath();
+        var npcs = ProbeReferences.DefaultNpcsPath();
+        var refs = ProbeReferences.Load(landmarks, npcs, area: "AreaEltibule");
+
+        refs.Should().NotBeEmpty();
+        refs.Select(r => r.LandmarkType).Distinct().Should().BeSubsetOf(new[]
+        {
+            "Portal", "MeditationPillar", "TeleportationPlatform", "Npc",
+        });
+        // From the handoff: Eltibule has 38 refs.
+        refs.Should().HaveCount(38);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Expected: BUILD FAILURE — `ProbeReferences` not found.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// ProbeReferences.cs
+using Mithril.Tools.MapCalibration.Common;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class ProbeReferences
+{
+    public static IReadOnlyList<ReferencePoint> Load(string landmarksJson, string npcsJson, string area)
+    {
+        var result = new List<ReferencePoint>();
+        foreach (var l in LandmarksReader.ReadForArea(landmarksJson, area))
+        {
+            // LandmarksReader yields entries with Type already canonicalized to
+            // Portal / MeditationPillar / TeleportationPlatform (the 3 non-Npc types).
+            result.Add(new ReferencePoint(l.Name, l.Type, l.X, l.Z));
+        }
+        foreach (var n in NpcsReader.ReadForArea(npcsJson, area))
+        {
+            result.Add(new ReferencePoint(n.Name, "Npc", n.X, n.Z));
+        }
+        return result;
+    }
+
+    public static string DefaultLandmarksPath() => RepoPaths.LandmarksJson();
+    public static string DefaultNpcsPath() => RepoPaths.NpcsJson();
+}
+```
+
+> **Note:** if `LandmarksReader.ReadForArea` / `NpcsReader.ReadForArea` have different signatures (return shape, property names), adapt the call sites — the tests-common reader is the source of truth. Same for `RepoPaths`. Verify by reading those files in `tools/Mithril.MapCalibration.Tools.Common/`.
+
+- [ ] **Step 4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~ProbeReferencesTests"
+```
+
+Expected: PASS — 38 refs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/ProbeReferences.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ProbeReferencesTests.cs
+git commit -m "feat(synthesis-probe): load area refs with canonical landmark types"
+```
+
+---
+
+### Task 14: SynthesisProbePhase end-to-end wiring
+
+This task replaces the stub from Task 1 with the real entry point.
+
+**Files:**
+- Modify: `tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs`
+
+- [ ] **Step 1: Write the wiring**
+
+```csharp
+// SynthesisProbePhase.cs (replacing the stub)
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class SynthesisProbePhase
+{
+    public static int Run(CliArgs args)
+    {
+        if (args.TruthCal is null)
+        {
+            Console.Error.WriteLine("--truth-cal required for --phase synthesis-probe");
+            return 2;
+        }
+        if (string.IsNullOrEmpty(args.ScreenshotPath))
+        {
+            Console.Error.WriteLine("--screenshot required for --phase synthesis-probe");
+            return 2;
+        }
+        if (args.MapRect is null)
+        {
+            Console.Error.WriteLine("--map-rect required for --phase synthesis-probe (auto-detect is not reliable enough for the diagnostic)");
+            return 2;
+        }
+
+        using var tracer = SynthesisProbeTracer.Configure(args.TraceConsole, args.OtlpEndpoint);
+        using var rootSpan = SynthesisProbeTracer.Source.StartActivity("probe.attempt");
+        rootSpan?.SetTag("area", args.Area);
+        rootSpan?.SetTag("screenshot", args.ScreenshotPath);
+
+        var truth = new CandidateTransform(
+            Scale: args.TruthCal.Value.Scale,
+            RotRadians: args.TruthCal.Value.Rot,
+            Mirror: args.TruthCal.Value.Mirror,
+            Tx: args.TruthCal.Value.Ox,
+            Ty: args.TruthCal.Value.Oy);
+        rootSpan?.SetTag("truth.scale", truth.Scale);
+        rootSpan?.SetTag("truth.rot", truth.RotRadians);
+        rootSpan?.SetTag("truth.mirror", truth.Mirror);
+
+        // Load screenshot + aligned base + templates.
+        var screenshot = ImageIo.LoadGray(args.ScreenshotPath);
+        var (mx, my, mw, mh) = args.MapRect.Value;
+        var screenshotCrop = ImageIo.CropGray(screenshot, mx, my, mw, mh);
+        rootSpan?.SetTag("crop.w", mw);
+        rootSpan?.SetTag("crop.h", mh);
+
+        var pgInstall = SteamInstall.FindPgInstall();
+        var mapDir = args.MapDir ?? Path.Combine(Path.GetTempPath(), "mithril-852", "maps");
+        var mapPng = MapTextureExtractor.EnsureExtracted(pgInstall, mapDir, args.Area);
+        var baseTexture = ImageIo.LoadGray(mapPng);
+        var alignedBase = ImageIo.BilinearResize(baseTexture, mw, mh);
+
+        var iconsDir = args.IconsDir ?? Path.Combine(Path.GetTempPath(), "mithril-852", "icons");
+        var tpkPath = args.TpkPath ?? Path.Combine(AppContext.BaseDirectory, "classdata.tpk");
+        IconTemplateExtractor.EnsureExtracted(pgInstall, iconsDir, tpkPath);
+        var templates = IconTemplateExtractor.LoadAll(iconsDir, renderSizePx: args.IconRenderSize > 0 ? args.IconRenderSize : 16);
+
+        var fieldsByType = new Dictionary<string, double[,]>();
+        foreach (var template in templates)
+        {
+            using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
+            fieldSpan?.SetTag("template.type", template.LandmarkType);
+            fieldSpan?.SetTag("template.size_px", template.Width);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            fieldsByType[template.LandmarkType] = IconLikelihoodField.Build(screenshotCrop, alignedBase, template);
+            fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
+        }
+
+        var refs = ProbeReferences.Load(
+            args.LandmarksPath ?? ProbeReferences.DefaultLandmarksPath(),
+            args.NpcsPath ?? ProbeReferences.DefaultNpcsPath(),
+            args.Area);
+
+        var outDir = Path.Combine(RepoPaths.RepoRoot(), "study", "synthesis-probe", args.Area);
+        using var writer = new SynthesisProbeWriter(outDir);
+
+        foreach (var (type, field) in fieldsByType) writer.WriteFieldPng(type, field);
+
+        E1_TruthScore.Run(fieldsByType, refs, truth, writer);
+        E2_TranslationSweep.Run(fieldsByType, refs, truth, templateSizePx: 16, writer);
+        E3_ScaleSweep.Run(fieldsByType, refs, truth, writer);
+
+        if (!string.IsNullOrEmpty(args.RansacSeedsCsvPath))
+            E4_RansacSeedScore.Run(fieldsByType, refs, truth, args.RansacSeedsCsvPath, writer);
+
+        E5_ColdGrid.Run(fieldsByType, refs, truth,
+            scaleBracket: (0.1, 2.0),
+            scaleSamples: 16,
+            cropWidth: mw,
+            cropHeight: mh,
+            gridStepPx: 16,
+            templateSizePx: 16,
+            writer);
+
+        Console.WriteLine($"[synthesis-probe] artifacts written to {outDir}");
+        return 0;
+    }
+}
+```
+
+> **Note:** `ImageIo.CropGray` and `ImageIo.BilinearResize` may need to be added to `Mithril.MapCalibration.Tools.Common/ImageIo.cs` if they don't exist. If they don't, add them as small BCL-only helpers — they're straightforward (slice the byte array; bilinear resample). Treat that as part of Task 14.
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build tools/MapCalibrationFromScreenshot -c Release
+```
+
+Expected: BUILD SUCCESS. Any compile errors → fix; if a method is missing on `ImageIo`/`IconTemplateExtractor`, add a small BCL-only helper in `tools/Mithril.MapCalibration.Tools.Common/`.
+
+- [ ] **Step 3: Run all tests to confirm no regression**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release
+```
+
+Expected: PASS — all tests previously green stay green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs tools/Mithril.MapCalibration.Tools.Common/ImageIo.cs
+git commit -m "feat(synthesis-probe): wire E1-E5 into --phase synthesis-probe end-to-end"
+```
+
+---
+
+### Task 15: Frame 2 smoke run (positive control)
+
+Manual diagnostic run, no new code.
+
+**Files:** none new.
+
+- [ ] **Step 1: Locate Frame 2 fixture + its truth calibration**
+
+Fixture: `tests/Mithril.MapCalibration.Harness.Tests/Fixtures/eltibule-frame2-accepted-7.61px.gray.png`
+
+The truth `AreaCalibration` for this frame is what production accepts today (residual 7.61 px). Look it up in `src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json` under the `AreaEltibule` key, or run the existing `--phase full` on the same fixture and read off the recovered calibration.
+
+- [ ] **Step 2: Get the map-rect for Frame 2**
+
+The fixture is the cropped post-ECC frame — its map-rect is `0,0,W,H` where W,H are the fixture's pixel dimensions. Read with:
+
+```bash
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- --phase extract-map --area AreaEltibule
+```
+
+(populates the base-texture cache so the probe can read it).
+
+- [ ] **Step 3: Run the probe**
+
+```bash
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
+  --phase synthesis-probe `
+  --area AreaEltibule `
+  --screenshot tests/Mithril.MapCalibration.Harness.Tests/Fixtures/eltibule-frame2-accepted-7.61px.gray.png `
+  --map-rect 0,0,<W>,<H> `
+  --truth-cal <scale>,<rot>,<ox>,<oy>,<mirror> `
+  --trace-console
+```
+
+Replace `<W>`, `<H>` with the fixture pixel dimensions and `<scale>,<rot>,<ox>,<oy>,<mirror>` with Frame 2's truth.
+
+- [ ] **Step 4: Inspect artifacts**
+
+Open `study/synthesis-probe/AreaEltibule/`:
+
+- `field_*.png` — should look like an empty grayscale with bright dots at icon positions.
+- `synthesis_probe.csv` — E1's row should show high `J` and high `refs_above_0.5`.
+- `grid_landscape_translation.png` — should show a single bright peak at the center.
+
+Spot-check that E5's `truth_in_topk` is `true` in the OTel console output. If Frame 2 fails any of these, the probe itself is broken — do not proceed to Frame 1 until fixed.
+
+- [ ] **Step 5: Commit the Frame 2 artifacts under study/ (optional)**
+
+`study/` is gitignored — these are local-only. No commit step here unless we want to start tracking probe outputs (we don't, per spec out-of-scope).
+
+---
+
+### Task 16: Frame 1 diagnostic run (the decision data)
+
+Manual diagnostic run, no new code.
+
+**Files:** none new.
+
+- [ ] **Step 1: Locate Frame 1 fixture + its truth calibration**
+
+Fixture: `tests/Mithril.MapCalibration.Harness.Tests/Fixtures/eltibule-frame1-rejected-3inliers.gray.png`.
+
+Truth calibration: per the handoff doc, the offline tool's 16-inlier / 1.31 px solve produced it. Run that solve once on Frame 1 to recover the truth, OR look up the value in the harness's `Registration_search_reproduces_ground_truth` test which encodes it.
+
+- [ ] **Step 2: Run the probe**
+
+```bash
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
+  --phase synthesis-probe `
+  --area AreaEltibule `
+  --screenshot tests/Mithril.MapCalibration.Harness.Tests/Fixtures/eltibule-frame1-rejected-3inliers.gray.png `
+  --map-rect 0,0,<W>,<H> `
+  --truth-cal <frame1 truth> `
+  --trace-console
+```
+
+(If you have a CSV of Frame 1's RANSAC candidates from a previous diagnostic run, also pass `--ransac-seeds-csv <path>` to drive E4.)
+
+- [ ] **Step 3: Analyze**
+
+Open `synthesis_probe.csv` and the landscape PNGs. Apply the decision rules from the spec's §"Decision criteria":
+
+- E1 high + E2/E3 sharp peaks + E5 top-8 contains a ≤5 px-of-truth entry → **Proposal A** (cold synthesis solver).
+- E1 high + E2/E3 sharp peaks + E5 misses, but E4 has a near-truth RANSAC seed → **Proposal B** (hybrid).
+- Otherwise → neither proposal ships; investigate why the field isn't informative.
+
+- [ ] **Step 4: Record the decision in the spec doc**
+
+Edit `docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md`, append a "Result" section under `## Decision criteria` with the actual numbers measured + the A-vs-B-vs-neither verdict. Commit:
+
+```bash
+git add docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
+git commit -m "docs(synthesis-probe): record Frame 1 diagnostic result + architecture verdict"
+```
+
+---
+
+### Task 17: README update
+
+**Files:**
+- Modify: `tools/MapCalibrationFromScreenshot/README.md`
+
+- [ ] **Step 1: Add a section for the new phase**
+
+Append (just before the "Out of scope (v1)" section):
+
+````markdown
+## `--phase synthesis-probe` — icon-likelihood-field diagnostic
+
+Standalone experiment runner that scores the synthesis objective `J(T) = Σ L_{type(r)}(T·r)` across five experiments on a given screenshot. Output is a CSV + per-type field PNGs + a translation landscape PNG, plus OTel spans. The data decides which of two production-solver proposals to build (cold synthesis vs. RANSAC-seeded hybrid). See [`docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md`](../../docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md).
+
+```powershell
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
+  --phase synthesis-probe `
+  --area AreaEltibule `
+  --screenshot path/to/screenshot.png `
+  --map-rect x,y,w,h `
+  --truth-cal scale,rot,ox,oy,mirror `
+  --trace-console
+```
+
+Artifacts are written to `study/synthesis-probe/<area>/`.
+
+Flags specific to this phase: `--truth-cal`, `--ransac-seeds-csv`, `--trace-console`, `--otlp`. The full flag table near the top of this README documents each.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/README.md
+git commit -m "docs(synthesis-probe): document --phase synthesis-probe in tool README"
+```
+
+---
+
+## Self-Review Notes
+
+(Run after writing the plan; record findings inline above.)
+
+**Spec coverage:** Each spec section maps to at least one task —
+- §"The math" → Tasks 4, 5
+- §"Tool surface" → Task 1, 3, 17
+- §"Outputs" → Tasks 7, 14
+- §"Experiments E1–E5" → Tasks 9, 10, 12, 14
+- §"OTel instrumentation" → Task 8, 14
+- §"Decision criteria" → Task 16
+- §"Out of scope" — implicit; no task creates production code.
+- §"Open questions / Verification owed" — partially deferred to Task 16's analysis step (truth re-derivation noted as open in the spec; not a blocker for v0 since we proceed with the tool's existing 16-inlier solve).
+
+**Type consistency:** `CandidateTransform.Apply` is used in `JEvaluator` (Task 6), `LocalRefine` (Task 11), `E5_ColdGrid` (Task 12), and `SynthesisProbePhase` (Task 14). `ReferencePoint.LandmarkType` is a `string` matching the four canonical types declared in `CanonicalLandmarkTypes` ([src/Mithril.MapCalibration/Detection/CanonicalLandmarkTypes.cs](../../../../../../../src/Mithril.MapCalibration/Detection/CanonicalLandmarkTypes.cs)); confirm at Task 13 implementation time that `LandmarksReader.ReadForArea`'s `Type` property is already in that vocabulary (per CLAUDE.md memory `map_calibration_engine_914_plan`/handoff §"#974", it is).
+
+**Placeholders:** none.
+
+---
+
+## Execution Handoff (to be performed after plan acceptance)
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-01-synthesis-probe-diagnostic.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Choose at execution time.

--- a/docs/superpowers/plans/2026-06-02-synthesis-probe-bundle-consumption.md
+++ b/docs/superpowers/plans/2026-06-02-synthesis-probe-bundle-consumption.md
@@ -1,0 +1,1302 @@
+# Synthesis-Probe Bundle Consumption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the synthesis-probe diagnostic (`tools/MapCalibrationFromScreenshot`) to consume the per-attempt calibration diagnostic bundles produced by Mithril's live engine after PR #985. Specifically: read `04-maprect.json` for the texture↔aligned-pair transform, `11-recovered-cal.json` for the production-recovered truth `AreaCalibration`, and `07-deviation.png` for the post-ECC deviation map; derive a screenshot-crop-space `CandidateTransform` for truth-cal; and tighten E5's scale bracket using the MapRect's resize ratio so the tiny-scale degeneracy is excluded by construction.
+
+**Architecture:** Six additive CLI flags (`--bundle-dir`, `--maprect-json`, `--recovered-cal-json`, `--aligned-deviation`, `--detections-json`, `--hand-truth-cal`); a `BundleLoader` that resolves a directory into the typed JSON DTOs (replicas of `Mithril.MapCalibration.Capture.Diagnostics.CalibrationBundleJson` — the tool stays decoupled from the WPF-flavored Capture project); a `CandidateTransform.FromRecoveredCalibration(RecoveredCalibrationJson, MapRect)` converter that handles texture-pixel → aligned-pair-pixel conversion; an `IconLikelihoodField.LoadDeviationAsField` alternate to `Build` that skips the screenshot-minus-base subtraction when the live engine has already produced the deviation; and an E5 scale-bracket function that narrows the search to `±20%` around the MapRect-implied scale. The existing `--screenshot`/`--map-rect`/`--truth-cal` paths remain — bundle consumption is opt-in.
+
+**Truth-cal precedence in `SynthesisProbePhase`** (highest priority first):
+
+1. `--truth-cal scale,rot,ox,oy,mirror` — explicit, **crop-pixel space** (used for synthetic tests and legacy probe runs). Wins outright.
+2. `--hand-truth-cal scale,rot,ox,oy,mirror` — explicit, **texture-pixel space**. Converted to crop-pixel via `MapRectConversion.FromRecoveredCalibration` using `--maprect-json` (or the MapRect resolved from `--bundle-dir`). Used when production's `--recovered-cal-json` is known-wrong (e.g. 2026-06-02 captures: the live engine accepts 4-inlier fits at residual ≈4 px that are geometrically wrong, so the user supplies the hand-verified texture-space cal — typically the `src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json` entry for the area).
+3. `--recovered-cal-json` (auto from `--bundle-dir` or explicit) + `--maprect-json` — converted via the same path as `--hand-truth-cal`. Used when production's recovered cal is trustworthy.
+4. Error: no truth-cal source → exit 2.
+
+**Tech Stack:** .NET 10 / net10.0-windows, xunit + FluentAssertions, source-generated JSON contexts (System.Text.Json), existing tool primitives (`CandidateTransform`, `JEvaluator`, `IconLikelihoodField`, `SynthesisProbeWriter`, `SynthesisProbeTracer`).
+
+**Context:** This plan executes on `claude/synthesis-probe-impl` (already rebased onto merged main at `d0d7f192`, 29/29 tests passing). Spec: [`docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md`](../specs/2026-06-01-synthesis-probe-diagnostic-design.md) plus its "Results & open questions" section that motivated the bundle work. PR #985's design spec: [`docs/superpowers/specs/2026-06-01-calibration-diagnostic-bundle-design.md`](../specs/2026-06-01-calibration-diagnostic-bundle-design.md) (now on `main`).
+
+**Task blocking:** Three task blocks, each one subagent dispatch:
+
+- **Task 1** — Bundle data layer (DTOs + Converter + Loader). All in new `SynthesisProbe/Bundle/` namespace.
+- **Task 2** — Probe consumers + CLI surface (alternate `IconLikelihoodField` entry point + five new CLI flags).
+- **Task 3** — Integration + E5 bracket + README (the wiring that ties it all together, plus the tightened scale bracket, plus the doc update).
+
+---
+
+## File Structure
+
+### New files (tool project, `tools/MapCalibrationFromScreenshot/`)
+
+| File | Responsibility |
+|---|---|
+| `SynthesisProbe/Bundle/BundleJsonDtos.cs` | Replicates the bundle's JSON DTOs (`AttemptJson`, `AttemptFilesJson`, `MapRectJson`, `RecoveredCalibrationJson`, `InlierJson`, `DetectionsJson`, `DetectionJson`) with a source-generated `JsonSerializerContext`. The tool needs to deserialize bundle artifacts but doesn't take a project reference on `Mithril.MapCalibration.Capture` (which is WPF-flavored). Shape parity is enforced by a round-trip test. |
+| `SynthesisProbe/Bundle/LoadedBundle.cs` | Plain record carrying `AttemptJson Attempt`, `MapRectJson? MapRect`, `RecoveredCalibrationJson? RecoveredCal`, `DetectionsJson? Detections`, `string? DeviationPath`. Optional fields are null when the corresponding bundle file isn't present (e.g. `RecoveredCalibration` is null on rejected attempts). |
+| `SynthesisProbe/Bundle/BundleLoader.cs` | Resolves a bundle directory: reads `01-attempt.json` to discover file names, then deserializes each typed JSON + opens the deviation PNG. Exposes `BundleLoader.Open(string dir) → LoadedBundle`. |
+| `SynthesisProbe/Bundle/MapRectConversion.cs` | Holds `CandidateTransform FromRecoveredCalibration(RecoveredCalibrationJson cal, MapRect mapRect, out double anisotropyPercent)` (+ overload without the out-param). Translates a production-recovered `AreaCalibration` (texture-pixel space) to the aligned-pair-pixel space the synthesis probe scores in. |
+
+### Modified files (tool project, `tools/MapCalibrationFromScreenshot/`)
+
+- `CliArgs.cs` — add `BundleDir`, `MapRectJsonPath`, `RecoveredCalJsonPath`, `AlignedDeviationPath`, `DetectionsJsonPath`, and `HandTruthCal` fields, parsers, help text.
+- `SynthesisProbe/IconLikelihoodField.cs` — add `LoadDeviationAsField(GrayImage deviation, IconTemplate template)` static method that skips the screenshot-minus-base step and runs `ScoreAll` directly on the supplied deviation.
+- `SynthesisProbe/SynthesisProbePhase.cs` — branch on `--bundle-dir` / `--aligned-deviation`: if a deviation is provided directly, skip the auto-load + screenshot-minus-base step. If `--bundle-dir` and `--recovered-cal-json` are both present, derive truth-cal automatically. The legacy `--screenshot` + `--map-rect` + `--truth-cal` path stays for synthetic tests.
+- `SynthesisProbe/Experiments/E5_ColdGrid.cs` — narrow `scaleBracket` from `[0.1, 2.0]` to `±20%` around an expected scale via a new `BracketAroundExpected` helper; pass that bracket through from `SynthesisProbePhase` when a MapRect is available.
+- `README.md` — document the bundle-driven workflow.
+
+### New files (test project, `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/`)
+
+| File | Tests |
+|---|---|
+| `Bundle/BundleJsonDtosTests.cs` | Round-trip canonical bundle JSON strings through `BundleJsonContext`: `MapRectJson`, `RecoveredCalibrationJson` (with inliers), `AttemptJson`. |
+| `Bundle/MapRectConversionTests.cs` | `FromRecoveredCalibration` round-trip: known `(scale_texture, origin_texture)` + `MapRect` produces a `CandidateTransform` whose `Apply(WorldCoord)` matches `MapRect.TextureToScreenshot(AreaCalibration.WorldToWindow(world)) − MapRect.Origin` for a test point. Anisotropic-MapRect warning path. |
+| `Bundle/BundleLoaderTests.cs` | Open a synthetic bundle directory built in temp during the test, confirm typed values + nullability (rejected attempts have null `RecoveredCal`). Verify `Throws<FileNotFoundException>` when `01-attempt.json` is absent. |
+| `IconLikelihoodFieldLoadDeviationTests.cs` | `LoadDeviationAsField` on a known synthetic deviation (one bright cross at (32, 32) on a 64×64 black background) peaks at (32, 32) with score > 0.8. |
+| `CliArgsBundleFlagsTests.cs` | Six facts, one per new flag, asserting `CliArgs.Parse` puts the value on the right record field. Includes `--hand-truth-cal scale,rot,ox,oy,mirror` parsing into a `(double, double, double, double, bool)?` tuple — same shape as the existing `--truth-cal` parser. |
+| `Experiments/E5_ColdGrid_BracketedTests.cs` | `BracketAroundExpected(0.5, 0.2)` → all explored scales within `[0.4, 0.6]`. |
+
+---
+
+### Task 1: Bundle data layer (DTOs + Loader + Converter)
+
+This block builds the entire `SynthesisProbe/Bundle/` namespace as one unit — the DTOs, the loader, and the conversion helper. They're tightly coupled (loader and converter both consume the DTOs) so one subagent should hold the whole bundle data layer in context.
+
+**Files:**
+
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleJsonDtos.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/LoadedBundle.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleLoader.cs`
+- Create: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/MapRectConversion.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleJsonDtosTests.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/MapRectConversionTests.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleLoaderTests.cs`
+
+#### Sub-task 1A — DTOs
+
+- [ ] **1A.1: Write the failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleJsonDtosTests.cs
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Bundle;
+
+public class BundleJsonDtosTests
+{
+    [Fact]
+    public void MapRectJson_round_trips()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "originX": 130, "originY": 60,
+              "width": 995, "height": 986,
+              "textureWidth": 2048, "textureHeight": 2033,
+              "autoDetectScore": null, "sourceScaleFactor": null }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.MapRectJson)!;
+
+        parsed.SchemaVersion.Should().Be(1);
+        parsed.OriginX.Should().Be(130);
+        parsed.OriginY.Should().Be(60);
+        parsed.Width.Should().Be(995);
+        parsed.Height.Should().Be(986);
+        parsed.TextureWidth.Should().Be(2048);
+        parsed.TextureHeight.Should().Be(2033);
+        parsed.AutoDetectScore.Should().BeNull();
+        parsed.SourceScaleFactor.Should().BeNull();
+    }
+
+    [Fact]
+    public void RecoveredCalibrationJson_round_trips_with_inliers()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "scale": 0.31536, "rotationRadians": -3.14153,
+              "originX": 1039.45, "originY": -36.38,
+              "mirrorNorth": false, "calibrationZoom": 1.0,
+              "residualPixels": 0.34, "referenceCount": 4,
+              "source": "UserRefinement",
+              "inliers": [
+                { "label": "Meditation Pillar", "worldX": 916.8, "worldZ": 2428.8,
+                  "pixelX": 179.8, "pixelY": 235.6, "matchScore": 0.921 }
+              ] }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.RecoveredCalibrationJson)!;
+
+        parsed.Scale.Should().BeApproximately(0.31536, 1e-9);
+        parsed.MirrorNorth.Should().BeFalse();
+        parsed.Inliers.Should().HaveCount(1);
+        parsed.Inliers[0].Label.Should().Be("Meditation Pillar");
+    }
+
+    [Fact]
+    public void AttemptJson_round_trips()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "area": "AreaEltibule",
+              "attemptStartedUtc": "2026-06-02T01:23:45Z",
+              "attemptFinalizedUtc": "2026-06-02T01:23:46Z",
+              "outcome": "accepted",
+              "rejectReason": null,
+              "engineVersion": "1.0.0",
+              "files": {
+                "rawScreenshot": "02-screenshot-raw.png",
+                "grayScreenshot": "03-screenshot-gray.png",
+                "mapRect": "04-maprect.json",
+                "baseTextureResampled": "05-base-resampled.png",
+                "alignedScreenshot": "06-aligned-screenshot.png",
+                "deviation": "07-deviation.png",
+                "detectionsImage": "08-detections.png",
+                "projectionOverlay": "09-projection-overlay.png",
+                "detections": "10-detections.json",
+                "recoveredCalibration": "11-recovered-cal.json"
+              } }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.AttemptJson)!;
+
+        parsed.Area.Should().Be("AreaEltibule");
+        parsed.Outcome.Should().Be("accepted");
+        parsed.RejectReason.Should().BeNull();
+        parsed.Files.Deviation.Should().Be("07-deviation.png");
+        parsed.Files.RecoveredCalibration.Should().Be("11-recovered-cal.json");
+    }
+}
+```
+
+- [ ] **1A.2: Run, verify it fails**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~BundleJsonDtosTests"
+```
+
+Expected: BUILD FAILURE — `Bundle.BundleJsonContext` not found.
+
+- [ ] **1A.3: Implement the DTOs + context**
+
+```csharp
+// tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleJsonDtos.cs
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+// Mirrors src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs.
+// Replicated here (rather than ProjectReference'd) to keep the tool decoupled
+// from the WPF-flavored Capture project. Shape parity is the contract — if
+// CalibrationBundleJsonContext gains a field, mirror it here too.
+internal sealed record AttemptJson(
+    int SchemaVersion,
+    string Area,
+    string AttemptStartedUtc,
+    string AttemptFinalizedUtc,
+    string Outcome,
+    string? RejectReason,
+    string EngineVersion,
+    AttemptFilesJson Files);
+
+internal sealed record AttemptFilesJson(
+    string? RawScreenshot,
+    string? GrayScreenshot,
+    string? MapRect,
+    string? BaseTextureResampled,
+    string? AlignedScreenshot,
+    string? Deviation,
+    string? DetectionsImage,
+    string? ProjectionOverlay,
+    string? Detections,
+    string? RecoveredCalibration);
+
+internal sealed record MapRectJson(
+    int SchemaVersion,
+    int OriginX,
+    int OriginY,
+    int Width,
+    int Height,
+    int TextureWidth,
+    int TextureHeight,
+    double? AutoDetectScore,
+    double? SourceScaleFactor);
+
+internal sealed record DetectionJson(
+    string LandmarkType,
+    string IconName,
+    double AnchorX,
+    double AnchorY,
+    double Score);
+
+internal sealed record DetectionsJson(
+    int SchemaVersion,
+    int RenderSizePx,
+    IReadOnlyList<DetectionJson> Detections);
+
+internal sealed record InlierJson(
+    string Label,
+    double WorldX,
+    double WorldZ,
+    double PixelX,
+    double PixelY,
+    double MatchScore);
+
+internal sealed record RecoveredCalibrationJson(
+    int SchemaVersion,
+    double Scale,
+    double RotationRadians,
+    double OriginX,
+    double OriginY,
+    bool MirrorNorth,
+    double CalibrationZoom,
+    double ResidualPixels,
+    int ReferenceCount,
+    string Source,
+    IReadOnlyList<InlierJson> Inliers);
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+[JsonSerializable(typeof(AttemptJson))]
+[JsonSerializable(typeof(MapRectJson))]
+[JsonSerializable(typeof(DetectionsJson))]
+[JsonSerializable(typeof(RecoveredCalibrationJson))]
+internal partial class BundleJsonContext : JsonSerializerContext;
+```
+
+- [ ] **1A.4: Run, verify passes**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~BundleJsonDtosTests"
+```
+
+Expected: PASS — 3 tests.
+
+#### Sub-task 1B — MapRectConversion
+
+- [ ] **1B.1: Write the failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/MapRectConversionTests.cs
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Bundle;
+
+public class MapRectConversionTests
+{
+    [Fact]
+    public void FromRecoveredCalibration_projects_world_to_aligned_pair_pixel()
+    {
+        var cal = new RecoveredCalibrationJson(
+            SchemaVersion: 1,
+            Scale: 0.31536, RotationRadians: -3.14153,
+            OriginX: 1039.45, OriginY: -36.38,
+            MirrorNorth: false, CalibrationZoom: 1.0,
+            ResidualPixels: 0.34, ReferenceCount: 4,
+            Source: "UserRefinement",
+            Inliers: System.Array.Empty<InlierJson>());
+
+        var mapRect = new MapRect(OriginX: 130, OriginY: 60,
+            Width: 1013, Height: 1001,
+            TextureWidth: 2048, TextureHeight: 2033);
+
+        var t = MapRectConversion.FromRecoveredCalibration(cal, mapRect);
+
+        // Spot-check: world (0, 0, 0) projects to what we'd get composing the
+        // canonical AreaCalibration with (MapRect.TextureToScreenshot − origin).
+        var canonical = new AreaCalibration(
+            cal.Scale, cal.RotationRadians, cal.OriginX, cal.OriginY,
+            cal.ReferenceCount, cal.ResidualPixels) { MirrorNorth = cal.MirrorNorth };
+        var texturePixel = canonical.WorldToWindow(new WorldCoord(0, 0, 0));
+        var screenshotPixel = mapRect.TextureToScreenshot(texturePixel.X, texturePixel.Y);
+        var expectedAlignedX = screenshotPixel.Sx - mapRect.OriginX;
+        var expectedAlignedY = screenshotPixel.Sy - mapRect.OriginY;
+
+        var actual = t.Apply(new WorldCoord(0, 0, 0));
+        actual.X.Should().BeApproximately(expectedAlignedX, 1e-6);
+        actual.Y.Should().BeApproximately(expectedAlignedY, 1e-6);
+    }
+
+    [Fact]
+    public void Anisotropic_MapRect_warns_via_out_param()
+    {
+        var cal = new RecoveredCalibrationJson(
+            1, Scale: 1.0, RotationRadians: 0.0, OriginX: 0.0, OriginY: 0.0,
+            MirrorNorth: false, CalibrationZoom: 1.0,
+            ResidualPixels: 0.0, ReferenceCount: 1, Source: "UserRefinement",
+            Inliers: System.Array.Empty<InlierJson>());
+
+        // 10% anisotropic resize (X factor 0.5, Y factor 0.45).
+        var mapRect = new MapRect(0, 0, 1000, 900, 2000, 2000);
+
+        MapRectConversion.FromRecoveredCalibration(cal, mapRect, out var anisotropyPercent);
+        anisotropyPercent.Should().BeGreaterThan(1.0);
+    }
+}
+```
+
+- [ ] **1B.2: Run, verify it fails**
+
+Expected: BUILD FAILURE — `MapRectConversion` not found.
+
+- [ ] **1B.3: Implement**
+
+```csharp
+// tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/MapRectConversion.cs
+using System;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+internal static class MapRectConversion
+{
+    /// <summary>
+    /// Convert a production-recovered AreaCalibration (texture-pixel space) plus
+    /// a MapRect (texture↔screenshot mapping) into a CandidateTransform that
+    /// projects world coords into the aligned-pair-pixel space the synthesis
+    /// probe's L_t fields live in. The aligned pair is the MapRect's crop minus
+    /// its origin — i.e., a local (0, 0) coordinate system whose pixel (0, 0)
+    /// is the top-left of the crop, with dimensions (Width, Height).
+    ///
+    /// MapRect.TextureToScreenshot scales texture coords by (Width/TextureWidth,
+    /// Height/TextureHeight) and offsets by (OriginX, OriginY). The aligned-pair
+    /// space is that minus the offset:
+    ///
+    ///     aligned_pair_x = texture_x * (Width / TextureWidth)
+    ///     aligned_pair_y = texture_y * (Height / TextureHeight)
+    ///
+    /// CandidateTransform is isotropic-scale-only; if the X and Y resize ratios
+    /// differ, the geometric mean is used and the difference is surfaced via
+    /// <paramref name="anisotropyPercent"/>. Callers should warn if it exceeds
+    /// roughly 1%.
+    /// </summary>
+    public static CandidateTransform FromRecoveredCalibration(
+        RecoveredCalibrationJson cal,
+        MapRect mapRect,
+        out double anisotropyPercent)
+    {
+        double ratioX = (double)mapRect.Width / mapRect.TextureWidth;
+        double ratioY = (double)mapRect.Height / mapRect.TextureHeight;
+        double geom = Math.Sqrt(ratioX * ratioY);
+        anisotropyPercent = 100.0 * Math.Abs(ratioX - ratioY) / geom;
+
+        return new CandidateTransform(
+            Scale: cal.Scale * geom,
+            RotRadians: cal.RotationRadians,
+            Mirror: cal.MirrorNorth,
+            Tx: cal.OriginX * ratioX,
+            Ty: cal.OriginY * ratioY);
+    }
+
+    /// <summary>Overload without the anisotropy out-param.</summary>
+    public static CandidateTransform FromRecoveredCalibration(
+        RecoveredCalibrationJson cal, MapRect mapRect)
+        => FromRecoveredCalibration(cal, mapRect, out _);
+}
+```
+
+- [ ] **1B.4: Run, verify passes**
+
+Expected: PASS — 2 tests.
+
+#### Sub-task 1C — BundleLoader + LoadedBundle
+
+- [ ] **1C.1: Write the failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleLoaderTests.cs
+using System.IO;
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Bundle;
+
+public class BundleLoaderTests
+{
+    [Fact]
+    public void Loads_full_bundle_with_recovered_cal()
+    {
+        var dir = NewBundleDir();
+        try
+        {
+            WriteAttemptJson(dir, outcome: "accepted", includeRecoveredCal: true);
+            WriteMapRectJson(dir);
+            WriteRecoveredCalJson(dir);
+            File.WriteAllBytes(Path.Combine(dir, "07-deviation.png"), new byte[1]); // placeholder
+
+            var bundle = BundleLoader.Open(dir);
+
+            bundle.Attempt.Outcome.Should().Be("accepted");
+            bundle.Attempt.Area.Should().Be("AreaEltibule");
+            bundle.MapRect.Should().NotBeNull();
+            bundle.RecoveredCal.Should().NotBeNull();
+            bundle.DeviationPath.Should().EndWith("07-deviation.png");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Loads_rejected_bundle_with_null_recovered_cal()
+    {
+        var dir = NewBundleDir();
+        try
+        {
+            WriteAttemptJson(dir, outcome: "rejected-3inliers", includeRecoveredCal: false);
+            WriteMapRectJson(dir);
+            File.WriteAllBytes(Path.Combine(dir, "07-deviation.png"), new byte[1]);
+
+            var bundle = BundleLoader.Open(dir);
+
+            bundle.Attempt.Outcome.Should().Be("rejected-3inliers");
+            bundle.MapRect.Should().NotBeNull();
+            bundle.RecoveredCal.Should().BeNull("rejected attempts have no recovered-cal");
+            bundle.DeviationPath.Should().EndWith("07-deviation.png");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Throws_when_attempt_json_missing()
+    {
+        var dir = NewBundleDir();
+        try
+        {
+            var act = () => BundleLoader.Open(dir);
+            act.Should().Throw<FileNotFoundException>();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    private static string NewBundleDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-bundle-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void WriteAttemptJson(string dir, string outcome, bool includeRecoveredCal)
+    {
+        var recoveredField = includeRecoveredCal ? "\"11-recovered-cal.json\"" : "null";
+        File.WriteAllText(Path.Combine(dir, "01-attempt.json"), $$"""
+            { "schemaVersion": 1,
+              "area": "AreaEltibule",
+              "attemptStartedUtc": "2026-06-02T01:00:00Z",
+              "attemptFinalizedUtc": "2026-06-02T01:00:01Z",
+              "outcome": "{{outcome}}",
+              "rejectReason": null,
+              "engineVersion": "1.0.0",
+              "files": {
+                "rawScreenshot": "02-screenshot-raw.png",
+                "grayScreenshot": "03-screenshot-gray.png",
+                "mapRect": "04-maprect.json",
+                "baseTextureResampled": null,
+                "alignedScreenshot": null,
+                "deviation": "07-deviation.png",
+                "detectionsImage": null,
+                "projectionOverlay": null,
+                "detections": null,
+                "recoveredCalibration": {{recoveredField}}
+              } }
+            """);
+    }
+
+    private static void WriteMapRectJson(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "04-maprect.json"), """
+            { "schemaVersion": 1, "originX": 130, "originY": 60,
+              "width": 1013, "height": 1001,
+              "textureWidth": 2048, "textureHeight": 2033,
+              "autoDetectScore": null, "sourceScaleFactor": null }
+            """);
+    }
+
+    private static void WriteRecoveredCalJson(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "11-recovered-cal.json"), """
+            { "schemaVersion": 1, "scale": 0.31536, "rotationRadians": -3.14153,
+              "originX": 1039.45, "originY": -36.38, "mirrorNorth": false,
+              "calibrationZoom": 1.0, "residualPixels": 0.34,
+              "referenceCount": 4, "source": "UserRefinement", "inliers": [] }
+            """);
+    }
+}
+```
+
+- [ ] **1C.2: Run, verify it fails**
+
+Expected: BUILD FAILURE — `BundleLoader` not found.
+
+- [ ] **1C.3: Implement LoadedBundle + BundleLoader**
+
+```csharp
+// tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/LoadedBundle.cs
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+internal sealed record LoadedBundle(
+    string Directory,
+    AttemptJson Attempt,
+    MapRectJson? MapRect,
+    RecoveredCalibrationJson? RecoveredCal,
+    DetectionsJson? Detections,
+    string? DeviationPath);
+```
+
+```csharp
+// tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleLoader.cs
+using System.IO;
+using System.Text.Json;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+internal static class BundleLoader
+{
+    public static LoadedBundle Open(string directory)
+    {
+        var attemptPath = Path.Combine(directory, "01-attempt.json");
+        if (!File.Exists(attemptPath))
+            throw new FileNotFoundException($"Bundle missing 01-attempt.json", attemptPath);
+
+        var attempt = JsonSerializer.Deserialize(
+            File.ReadAllText(attemptPath),
+            BundleJsonContext.Default.AttemptJson)!;
+
+        var mapRect = LoadOptionalJson(directory, attempt.Files.MapRect, BundleJsonContext.Default.MapRectJson);
+        var recoveredCal = LoadOptionalJson(directory, attempt.Files.RecoveredCalibration, BundleJsonContext.Default.RecoveredCalibrationJson);
+        var detections = LoadOptionalJson(directory, attempt.Files.Detections, BundleJsonContext.Default.DetectionsJson);
+
+        string? deviationPath = attempt.Files.Deviation is { } name
+            ? Path.Combine(directory, name)
+            : null;
+        if (deviationPath is not null && !File.Exists(deviationPath))
+            deviationPath = null;
+
+        return new LoadedBundle(directory, attempt, mapRect, recoveredCal, detections, deviationPath);
+    }
+
+    private static T? LoadOptionalJson<T>(
+        string directory,
+        string? fileName,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+        where T : class
+    {
+        if (fileName is null) return null;
+        var path = Path.Combine(directory, fileName);
+        if (!File.Exists(path)) return null;
+        return JsonSerializer.Deserialize(File.ReadAllText(path), typeInfo);
+    }
+}
+```
+
+- [ ] **1C.4: Run, verify passes**
+
+Expected: PASS — 3 tests.
+
+#### Task 1 wrap-up
+
+- [ ] **1D: Run the full new-tests filter to confirm all 8 tests pass**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --filter "FullyQualifiedName~Bundle"
+```
+
+Expected: PASS — 8 tests (3 + 2 + 3).
+
+- [ ] **1E: Run the full test suite to confirm no regressions**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release
+```
+
+Expected: 37 passing (29 existing + 8 new), 0 failing.
+
+- [ ] **1F: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/ tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/
+git commit -m "$(cat <<'EOF'
+feat(synthesis-probe): bundle data layer — DTOs + loader + MapRect conversion
+
+Replicates Mithril.MapCalibration.Capture.Diagnostics.CalibrationBundleJson's
+DTO shapes in the tool (BundleJsonContext, source-generated). BundleLoader.Open
+reads 01-attempt.json and follows its Files map to resolve typed JSON + the
+deviation PNG. MapRectConversion.FromRecoveredCalibration converts a production
+AreaCalibration (texture-pixel space) plus a MapRect into a CandidateTransform
+that projects into the synthesis probe's aligned-pair-pixel field space.
+Anisotropic resize ratios are surfaced via an out-param.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Probe consumers + CLI surface
+
+This block adds the alternate field-build entry point and the five new CLI flags. Two independent extensions, but small enough to share one subagent + one commit.
+
+**Files:**
+
+- Modify: `tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs`
+- Modify: `tools/MapCalibrationFromScreenshot/CliArgs.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationTests.cs`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs`
+
+#### Sub-task 2A — IconLikelihoodField.LoadDeviationAsField
+
+- [ ] **2A.1: Write the failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationTests.cs
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldLoadDeviationTests
+{
+    [Fact]
+    public void LoadDeviationAsField_peaks_at_pre_subtracted_icon_location()
+    {
+        const int W = 64, H = 64;
+        // Synthetic pre-subtracted deviation: black background, single 5x5
+        // cross stamped at (32, 32). This is what the live engine produces
+        // post-ECC, post-subtraction.
+        var devPixels = new byte[W * H];
+        StampCross(devPixels, W, cx: 32, cy: 32);
+        var deviation = new GrayImage(W, H, devPixels);
+
+        var template = MakeCrossTemplate();
+        var field = IconLikelihoodField.LoadDeviationAsField(deviation, template);
+
+        field.GetLength(0).Should().Be(H);
+        field.GetLength(1).Should().Be(W);
+
+        var (maxX, maxY) = Argmax(field);
+        maxX.Should().BeInRange(31, 33);
+        maxY.Should().BeInRange(31, 33);
+        field[maxY, maxX].Should().BeGreaterThan(0.8);
+    }
+
+    private static void StampCross(byte[] pixels, int width, int cx, int cy)
+    {
+        for (int dy = -2; dy <= 2; dy++)
+            pixels[(cy + dy) * width + cx] = 200;
+        for (int dx = -2; dx <= 2; dx++)
+            pixels[cy * width + (cx + dx)] = 200;
+        pixels[cy * width + cx] = 255;
+    }
+
+    private static IconTemplate MakeCrossTemplate()
+    {
+        var gray = new byte[]   { 0,0,200,0,0,  0,0,200,0,0,  200,200,255,200,200,  0,0,200,0,0,  0,0,200,0,0 };
+        var alpha = new byte[]  { 0,0,255,0,0,  0,0,255,0,0,  255,255,255,255,255,  0,0,255,0,0,  0,0,255,0,0 };
+        return new IconTemplate(
+            Name: "x", LandmarkType: "Portal", PivotX: 0.5, PivotY: 0.5,
+            Gray: new GrayImage(5, 5, gray),
+            Alpha: new GrayImage(5, 5, alpha));
+    }
+
+    private static (int X, int Y) Argmax(double[,] field)
+    {
+        int bestX = 0, bestY = 0; double bestV = double.NegativeInfinity;
+        for (int y = 0; y < field.GetLength(0); y++)
+            for (int x = 0; x < field.GetLength(1); x++)
+                if (field[y, x] > bestV) { bestV = field[y, x]; bestX = x; bestY = y; }
+        return (bestX, bestY);
+    }
+}
+```
+
+- [ ] **2A.2: Run, verify fails**
+
+Expected: BUILD FAILURE — `LoadDeviationAsField` not found.
+
+- [ ] **2A.3: Implement**
+
+Add to `tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs`, right after `Build`:
+
+```csharp
+/// <summary>
+/// Build a field from a pre-computed deviation map. Skips the screenshot-minus-
+/// aligned-base subtraction step that <see cref="Build"/> performs; equivalent
+/// to calling <see cref="ScoreAll"/> directly with a deviation supplied by the
+/// caller. Used by the bundle-consumption path where the live engine has
+/// already produced a post-ECC deviation via #978's ECC refiner.
+/// </summary>
+/// <returns>Same row-major [H, W] layout as <see cref="ScoreAll"/>.</returns>
+public static double[,] LoadDeviationAsField(GrayImage deviation, IconTemplate template)
+    => ScoreAll(deviation, template);
+```
+
+- [ ] **2A.4: Run, verify passes**
+
+Expected: PASS — 1 test.
+
+#### Sub-task 2B — Five CLI flags
+
+- [ ] **2B.1: Write the failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class CliArgsBundleFlagsTests
+{
+    [Fact]
+    public void Parses_bundle_dir()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--bundle-dir", "C:/bundles/foo",
+        })!;
+        args.BundleDir.Should().Be("C:/bundles/foo");
+    }
+
+    [Fact]
+    public void Parses_maprect_json()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--maprect-json", "C:/bundles/foo/04-maprect.json",
+        })!;
+        args.MapRectJsonPath.Should().Be("C:/bundles/foo/04-maprect.json");
+    }
+
+    [Fact]
+    public void Parses_recovered_cal_json()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--recovered-cal-json", "C:/bundles/foo/11-recovered-cal.json",
+        })!;
+        args.RecoveredCalJsonPath.Should().Be("C:/bundles/foo/11-recovered-cal.json");
+    }
+
+    [Fact]
+    public void Parses_aligned_deviation()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--aligned-deviation", "C:/bundles/foo/07-deviation.png",
+        })!;
+        args.AlignedDeviationPath.Should().Be("C:/bundles/foo/07-deviation.png");
+    }
+
+    [Fact]
+    public void Parses_detections_json()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--detections-json", "C:/bundles/foo/10-detections.json",
+        })!;
+        args.DetectionsJsonPath.Should().Be("C:/bundles/foo/10-detections.json");
+    }
+
+    [Fact]
+    public void Parses_hand_truth_cal_five_tuple()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--hand-truth-cal", "0.7632,3.141276,2146.21,-202.47,false",
+        })!;
+
+        args.HandTruthCal.Should().NotBeNull();
+        args.HandTruthCal!.Value.Scale.Should().BeApproximately(0.7632, 1e-9);
+        args.HandTruthCal.Value.Rot.Should().BeApproximately(3.141276, 1e-9);
+        args.HandTruthCal.Value.Ox.Should().BeApproximately(2146.21, 1e-9);
+        args.HandTruthCal.Value.Oy.Should().BeApproximately(-202.47, 1e-9);
+        args.HandTruthCal.Value.Mirror.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **2B.2: Run, verify fails**
+
+Expected: BUILD FAILURE — five new properties not on `CliArgs`.
+
+- [ ] **2B.3: Add the five fields + parser cases**
+
+In `CliArgs.cs`, after the existing `AlignedBasePath` field on the record:
+
+```csharp
+string? BundleDir,
+string? MapRectJsonPath,
+string? RecoveredCalJsonPath,
+string? AlignedDeviationPath,
+string? DetectionsJsonPath,
+(double Scale, double Rot, double Ox, double Oy, bool Mirror)? HandTruthCal
+```
+
+In `Parse`, alongside the existing `--aligned-base` case:
+
+```csharp
+case "--bundle-dir":
+    bundleDir = Next(argv, ref i);
+    break;
+case "--maprect-json":
+    mapRectJsonPath = Next(argv, ref i);
+    break;
+case "--recovered-cal-json":
+    recoveredCalJsonPath = Next(argv, ref i);
+    break;
+case "--aligned-deviation":
+    alignedDeviationPath = Next(argv, ref i);
+    break;
+case "--detections-json":
+    detectionsJsonPath = Next(argv, ref i);
+    break;
+case "--hand-truth-cal":
+    handTruthCal = ParseTruthCal(Next(argv, ref i));  // reuse the existing 'scale,rot,ox,oy,mirror' parser from --truth-cal
+    break;
+```
+
+Add the local declarations alongside `alignedBasePath`:
+
+```csharp
+string? bundleDir = null;
+string? mapRectJsonPath = null;
+string? recoveredCalJsonPath = null;
+string? alignedDeviationPath = null;
+string? detectionsJsonPath = null;
+(double, double, double, double, bool)? handTruthCal = null;
+```
+
+Pass the six new fields to the constructor at the bottom of `Parse`. Update help text:
+
+```
+  --bundle-dir <dir>                    a per-attempt diagnostic bundle directory written by Mithril's
+                                         AutoCalibrationEngine. Auto-resolves --maprect-json /
+                                         --recovered-cal-json / --aligned-deviation / --detections-json
+                                         from the bundle's 01-attempt.json manifest if those flags aren't
+                                         given explicitly.
+  --maprect-json <path>                 the bundle's 04-maprect.json (texture↔aligned-pair transform).
+  --recovered-cal-json <path>           the bundle's 11-recovered-cal.json (production-recovered
+                                         AreaCalibration). When given with --maprect-json, the
+                                         synthesis-probe derives --truth-cal automatically.
+  --aligned-deviation <path>            the bundle's 07-deviation.png (post-ECC, post-subtraction
+                                         deviation). Bypasses IconLikelihoodField.Build's subtraction.
+  --detections-json <path>              the bundle's 10-detections.json (production's NCC detection set).
+                                         Optional; not consumed in v1.
+  --hand-truth-cal <scale,rot,ox,oy,mirror>
+                                         user-supplied texture-pixel-space truth cal (mirror = true|false).
+                                         Converted to crop-pixel via --maprect-json before use. Takes
+                                         precedence over --recovered-cal-json (use when production's
+                                         recovered cal is known-wrong, e.g. the 2026-06-02 4-inlier
+                                         residual-4-px solves; supply the hand-verified entry from
+                                         src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json).
+```
+
+- [ ] **2B.4: Run, verify passes**
+
+Expected: PASS — 6 tests.
+
+#### Task 2 wrap-up
+
+- [ ] **2C: Run all tests to confirm no regressions**
+
+```bash
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release
+```
+
+Expected: 44 passing (37 from Task 1 + 1 deviation + 6 CLI), 0 failing.
+
+- [ ] **2D: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs tools/MapCalibrationFromScreenshot/CliArgs.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationTests.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
+git commit -m "$(cat <<'EOF'
+feat(synthesis-probe): LoadDeviationAsField alt + five bundle-consumption flags
+
+LoadDeviationAsField skips Build's screenshot-minus-base step when the live
+engine has already produced a post-ECC deviation (#978). Five new CLI flags
+(--bundle-dir + --maprect-json / --recovered-cal-json / --aligned-deviation
+/ --detections-json) expose the bundle artifacts to the probe.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Integration + E5 bracket + README
+
+This block ties everything together: the wiring in `SynthesisProbePhase`, the new `E5_ColdGrid.BracketAroundExpected` helper that uses the MapRect-implied scale, and the README documentation. All three changes are part of the "consumption now works end-to-end" story; bundling them into one commit makes git history clean.
+
+**Files:**
+
+- Modify: `tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs`
+- Modify: `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs`
+- Modify: `tools/MapCalibrationFromScreenshot/README.md`
+- Create: `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs`
+
+#### Sub-task 3A — E5 BracketAroundExpected
+
+- [ ] **3A.1: Write the failing test**
+
+```csharp
+// tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E5_ColdGrid_BracketedTests
+{
+    [Fact]
+    public void Bracketed_scaleRange_centers_at_expected_scale()
+    {
+        var portal = new double[64, 64];
+        portal[20, 20] = 0.9;
+        var fields = new System.Collections.Generic.Dictionary<string, double[,]> { ["Portal"] = portal };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var truth = new CandidateTransform(0.5, 0.0, false, 20, 20);
+
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "synth-probe-e5-bracket-" + System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var report = E5_ColdGrid.Run(
+                fields, refs, truth,
+                scaleBracket: E5_ColdGrid.BracketAroundExpected(0.5, fractionAbove: 0.2),
+                scaleSamples: 8,
+                cropWidth: 64, cropHeight: 64,
+                gridStepPx: 8,
+                templateSizePx: 5,
+                writer: w);
+
+            // All explored scales must be within ±20% of 0.5 → [0.4, 0.6].
+            foreach (var (t, _, _) in report.Top8AfterRefine)
+            {
+                t.Scale.Should().BeInRange(0.4 * 0.99, 0.6 * 1.01,
+                    "bracketed E5 must not consider scales outside ±20% of expected");
+            }
+        }
+        finally { System.IO.Directory.Delete(dir, recursive: true); }
+    }
+}
+```
+
+- [ ] **3A.2: Run, verify fails**
+
+Expected: BUILD FAILURE — `E5_ColdGrid.BracketAroundExpected` not found.
+
+- [ ] **3A.3: Implement**
+
+In `tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs`, add to the class:
+
+```csharp
+/// <summary>
+/// Compute a tight scaleBracket around an expected scale (typically derived
+/// from the MapRect's resize ratio + production AreaCalibration). Excludes the
+/// tiny-scale degeneracy by construction — the synthesis objective's worst
+/// failure mode is at scales orders of magnitude below truth, which never
+/// arise inside a physically-plausible bracket.
+/// </summary>
+public static (double Min, double Max) BracketAroundExpected(double expected, double fractionAbove)
+    => (expected * (1.0 - fractionAbove), expected * (1.0 + fractionAbove));
+```
+
+The existing `Run` method already accepts `scaleBracket: (double Min, double Max)` — no signature change.
+
+- [ ] **3A.4: Run, verify passes**
+
+Expected: PASS — 1 test.
+
+#### Sub-task 3B — SynthesisProbePhase wiring
+
+- [ ] **3B.1: Read the current `SynthesisProbePhase.cs`**
+
+Read the file fully. The existing wiring is the entry point added in yesterday's Task 14; you're extending it.
+
+- [ ] **3B.2: Add the bundle-resolution + truth-cal-derivation branches**
+
+Insert this logic near the top of `Run`, after validating `args.Area`:
+
+```csharp
+// Resolve --bundle-dir into the four file paths if not explicitly overridden.
+LoadedBundle? loadedBundle = null;
+string? mapRectJsonPath = args.MapRectJsonPath;
+string? recoveredCalJsonPath = args.RecoveredCalJsonPath;
+string? alignedDeviationPath = args.AlignedDeviationPath;
+string? detectionsJsonPath = args.DetectionsJsonPath;
+
+if (!string.IsNullOrEmpty(args.BundleDir))
+{
+    loadedBundle = BundleLoader.Open(args.BundleDir);
+    mapRectJsonPath ??= loadedBundle.Attempt.Files.MapRect is { } mr ? Path.Combine(args.BundleDir, mr) : null;
+    recoveredCalJsonPath ??= loadedBundle.Attempt.Files.RecoveredCalibration is { } rc ? Path.Combine(args.BundleDir, rc) : null;
+    alignedDeviationPath ??= loadedBundle.DeviationPath;
+    detectionsJsonPath ??= loadedBundle.Attempt.Files.Detections is { } d ? Path.Combine(args.BundleDir, d) : null;
+}
+
+// Derive truth-cal per the precedence in the plan header:
+//   1. --truth-cal           (crop-pixel space, wins outright)
+//   2. --hand-truth-cal      (texture-pixel space + MapRect → conversion)
+//   3. --recovered-cal-json  (texture-pixel space + MapRect → conversion)
+// All three of cases 2/3 share the same MapRectConversion path.
+CandidateTransform? truth = null;
+
+if (args.TruthCal is { } tc)
+{
+    truth = new CandidateTransform(tc.Scale, tc.Rot, tc.Mirror, tc.Ox, tc.Oy);
+}
+else if (args.HandTruthCal is { } htc)
+{
+    if (mapRectJsonPath is null)
+    {
+        Console.Error.WriteLine("[err] --hand-truth-cal requires --maprect-json (directly or via --bundle-dir).");
+        return 2;
+    }
+    var mapRectJson = JsonSerializer.Deserialize(
+        File.ReadAllText(mapRectJsonPath),
+        BundleJsonContext.Default.MapRectJson)!;
+    var mapRect = new MapRect(
+        mapRectJson.OriginX, mapRectJson.OriginY,
+        mapRectJson.Width, mapRectJson.Height,
+        mapRectJson.TextureWidth, mapRectJson.TextureHeight,
+        mapRectJson.AutoDetectScore, mapRectJson.SourceScaleFactor);
+    var handCalJson = new RecoveredCalibrationJson(
+        SchemaVersion: 1,
+        Scale: htc.Scale, RotationRadians: htc.Rot,
+        OriginX: htc.Ox, OriginY: htc.Oy,
+        MirrorNorth: htc.Mirror,
+        CalibrationZoom: 1.0,
+        ResidualPixels: 0.0,
+        ReferenceCount: 0,
+        Source: "HandSupplied",
+        Inliers: System.Array.Empty<InlierJson>());
+    truth = MapRectConversion.FromRecoveredCalibration(handCalJson, mapRect, out var handAnisoPct);
+    if (handAnisoPct > 1.0)
+        Console.Error.WriteLine($"[warn] MapRect resize is anisotropic by {handAnisoPct:0.00}%; using geometric mean.");
+    Console.Error.WriteLine("[truth] using --hand-truth-cal (texture-pixel space → crop-pixel via MapRect).");
+}
+else if (mapRectJsonPath is not null && recoveredCalJsonPath is not null)
+{
+    var mapRectJson = JsonSerializer.Deserialize(
+        File.ReadAllText(mapRectJsonPath),
+        BundleJsonContext.Default.MapRectJson)!;
+    var recoveredCalJson = JsonSerializer.Deserialize(
+        File.ReadAllText(recoveredCalJsonPath),
+        BundleJsonContext.Default.RecoveredCalibrationJson)!;
+    var mapRect = new MapRect(
+        mapRectJson.OriginX, mapRectJson.OriginY,
+        mapRectJson.Width, mapRectJson.Height,
+        mapRectJson.TextureWidth, mapRectJson.TextureHeight,
+        mapRectJson.AutoDetectScore, mapRectJson.SourceScaleFactor);
+    truth = MapRectConversion.FromRecoveredCalibration(recoveredCalJson, mapRect, out var anisoPct);
+    if (anisoPct > 1.0)
+        Console.Error.WriteLine($"[warn] MapRect resize is anisotropic by {anisoPct:0.00}%; using geometric mean.");
+    Console.Error.WriteLine(
+        $"[truth] using --recovered-cal-json (production's recovered cal, residual {recoveredCalJson.ResidualPixels:0.00} px). " +
+        "If production's solve is suspect, override with --hand-truth-cal.");
+}
+
+if (truth is null)
+{
+    Console.Error.WriteLine("[err] No truth-cal: pass --truth-cal, or --hand-truth-cal + --maprect-json, or --bundle-dir/--recovered-cal-json + --maprect-json.");
+    return 2;
+}
+```
+
+Then later, where the existing code does `IconLikelihoodField.Build(screenshotCrop, alignedBase, template)` for each template, branch on `alignedDeviationPath`:
+
+```csharp
+var fieldsByType = new Dictionary<string, double[,]>();
+if (alignedDeviationPath is not null)
+{
+    var deviation = ImageIo.LoadGray(alignedDeviationPath);
+    foreach (var template in templates)
+    {
+        using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
+        fieldSpan?.SetTag("template.type", template.LandmarkType);
+        fieldSpan?.SetTag("template.size_px", template.Gray.Width);
+        fieldSpan?.SetTag("source", "aligned-deviation");
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        fieldsByType[template.LandmarkType] = IconLikelihoodField.LoadDeviationAsField(deviation, template);
+        fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
+    }
+}
+else
+{
+    // ... existing Build(...) path stays here unchanged ...
+}
+```
+
+Wire the new `truth!.Value` through to the experiment calls (the experiments already accept a `CandidateTransform` — verify their signatures and call sites haven't drifted).
+
+Replace the existing E5 call's `scaleBracket: (0.1, 2.0)` with a bracketed call:
+
+```csharp
+var scaleBracket = E5_ColdGrid.BracketAroundExpected(truth.Value.Scale, fractionAbove: 0.2);
+E5_ColdGrid.Run(fieldsByType, refs, truth.Value,
+    scaleBracket: scaleBracket,
+    scaleSamples: 16,
+    cropWidth: mw, cropHeight: mh,
+    gridStepPx: 16,
+    templateSizePx: 16,
+    writer: writer);
+```
+
+- [ ] **3B.3: Build + run all tests**
+
+```bash
+dotnet build tools/MapCalibrationFromScreenshot -c Release
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --no-build
+```
+
+Expected: BUILD SUCCESS (0 warnings), all 45 tests pass (43 from Task 2 + 1 from E5 bracket), 0 failed.
+
+- [ ] **3B.4: Smoke-test the CLI surface manually**
+
+```bash
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- --phase synthesis-probe --area AreaEltibule
+```
+
+Expected: stderr `[err] No truth-cal: …`, exit code 2.
+
+```bash
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- --phase synthesis-probe --area AreaEltibule --bundle-dir /nonexistent
+```
+
+Expected: a `FileNotFoundException` for `01-attempt.json`.
+
+#### Sub-task 3C — README
+
+- [ ] **3C.1: Append a section for the bundle-driven workflow**
+
+Find the existing `## --phase synthesis-probe — icon-likelihood-field diagnostic` section. Append, just before its closing line:
+
+````markdown
+### Bundle-driven workflow (after PR #985)
+
+The synthesis probe consumes the per-attempt diagnostic bundles Mithril's live engine writes (`%LocalAppData%/Mithril/diagnostics/calibration/<Area>-<timestamp>-<outcome>/`). For a single attempt:
+
+```powershell
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
+  --phase synthesis-probe `
+  --area AreaEltibule `
+  --bundle-dir "C:/Users/<you>/AppData/Local/Mithril/diagnostics/calibration/AreaEltibule-20260602-1230-accepted"
+```
+
+`--bundle-dir` resolves the rest from the bundle's `01-attempt.json` manifest:
+
+| Bundle file | Probe flag (auto-resolved) |
+|---|---|
+| `04-maprect.json` | `--maprect-json` |
+| `07-deviation.png` | `--aligned-deviation` |
+| `11-recovered-cal.json` | `--recovered-cal-json` |
+| `10-detections.json` | `--detections-json` (not consumed in v1) |
+
+When both `--maprect-json` and `--recovered-cal-json` are present, the probe derives truth-cal automatically — no manual `--truth-cal` needed.
+
+If production's recovered cal is known-wrong (e.g. a 4-inlier, residual-≈4-px solve that geometrically misaligns the overlay), override with `--hand-truth-cal scale,rot,ox,oy,mirror` — texture-pixel-space, gets converted via the same MapRect to the field's coord space. Source for hand-verified Eltibule: `src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json`.
+
+When `--aligned-deviation` is present, the probe skips `IconLikelihoodField.Build`'s screenshot-minus-base subtraction and runs `ScoreAll` directly on the bundle's post-ECC deviation.
+
+E5's scale bracket auto-narrows to ±20% of the expected aligned-pair-pixel scale (derived from the MapRect's resize ratio), excluding the tiny-scale degeneracy by construction.
+
+Override any auto-resolved flag by passing it explicitly — the explicit flag wins.
+````
+
+#### Task 3 wrap-up
+
+- [ ] **3D: Final build + full test run**
+
+```bash
+dotnet build Mithril.slnx -c Release 2>&1 | tail -5
+dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release --no-build 2>&1 | tail -5
+```
+
+Expected: 0 warnings / 0 errors in build; 45/45 passing in the probe test project.
+
+- [ ] **3E: Commit**
+
+```bash
+git add tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs tools/MapCalibrationFromScreenshot/README.md
+git commit -m "$(cat <<'EOF'
+feat(synthesis-probe): integrate bundle consumption + bracket E5 by MapRect
+
+SynthesisProbePhase now branches on --bundle-dir / --aligned-deviation /
+--recovered-cal-json + --maprect-json. Truth-cal is derived automatically
+when the bundle supplies both MapRect and recovered cal. The aligned-
+deviation path skips Build's screenshot-minus-base subtraction. E5's
+scale bracket is ±20% around the MapRect-implied expected scale,
+excluding the tiny-scale degeneracy (yesterday's diagnostic finding).
+
+README documents the bundle-driven workflow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- §"What we have right now" + §"What a clean diagnostic of the synthesis objective would need" from the synthesis-probe spec's Results section → Task 1 (DTOs/Loader/Converter), Task 3 (wiring).
+- §"Open questions" item 1 (`--aligned-deviation`) → Task 2 (LoadDeviationAsField + flag), Task 3 (wiring).
+- §"Open questions" item 2 (truth-cal extraction) → Task 1 (MapRectConversion), Task 3 (wiring).
+- §"Open questions" item 3 (E5 bracket tightening) → Task 3 (BracketAroundExpected + wiring).
+- §"Open questions" item 5 (test pair captures) → out-of-scope here; depends on user-side capture once new dumper is live (parallel to this work).
+
+**Placeholder scan:** None. All steps have concrete code blocks. The "existing Build(...) path stays here unchanged" reference in Task 3B is a scoping marker (engineer reads the file in 3B.1) but doesn't hide any specific code that needs to be written.
+
+**Type consistency:**
+
+- `CandidateTransform(Scale, RotRadians, Mirror, Tx, Ty)` — used consistently throughout.
+- `LoadedBundle(Directory, Attempt, MapRect, RecoveredCal, Detections, DeviationPath)` — Task 1 defines, Task 3 consumes.
+- `MapRectConversion.FromRecoveredCalibration(cal, mapRect, out anisoPct)` — Task 1 defines, Task 3 consumes.
+- `E5_ColdGrid.BracketAroundExpected(expected, fractionAbove)` — defined in 3A.3, used in 3B.2.
+- `IconLikelihoodField.LoadDeviationAsField(deviation, template)` — defined in 2A.3, used in 3B.2.
+
+All consistent.
+
+**Open assumption** (flagged at execution time): the bundle's `07-deviation.png` is a single-channel byte PNG that `ImageIo.LoadGray` decodes correctly. PR #985's visualizer is WPF-based and the production deviation export is gray, but if the actual file turns out to be RGB-encoded grayscale, `LoadGray` may need a small adaptation. The Task 2A test (synthetic deviation) won't catch this; Task 3B's smoke test on a real bundle will.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-02-synthesis-probe-bundle-consumption.md`.
+
+Three task blocks, each one subagent dispatch:
+
+- **Task 1** — bundle data layer (DTOs + Loader + Converter, 8 tests)
+- **Task 2** — probe consumers + CLI surface (1 new test + 6 new tests including `--hand-truth-cal`)
+- **Task 3** — integration + E5 bracket + README (1 new test + smoke + docs; wires the 3-tier truth-cal precedence)
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — three subagent dispatches with two-stage review per block.
+2. **Inline Execution** — `superpowers:executing-plans` with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
@@ -1,0 +1,147 @@
+# Synthesis-Probe Diagnostic for Map Auto-Calibration
+
+**Status:** design spec (output of brainstorming, 2026-06-01). Implementation plan to follow in a separate document / GitHub issue.
+
+## Goal
+
+Decide which of two auto-calibration redesigns to build, by measuring whether a continuous **icon-likelihood-field** objective can explain the in-game world-map screenshot well enough to recover the per-area `AreaCalibration` transform.
+
+This spec describes only the **diagnostic tool**, not the production solver. The tool lives in `tools/MapCalibrationFromScreenshot` as a new `--phase synthesis-probe`. Its output is a CSV + a handful of PNGs that answer a single decision question:
+
+> Does `J(T_truth)` dominate `J(T_anything_else)`, and is `J` a sharp peak around `T_truth`?
+
+- If yes everywhere → **Proposal A (cold synthesis solver, no detector)**.
+- If yes only when seeded near truth → **Proposal B (hybrid: RANSAC nominates, synthesis re-ranks)**.
+- If neither → field/templates/deviation aren't informative enough; neither proposal ships in this form, and the diagnostic told us before we shipped a broken solver.
+
+## Background
+
+The current auto-calibration pipeline (full territory map in `scratch/auto-calibration-handoff.md`) is `detect → threshold → RANSAC → gate`. It fails on zoomed-out captures (the committed Frame 1 fixture) because:
+
+1. Thresholding discards occluded icons — measured 0.3–0.66 when occluded, below the 0.80 floor; isolated they score 0.91–1.00.
+2. Discrete correspondences are unreliable in clusters.
+3. RANSAC's inlier-count objective is gameable by tightly clustered (spatially small) fits — we have a documented 6-inlier / 5.29 px / 63×26 px-span "garbage" solve that the gate accepted.
+
+The problem is heavily over-constrained but solved with an under-constrained method. Unused priors:
+
+- The 38 reference world positions for the area are known.
+- The transform has only ~3 continuous DOF (`Scale`, `OriginX`, `OriginY`) plus discrete `{rotation ∈ {0, π}, MirrorNorth ∈ {0, 1}}`.
+- Post-#978 ECC registration makes the screenshot sub-pixel-aligned to the base texture.
+
+The continuous-evidence objective **`J(T) = Σᵣ L_{type(r)}(T · r)`** consumes all three priors at once. This diagnostic measures whether `J` is sharp and dominant enough at the true `T` to be the basis of a new solver.
+
+## The math
+
+For each of the 4 landmark types t (`Portal`, `MeditationPillar`, `TeleportationPlatform`, `Npc`):
+
+- Compute deviation map `D = max(0, screenshot_crop − aligned_base_texture)` (additive-only).
+- Build per-type score field `L_t[y, x] = LocalNCC(D, T_t)` over the whole crop, integral-image, `O(W·H)`.
+- No threshold.
+
+For a candidate transform `T = (scale, rot ∈ {0, π}, mirror ∈ {0, 1}, tx, ty)`:
+
+```
+J(T) = Σ_{r ∈ refs(area)}  L_{type(r)} [ bicubic( T · r ) ]
+```
+
+`T · r` is the world→texture-pixel projection (the same math `AreaCalibration.WorldToWindow` performs today), composed with a texture→crop affine derived from the `MapRect`. Refs that project outside the crop contribute 0.
+
+Indicative cost (Frame 1, 847×841 crop, 4 templates at 16 px):
+
+- Field build: ~1 GFLOP total, ~30 ms.
+- Memory: 4 × 847 × 841 × 4 B ≈ 11 MB.
+- Per-`T` `J` evaluation: 38 bicubic lookups, ns each → billions/sec achievable.
+
+## Tool surface
+
+**Existing host:** `tools/MapCalibrationFromScreenshot/` — already has decoders, asset extraction, ref-loading (`study/refs/<area>.json`), debug-PNG plumbing, and the CLI flag surface. The Frame 1 / Frame 2 fixtures live in `tests/Mithril.MapCalibration.Harness.Tests/Fixtures/` and are reachable directly.
+
+**Added:** new `--phase synthesis-probe`. The phase is purely additive — every existing phase keeps working unchanged.
+
+New flags (in addition to existing `--screenshot`, `--area`, `--map-rect`, `--debug --outdir`):
+
+| Flag | Purpose |
+|---|---|
+| `--truth-cal scale,rot,ox,oy,mirror` | Known-correct calibration to evaluate `J` at. Frame 1's comes from the tool's existing 16-inlier solve; Frame 2's from production. |
+| `--ransac-seeds-csv <path>` | CSV of candidate calibrations to evaluate (one row per candidate: `label,scale,rot,ox,oy,mirror`). Hand-fed for now (Proposal B's seed-locality test). |
+| `--trace-console` | Emit OTel spans to stdout. |
+| `--otlp <endpoint>` | Emit OTel spans via OTLP to the named endpoint (Aspire Dashboard / Seq / Jaeger). |
+
+## Outputs
+
+All written under `--outdir` (defaulting to `study/synthesis-probe/<area>/`):
+
+- `field_<type>.png` — 16-bit grayscale of each per-type field `L_t`, normalized to [0, 65535].
+- `synthesis_probe.csv` — one row per evaluated transform with columns `experiment, label, scale, rot, mirror, tx, ty, J, refs_above_0.5, dominance_vs_runner_up`.
+- `grid_landscape_tx_ty.png` — 2D image of `J(tx, ty)` from experiment E2 (at truth scale/rot/mirror), colormapped.
+- `grid_landscape_scale.png` — 1D plot of `J(scale)` from experiment E3, written as a PNG strip.
+- OTel trace stream (destination per the `--trace-console` / `--otlp` flag).
+
+## Experiments
+
+All experiments run sequentially within one `--phase synthesis-probe` invocation. Each emits CSV rows and OTel spans.
+
+| Tag | What | Evals | Pass criterion |
+|---|---|---|---|
+| **E1** | Score `J(T_truth)` once | 1 | `refs_above_0.5 ≥ 20` of 38; zero truth-projected refs land off-crop |
+| **E2** | Sweep `(tx, ty)` over `±(2 × template_render_size_px) ≈ ±32 px` around truth, step 1 px | 65² = 4 225 | Truth is a sharp local max; FWHM ≤ template render size |
+| **E3** | Sweep `scale` over `±25%` of truth scale, step `1%` of truth scale | 51 | Truth is a sharp peak; `J` monotonically decreasing away from truth in both directions |
+| **E4** | Score each row of `--ransac-seeds-csv` (if provided) | K (~8) | `J(T_truth) ≥ 1.5 × max_k J(T_k)` — truth dominates the best wrong RANSAC candidate by ≥50% |
+| **E5** | Cold coarse grid: `scale ∈ 16 log-spaced values over [0.1, 2.0] px/unit × tx, ty stepped by ≤ template_render_size_px over the full crop × {rot, mirror} ∈ 4` | ~50–110 k | At least one of the top-8 grid maxima by `J` is within 5 px of truth's `(tx, ty)` after a local LM refine |
+
+**Sweep widths are tied to physical priors, not magic numbers:**
+
+- **E2 translation window = `2 × template_render_size_px`.** Templates are pinned at ~16 px on screen, so the score field has its primary structure on that scale. ±32 px captures one full peak plus its falloff. A 1 px-wide truth spike, a 10 px-wide bell, and a flat plateau are all distinguishable inside that window.
+- **E3 scale window = `±25%`.** The Frame 1 pathology is a cluster fit at `scale ≈ 0.06 × scale_truth` (a ~16× collapse). ±25% is wide enough to see whether the objective starts curving toward that pathology, while still being tight enough to sample the local peak densely. If `J(scale_truth × 0.75) ≈ J(scale_truth)`, the objective alone won't reject the cluster pathology and we need a scale-plausibility gate downstream.
+- **E5 grid step = `template_render_size_px` in (tx, ty).** The refine stage pulls in to the nearest local maximum; step finer than ~half the template width and we duplicate work, step coarser than the template width and the refine can miss the truth peak entirely. The scale bracket `[0.1, 2.0] px/unit` is set from "any plausible PG area" rather than from truth so this experiment honestly simulates a cold solve where truth isn't known.
+
+**Run on both fixtures** in this order:
+
+1. `eltibule-frame2-accepted-7.61px.gray.png` — zoomed-in, **positive control** (RANSAC succeeds today; synthesis must too, or our objective is broken).
+2. `eltibule-frame1-rejected-3inliers.gray.png` — zoomed-out, **the hard case**.
+
+If Frame 2 fails E1–E5, the probe itself has a bug; stop and fix it before reading anything into Frame 1's behavior.
+
+## OTel instrumentation
+
+The tool lives outside `Mithril.slnx`, so it does **not** depend on `Mithril.Shared.Diagnostics.Telemetry`. Instead: tool-local `ActivitySource("Mithril.Tools.MapCalibrationSynthesisProbe")` + the OTel SDK directly.
+
+Span hierarchy:
+
+- `probe.attempt` (root) — tags: `area`, `screenshot`, `truth.scale`, `truth.rot`, `truth.mirror`, `crop.w`, `crop.h`
+  - `field.build` ×4 — tags: `template.type`, `template.size_px`, `duration_ms`, `mean_L`, `max_L`
+  - `experiment.E1` … `experiment.E5` — tags: `eval_count`, `J_best`, `J_truth`, `truth_in_topk` (E5 only), `dominance` (E4 only)
+    - `J.eval` — **sampled 1 in 1000** (E5 alone is 65 k evals; per-eval spans would dominate the trace). Full per-eval data lives in the CSV; OTel keeps the waterfall readable.
+
+Exporter selection:
+
+- `--trace-console`: `AddConsoleExporter()`
+- `--otlp <endpoint>`: `AddOtlpExporter(o => o.Endpoint = new Uri(endpoint))`
+- Neither: no listener attached → zero cost (per project convention; producers don't guard with `if (active)`).
+
+## Decision criteria
+
+Read the synthesis_probe.csv across both fixtures. Outcome → architecture mapping:
+
+| Signal | Decision |
+|---|---|
+| Frame 2 fails E1 | Stop. Diagnostic itself is broken. |
+| Frame 1 E1 high AND E4 truth ≫ all RANSAC candidates AND E2 + E3 both sharp peaks at truth AND E5 top-8 contains a ≤5 px-of-truth entry | **Proposal A** (cold synthesis solver, no detector) confirmed. |
+| Frame 1 E1 high AND E4 truth ≫ all RANSAC candidates AND E2 + E3 sharp at truth, but E5 misses (no near-truth in top-8) | **Proposal B** (RANSAC seeds + synthesis re-rank + refine). Synthesis can localize the truth given a seed but can't find it cold. |
+| Frame 1 E1 low OR E2/E3 flat at truth | Neither proposal ships in this form. The diagnostic surfaces the failure rather than letting it lurk. Investigate why `L_t` isn't informative (template mismatch? deviation contamination? something we haven't anticipated). |
+
+## Out of scope (v0)
+
+- No production code changes. The `IconLikelihoodField` builder lives in the tool, not in `src/Mithril.MapCalibration`.
+- No new committed fixtures — use Frame 1, Frame 2, and the existing AreaSerbule artifacts.
+- No RANSAC top-K refactor. `--ransac-seeds-csv` is hand-fed from separate runs (or from harness output we dump locally).
+- No live wiring. `AutoCalibrationEngine` untouched.
+- Hard regression bar: must not change any existing `--phase` behavior.
+
+## Open questions / verification owed
+
+1. **Truth calibration for Frame 1.** The existing tool's 16-inlier solve produced it. Worth re-deriving it from a hand-clicked landmark set (Legolas-style) as a second source-of-truth so we're not begging the question.
+2. **Rotation enumeration.** Production enumerates `{0, π}` only — Legolas calibration findings, world A. If a future PG patch ships a `π/2` map orientation for some area, this assumption breaks; out of scope here.
+3. **Co-located refs.** Frame 1 has refs at ~2 px separation. The field-based objective doesn't separate them — both refs contribute additively to the same field peak. Expected behaviour, but the diagnostic surfaces it through E1's `refs_above_0.5` count: if it's low, co-located peaks may be getting credit only once and the objective is undercounting them.
+4. **Field memory.** 11 MB at 4× the live engine's crop size — easily fits, but verify no GC pressure on the OTLP-export path if we end up running E5's 65 k evals with sampling-off for a debug session.
+5. **Pivot semantics in projection.** Production uses `Sprite.m_Pivot = (0.5, 0.5)` for all four sprites (verified in `tools/MapCalibrationFromScreenshot/README.md`). The probe must consume the *same* pivot when computing `T · r` so the field lookup site matches the icon-anchor pixel; mis-pivoting would put us a half-template-width away from the field peak and look like a flat objective.

--- a/docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
@@ -145,3 +145,47 @@ Read the synthesis_probe.csv across both fixtures. Outcome → architecture mapp
 3. **Co-located refs.** Frame 1 has refs at ~2 px separation. The field-based objective doesn't separate them — both refs contribute additively to the same field peak. Expected behaviour, but the diagnostic surfaces it through E1's `refs_above_0.5` count: if it's low, co-located peaks may be getting credit only once and the objective is undercounting them.
 4. **Field memory.** 11 MB at 4× the live engine's crop size — easily fits, but verify no GC pressure on the OTLP-export path if we end up running E5's 65 k evals with sampling-off for a debug session.
 5. **Pivot semantics in projection.** Production uses `Sprite.m_Pivot = (0.5, 0.5)` for all four sprites (verified in `tools/MapCalibrationFromScreenshot/README.md`). The probe must consume the *same* pivot when computing `T · r` so the field lookup site matches the icon-anchor pixel; mis-pivoting would put us a half-template-width away from the field peak and look like a flat objective.
+
+---
+
+## Results & open questions — first integration runs (2026-06-01)
+
+### What's built and landed on `claude/synthesis-probe-impl`
+
+- 18 tasks complete (1–14 + 17 + 18), ~30 commits, 29 unit tests green, tool builds clean.
+- `--phase synthesis-probe` runs end-to-end: produces `synthesis_probe.csv`, four `field_<type>.png`, `grid_landscape_translation.png`, and an OTel trace.
+- `--aligned-base <path>` flag added in Task 18 so the auto-load+resize step can be overridden when ECC-aligned base inputs are available.
+
+### Smoke-run findings
+
+Smoke runs were attempted against `frame{1,2}-crop.png` + `frame{1,2}-texture-resampled.png` from `%LocalAppData%/Mithril/diagnostics/calibration/938-masks/`, and against the raw screenshot dumps from the parent dir. The numbers across runs:
+
+- **E1 J(truth)** = −1.86 (frame 2) and +0.06 (frame 1) — only 1–2 of 38 refs above 0.5.
+- **E3 scale sweep**: a local peak ~4–9% away from the computed crop-space truth-cal, J ≈ 2.5–3.2. Sharp but offset from the truth-cal value I supplied.
+- **E5 cold-grid top-8**: consistently lands at scale ≈ 0.10 with J ≈ 10–11. **3–4× higher J than the real-scale local peak in E3.**
+
+### What that meant — and what it didn't
+
+The headline E5 finding (cold-grid finds clustered tiny-scale fits with J that *dominates* the real-scale truth) is **not synthesis-specific** — it surfaces in the existing offline `--phase full` CLI too. Running `--phase full` on the same `frame{1,2}-crop.png` inputs and on the raw dumps produces `scale ∈ [0.07, 0.11]` with 3–5 inliers — the same tiny-scale clustered-fit pathology, just expressed via RANSAC's inlier count instead of the synthesis cumulative-J. The production **live engine** sidesteps this in two ways the offline path doesn't:
+
+1. **ECC-aligned inputs** (#978). Production registers the screenshot to the texture sub-pixel before deviation, so the deviation map is dominated by actual icons rather than terrain-mismatch noise; tiny-scale fits then have nothing to project onto.
+2. **The 4-inlier acceptance gate.** A 3-inlier fit at scale 0.07 still gets rejected even if it materializes.
+
+Neither of these is wired into the CLI's `--phase full` or into the synthesis probe today. So the smoke runs were testing a degraded version of the synthesis objective on un-aligned inputs.
+
+### Open questions to pick up next
+
+1. **`--aligned-deviation <path>` flag** — extend the probe to skip `IconLikelihoodField.Build`'s subtraction step and consume a pre-computed deviation map directly. Then point it at `frame{1,2}-aligned-1-deviation.png` (the live engine's post-ECC, post-subtraction deviation dump) and rerun E1–E5. This is the cleanest test of the synthesis math.
+2. **Truth-cal extraction.** Live engine's `%LocalAppData%/Mithril/MapCalibration/refinements.json` has the recovered `AreaCalibration` (Eltibule: `scale=0.31536, rotation≈-π, origin=(1039.45, -36.38)`, residual 0.34) in **texture-pixel** space. Converting to screenshot-pixel space for the probe requires the ECC's sub-rect (texture region the screenshot covers), which is internal to the live engine. Two options:
+   - Expose the sub-rect alongside the recovered calibration in `refinements.json`.
+   - Or have the probe operate in texture-pixel space directly (resample screenshot UP into the texture sub-rect; build fields in texture coords).
+3. **E5 cold-grid scale bracket.** Once truth-cal is rigorous, tighten `scaleBracket` from `[0.1, 2.0]` to a physically-plausible range around the expected `S_crop`. Excludes the tiny-scale degeneracy by construction rather than by post-hoc gate.
+4. **Input pair semantics in 938-masks/.** The `frame{1,2}-texture-resampled.png` files are *bilinear resizes of the full texture to the crop's dimensions*, NOT the post-ECC warped textures. So `--aligned-base` on those is a no-op vs auto-load. The actual post-ECC artifacts are the `aligned-1-deviation.png` etc. intermediate dumps.
+5. **The captured-screenshot pair to test.** Raw dumps confirmed by user:
+   - `map-67x51-1257x1049-color-20260601-122726-226.png` — **zoomed-OUT**, production does NOT solve.
+   - `map-67x51-1257x1049-color-20260601-123012-696.png` — **zoomed-IN**, production solves (`refinements.json` value above is presumed from this run).
+   These should be the working test pair, with their corresponding live-engine ECC outputs.
+
+### Architectural takeaway so far (provisional)
+
+The synthesis objective `J(T) = Σ L_t(T·r)` is consistent with what we'd want — but it inherits the same data-ambiguity gap that already bites RANSAC: without ECC-aligned inputs and a physically-meaningful scale prior, both objectives can be dominated by tiny-scale clustered "fits" that project all refs into a small high-noise region. So whichever solver we eventually ship — Proposal A (cold synthesis), Proposal B (RANSAC seed + synthesis re-rank), or a third option — it MUST consume ECC-aligned inputs AND constrain scale within the physically-plausible range. Today's runs were below that bar; the open questions above are how to get above it.

--- a/docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md
@@ -189,3 +189,80 @@ Neither of these is wired into the CLI's `--phase full` or into the synthesis pr
 ### Architectural takeaway so far (provisional)
 
 The synthesis objective `J(T) = Σ L_t(T·r)` is consistent with what we'd want — but it inherits the same data-ambiguity gap that already bites RANSAC: without ECC-aligned inputs and a physically-meaningful scale prior, both objectives can be dominated by tiny-scale clustered "fits" that project all refs into a small high-noise region. So whichever solver we eventually ship — Proposal A (cold synthesis), Proposal B (RANSAC seed + synthesis re-rank), or a third option — it MUST consume ECC-aligned inputs AND constrain scale within the physically-plausible range. Today's runs were below that bar; the open questions above are how to get above it.
+
+---
+
+## 2026-06-02 — bundle-driven runs
+
+Three per-attempt calibration bundles produced by the live engine (Mithril.MapCalibration's `AutoCalibrationEngine`, post-#985) were fed to the probe via the new `--bundle-dir`/`--maprect-json`/`--recovered-cal-json`/`--aligned-deviation`/`--hand-truth-cal` flags. The bundles consume post-ECC, post-subtraction deviation maps directly — the cleanest synthesis input we can give the probe today.
+
+All three bundles are AreaEltibule. Hand-truth-cal for B and C is the bundled-baseline entry (`map-calibration-baseline.json` — `scale=0.7632337, rotation=3.141276, origin=(2146.21, -202.47), mirror=false, residual=0.65 px, 5 refs`).
+
+### Run summary
+
+| Bundle | Production verdict | E1 J(truth) | E1 refs ≥ 0.5 | E2 J_best | E3 J_best | E5 J_best_refined | E5 truth in top-8? | E5 best-dist to truth |
+|---|---|---|---|---|---|---|---|---|
+| A (031105-069, accepted, 10 inliers, 0.79 px) | clean accept | **19.02** | **21 / 38** | 19.02 | 19.02 | 5.10 | **no** | 542 px |
+| B (031130-122, wrong-fit accept, 4 inliers, 4.03 px) — hand-truth | wrong | **−2.76** | **0 / 38** | 11.33 | 4.99 | 6.84 | no | 335 px |
+| B (031130-122) — production-recovered | wrong | +0.39 | 2 / 38 | 4.06 | 3.22 | 6.78 | no | 65 px |
+| C (031004-908, rejected, only 3 inliers) — hand-truth | rejected | **13.96** | **13 / 38** | 15.39 | 13.96 | 5.12 | **no** | 290 px |
+
+E2 sweeps ±32 px around truth at 1 px step (4 225 evals); E3 sweeps scale ±25 % at 1 % step (51 evals); E5 cold-grid is ~118 k–250 k evals depending on MapRect-bracketed scale span, with the top-8 hill-climbed after sampling.
+
+### Bundle A — positive control: J(truth) dominates locally, but cold-grid misses globally
+
+E1 J(truth)=19.02 with 21/38 refs above 0.5 clears the design-criterion threshold of "≥20 refs above 0.5". E2 J_best = J_truth → truth IS the local maximum in the ±32 px translation neighborhood. E3 J_best = J_truth → truth IS the maximum in the ±25 % scale neighborhood. E2 falls off rapidly: at +6.7 px from truth J drops to 6.06 (-68 %), at +9.5 px J drops to 5.45 (-71 %). Sharp peak, as required.
+
+But E5 cold-grid + LM refine **misses** truth: top-8 refined J values are all in the 4.1–5.1 range (vs J_truth=19.02), the closest top-8 candidate is 542 px from truth, and none of the eight survive the ≤5 px design criterion. The MapRect-bracketed scale span did exclude the tiny-scale degeneracy (E5 scales are 0.27–0.37, within ±25 % of truth's 0.337) — what remains is the spacing trap the design spec called out: at 16 px grid stride no sample lands within 5 px of truth, and the LM refine basin doesn't reach truth from 8–11 px away because J falls below the local-search horizon within 6 px.
+
+**Verdict on A:** synthesis correctly *scores* truth as the dominant peak when it's given. Cold synthesis (Proposal A) does NOT find that peak from a uniform grid + LM refine. **Proposal B** (RANSAC seed + synthesis re-rank/refine) is consistent with this data.
+
+### Bundle B — degraded ECC alignment; synthesis CANNOT rescue it
+
+Bundle B's deviation map (07-deviation.png) is visibly contaminated: terrain features and map borders fluoresce at the same intensity as icons, and icon peaks are blurred. Production's 4-inlier residual-4.03 px accept reflects this — the detector found just enough matches to clear the gate floor but pointed RANSAC at a geometrically wrong fit (scale=0.582, rotation=-2.046 rad, mirror=true, 117° off truth).
+
+The probe's hand-truth-cal `J = −2.76` with **0 / 38 refs above 0.5** is the headline: at the geometrically-correct cal, no ref projects onto a deviation peak. Production's wrong-recovered cal scores higher (J=+0.39, 2 refs above 0.5) — only because its 4 inliers were picked to line up with *whatever the noisy deviation map happens to show*. The wrong-fit is consistent with the contaminated input.
+
+Neither candidate dominates: E5 cold-grid finds an unrelated candidate at J=6.84 some 335 px from hand-truth and 65 px from production-recovered (i.e., synthesis re-rank would prefer the E5 candidate over either named "truth"). The cold-grid candidate is also wrong — it's just the highest peak in a noisy field.
+
+The Bundle B failure is at the **ECC stage**, not the solver. The right fix isn't a better solver; it's either (i) rejecting captures with poor ECC alignment, or (ii) better ECC. Synthesis is downstream of that gate. (See follow-up §1 below.)
+
+Also note: Bundle B's MapRect.json records `height=999`, but the deviation/aligned-screenshot/base-texture-resampled files are actually 1006 × **986** (the screenshot is 1274 × 1047, so origin.y=61 + height=999 = 1060 overflows by 13 px and the engine clamps to fit). The probe ran with an override MapRect `(143, 61, 1006, 986)` written to scratch. The bundle's recorded height is a small live-engine bug (see follow-up §2).
+
+### Bundle C — production rejected, synthesis scores truth correctly
+
+Bundle C is the **architecturally interesting case**: production rejected with "only 3 inliers (need ≥ 4)" because NPC detection starved on the more-zoomed-out 688 × 683 view (per the pre-flight investigation: 0 NPCs detected vs 3 in Bundle A; Eltibule has 17 NPCs = 45 % of the 38-ref pool, so losing them all crippled same-type RANSAC). The probe's E1 J(hand-truth) = **13.96** with **13 / 38 refs above 0.5** and `refs_off_crop=0` shows that synthesis evaluates truth correctly even on the smaller MapRect. E3 J_best = J_truth → truth is the scale peak. E2 J_best=15.39 slightly above J_truth, with the small offset consistent with the hand-truth-cal's published residual of 0.65 px.
+
+So on the rejected-908 capture: **production rejected, synthesis would have ACCEPTED truth given a near-truth seed**. The same continuous-evidence objective that aggregates `L_t(T·r)` over all 38 refs without a per-type discrete threshold doesn't care that 0 NPCs cleared the NCC threshold — the weak NPC-field correlations still contribute positive J, and the 13 portals + meditation pillars carry the rest. This is exactly the architectural case for the redesign predicted in the pre-flight notes.
+
+E5 cold-grid still misses (truth_in_topk=false, best-distance=290 px) — same spacing-vs-peak-width trap as Bundle A.
+
+**Verdict on C:** synthesis re-rank/refine layered on top of *any* near-truth seed source (current RANSAC, a wider RANSAC, hand-clicked anchors, or an ECC-based seed) would rescue Bundle C. Pure cold synthesis would not.
+
+### Architectural verdict: **Proposal B** (RANSAC seed + synthesis re-rank), with ECC quality as a prerequisite
+
+Three independent data points, all from real bundles:
+
+- **A:** synthesis scores truth as the dominant local peak (J=19, 21/38 refs); cold grid misses by 542 px. → Re-rank wins; cold doesn't.
+- **B:** ECC alignment failed → deviation map degraded → J(truth)=−2.76. Synthesis CAN'T fix what RANSAC also can't fix here. → Out of solver scope; needs ECC quality gate.
+- **C:** production rejected (insufficient inliers) but J(truth)=14 with 13/38 refs; cold grid misses by 290 px. → Re-rank rescues this rejection; cold doesn't.
+
+The criterion table at the top of this spec said Proposal B was the verdict when "E1 high AND E4 truth ≫ all RANSAC candidates AND E2 + E3 sharp at truth, but E5 misses (no near-truth in top-8)". That's exactly the A and C signature. B is below the bar for either proposal — but the failure is upstream of where either solver intervenes.
+
+What this means for an implementation plan:
+
+1. **Keep RANSAC as the cheap seed generator.** It's not bad at producing near-truth candidates when the deviation is clean; A's production solve is proof. Synthesis isn't going to replace it cold.
+2. **Replace the post-RANSAC inlier-count gate with a synthesis-J re-rank.** RANSAC nominates K candidates → score each via `J(T_k)` → pick top, LM-refine, accept/reject by `J ≥ J_min` and `refs_above_0.5 ≥ N_min`. This change alone would have rejected Bundle B's wrong-fit (J=0.39, 2 refs vs the A baseline of J=19, 21 refs) and would have accepted Bundle C (synthesis's J=14, 13 refs vs no current acceptance path at all).
+3. **Add an ECC-quality gate upstream** so degraded captures don't reach any solver. Bundle B was correctly *captured* but poorly *aligned*; production accepted a wrong-fit largely because the gate floor is inlier-count, not deviation-map quality. (See follow-up §1.)
+
+Cold synthesis (Proposal A) is not warranted by this evidence. The spec's E5 design criterion ("at least one of the top-8 grid maxima within 5 px of truth after a local LM refine") fails on every bundle, including the positive control. The fix isn't to widen the cold-grid scale span — that's already MapRect-bracketed and the result is unchanged — it's to seed it.
+
+### Follow-ups (out of scope for this PR)
+
+1. **Acceptance-gate monotonicity check (Mithril-engine-side).** Bundle A was a clean accept (0.79 px residual) at 03:11:05; Bundle B's wrong-fit was accepted at 03:11:30, *replacing* Bundle A's good calibration in `UserRefinements.json`. The acceptance gate should reject a new fit when its J (or its residual) is meaningfully worse than the currently-stored calibration's J for the same area. This is a small surgical fix in `AutoCalibrationEngine`'s accept path — file as a separate issue after this PR lands.
+
+2. **Bundle MapRect height clamp.** Bundle B's `04-maprect.json` records `height=999` but the engine clamps to 986 to fit the 1047-tall screenshot, so the recorded MapRect is inconsistent with the 1006×986 deviation/aligned files. File as a small data-quality bug; the fix is to record the clamped height.
+
+3. **Investigate rejected-908 (Bundle C) NPC NCC starvation.** The pre-flight investigation found 0/17 NPCs detected because the more-zoomed-out 688×683 view (vs Bundle A's 905×898) put NPC icons below the 0.90 same-type NCC threshold. That detection-side issue is real and would benefit from either (i) a zoom-aware NCC threshold, (ii) a smaller NPC template that survives the resize, or (iii) the synthesis re-rank above — which makes the NPC-NCC starvation moot because synthesis aggregates *weak* field correlations rather than requiring a per-template threshold. The synthesis re-rank in follow-up #2 (above) is the simplest dominant fix; the detection-side tweaks become optional.
+
+4. **Cold-grid spacing-vs-peak-width.** Bundle A's E5 misses by 542 px not because the peak isn't there but because at 16 px grid stride no sample lands within 5 px of truth, and the LM refine basin is narrower than the half-stride. If we ever wanted to revisit Proposal A, the cold grid would need either (i) a finer stride (proportional to template size, not equal to it) or (ii) a more aggressive multi-restart refine that explores beyond the nearest local max. Not worth it now given the seed-and-rerank path is cleaner.

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleJsonDtosTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleJsonDtosTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Bundle;
+
+public class BundleJsonDtosTests
+{
+    [Fact]
+    public void MapRectJson_round_trips()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "originX": 130, "originY": 60,
+              "width": 995, "height": 986,
+              "textureWidth": 2048, "textureHeight": 2033,
+              "autoDetectScore": null, "sourceScaleFactor": null }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.MapRectJson)!;
+
+        parsed.SchemaVersion.Should().Be(1);
+        parsed.OriginX.Should().Be(130);
+        parsed.OriginY.Should().Be(60);
+        parsed.Width.Should().Be(995);
+        parsed.Height.Should().Be(986);
+        parsed.TextureWidth.Should().Be(2048);
+        parsed.TextureHeight.Should().Be(2033);
+        parsed.AutoDetectScore.Should().BeNull();
+        parsed.SourceScaleFactor.Should().BeNull();
+    }
+
+    [Fact]
+    public void RecoveredCalibrationJson_round_trips_with_inliers()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "scale": 0.31536, "rotationRadians": -3.14153,
+              "originX": 1039.45, "originY": -36.38,
+              "mirrorNorth": false, "calibrationZoom": 1.0,
+              "residualPixels": 0.34, "referenceCount": 4,
+              "source": "UserRefinement",
+              "inliers": [
+                { "label": "Meditation Pillar", "worldX": 916.8, "worldZ": 2428.8,
+                  "pixelX": 179.8, "pixelY": 235.6, "matchScore": 0.921 }
+              ] }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.RecoveredCalibrationJson)!;
+
+        parsed.Scale.Should().BeApproximately(0.31536, 1e-9);
+        parsed.MirrorNorth.Should().BeFalse();
+        parsed.Inliers.Should().HaveCount(1);
+        parsed.Inliers[0].Label.Should().Be("Meditation Pillar");
+    }
+
+    [Fact]
+    public void AttemptJson_round_trips()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "area": "AreaEltibule",
+              "attemptStartedUtc": "2026-06-02T01:23:45Z",
+              "attemptFinalizedUtc": "2026-06-02T01:23:46Z",
+              "outcome": "accepted",
+              "rejectReason": null,
+              "engineVersion": "1.0.0",
+              "files": {
+                "rawScreenshot": "02-screenshot-raw.png",
+                "grayScreenshot": "03-screenshot-gray.png",
+                "mapRect": "04-maprect.json",
+                "baseTextureResampled": "05-base-resampled.png",
+                "alignedScreenshot": "06-aligned-screenshot.png",
+                "deviation": "07-deviation.png",
+                "detectionsImage": "08-detections.png",
+                "projectionOverlay": "09-projection-overlay.png",
+                "detections": "10-detections.json",
+                "recoveredCalibration": "11-recovered-cal.json"
+              } }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.AttemptJson)!;
+
+        parsed.Area.Should().Be("AreaEltibule");
+        parsed.Outcome.Should().Be("accepted");
+        parsed.RejectReason.Should().BeNull();
+        parsed.Files.Deviation.Should().Be("07-deviation.png");
+        parsed.Files.RecoveredCalibration.Should().Be("11-recovered-cal.json");
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleJsonDtosTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleJsonDtosTests.cs
@@ -88,4 +88,27 @@ public class BundleJsonDtosTests
         parsed.Files.Deviation.Should().Be("07-deviation.png");
         parsed.Files.RecoveredCalibration.Should().Be("11-recovered-cal.json");
     }
+
+    [Fact]
+    public void DetectionsJson_round_trips()
+    {
+        const string json = """
+            { "schemaVersion": 1,
+              "renderSizePx": 32,
+              "detections": [
+                { "landmarkType": "Portal", "iconName": "landmark_portal",
+                  "anchorX": 123.45, "anchorY": 678.9, "score": 0.873 }
+              ] }
+            """;
+
+        var parsed = JsonSerializer.Deserialize(json, BundleJsonContext.Default.DetectionsJson)!;
+
+        parsed.SchemaVersion.Should().Be(1);
+        parsed.RenderSizePx.Should().Be(32);
+        parsed.Detections.Should().HaveCount(1);
+        parsed.Detections[0].LandmarkType.Should().Be("Portal");
+        parsed.Detections[0].IconName.Should().Be("landmark_portal");
+        parsed.Detections[0].AnchorX.Should().BeApproximately(123.45, 1e-9);
+        parsed.Detections[0].Score.Should().BeApproximately(0.873, 1e-9);
+    }
 }

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleLoaderTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleLoaderTests.cs
@@ -13,9 +13,10 @@ public class BundleLoaderTests
         var dir = NewBundleDir();
         try
         {
-            WriteAttemptJson(dir, outcome: "accepted", includeRecoveredCal: true);
+            WriteAttemptJson(dir, outcome: "accepted", includeRecoveredCal: true, includeDetections: true);
             WriteMapRectJson(dir);
             WriteRecoveredCalJson(dir);
+            WriteDetectionsJson(dir);
             File.WriteAllBytes(Path.Combine(dir, "07-deviation.png"), new byte[1]); // placeholder
 
             var bundle = BundleLoader.Open(dir);
@@ -24,6 +25,8 @@ public class BundleLoaderTests
             bundle.Attempt.Area.Should().Be("AreaEltibule");
             bundle.MapRect.Should().NotBeNull();
             bundle.RecoveredCal.Should().NotBeNull();
+            bundle.Detections.Should().NotBeNull();
+            bundle.Detections!.Detections.Should().HaveCount(1);
             bundle.DeviationPath.Should().EndWith("07-deviation.png");
         }
         finally { Directory.Delete(dir, recursive: true); }
@@ -35,7 +38,7 @@ public class BundleLoaderTests
         var dir = NewBundleDir();
         try
         {
-            WriteAttemptJson(dir, outcome: "rejected-3inliers", includeRecoveredCal: false);
+            WriteAttemptJson(dir, outcome: "rejected-3inliers", includeRecoveredCal: false, includeDetections: false);
             WriteMapRectJson(dir);
             File.WriteAllBytes(Path.Combine(dir, "07-deviation.png"), new byte[1]);
 
@@ -68,9 +71,10 @@ public class BundleLoaderTests
         return dir;
     }
 
-    private static void WriteAttemptJson(string dir, string outcome, bool includeRecoveredCal)
+    private static void WriteAttemptJson(string dir, string outcome, bool includeRecoveredCal, bool includeDetections)
     {
         var recoveredField = includeRecoveredCal ? "\"11-recovered-cal.json\"" : "null";
+        var detectionsField = includeDetections ? "\"10-detections.json\"" : "null";
         File.WriteAllText(Path.Combine(dir, "01-attempt.json"), $$"""
             { "schemaVersion": 1,
               "area": "AreaEltibule",
@@ -88,7 +92,7 @@ public class BundleLoaderTests
                 "deviation": "07-deviation.png",
                 "detectionsImage": null,
                 "projectionOverlay": null,
-                "detections": null,
+                "detections": {{detectionsField}},
                 "recoveredCalibration": {{recoveredField}}
               } }
             """);
@@ -111,6 +115,17 @@ public class BundleLoaderTests
               "originX": 1039.45, "originY": -36.38, "mirrorNorth": false,
               "calibrationZoom": 1.0, "residualPixels": 0.34,
               "referenceCount": 4, "source": "UserRefinement", "inliers": [] }
+            """);
+    }
+
+    private static void WriteDetectionsJson(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "10-detections.json"), """
+            { "schemaVersion": 1, "renderSizePx": 32,
+              "detections": [
+                { "landmarkType": "Portal", "iconName": "landmark_portal",
+                  "anchorX": 123.45, "anchorY": 678.9, "score": 0.873 }
+              ] }
             """);
     }
 }

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleLoaderTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/BundleLoaderTests.cs
@@ -1,0 +1,116 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Bundle;
+
+public class BundleLoaderTests
+{
+    [Fact]
+    public void Loads_full_bundle_with_recovered_cal()
+    {
+        var dir = NewBundleDir();
+        try
+        {
+            WriteAttemptJson(dir, outcome: "accepted", includeRecoveredCal: true);
+            WriteMapRectJson(dir);
+            WriteRecoveredCalJson(dir);
+            File.WriteAllBytes(Path.Combine(dir, "07-deviation.png"), new byte[1]); // placeholder
+
+            var bundle = BundleLoader.Open(dir);
+
+            bundle.Attempt.Outcome.Should().Be("accepted");
+            bundle.Attempt.Area.Should().Be("AreaEltibule");
+            bundle.MapRect.Should().NotBeNull();
+            bundle.RecoveredCal.Should().NotBeNull();
+            bundle.DeviationPath.Should().EndWith("07-deviation.png");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Loads_rejected_bundle_with_null_recovered_cal()
+    {
+        var dir = NewBundleDir();
+        try
+        {
+            WriteAttemptJson(dir, outcome: "rejected-3inliers", includeRecoveredCal: false);
+            WriteMapRectJson(dir);
+            File.WriteAllBytes(Path.Combine(dir, "07-deviation.png"), new byte[1]);
+
+            var bundle = BundleLoader.Open(dir);
+
+            bundle.Attempt.Outcome.Should().Be("rejected-3inliers");
+            bundle.MapRect.Should().NotBeNull();
+            bundle.RecoveredCal.Should().BeNull("rejected attempts have no recovered-cal");
+            bundle.DeviationPath.Should().EndWith("07-deviation.png");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Throws_when_attempt_json_missing()
+    {
+        var dir = NewBundleDir();
+        try
+        {
+            var act = () => BundleLoader.Open(dir);
+            act.Should().Throw<FileNotFoundException>();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    private static string NewBundleDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-bundle-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void WriteAttemptJson(string dir, string outcome, bool includeRecoveredCal)
+    {
+        var recoveredField = includeRecoveredCal ? "\"11-recovered-cal.json\"" : "null";
+        File.WriteAllText(Path.Combine(dir, "01-attempt.json"), $$"""
+            { "schemaVersion": 1,
+              "area": "AreaEltibule",
+              "attemptStartedUtc": "2026-06-02T01:00:00Z",
+              "attemptFinalizedUtc": "2026-06-02T01:00:01Z",
+              "outcome": "{{outcome}}",
+              "rejectReason": null,
+              "engineVersion": "1.0.0",
+              "files": {
+                "rawScreenshot": "02-screenshot-raw.png",
+                "grayScreenshot": "03-screenshot-gray.png",
+                "mapRect": "04-maprect.json",
+                "baseTextureResampled": null,
+                "alignedScreenshot": null,
+                "deviation": "07-deviation.png",
+                "detectionsImage": null,
+                "projectionOverlay": null,
+                "detections": null,
+                "recoveredCalibration": {{recoveredField}}
+              } }
+            """);
+    }
+
+    private static void WriteMapRectJson(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "04-maprect.json"), """
+            { "schemaVersion": 1, "originX": 130, "originY": 60,
+              "width": 1013, "height": 1001,
+              "textureWidth": 2048, "textureHeight": 2033,
+              "autoDetectScore": null, "sourceScaleFactor": null }
+            """);
+    }
+
+    private static void WriteRecoveredCalJson(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "11-recovered-cal.json"), """
+            { "schemaVersion": 1, "scale": 0.31536, "rotationRadians": -3.14153,
+              "originX": 1039.45, "originY": -36.38, "mirrorNorth": false,
+              "calibrationZoom": 1.0, "residualPixels": 0.34,
+              "referenceCount": 4, "source": "UserRefinement", "inliers": [] }
+            """);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/MapRectConversionTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Bundle/MapRectConversionTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Bundle;
+
+public class MapRectConversionTests
+{
+    [Fact]
+    public void FromRecoveredCalibration_projects_world_to_aligned_pair_pixel()
+    {
+        var cal = new RecoveredCalibrationJson(
+            SchemaVersion: 1,
+            Scale: 0.31536, RotationRadians: -3.14153,
+            OriginX: 1039.45, OriginY: -36.38,
+            MirrorNorth: false, CalibrationZoom: 1.0,
+            ResidualPixels: 0.34, ReferenceCount: 4,
+            Source: "UserRefinement",
+            Inliers: System.Array.Empty<InlierJson>());
+
+        var mapRect = new MapRect(OriginX: 130, OriginY: 60,
+            Width: 1013, Height: 1001,
+            TextureWidth: 2048, TextureHeight: 2033);
+
+        var t = MapRectConversion.FromRecoveredCalibration(cal, mapRect);
+
+        // Spot-check: world (0, 0, 0) projects to what we'd get composing the
+        // canonical AreaCalibration with (MapRect.TextureToScreenshot − origin).
+        var canonical = new AreaCalibration(
+            cal.Scale, cal.RotationRadians, cal.OriginX, cal.OriginY,
+            cal.ReferenceCount, cal.ResidualPixels) { MirrorNorth = cal.MirrorNorth };
+        var texturePixel = canonical.WorldToWindow(new WorldCoord(0, 0, 0));
+        var screenshotPixel = mapRect.TextureToScreenshot(texturePixel.X, texturePixel.Y);
+        var expectedAlignedX = screenshotPixel.Sx - mapRect.OriginX;
+        var expectedAlignedY = screenshotPixel.Sy - mapRect.OriginY;
+
+        var actual = t.Apply(new WorldCoord(0, 0, 0));
+        actual.X.Should().BeApproximately(expectedAlignedX, 1e-6);
+        actual.Y.Should().BeApproximately(expectedAlignedY, 1e-6);
+    }
+
+    [Fact]
+    public void Anisotropic_MapRect_warns_via_out_param()
+    {
+        var cal = new RecoveredCalibrationJson(
+            1, Scale: 1.0, RotationRadians: 0.0, OriginX: 0.0, OriginY: 0.0,
+            MirrorNorth: false, CalibrationZoom: 1.0,
+            ResidualPixels: 0.0, ReferenceCount: 1, Source: "UserRefinement",
+            Inliers: System.Array.Empty<InlierJson>());
+
+        // 10% anisotropic resize (X factor 0.5, Y factor 0.45).
+        var mapRect = new MapRect(0, 0, 1000, 900, 2000, 2000);
+
+        MapRectConversion.FromRecoveredCalibration(cal, mapRect, out var anisotropyPercent);
+        anisotropyPercent.Should().BeGreaterThan(1.0);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CandidateTransformTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CandidateTransformTests.cs
@@ -12,6 +12,7 @@ public class CandidateTransformTests
     [InlineData(true, 0.0)]
     [InlineData(false, Math.PI)]
     [InlineData(true, Math.PI)]
+    [InlineData(false, Math.PI / 6)]
     public void Apply_matches_AreaCalibration_WorldToWindow(bool mirror, double rot)
     {
         var t = new CandidateTransform(Scale: 0.82, RotRadians: rot, Mirror: mirror, Tx: 100.0, Ty: 200.0);

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CandidateTransformTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CandidateTransformTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using Mithril.MapCalibration;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class CandidateTransformTests
+{
+    [Theory]
+    [InlineData(false, 0.0)]
+    [InlineData(true, 0.0)]
+    [InlineData(false, Math.PI)]
+    [InlineData(true, Math.PI)]
+    public void Apply_matches_AreaCalibration_WorldToWindow(bool mirror, double rot)
+    {
+        var t = new CandidateTransform(Scale: 0.82, RotRadians: rot, Mirror: mirror, Tx: 100.0, Ty: 200.0);
+        var cal = new AreaCalibration(0.82, rot, 100.0, 200.0, ReferenceCount: 1, ResidualPixels: 0.0) { MirrorNorth = mirror };
+        var world = new WorldCoord(50, 0, 30);
+
+        var fromCandidate = t.Apply(world);
+        var fromCalibration = cal.WorldToWindow(world);
+
+        fromCandidate.X.Should().BeApproximately(fromCalibration.X, 1e-9);
+        fromCandidate.Y.Should().BeApproximately(fromCalibration.Y, 1e-9);
+    }
+
+    [Fact]
+    public void FromAreaCalibration_copies_all_fields()
+    {
+        var cal = new AreaCalibration(0.5, Math.PI, 12.0, 34.0, 5, 0.7) { MirrorNorth = true };
+        var t = CandidateTransform.FromAreaCalibration(cal);
+
+        t.Scale.Should().Be(0.5);
+        t.RotRadians.Should().Be(Math.PI);
+        t.Mirror.Should().BeTrue();
+        t.Tx.Should().Be(12.0);
+        t.Ty.Should().Be(34.0);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class CliArgsBundleFlagsTests
+{
+    [Fact]
+    public void Parses_bundle_dir()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--bundle-dir", "C:/bundles/foo",
+        })!;
+        args.BundleDir.Should().Be("C:/bundles/foo");
+    }
+
+    [Fact]
+    public void Parses_maprect_json()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--maprect-json", "C:/bundles/foo/04-maprect.json",
+        })!;
+        args.MapRectJsonPath.Should().Be("C:/bundles/foo/04-maprect.json");
+    }
+
+    [Fact]
+    public void Parses_recovered_cal_json()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--recovered-cal-json", "C:/bundles/foo/11-recovered-cal.json",
+        })!;
+        args.RecoveredCalJsonPath.Should().Be("C:/bundles/foo/11-recovered-cal.json");
+    }
+
+    [Fact]
+    public void Parses_aligned_deviation()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--aligned-deviation", "C:/bundles/foo/07-deviation.png",
+        })!;
+        args.AlignedDeviationPath.Should().Be("C:/bundles/foo/07-deviation.png");
+    }
+
+    [Fact]
+    public void Parses_detections_json()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--detections-json", "C:/bundles/foo/10-detections.json",
+        })!;
+        args.DetectionsJsonPath.Should().Be("C:/bundles/foo/10-detections.json");
+    }
+
+    [Fact]
+    public void Parses_hand_truth_cal_five_tuple()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--hand-truth-cal", "0.7632,3.141276,2146.21,-202.47,false",
+        })!;
+
+        args.HandTruthCal.Should().NotBeNull();
+        args.HandTruthCal!.Value.Scale.Should().BeApproximately(0.7632, 1e-9);
+        args.HandTruthCal.Value.Rot.Should().BeApproximately(3.141276, 1e-9);
+        args.HandTruthCal.Value.Ox.Should().BeApproximately(2146.21, 1e-9);
+        args.HandTruthCal.Value.Oy.Should().BeApproximately(-202.47, 1e-9);
+        args.HandTruthCal.Value.Mirror.Should().BeFalse();
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Mithril.Tools.MapCalibration.Common;
 using Mithril.Tools.MapCalibrationFromScreenshot;
 using Xunit;
 
@@ -76,5 +77,18 @@ public class CliArgsBundleFlagsTests
         args.HandTruthCal.Value.Ox.Should().BeApproximately(2146.21, 1e-9);
         args.HandTruthCal.Value.Oy.Should().BeApproximately(-202.47, 1e-9);
         args.HandTruthCal.Value.Mirror.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Malformed_hand_truth_cal_error_message_names_the_correct_flag()
+    {
+        var act = () => CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--hand-truth-cal", "0.5,0.0,0.0",  // only 3 components, want 5
+        });
+        act.Should().Throw<UserFacingException>()
+            .WithMessage("*--hand-truth-cal*")
+            .Which.Message.Should().NotContain("--truth-cal wants");
     }
 }

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsSynthesisProbeTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsSynthesisProbeTests.cs
@@ -59,4 +59,15 @@ public class CliArgsSynthesisProbeTests
         })!;
         args.OtlpEndpoint.Should().Be("http://localhost:4317");
     }
+
+    [Fact]
+    public void Parses_aligned_base_path()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--screenshot", "x.png", "--area", "AreaEltibule",
+            "--aligned-base", "C:/some/base.png",
+        })!;
+        args.AlignedBasePath.Should().Be("C:/some/base.png");
+    }
 }

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsSynthesisProbeTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsSynthesisProbeTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class CliArgsSynthesisProbeTests
+{
+    [Fact]
+    public void Parses_truth_cal_five_tuple()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe",
+            "--screenshot", "x.png",
+            "--area", "AreaEltibule",
+            "--truth-cal", "0.82,0.0,100.5,200.5,false",
+        })!;
+
+        args.TruthCal.Should().NotBeNull();
+        args.TruthCal!.Value.Scale.Should().Be(0.82);
+        args.TruthCal.Value.Rot.Should().Be(0.0);
+        args.TruthCal.Value.Ox.Should().Be(100.5);
+        args.TruthCal.Value.Oy.Should().Be(200.5);
+        args.TruthCal.Value.Mirror.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parses_ransac_seeds_csv_path()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe",
+            "--screenshot", "x.png",
+            "--area", "AreaEltibule",
+            "--ransac-seeds-csv", "C:/seeds.csv",
+        })!;
+        args.RansacSeedsCsvPath.Should().Be("C:/seeds.csv");
+    }
+
+    [Fact]
+    public void Parses_trace_console_flag()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--screenshot", "x.png", "--area", "AreaEltibule",
+            "--trace-console",
+        })!;
+        args.TraceConsole.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parses_otlp_endpoint()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--screenshot", "x.png", "--area", "AreaEltibule",
+            "--otlp", "http://localhost:4317",
+        })!;
+        args.OtlpEndpoint.Should().Be("http://localhost:4317");
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E1_E2_E3_Tests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E1_E2_E3_Tests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E1_E2_E3_Tests
+{
+    private static (IReadOnlyDictionary<string, double[,]> fields, IReadOnlyList<ReferencePoint> refs, CandidateTransform truth) SyntheticScene()
+    {
+        // 64x64 portal field with one strong peak at (20,20).
+        var portal = new double[64, 64];
+        portal[20, 20] = 0.9;
+        var refs = new[] { new ReferencePoint("p1", "Portal", WorldX: 0, WorldZ: 0) };
+        var truth = new CandidateTransform(Scale: 1.0, RotRadians: 0.0, Mirror: false, Tx: 20.0, Ty: 20.0);
+        return (new Dictionary<string, double[,]> { ["Portal"] = portal }, refs, truth);
+    }
+
+    [Fact]
+    public void E1_writes_truth_row()
+    {
+        var (fields, refs, truth) = SyntheticScene();
+        var dir = NewTempDir();
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+                E1_TruthScore.Run(fields, refs, truth, w);
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            rows.Should().Contain(r => r.StartsWith("E1,truth,"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void E2_writes_landscape_with_peak_at_truth_center()
+    {
+        var (fields, refs, truth) = SyntheticScene();
+        var dir = NewTempDir();
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+                E2_TranslationSweep.Run(fields, refs, truth, templateSizePx: 5, w);
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            rows.Where(r => r.StartsWith("E2,")).Should().NotBeEmpty();
+            File.Exists(Path.Combine(dir, "grid_landscape_translation.png")).Should().BeTrue();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void E3_writes_51_scale_rows()
+    {
+        var (fields, refs, truth) = SyntheticScene();
+        var dir = NewTempDir();
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+                E3_ScaleSweep.Run(fields, refs, truth, w);
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            rows.Count(r => r.StartsWith("E3,")).Should().Be(51);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-e123-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E4_RansacSeedScoreTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E4_RansacSeedScoreTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E4_RansacSeedScoreTests
+{
+    [Fact]
+    public void Reads_csv_and_scores_each_seed_with_dominance()
+    {
+        var portal = new double[64, 64];
+        portal[20, 20] = 0.9;
+        var fields = new Dictionary<string, double[,]> { ["Portal"] = portal };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var truth = new CandidateTransform(1.0, 0.0, false, 20, 20);
+
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-e4-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var csv = Path.Combine(dir, "seeds.csv");
+            File.WriteAllLines(csv, new[]
+            {
+                "label,scale,rot,ox,oy,mirror",
+                "near_truth,1.0,0.0,20.5,20.5,false",
+                "far_off,1.0,0.0,-100,-100,false",
+            });
+
+            using (var w = new SynthesisProbeWriter(dir))
+                E4_RansacSeedScore.Run(fields, refs, truth, csv, w);
+
+            var rows = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv")).Where(r => r.StartsWith("E4,")).ToList();
+            rows.Should().HaveCount(2);
+            var nearRow = rows.Single(r => r.Contains(",near_truth,"));
+            var farRow = rows.Single(r => r.Contains(",far_off,"));
+            double JOf(string row) => double.Parse(row.Split(',')[7], System.Globalization.CultureInfo.InvariantCulture);
+            JOf(nearRow).Should().BeGreaterThan(JOf(farRow));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGridTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGridTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E5_ColdGridTests
+{
+    [Fact]
+    public void Top8_includes_a_near_truth_entry_after_refine()
+    {
+        var f = new double[128, 128];
+        for (int y = 0; y < 128; y++)
+            for (int x = 0; x < 128; x++)
+            {
+                double dx = x - 64, dy = y - 64;
+                f[y, x] = Math.Exp(-(dx * dx + dy * dy) / (2 * 3.0 * 3.0));
+            }
+        var fields = new Dictionary<string, double[,]> { ["Portal"] = f };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var truth = new CandidateTransform(1.0, 0.0, false, 64, 64);
+
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-e5-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var report = E5_ColdGrid.Run(
+                fields, refs, truth,
+                scaleBracket: (0.5, 2.0),
+                scaleSamples: 8,
+                cropWidth: 128, cropHeight: 128,
+                gridStepPx: 8,
+                templateSizePx: 5,
+                writer: w);
+            report.BestDistanceToTruthPx.Should().BeLessThan(5.0);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs
@@ -8,7 +8,7 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experi
 public class E5_ColdGrid_BracketedTests
 {
     [Fact]
-    public void Bracketed_scaleRange_centers_at_expected_scale()
+    public void Bracketed_candidates_stay_within_scale_bracket()
     {
         var portal = new double[64, 64];
         portal[20, 20] = 0.9;

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/Experiments/E5_ColdGrid_BracketedTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests.Experiments;
+
+public class E5_ColdGrid_BracketedTests
+{
+    [Fact]
+    public void Bracketed_scaleRange_centers_at_expected_scale()
+    {
+        var portal = new double[64, 64];
+        portal[20, 20] = 0.9;
+        var fields = new System.Collections.Generic.Dictionary<string, double[,]> { ["Portal"] = portal };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var truth = new CandidateTransform(0.5, 0.0, false, 20, 20);
+
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "synth-probe-e5-bracket-" + System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var report = E5_ColdGrid.Run(
+                fields, refs, truth,
+                scaleBracket: E5_ColdGrid.BracketAroundExpected(0.5, fractionAbove: 0.2),
+                scaleSamples: 8,
+                cropWidth: 64, cropHeight: 64,
+                gridStepPx: 8,
+                templateSizePx: 5,
+                writer: w);
+
+            // All explored scales must be within ±20% of 0.5 → [0.4, 0.6].
+            foreach (var (t, _, _) in report.Top8AfterRefine)
+            {
+                t.Scale.Should().BeInRange(0.4 * 0.99, 0.6 * 1.01,
+                    "bracketed E5 must not consider scales outside ±20% of expected");
+            }
+        }
+        finally { System.IO.Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldBuildTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldBuildTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldBuildTests
+{
+    [Fact]
+    public void Field_peaks_at_known_icon_location()
+    {
+        // 64x64 black background. Base is also black.
+        // Using fill=0 means deviation = max(0, screenshot - base) = screenshot itself,
+        // so the stamped template pixels propagate unchanged into the deviation image.
+        const int W = 64, H = 64;
+        var screenshot = NewGray(W, H, fill: 0);
+        var baseTex = NewGray(W, H, fill: 0);
+
+        // 5x5 template: bright cross with varying pixel values so NCC is well-defined.
+        // Opaque region: center (2,2) = 255, arms = 200. Transparent corners = 0.
+        // Alpha mirrors the cross shape (opaque where cross arm pixels are).
+        // IconTemplate uses GrayImage Gray + GrayImage Alpha (not flat byte arrays).
+        var crossPixels = new byte[]
+        {
+              0,  0,200,  0,  0,
+              0,  0,200,  0,  0,
+            200,200,255,200,200,
+              0,  0,200,  0,  0,
+              0,  0,200,  0,  0
+        };
+        var crossAlpha = new byte[]
+        {
+            0,0,255,0,0,
+            0,0,255,0,0,
+            255,255,255,255,255,
+            0,0,255,0,0,
+            0,0,255,0,0
+        };
+        var template = new IconTemplate(
+            Name: "x",
+            LandmarkType: "Portal",
+            PivotX: 0.5,
+            PivotY: 0.5,
+            Gray: new GrayImage(5, 5, crossPixels),
+            Alpha: new GrayImage(5, 5, crossAlpha));
+
+        // Stamp the template on the screenshot at center (32,32).
+        StampTemplate(screenshot, template, cx: 32, cy: 32);
+
+        var field = IconLikelihoodField.Build(screenshot, baseTex, template);
+
+        field.GetLength(0).Should().Be(H);
+        field.GetLength(1).Should().Be(W);
+        var (maxX, maxY) = Argmax(field);
+        maxX.Should().BeInRange(31, 33);
+        maxY.Should().BeInRange(31, 33);
+        field[maxY, maxX].Should().BeGreaterThan(0.8);
+    }
+
+    private static GrayImage NewGray(int w, int h, byte fill)
+    {
+        var p = new byte[w * h];
+        Array.Fill(p, fill);
+        return new GrayImage(w, h, p);
+    }
+
+    private static void StampTemplate(GrayImage img, IconTemplate t, int cx, int cy)
+    {
+        int tw = t.Gray.Width;
+        int th = t.Gray.Height;
+        int x0 = cx - tw / 2;
+        int y0 = cy - th / 2;
+        for (int ty = 0; ty < th; ty++)
+            for (int tx = 0; tx < tw; tx++)
+            {
+                if (t.Alpha.Pixels[ty * tw + tx] < 128) continue;
+                int x = x0 + tx, y = y0 + ty;
+                if (x < 0 || y < 0 || x >= img.Width || y >= img.Height) continue;
+                img.Pixels[y * img.Width + x] = t.Gray.Pixels[ty * tw + tx];
+            }
+    }
+
+    private static (int X, int Y) Argmax(double[,] field)
+    {
+        int bestX = 0, bestY = 0;
+        double bestV = double.NegativeInfinity;
+        for (int y = 0; y < field.GetLength(0); y++)
+            for (int x = 0; x < field.GetLength(1); x++)
+                if (field[y, x] > bestV) { bestV = field[y, x]; bestX = x; bestY = y; }
+        return (bestX, bestY);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldLoadDeviationTests
+{
+    [Fact]
+    public void LoadDeviationAsField_peaks_at_pre_subtracted_icon_location()
+    {
+        const int W = 64, H = 64;
+        // Synthetic pre-subtracted deviation: black background, single 5x5
+        // cross stamped at (32, 32). This is what the live engine produces
+        // post-ECC, post-subtraction.
+        var devPixels = new byte[W * H];
+        StampCross(devPixels, W, cx: 32, cy: 32);
+        var deviation = new GrayImage(W, H, devPixels);
+
+        var template = MakeCrossTemplate();
+        var field = IconLikelihoodField.LoadDeviationAsField(deviation, template);
+
+        field.GetLength(0).Should().Be(H);
+        field.GetLength(1).Should().Be(W);
+
+        var (maxX, maxY) = Argmax(field);
+        maxX.Should().BeInRange(31, 33);
+        maxY.Should().BeInRange(31, 33);
+        field[maxY, maxX].Should().BeGreaterThan(0.8);
+    }
+
+    private static void StampCross(byte[] pixels, int width, int cx, int cy)
+    {
+        for (int dy = -2; dy <= 2; dy++)
+            pixels[(cy + dy) * width + cx] = 200;
+        for (int dx = -2; dx <= 2; dx++)
+            pixels[cy * width + (cx + dx)] = 200;
+        pixels[cy * width + cx] = 255;
+    }
+
+    private static IconTemplate MakeCrossTemplate()
+    {
+        var gray = new byte[]   { 0,0,200,0,0,  0,0,200,0,0,  200,200,255,200,200,  0,0,200,0,0,  0,0,200,0,0 };
+        var alpha = new byte[]  { 0,0,255,0,0,  0,0,255,0,0,  255,255,255,255,255,  0,0,255,0,0,  0,0,255,0,0 };
+        return new IconTemplate(
+            Name: "x", LandmarkType: "Portal", PivotX: 0.5, PivotY: 0.5,
+            Gray: new GrayImage(5, 5, gray),
+            Alpha: new GrayImage(5, 5, alpha));
+    }
+
+    private static (int X, int Y) Argmax(double[,] field)
+    {
+        int bestX = 0, bestY = 0; double bestV = double.NegativeInfinity;
+        for (int y = 0; y < field.GetLength(0); y++)
+            for (int x = 0; x < field.GetLength(1); x++)
+                if (field[y, x] > bestV) { bestV = field[y, x]; bestX = x; bestY = y; }
+        return (bestX, bestY);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldSampleTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldSampleTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldSampleTests
+{
+    [Fact]
+    public void Sample_at_integer_position_returns_grid_value()
+    {
+        var field = new double[3, 3];
+        field[1, 1] = 0.7;
+        IconLikelihoodField.Sample(field, 1.0, 1.0).Should().BeApproximately(0.7, 1e-9);
+    }
+
+    [Fact]
+    public void Sample_between_grid_points_interpolates_monotonically()
+    {
+        // Linearly-rising field along x: f(x,y) = x*0.1.
+        var field = new double[3, 5];
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 5; x++)
+                field[y, x] = x * 0.1;
+
+        var s1 = IconLikelihoodField.Sample(field, 1.0, 1.0);
+        var s15 = IconLikelihoodField.Sample(field, 1.5, 1.0);
+        var s2 = IconLikelihoodField.Sample(field, 2.0, 1.0);
+
+        s15.Should().BeGreaterThan(s1);
+        s15.Should().BeLessThan(s2);
+        s15.Should().BeApproximately(0.15, 0.02);  // bicubic stays close to linear on a linear field
+    }
+
+    [Fact]
+    public void Sample_outside_field_returns_zero()
+    {
+        var field = new double[3, 3];
+        for (int y = 0; y < 3; y++) for (int x = 0; x < 3; x++) field[y, x] = 1.0;
+
+        IconLikelihoodField.Sample(field, -1.0, 1.0).Should().Be(0.0);
+        IconLikelihoodField.Sample(field, 3.5, 1.0).Should().Be(0.0);
+        IconLikelihoodField.Sample(field, 1.0, -0.5).Should().Be(0.0);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/JEvaluatorTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/JEvaluatorTests.cs
@@ -1,0 +1,51 @@
+// JEvaluatorTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class JEvaluatorTests
+{
+    [Fact]
+    public void J_is_high_when_refs_project_onto_field_peaks()
+    {
+        // Two 64x64 fields with one peak each at known crop pixels.
+        var portalField = ZerosWithPeak(64, 64, peakX: 20, peakY: 20, value: 0.95);
+        var npcField = ZerosWithPeak(64, 64, peakX: 50, peakY: 40, value: 0.92);
+        var fields = new Dictionary<string, double[,]>
+        {
+            ["Portal"] = portalField,
+            ["Npc"] = npcField,
+        };
+
+        // Two refs in world coords that land at the peaks under identity-ish transform.
+        var refs = new[]
+        {
+            new ReferencePoint("p1", "Portal", WorldX: 0, WorldZ: 0),
+            new ReferencePoint("n1", "Npc", WorldX: 30, WorldZ: -20),
+        };
+
+        // Transform: identity-ish, picking origin so world (0,0) lands at (20,20)
+        // and (30,-20) lands at (50,40). Scale = 1 px/unit, no rotation, no mirror.
+        var truth = new CandidateTransform(Scale: 1.0, RotRadians: 0.0, Mirror: false, Tx: 20.0, Ty: 20.0);
+
+        var jTruth = JEvaluator.Evaluate(truth, fields, refs);
+        jTruth.J.Should().BeGreaterThan(1.8); // sum of two ~0.9 peaks
+        jTruth.RefsAboveHalf.Should().Be(2);
+        jTruth.RefsOffCrop.Should().Be(0);
+
+        // Shift origin so refs land far off the peaks.
+        var wrong = truth with { Tx = -100.0, Ty = -100.0 };
+        var jWrong = JEvaluator.Evaluate(wrong, fields, refs);
+        jWrong.J.Should().BeLessThan(0.1);
+        jWrong.RefsOffCrop.Should().Be(2);
+    }
+
+    private static double[,] ZerosWithPeak(int w, int h, int peakX, int peakY, double value)
+    {
+        var f = new double[h, w];
+        f[peakY, peakX] = value;
+        return f;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/JEvaluatorTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/JEvaluatorTests.cs
@@ -11,8 +11,8 @@ public class JEvaluatorTests
     public void J_is_high_when_refs_project_onto_field_peaks()
     {
         // Two 64x64 fields with one peak each at known crop pixels.
-        var portalField = ZerosWithPeak(64, 64, peakX: 20, peakY: 20, value: 0.95);
-        var npcField = ZerosWithPeak(64, 64, peakX: 50, peakY: 40, value: 0.92);
+        var portalField = ZerosWithPeak(h: 64, w: 64, peakX: 20, peakY: 20, value: 0.95);
+        var npcField = ZerosWithPeak(h: 64, w: 64, peakX: 50, peakY: 40, value: 0.92);
         var fields = new Dictionary<string, double[,]>
         {
             ["Portal"] = portalField,
@@ -42,7 +42,7 @@ public class JEvaluatorTests
         jWrong.RefsOffCrop.Should().Be(2);
     }
 
-    private static double[,] ZerosWithPeak(int w, int h, int peakX, int peakY, double value)
+    private static double[,] ZerosWithPeak(int h, int w, int peakX, int peakY, double value)
     {
         var f = new double[h, w];
         f[peakY, peakX] = value;

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/LocalRefineTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/LocalRefineTests.cs
@@ -1,0 +1,30 @@
+// LocalRefineTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class LocalRefineTests
+{
+    [Fact]
+    public void Pulls_in_from_5px_offset_on_gaussian_peak()
+    {
+        int W = 64, H = 64;
+        var f = new double[H, W];
+        for (int y = 0; y < H; y++)
+            for (int x = 0; x < W; x++)
+            {
+                double dx = x - 32, dy = y - 32;
+                f[y, x] = Math.Exp(-(dx * dx + dy * dy) / (2 * 3.0 * 3.0));
+            }
+        var fields = new Dictionary<string, double[,]> { ["Portal"] = f };
+        var refs = new[] { new ReferencePoint("p1", "Portal", 0, 0) };
+        var seed = new CandidateTransform(Scale: 1.0, RotRadians: 0.0, Mirror: false, Tx: 27.0, Ty: 32.0);
+
+        var refined = LocalRefine.Run(seed, fields, refs, maxIter: 60, stepInit: 1.0);
+
+        refined.Tx.Should().BeApproximately(32.0, 0.5);
+        refined.Ty.Should().BeApproximately(32.0, 0.5);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/MapCalibrationFromScreenshot.SynthesisProbe.Tests.csproj
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/MapCalibrationFromScreenshot.SynthesisProbe.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MapCalibrationFromScreenshot\MapCalibrationFromScreenshot.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ProbeReferencesTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ProbeReferencesTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class ProbeReferencesTests
+{
+    [Fact]
+    public void Loads_eltibule_refs_with_canonical_types()
+    {
+        var landmarks = ProbeReferences.DefaultLandmarksPath();
+        var npcs = ProbeReferences.DefaultNpcsPath();
+        var refs = ProbeReferences.Load(landmarks, npcs, area: "AreaEltibule");
+
+        refs.Should().NotBeEmpty();
+        refs.Select(r => r.LandmarkType).Distinct().Should().BeSubsetOf(new[]
+        {
+            "Portal", "MeditationPillar", "TeleportationPlatform", "Npc",
+        });
+        refs.Should().HaveCount(38);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ScaffoldTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/ScaffoldTests.cs
@@ -1,0 +1,14 @@
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class ScaffoldTests
+{
+    [Fact]
+    public void Phase_synthesis_probe_is_a_recognized_phase_value()
+    {
+        Enum.IsDefined(typeof(Phase), Phase.SynthesisProbe).Should().BeTrue();
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeTracerTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeTracerTests.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class SynthesisProbeTracerTests
+{
+    [Fact]
+    public void ActivitySource_emits_span_when_listener_is_attached()
+    {
+        var emitted = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == SynthesisProbeTracer.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = emitted.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using (var act = SynthesisProbeTracer.Source.StartActivity("test.span"))
+        {
+            act?.SetTag("foo", "bar");
+        }
+
+        emitted.Should().ContainSingle(a => a.OperationName == "test.span");
+        emitted[0].Tags.Should().Contain(kv => kv.Key == "foo" && kv.Value == "bar");
+    }
+
+    [Fact]
+    public void No_exception_when_no_listener_attached()
+    {
+        var act = SynthesisProbeTracer.Source.StartActivity("never.listened");
+        act.Should().BeNull();
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeWriterTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeWriterTests.cs
@@ -1,0 +1,65 @@
+// SynthesisProbeWriterTests.cs
+using FluentAssertions;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class SynthesisProbeWriterTests
+{
+    [Fact]
+    public void Csv_writes_header_and_row()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-csv-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using (var w = new SynthesisProbeWriter(dir))
+            {
+                var t = new CandidateTransform(0.5, 0.0, false, 100, 200);
+                var jr = new JResult(J: 1.7, RefsAboveHalf: 2, RefsOffCrop: 0, PerRefScores: new[] { 0.9, 0.8 });
+                w.AppendCsvRow("E1", "truth", t, jr, dominanceVsRunnerUp: double.NaN);
+            }
+            var lines = File.ReadAllLines(Path.Combine(dir, "synthesis_probe.csv"));
+            lines[0].Should().Be("experiment,label,scale,rot,mirror,tx,ty,J,refs_above_0.5,dominance_vs_runner_up");
+            lines[1].Should().StartWith("E1,truth,0.5,0,false,100,200,1.7,2,");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Field_png_written_with_expected_dims()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-png-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var field = new double[10, 20];
+            field[5, 10] = 0.9;
+            w.WriteFieldPng("Portal", field);
+            File.Exists(Path.Combine(dir, "field_Portal.png")).Should().BeTrue();
+            using var img = System.Drawing.Image.FromFile(Path.Combine(dir, "field_Portal.png"));
+            img.Width.Should().Be(20);
+            img.Height.Should().Be(10);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Landscape_png_dimensions_match_input()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "synth-probe-land-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            using var w = new SynthesisProbeWriter(dir);
+            var landscape = new double[65, 65];
+            w.WriteLandscapePng("translation", landscape);
+            using var img = System.Drawing.Image.FromFile(Path.Combine(dir, "grid_landscape_translation.png"));
+            img.Width.Should().Be(65);
+            img.Height.Should().Be(65);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeWriterTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/SynthesisProbeWriterTests.cs
@@ -39,9 +39,12 @@ public class SynthesisProbeWriterTests
             field[5, 10] = 0.9;
             w.WriteFieldPng("Portal", field);
             File.Exists(Path.Combine(dir, "field_Portal.png")).Should().BeTrue();
-            using var img = System.Drawing.Image.FromFile(Path.Combine(dir, "field_Portal.png"));
+            using var img = (System.Drawing.Bitmap)System.Drawing.Image.FromFile(Path.Combine(dir, "field_Portal.png"));
             img.Width.Should().Be(20);
             img.Height.Should().Be(10);
+            // field[5, 10] = 0.9 in NCC space [-1, 1] → 8-bit gray ≈ (0.9 - (-1)) / 2 * 255 ≈ 242
+            var peak = img.GetPixel(10, 5);
+            peak.R.Should().BeGreaterThan(200, "peak pixel should be bright");
         }
         finally { Directory.Delete(dir, recursive: true); }
     }

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -190,8 +190,16 @@ internal sealed record CliArgs(
                     detectionsJsonPath = Next(argv, ref i);
                     break;
                 case "--hand-truth-cal":
-                    handTruthCal = ParseTruthCal(Next(argv, ref i));  // reuses the scale,rot,ox,oy,mirror parser
+                {
+                    var raw = Next(argv, ref i);
+                    try { handTruthCal = ParseTruthCal(raw); }
+                    catch (UserFacingException)
+                    {
+                        throw new UserFacingException(
+                            $"--hand-truth-cal wants 'scale,rot,ox,oy,mirror' (got '{raw}')");
+                    }
                     break;
+                }
                 case "-h" or "--help":
                     return null;
                 default:

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -148,6 +148,8 @@ internal sealed record CliArgs(
         // Only the full pipeline needs --screenshot. extract-icons and
         // extract-map are cache-population modes; self-test synthesises its
         // own inputs.
+        // SynthesisProbe also requires --screenshot; guard added in Task 14 where
+        // SynthesisProbePhase.Run first reads args.ScreenshotPath.
         if (screenshot is null && phase is Phase.Full)
         {
             Console.Error.WriteLine("--screenshot required for --phase full");

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -40,7 +40,13 @@ internal sealed record CliArgs(
     string? RansacSeedsCsvPath,
     bool TraceConsole,
     string? OtlpEndpoint,
-    string? AlignedBasePath)
+    string? AlignedBasePath,
+    string? BundleDir,
+    string? MapRectJsonPath,
+    string? RecoveredCalJsonPath,
+    string? AlignedDeviationPath,
+    string? DetectionsJsonPath,
+    (double Scale, double Rot, double Ox, double Oy, bool Mirror)? HandTruthCal)
 {
     public static CliArgs? Parse(string[] argv)
     {
@@ -78,6 +84,12 @@ internal sealed record CliArgs(
         bool traceConsole = false;
         string? otlpEndpoint = null;
         string? alignedBasePath = null;
+        string? bundleDir = null;
+        string? mapRectJsonPath = null;
+        string? recoveredCalJsonPath = null;
+        string? alignedDeviationPath = null;
+        string? detectionsJsonPath = null;
+        (double, double, double, double, bool)? handTruthCal = null;
 
         for (int i = 0; i < argv.Length; i++)
         {
@@ -162,6 +174,24 @@ internal sealed record CliArgs(
                 case "--aligned-base":
                     alignedBasePath = Next(argv, ref i);
                     break;
+                case "--bundle-dir":
+                    bundleDir = Next(argv, ref i);
+                    break;
+                case "--maprect-json":
+                    mapRectJsonPath = Next(argv, ref i);
+                    break;
+                case "--recovered-cal-json":
+                    recoveredCalJsonPath = Next(argv, ref i);
+                    break;
+                case "--aligned-deviation":
+                    alignedDeviationPath = Next(argv, ref i);
+                    break;
+                case "--detections-json":
+                    detectionsJsonPath = Next(argv, ref i);
+                    break;
+                case "--hand-truth-cal":
+                    handTruthCal = ParseTruthCal(Next(argv, ref i));  // reuses the scale,rot,ox,oy,mirror parser
+                    break;
                 case "-h" or "--help":
                     return null;
                 default:
@@ -241,7 +271,13 @@ internal sealed record CliArgs(
             RansacSeedsCsvPath: ransacSeedsCsv,
             TraceConsole: traceConsole,
             OtlpEndpoint: otlpEndpoint,
-            AlignedBasePath: alignedBasePath);
+            AlignedBasePath: alignedBasePath,
+            BundleDir: bundleDir,
+            MapRectJsonPath: mapRectJsonPath,
+            RecoveredCalJsonPath: recoveredCalJsonPath,
+            AlignedDeviationPath: alignedDeviationPath,
+            DetectionsJsonPath: detectionsJsonPath,
+            HandTruthCal: handTruthCal);
     }
 
     private static (double, double, double, double, bool) ParseSeed(string s)
@@ -453,6 +489,26 @@ internal sealed record CliArgs(
                                                      crop dimensions. Overrides the auto-load+resize path; use when
                                                      a fixture pre-pair was prepared by the live capture pipeline
                                                      (e.g. study fixtures with matching foo-crop.png + foo-texture-resampled.png).
+              --bundle-dir <dir>                    a per-attempt diagnostic bundle directory written by Mithril's
+                                                     AutoCalibrationEngine. Auto-resolves --maprect-json /
+                                                     --recovered-cal-json / --aligned-deviation / --detections-json
+                                                     from the bundle's 01-attempt.json manifest if those flags aren't
+                                                     given explicitly.
+              --maprect-json <path>                 the bundle's 04-maprect.json (texture↔aligned-pair transform).
+              --recovered-cal-json <path>           the bundle's 11-recovered-cal.json (production-recovered
+                                                     AreaCalibration). When given with --maprect-json, the
+                                                     synthesis-probe derives --truth-cal automatically.
+              --aligned-deviation <path>            the bundle's 07-deviation.png (post-ECC, post-subtraction
+                                                     deviation). Bypasses IconLikelihoodField.Build's subtraction.
+              --detections-json <path>              the bundle's 10-detections.json (production's NCC detection set).
+                                                     Optional; not consumed in v1.
+              --hand-truth-cal <scale,rot,ox,oy,mirror>
+                                                     user-supplied texture-pixel-space truth cal (mirror = true|false).
+                                                     Converted to crop-pixel via --maprect-json before use. Takes
+                                                     precedence over --recovered-cal-json (use when production's
+                                                     recovered cal is known-wrong, e.g. the 2026-06-02 4-inlier
+                                                     residual-4-px solves; supply the hand-verified entry from
+                                                     src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json).
             """);
     }
 }

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -35,7 +35,11 @@ internal sealed record CliArgs(
     bool UseBorderMask,
     string? DetectionsCsvPath,
     bool IgnoreTypes,
-    (double Rot, double Scale, double Ox, double Oy, bool Mirror)? Seed)
+    (double Rot, double Scale, double Ox, double Oy, bool Mirror)? Seed,
+    (double Scale, double Rot, double Ox, double Oy, bool Mirror)? TruthCal,
+    string? RansacSeedsCsvPath,
+    bool TraceConsole,
+    string? OtlpEndpoint)
 {
     public static CliArgs? Parse(string[] argv)
     {
@@ -68,6 +72,10 @@ internal sealed record CliArgs(
         string? detectionsCsv = null;
         bool ignoreTypes = false;
         (double, double, double, double, bool)? seed = null;
+        (double, double, double, double, bool)? truthCal = null;
+        string? ransacSeedsCsv = null;
+        bool traceConsole = false;
+        string? otlpEndpoint = null;
 
         for (int i = 0; i < argv.Length; i++)
         {
@@ -136,6 +144,18 @@ internal sealed record CliArgs(
                     break;
                 case "--seed":
                     seed = ParseSeed(Next(argv, ref i));
+                    break;
+                case "--truth-cal":
+                    truthCal = ParseTruthCal(Next(argv, ref i));
+                    break;
+                case "--ransac-seeds-csv":
+                    ransacSeedsCsv = Next(argv, ref i);
+                    break;
+                case "--trace-console":
+                    traceConsole = true;
+                    break;
+                case "--otlp":
+                    otlpEndpoint = Next(argv, ref i);
                     break;
                 case "-h" or "--help":
                     return null;
@@ -211,7 +231,11 @@ internal sealed record CliArgs(
             UseBorderMask: useBorderMask,
             DetectionsCsvPath: detectionsCsv,
             IgnoreTypes: ignoreTypes,
-            Seed: seed);
+            Seed: seed,
+            TruthCal: truthCal,
+            RansacSeedsCsvPath: ransacSeedsCsv,
+            TraceConsole: traceConsole,
+            OtlpEndpoint: otlpEndpoint);
     }
 
     private static (double, double, double, double, bool) ParseSeed(string s)
@@ -225,6 +249,21 @@ internal sealed record CliArgs(
         {
             throw new UserFacingException($"--seed wants 'rot,scale,ox,oy,mirror' (got '{s}')");
         }
+        return (
+            double.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
+            double.Parse(parts[1].Trim(), CultureInfo.InvariantCulture),
+            double.Parse(parts[2].Trim(), CultureInfo.InvariantCulture),
+            double.Parse(parts[3].Trim(), CultureInfo.InvariantCulture),
+            bool.Parse(parts[4].Trim()));
+    }
+
+    private static (double, double, double, double, bool) ParseTruthCal(string s)
+    {
+        // "scale,rot,ox,oy,mirror" — the known-correct calibration used as a
+        // reference truth for E1-E5 synthesis-probe diagnostics.
+        // NOTE: ordering is scale-first, unlike ParseSeed which is rot-first.
+        var parts = s.Split(',', 5);
+        if (parts.Length != 5) throw new UserFacingException($"--truth-cal wants 'scale,rot,ox,oy,mirror' (got '{s}')");
         return (
             double.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
             double.Parse(parts[1].Trim(), CultureInfo.InvariantCulture),
@@ -397,6 +436,13 @@ internal sealed record CliArgs(
               --phase self-test             synthetic end-to-end test (no PG/tpk needed)
               --phase synthesis-probe       run E1-E5 icon-likelihood-field diagnostic; emits CSV + PNGs + OTel
               --dry-run                     don't write the baseline JSON, just print what would change
+
+            synthesis-probe diagnostic (--phase synthesis-probe):
+              --truth-cal <scale,rot,ox,oy,mirror>  known-correct calibration for E1-E5 (mirror = true|false)
+              --ransac-seeds-csv <path>             CSV of candidate calibrations to score (E4):
+                                                      label,scale,rot,ox,oy,mirror
+              --trace-console                       emit OTel spans to stdout
+              --otlp <endpoint>                     emit OTel spans to the named OTLP endpoint
             """);
     }
 }

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -39,7 +39,8 @@ internal sealed record CliArgs(
     (double Scale, double Rot, double Ox, double Oy, bool Mirror)? TruthCal,
     string? RansacSeedsCsvPath,
     bool TraceConsole,
-    string? OtlpEndpoint)
+    string? OtlpEndpoint,
+    string? AlignedBasePath)
 {
     public static CliArgs? Parse(string[] argv)
     {
@@ -76,6 +77,7 @@ internal sealed record CliArgs(
         string? ransacSeedsCsv = null;
         bool traceConsole = false;
         string? otlpEndpoint = null;
+        string? alignedBasePath = null;
 
         for (int i = 0; i < argv.Length; i++)
         {
@@ -157,6 +159,9 @@ internal sealed record CliArgs(
                 case "--otlp":
                     otlpEndpoint = Next(argv, ref i);
                     break;
+                case "--aligned-base":
+                    alignedBasePath = Next(argv, ref i);
+                    break;
                 case "-h" or "--help":
                     return null;
                 default:
@@ -235,7 +240,8 @@ internal sealed record CliArgs(
             TruthCal: truthCal,
             RansacSeedsCsvPath: ransacSeedsCsv,
             TraceConsole: traceConsole,
-            OtlpEndpoint: otlpEndpoint);
+            OtlpEndpoint: otlpEndpoint,
+            AlignedBasePath: alignedBasePath);
     }
 
     private static (double, double, double, double, bool) ParseSeed(string s)
@@ -443,6 +449,10 @@ internal sealed record CliArgs(
                                                       label,scale,rot,ox,oy,mirror
               --trace-console                       emit OTel spans to stdout
               --otlp <endpoint>                     emit OTel spans to the named OTLP endpoint
+              --aligned-base <path>                 pre-ECC-aligned base texture PNG, resampled to the --map-rect
+                                                     crop dimensions. Overrides the auto-load+resize path; use when
+                                                     a fixture pre-pair was prepared by the live capture pipeline
+                                                     (e.g. study fixtures with matching foo-crop.png + foo-texture-resampled.png).
             """);
     }
 }

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -292,7 +292,8 @@ internal sealed record CliArgs(
         "full" => Phase.Full,
         "self-test" => Phase.SelfTest,
         "emit-templates" => Phase.EmitTemplates,
-        _ => throw new UserFacingException($"unknown phase '{s}' (extract-icons | extract-map | full | self-test | emit-templates)"),
+        "synthesis-probe" => Phase.SynthesisProbe,
+        _ => throw new UserFacingException($"unknown phase '{s}' (extract-icons | extract-map | full | self-test | emit-templates | synthesis-probe)"),
     };
 
     public static void PrintUsage()
@@ -392,6 +393,7 @@ internal sealed record CliArgs(
               --phase extract-map           only extract the area's map PNG from its bundle
               --phase full                  (default) run the full pipeline
               --phase self-test             synthetic end-to-end test (no PG/tpk needed)
+              --phase synthesis-probe       run E1-E5 icon-likelihood-field diagnostic; emits CSV + PNGs + OTel
               --dry-run                     don't write the baseline JSON, just print what would change
             """);
     }
@@ -404,4 +406,5 @@ internal enum Phase
     ExtractMap,
     SelfTest,
     EmitTemplates,
+    SynthesisProbe,
 }

--- a/tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj
+++ b/tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj
@@ -22,6 +22,11 @@
     <PackageReference Include="AssetsTools.NET" Version="3.0.4" />
     <PackageReference Include="AssetsTools.NET.Texture" Version="3.0.2" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+    <!--
+      OTel 1.15.3 (not the plan's 1.10.0): 1.10.0 fails NU1902 restore due to
+      GHSA-8785-wc3w-h8q6 / GHSA-g94r-2vxg-569j / GHSA-4625-4j76-fww9; 1.15.3 is
+      what Directory.Packages.props pins for the main solution.
+    -->
     <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj
+++ b/tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj
@@ -22,6 +22,9 @@
     <PackageReference Include="AssetsTools.NET" Version="3.0.4" />
     <PackageReference Include="AssetsTools.NET.Texture" Version="3.0.2" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,5 +36,10 @@
     -->
     <ProjectReference Include="..\..\src\Mithril.MapCalibration\Mithril.MapCalibration.csproj" />
     <ProjectReference Include="..\Mithril.MapCalibration.Tools.Common\Mithril.MapCalibration.Tools.Common.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>MapCalibrationFromScreenshot.SynthesisProbe.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/tools/MapCalibrationFromScreenshot/Pipeline.cs
+++ b/tools/MapCalibrationFromScreenshot/Pipeline.cs
@@ -19,6 +19,11 @@ internal static class Pipeline
             return SelfTest.Run();
         }
 
+        if (args.Phase == Phase.SynthesisProbe)
+        {
+            return SynthesisProbe.SynthesisProbePhase.Run(args);
+        }
+
         var pgInstall = SteamInstall.FindPgInstall();
         Console.WriteLine($"[steam] PG install: {pgInstall}");
 

--- a/tools/MapCalibrationFromScreenshot/README.md
+++ b/tools/MapCalibrationFromScreenshot/README.md
@@ -207,6 +207,36 @@ dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
 
 Artifacts are written to `study/synthesis-probe/<area>/`.
 
+### Bundle-driven workflow (after PR #985)
+
+The synthesis probe consumes the per-attempt diagnostic bundles Mithril's live engine writes (`%LocalAppData%/Mithril/diagnostics/calibration/<Area>-<timestamp>-<outcome>/`). For a single attempt:
+
+```powershell
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
+  --phase synthesis-probe `
+  --area AreaEltibule `
+  --bundle-dir "C:/Users/<you>/AppData/Local/Mithril/diagnostics/calibration/AreaEltibule-20260602-1230-accepted"
+```
+
+`--bundle-dir` resolves the rest from the bundle's `01-attempt.json` manifest:
+
+| Bundle file | Probe flag (auto-resolved) |
+|---|---|
+| `04-maprect.json` | `--maprect-json` |
+| `07-deviation.png` | `--aligned-deviation` |
+| `11-recovered-cal.json` | `--recovered-cal-json` |
+| `10-detections.json` | `--detections-json` (not consumed in v1) |
+
+When both `--maprect-json` and `--recovered-cal-json` are present, the probe derives truth-cal automatically — no manual `--truth-cal` needed.
+
+If production's recovered cal is known-wrong (e.g. a 4-inlier, residual-≈4-px solve that geometrically misaligns the overlay), override with `--hand-truth-cal scale,rot,ox,oy,mirror` — texture-pixel-space, gets converted via the same MapRect to the field's coord space. Source for hand-verified Eltibule: `src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json`.
+
+When `--aligned-deviation` is present, the probe skips `IconLikelihoodField.Build`'s screenshot-minus-base subtraction and runs `ScoreAll` directly on the bundle's post-ECC deviation.
+
+E5's scale bracket auto-narrows to ±20% of the expected aligned-pair-pixel scale (derived from the MapRect's resize ratio), excluding the tiny-scale degeneracy by construction.
+
+Override any auto-resolved flag by passing it explicitly — the explicit flag wins.
+
 Flags specific to this phase: `--truth-cal`, `--ransac-seeds-csv`, `--trace-console`, `--otlp`. The full flag table near the top of this README documents each.
 
 ## Out of scope (v1)

--- a/tools/MapCalibrationFromScreenshot/README.md
+++ b/tools/MapCalibrationFromScreenshot/README.md
@@ -191,6 +191,24 @@ Recovered calibration vs ground truth derived from manually-measured icon bboxes
 
 8 inliers used (after iterative refinement dropped 2 mis-paired NPCs from the central courtyard cluster). Per-inlier residuals 0.07-0.58 px. Well under the 12 px `CalibrationGoodResidualPx` shipping bar; at parity with manual click-calibration via Legolas.
 
+## `--phase synthesis-probe` — icon-likelihood-field diagnostic
+
+Standalone experiment runner that scores the synthesis objective `J(T) = Σ L_{type(r)}(T·r)` across five experiments on a given screenshot. Output is a CSV + per-type field PNGs + a translation landscape PNG, plus OTel spans. The data decides which of two production-solver proposals to build (cold synthesis vs. RANSAC-seeded hybrid). See [`docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md`](../../docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md).
+
+```powershell
+dotnet run --project tools/MapCalibrationFromScreenshot -c Release -- `
+  --phase synthesis-probe `
+  --area AreaEltibule `
+  --screenshot path/to/screenshot.png `
+  --map-rect x,y,w,h `
+  --truth-cal scale,rot,ox,oy,mirror `
+  --trace-console
+```
+
+Artifacts are written to `study/synthesis-probe/<area>/`.
+
+Flags specific to this phase: `--truth-cal`, `--ransac-seeds-csv`, `--trace-console`, `--otlp`. The full flag table near the top of this README documents each.
+
 ## Out of scope (v1)
 
 - **Shell integration.** This is a standalone tool. Once it has populated the baseline JSON, the result rides into Mithril via the existing [`BundledBaselineLoader`](../../src/Mithril.MapCalibration/Internal/BundledBaselineLoader.cs).

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleJsonDtos.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleJsonDtos.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+// Mirrors src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs.
+// Replicated here (rather than ProjectReference'd) to keep the tool decoupled
+// from the WPF-flavored Capture project. Shape parity is the contract — if
+// CalibrationBundleJsonContext gains a field, mirror it here too.
+internal sealed record AttemptJson(
+    int SchemaVersion,
+    string Area,
+    string AttemptStartedUtc,
+    string AttemptFinalizedUtc,
+    string Outcome,
+    string? RejectReason,
+    string EngineVersion,
+    AttemptFilesJson Files);
+
+internal sealed record AttemptFilesJson(
+    string? RawScreenshot,
+    string? GrayScreenshot,
+    string? MapRect,
+    string? BaseTextureResampled,
+    string? AlignedScreenshot,
+    string? Deviation,
+    string? DetectionsImage,
+    string? ProjectionOverlay,
+    string? Detections,
+    string? RecoveredCalibration);
+
+internal sealed record MapRectJson(
+    int SchemaVersion,
+    int OriginX,
+    int OriginY,
+    int Width,
+    int Height,
+    int TextureWidth,
+    int TextureHeight,
+    double? AutoDetectScore,
+    double? SourceScaleFactor);
+
+internal sealed record DetectionJson(
+    string LandmarkType,
+    string IconName,
+    double AnchorX,
+    double AnchorY,
+    double Score);
+
+internal sealed record DetectionsJson(
+    int SchemaVersion,
+    int RenderSizePx,
+    IReadOnlyList<DetectionJson> Detections);
+
+internal sealed record InlierJson(
+    string Label,
+    double WorldX,
+    double WorldZ,
+    double PixelX,
+    double PixelY,
+    double MatchScore);
+
+internal sealed record RecoveredCalibrationJson(
+    int SchemaVersion,
+    double Scale,
+    double RotationRadians,
+    double OriginX,
+    double OriginY,
+    bool MirrorNorth,
+    double CalibrationZoom,
+    double ResidualPixels,
+    int ReferenceCount,
+    string Source,
+    IReadOnlyList<InlierJson> Inliers);
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+[JsonSerializable(typeof(AttemptJson))]
+[JsonSerializable(typeof(MapRectJson))]
+[JsonSerializable(typeof(DetectionsJson))]
+[JsonSerializable(typeof(RecoveredCalibrationJson))]
+internal partial class BundleJsonContext : JsonSerializerContext;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleLoader.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/BundleLoader.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Text.Json;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+internal static class BundleLoader
+{
+    public static LoadedBundle Open(string directory)
+    {
+        var attemptPath = Path.Combine(directory, "01-attempt.json");
+        if (!File.Exists(attemptPath))
+            throw new FileNotFoundException($"Bundle missing 01-attempt.json", attemptPath);
+
+        var attempt = JsonSerializer.Deserialize(
+            File.ReadAllText(attemptPath),
+            BundleJsonContext.Default.AttemptJson)!;
+
+        var mapRect = LoadOptionalJson(directory, attempt.Files.MapRect, BundleJsonContext.Default.MapRectJson);
+        var recoveredCal = LoadOptionalJson(directory, attempt.Files.RecoveredCalibration, BundleJsonContext.Default.RecoveredCalibrationJson);
+        var detections = LoadOptionalJson(directory, attempt.Files.Detections, BundleJsonContext.Default.DetectionsJson);
+
+        string? deviationPath = attempt.Files.Deviation is { } name
+            ? Path.Combine(directory, name)
+            : null;
+        if (deviationPath is not null && !File.Exists(deviationPath))
+            deviationPath = null;
+
+        return new LoadedBundle(directory, attempt, mapRect, recoveredCal, detections, deviationPath);
+    }
+
+    private static T? LoadOptionalJson<T>(
+        string directory,
+        string? fileName,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+        where T : class
+    {
+        if (fileName is null) return null;
+        var path = Path.Combine(directory, fileName);
+        if (!File.Exists(path)) return null;
+        return JsonSerializer.Deserialize(File.ReadAllText(path), typeInfo);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/LoadedBundle.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/LoadedBundle.cs
@@ -1,0 +1,9 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+internal sealed record LoadedBundle(
+    string Directory,
+    AttemptJson Attempt,
+    MapRectJson? MapRect,
+    RecoveredCalibrationJson? RecoveredCal,
+    DetectionsJson? Detections,
+    string? DeviationPath);

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/MapRectConversion.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/MapRectConversion.cs
@@ -23,7 +23,10 @@ internal static class MapRectConversion
     /// CandidateTransform is isotropic-scale-only; if the X and Y resize ratios
     /// differ, the geometric mean is used and the difference is surfaced via
     /// <paramref name="anisotropyPercent"/>. Callers should warn if it exceeds
-    /// roughly 1%.
+    /// roughly 1%. The geometric mean is used as the denominator because it
+    /// equals the adopted Scale factor, making the percentage directly
+    /// interpretable as how much the X vs Y pixel-space error diverges from
+    /// the isotropic approximation.
     /// </summary>
     public static CandidateTransform FromRecoveredCalibration(
         RecoveredCalibrationJson cal,

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/MapRectConversion.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Bundle/MapRectConversion.cs
@@ -1,0 +1,50 @@
+using System;
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
+
+internal static class MapRectConversion
+{
+    /// <summary>
+    /// Convert a production-recovered AreaCalibration (texture-pixel space) plus
+    /// a MapRect (texture↔screenshot mapping) into a CandidateTransform that
+    /// projects world coords into the aligned-pair-pixel space the synthesis
+    /// probe's L_t fields live in. The aligned pair is the MapRect's crop minus
+    /// its origin — i.e., a local (0, 0) coordinate system whose pixel (0, 0)
+    /// is the top-left of the crop, with dimensions (Width, Height).
+    ///
+    /// MapRect.TextureToScreenshot scales texture coords by (Width/TextureWidth,
+    /// Height/TextureHeight) and offsets by (OriginX, OriginY). The aligned-pair
+    /// space is that minus the offset:
+    ///
+    ///     aligned_pair_x = texture_x * (Width / TextureWidth)
+    ///     aligned_pair_y = texture_y * (Height / TextureHeight)
+    ///
+    /// CandidateTransform is isotropic-scale-only; if the X and Y resize ratios
+    /// differ, the geometric mean is used and the difference is surfaced via
+    /// <paramref name="anisotropyPercent"/>. Callers should warn if it exceeds
+    /// roughly 1%.
+    /// </summary>
+    public static CandidateTransform FromRecoveredCalibration(
+        RecoveredCalibrationJson cal,
+        MapRect mapRect,
+        out double anisotropyPercent)
+    {
+        double ratioX = (double)mapRect.Width / mapRect.TextureWidth;
+        double ratioY = (double)mapRect.Height / mapRect.TextureHeight;
+        double geom = Math.Sqrt(ratioX * ratioY);
+        anisotropyPercent = 100.0 * Math.Abs(ratioX - ratioY) / geom;
+
+        return new CandidateTransform(
+            Scale: cal.Scale * geom,
+            RotRadians: cal.RotationRadians,
+            Mirror: cal.MirrorNorth,
+            Tx: cal.OriginX * ratioX,
+            Ty: cal.OriginY * ratioY);
+    }
+
+    /// <summary>Overload without the anisotropy out-param.</summary>
+    public static CandidateTransform FromRecoveredCalibration(
+        RecoveredCalibrationJson cal, MapRect mapRect)
+        => FromRecoveredCalibration(cal, mapRect, out _);
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/CandidateTransform.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/CandidateTransform.cs
@@ -4,6 +4,11 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
 
 internal readonly record struct CandidateTransform(double Scale, double RotRadians, bool Mirror, double Tx, double Ty)
 {
+    // Mirror of AreaCalibration.WorldToWindow at CalibrationZoom = 1.0 (no
+    // zoom factor). Intentional duplication — we don't allocate a full
+    // AreaCalibration per candidate, and we hold the canonical method on the
+    // persistable record. Keep in sync if AreaCalibration's projection math
+    // changes; the parity test in CandidateTransformTests is the trip-wire.
     public PixelPoint Apply(WorldCoord world)
     {
         var east = world.X;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/CandidateTransform.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/CandidateTransform.cs
@@ -1,0 +1,20 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal readonly record struct CandidateTransform(double Scale, double RotRadians, bool Mirror, double Tx, double Ty)
+{
+    public PixelPoint Apply(WorldCoord world)
+    {
+        var east = world.X;
+        var north = Mirror ? -world.Z : world.Z;
+        var cos = Math.Cos(RotRadians);
+        var sin = Math.Sin(RotRadians);
+        var rotE = east * cos + north * sin;
+        var rotN = -east * sin + north * cos;
+        return new PixelPoint(Tx + Scale * rotE, Ty - Scale * rotN);
+    }
+
+    public static CandidateTransform FromAreaCalibration(AreaCalibration cal) =>
+        new(cal.Scale, cal.RotationRadians, cal.MirrorNorth, cal.OriginX, cal.OriginY);
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E1_TruthScore.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E1_TruthScore.cs
@@ -1,0 +1,20 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E1_TruthScore
+{
+    public static JResult Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E1");
+        var jr = JEvaluator.Evaluate(truth, fieldsByType, refs);
+        act?.SetTag("eval_count", 1);
+        act?.SetTag("J_truth", jr.J);
+        act?.SetTag("refs_above_0.5", jr.RefsAboveHalf);
+        act?.SetTag("refs_off_crop", jr.RefsOffCrop);
+        writer.AppendCsvRow("E1", "truth", truth, jr, dominanceVsRunnerUp: double.NaN);
+        return jr;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E2_TranslationSweep.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E2_TranslationSweep.cs
@@ -1,0 +1,36 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E2_TranslationSweep
+{
+    public static void Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        int templateSizePx,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E2");
+        int halfWindow = 2 * templateSizePx;
+        int side = halfWindow * 2 + 1;
+        var landscape = new double[side, side];
+
+        double jBest = double.NegativeInfinity;
+        int evals = 0;
+        for (int dy = -halfWindow; dy <= halfWindow; dy++)
+            for (int dx = -halfWindow; dx <= halfWindow; dx++)
+            {
+                var t = truth with { Tx = truth.Tx + dx, Ty = truth.Ty + dy };
+                var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+                landscape[dy + halfWindow, dx + halfWindow] = jr.J;
+                if (jr.J > jBest) jBest = jr.J;
+                evals++;
+                if (evals % 100 == 0)
+                    writer.AppendCsvRow("E2", $"dx={dx},dy={dy}", t, jr, dominanceVsRunnerUp: double.NaN);
+            }
+        writer.WriteLandscapePng("translation", landscape);
+
+        act?.SetTag("eval_count", evals);
+        act?.SetTag("J_best", jBest);
+        act?.SetTag("window_px", halfWindow);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E3_ScaleSweep.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E3_ScaleSweep.cs
@@ -1,0 +1,27 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E3_ScaleSweep
+{
+    public static void Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E3");
+        double jBest = double.NegativeInfinity;
+        int evals = 0;
+        // -25% .. +25% in 1% steps = 51 samples.
+        for (int pct = -25; pct <= 25; pct++)
+        {
+            double factor = 1.0 + pct / 100.0;
+            var t = truth with { Scale = truth.Scale * factor };
+            var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+            writer.AppendCsvRow("E3", $"pct={pct}", t, jr, dominanceVsRunnerUp: double.NaN);
+            if (jr.J > jBest) jBest = jr.J;
+            evals++;
+        }
+        act?.SetTag("eval_count", evals);
+        act?.SetTag("J_best", jBest);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E4_RansacSeedScore.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E4_RansacSeedScore.cs
@@ -1,0 +1,32 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal static class E4_RansacSeedScore
+{
+    public static void Run(
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        string csvPath,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E4");
+        var seeds = RansacSeedsCsv.Read(csvPath);
+        var jTruth = JEvaluator.Evaluate(truth, fieldsByType, refs);
+        double jMaxSeed = double.NegativeInfinity;
+        foreach (var (_, t) in seeds)
+        {
+            var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+            if (jr.J > jMaxSeed) jMaxSeed = jr.J;
+        }
+        foreach (var (label, t) in seeds)
+        {
+            var jr = JEvaluator.Evaluate(t, fieldsByType, refs);
+            double dominance = jMaxSeed > 0 ? jr.J / jMaxSeed : double.NaN;
+            writer.AppendCsvRow("E4", label, t, jr, dominance);
+        }
+        act?.SetTag("eval_count", seeds.Count);
+        act?.SetTag("J_truth", jTruth.J);
+        act?.SetTag("J_max_seed", jMaxSeed);
+        act?.SetTag("dominance", jMaxSeed > 0 ? jTruth.J / jMaxSeed : double.NaN);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs
@@ -1,0 +1,65 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
+internal sealed record E5Report(double BestDistanceToTruthPx, double JBestAfterRefine, IReadOnlyList<(CandidateTransform T, double J, double DistanceToTruth)> Top8AfterRefine);
+
+internal static class E5_ColdGrid
+{
+    public static E5Report Run(
+        IReadOnlyDictionary<string, double[,]> fields,
+        IReadOnlyList<ReferencePoint> refs,
+        CandidateTransform truth,
+        (double Min, double Max) scaleBracket,
+        int scaleSamples,
+        int cropWidth, int cropHeight,
+        int gridStepPx,
+        int templateSizePx,
+        SynthesisProbeWriter writer)
+    {
+        using var act = SynthesisProbeTracer.Source.StartActivity("experiment.E5");
+        var rots = new[] { 0.0, Math.PI };
+        var mirrors = new[] { false, true };
+
+        var scales = new double[scaleSamples];
+        for (int i = 0; i < scaleSamples; i++)
+        {
+            double frac = (double)i / (scaleSamples - 1);
+            scales[i] = scaleBracket.Min * Math.Pow(scaleBracket.Max / scaleBracket.Min, frac);
+        }
+
+        var raw = new List<(CandidateTransform T, double J)>(capacity: 4096);
+        int evals = 0;
+        foreach (var mirror in mirrors)
+            foreach (var rot in rots)
+                foreach (var scale in scales)
+                    for (int ty = gridStepPx / 2; ty < cropHeight; ty += gridStepPx)
+                        for (int tx = gridStepPx / 2; tx < cropWidth; tx += gridStepPx)
+                        {
+                            var t = new CandidateTransform(scale, rot, mirror, tx, ty);
+                            var j = JEvaluator.Evaluate(t, fields, refs).J;
+                            raw.Add((t, j));
+                            evals++;
+                        }
+
+        var top8 = raw.OrderByDescending(p => p.J).Take(8).ToArray();
+
+        var refined = new List<(CandidateTransform T, double J, double Distance)>();
+        foreach (var (t, _) in top8)
+        {
+            var rt = LocalRefine.Run(t, fields, refs, maxIter: 60, stepInit: gridStepPx);
+            var rj = JEvaluator.Evaluate(rt, fields, refs).J;
+            double dx = rt.Tx - truth.Tx, dy = rt.Ty - truth.Ty;
+            double dist = Math.Sqrt(dx * dx + dy * dy);
+            refined.Add((rt, rj, dist));
+            writer.AppendCsvRow("E5", $"refined_J={rj:0.000}", rt, JEvaluator.Evaluate(rt, fields, refs), dominanceVsRunnerUp: double.NaN);
+        }
+
+        double bestDist = refined.Min(x => x.Distance);
+        double bestJ = refined.Max(x => x.J);
+        act?.SetTag("eval_count", evals);
+        act?.SetTag("J_best_after_refine", bestJ);
+        act?.SetTag("truth_in_topk", bestDist <= 5.0);
+        act?.SetTag("best_distance_px", bestDist);
+
+        return new E5Report(bestDist, bestJ, refined);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs
@@ -4,6 +4,16 @@ internal sealed record E5Report(double BestDistanceToTruthPx, double JBestAfterR
 
 internal static class E5_ColdGrid
 {
+    /// <summary>
+    /// Compute a tight scaleBracket around an expected scale (typically derived
+    /// from the MapRect's resize ratio + production AreaCalibration). Excludes the
+    /// tiny-scale degeneracy by construction — the synthesis objective's worst
+    /// failure mode is at scales orders of magnitude below truth, which never
+    /// arise inside a physically-plausible bracket.
+    /// </summary>
+    public static (double Min, double Max) BracketAroundExpected(double expected, double fractionAbove)
+        => (expected * (1.0 - fractionAbove), expected * (1.0 + fractionAbove));
+
     public static E5Report Run(
         IReadOnlyDictionary<string, double[,]> fields,
         IReadOnlyList<ReferencePoint> refs,

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
@@ -34,6 +34,50 @@ internal static class IconLikelihoodField
     }
 
     /// <summary>
+    /// Bicubic interpolation of <paramref name="field"/> at sub-pixel position
+    /// (<paramref name="x"/>, <paramref name="y"/>).
+    /// </summary>
+    /// <remarks>
+    /// Honors the [H, W] / <c>field[y, x]</c> row-major convention established by
+    /// <see cref="Build"/> and <see cref="ScoreAll"/>. Returns 0.0 for any position
+    /// that falls outside the field bounds.
+    /// </remarks>
+    public static double Sample(double[,] field, double x, double y)
+    {
+        int h = field.GetLength(0), w = field.GetLength(1);
+        if (x < 0 || y < 0 || x > w - 1 || y > h - 1) return 0.0;
+
+        int ix = (int)Math.Floor(x);
+        int iy = (int)Math.Floor(y);
+        double fx = x - ix;
+        double fy = y - iy;
+
+        // Cubic Hermite (Catmull-Rom-ish) over 4 samples per row, then over 4 row results.
+        double[] col = new double[4];
+        for (int j = -1; j <= 2; j++)
+        {
+            int yy = Math.Clamp(iy + j, 0, h - 1);
+            double[] row = new double[4];
+            for (int i = -1; i <= 2; i++)
+            {
+                int xx = Math.Clamp(ix + i, 0, w - 1);
+                row[i + 1] = field[yy, xx];
+            }
+            col[j + 1] = CubicHermite(row[0], row[1], row[2], row[3], fx);
+        }
+        return CubicHermite(col[0], col[1], col[2], col[3], fy);
+    }
+
+    private static double CubicHermite(double a, double b, double c, double d, double t)
+    {
+        double a0 = -0.5 * a + 1.5 * b - 1.5 * c + 0.5 * d;
+        double a1 = a - 2.5 * b + 2.0 * c - 0.5 * d;
+        double a2 = -0.5 * a + 0.5 * c;
+        double a3 = b;
+        return ((a0 * t + a1) * t + a2) * t + a3;
+    }
+
+    /// <summary>
     /// Alpha-masked NCC of <paramref name="template"/> slid over <paramref name="image"/>.
     /// Public so downstream tasks (e.g. probe scoring) can call it directly without
     /// going through the deviation step.

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
@@ -53,11 +53,13 @@ internal static class IconLikelihoodField
         double fy = y - iy;
 
         // Cubic Hermite (Catmull-Rom-ish) over 4 samples per row, then over 4 row results.
-        double[] col = new double[4];
+        // Both buffers hoisted above the loop to satisfy CA2014 (no stackalloc in a loop);
+        // `row` is overwritten every iteration so reuse is semantically identical.
+        Span<double> col = stackalloc double[4];
+        Span<double> row = stackalloc double[4];
         for (int j = -1; j <= 2; j++)
         {
             int yy = Math.Clamp(iy + j, 0, h - 1);
-            double[] row = new double[4];
             for (int i = -1; i <= 2; i++)
             {
                 int xx = Math.Clamp(ix + i, 0, w - 1);

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
@@ -1,0 +1,116 @@
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class IconLikelihoodField
+{
+    /// <summary>
+    /// Builds the per-type likelihood field L_t for <paramref name="template"/> by:
+    /// 1. Computing the additive deviation D = max(0, screenshot - alignedBase) — the
+    ///    positive residual layer where icons are drawn over terrain.
+    /// 2. Sliding <paramref name="template"/>'s gray+alpha mask across D with
+    ///    alpha-masked NCC (no threshold, no NMS), producing a dense score in [-1,1]
+    ///    at every pixel.
+    /// </summary>
+    /// <returns>Row-major [H, W] array of NCC scores; unscored border pixels = 0.</returns>
+    public static double[,] Build(GrayImage screenshot, GrayImage alignedBase, IconTemplate template)
+    {
+        if (screenshot.Width != alignedBase.Width || screenshot.Height != alignedBase.Height)
+            throw new ArgumentException("screenshot and aligned base must have matching dimensions");
+
+        int w = screenshot.Width, h = screenshot.Height;
+        var deviation = new byte[w * h];
+        for (int i = 0; i < deviation.Length; i++)
+        {
+            int d = screenshot.Pixels[i] - alignedBase.Pixels[i];
+            deviation[i] = d > 0 ? (byte)Math.Min(255, d) : (byte)0;
+        }
+        var devImage = new GrayImage(w, h, deviation);
+
+        return ScoreAll(devImage, template);
+    }
+
+    /// <summary>
+    /// Alpha-masked NCC of <paramref name="template"/> slid over <paramref name="image"/>.
+    /// Public so downstream tasks (e.g. probe scoring) can call it directly without
+    /// going through the deviation step.
+    /// </summary>
+    /// <returns>Row-major [H, W] dense score array; border pixels that can't fit the
+    /// template are left at 0.</returns>
+    public static double[,] ScoreAll(GrayImage image, IconTemplate template)
+    {
+        int W = image.Width, H = image.Height;
+        int tw = template.Gray.Width, th = template.Gray.Height;
+        int ax = (int)Math.Round(template.PivotX * tw);
+        int ay = (int)Math.Round(template.PivotY * th);
+
+        // Pre-compute template statistics over opaque pixels (alpha >= 128).
+        double tSum = 0;
+        int opaqueCount = 0;
+        for (int i = 0; i < tw * th; i++)
+        {
+            if (template.Alpha.Pixels[i] < 128) continue;
+            tSum += template.Gray.Pixels[i];
+            opaqueCount++;
+        }
+        if (opaqueCount == 0) return new double[H, W];
+
+        double tMean = tSum / opaqueCount;
+        double tVar = 0;
+        for (int i = 0; i < tw * th; i++)
+        {
+            if (template.Alpha.Pixels[i] < 128) continue;
+            double d = template.Gray.Pixels[i] - tMean;
+            tVar += d * d;
+        }
+        double tStd = Math.Sqrt(tVar);
+        if (tStd < 1e-9) return new double[H, W];
+
+        var field = new double[H, W];
+
+        // Parallelise outer rows — each (cx, cy) write is independent.
+        Parallel.For(0, H, cy =>
+        {
+            int y0 = cy - ay;
+            if (y0 < 0 || y0 + th > H) return;
+            for (int cx = 0; cx < W; cx++)
+            {
+                int x0 = cx - ax;
+                if (x0 < 0 || x0 + tw > W) continue;
+
+                // Window mean over opaque pixels.
+                double iSum = 0;
+                for (int ty = 0; ty < th; ty++)
+                {
+                    int srcRow = (y0 + ty) * W + x0;
+                    int alphaRow = ty * tw;
+                    for (int tx = 0; tx < tw; tx++)
+                    {
+                        if (template.Alpha.Pixels[alphaRow + tx] < 128) continue;
+                        iSum += image.Pixels[srcRow + tx];
+                    }
+                }
+                double iMean = iSum / opaqueCount;
+
+                // Covariance and window variance.
+                double iVar = 0, cov = 0;
+                for (int ty = 0; ty < th; ty++)
+                {
+                    int srcRow = (y0 + ty) * W + x0;
+                    int tplRow = ty * tw;
+                    for (int tx = 0; tx < tw; tx++)
+                    {
+                        if (template.Alpha.Pixels[tplRow + tx] < 128) continue;
+                        double di = image.Pixels[srcRow + tx] - iMean;
+                        double dt = template.Gray.Pixels[tplRow + tx] - tMean;
+                        iVar += di * di;
+                        cov += di * dt;
+                    }
+                }
+                double iStd = Math.Sqrt(iVar);
+                field[cy, cx] = (iStd < 1e-9) ? 0.0 : cov / (iStd * tStd);
+            }
+        });
+        return field;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
@@ -34,6 +34,17 @@ internal static class IconLikelihoodField
     }
 
     /// <summary>
+    /// Build a field from a pre-computed deviation map. Skips the screenshot-minus-
+    /// aligned-base subtraction step that <see cref="Build"/> performs; equivalent
+    /// to calling <see cref="ScoreAll"/> directly with a deviation supplied by the
+    /// caller. Used by the bundle-consumption path where the live engine has
+    /// already produced a post-ECC deviation via #978's ECC refiner.
+    /// </summary>
+    /// <returns>Same row-major [H, W] layout as <see cref="ScoreAll"/>.</returns>
+    public static double[,] LoadDeviationAsField(GrayImage deviation, IconTemplate template)
+        => ScoreAll(deviation, template);
+
+    /// <summary>
     /// Bicubic interpolation of <paramref name="field"/> at sub-pixel position
     /// (<paramref name="x"/>, <paramref name="y"/>).
     /// </summary>

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
@@ -12,7 +12,10 @@ internal static class IconLikelihoodField
     ///    alpha-masked NCC (no threshold, no NMS), producing a dense score in [-1,1]
     ///    at every pixel.
     /// </summary>
-    /// <returns>Row-major [H, W] array of NCC scores; unscored border pixels = 0.</returns>
+    /// <returns>NCC score array. Same row-major [H, W] layout as <see cref="ScoreAll"/>
+    /// (indexed <c>field[y, x]</c>, OPPOSITE of production
+    /// <c>Mithril.MapCalibration.Detection.NccTemplateMatch.ScoreAll</c>). Unscored
+    /// border pixels = 0.</returns>
     public static double[,] Build(GrayImage screenshot, GrayImage alignedBase, IconTemplate template)
     {
         if (screenshot.Width != alignedBase.Width || screenshot.Height != alignedBase.Height)
@@ -35,8 +38,13 @@ internal static class IconLikelihoodField
     /// Public so downstream tasks (e.g. probe scoring) can call it directly without
     /// going through the deviation step.
     /// </summary>
-    /// <returns>Row-major [H, W] dense score array; border pixels that can't fit the
-    /// template are left at 0.</returns>
+    /// <returns>
+    /// Row-major [H, W] dense score array indexed <c>field[y, x]</c> — note this is
+    /// the OPPOSITE of <c>Mithril.MapCalibration.Detection.NccTemplateMatch.ScoreAll</c>,
+    /// which returns [W, H] indexed <c>[x, y]</c>. Downstream synthesis-probe code
+    /// (J evaluator, refine, experiments) consistently uses [H, W] / <c>field[y, x]</c>;
+    /// don't transpose. Border pixels that can't fit the template are left at 0.
+    /// </returns>
     public static double[,] ScoreAll(GrayImage image, IconTemplate template)
     {
         int W = image.Width, H = image.Height;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/JEvaluator.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/JEvaluator.cs
@@ -1,0 +1,43 @@
+using Mithril.MapCalibration;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal readonly record struct JResult(double J, int RefsAboveHalf, int RefsOffCrop, IReadOnlyList<double> PerRefScores);
+
+internal static class JEvaluator
+{
+    public static JResult Evaluate(
+        CandidateTransform t,
+        IReadOnlyDictionary<string, double[,]> fieldsByType,
+        IReadOnlyList<ReferencePoint> refs)
+    {
+        double j = 0;
+        int aboveHalf = 0;
+        int offCrop = 0;
+        var perRef = new double[refs.Count];
+
+        for (int i = 0; i < refs.Count; i++)
+        {
+            var r = refs[i];
+            if (!fieldsByType.TryGetValue(r.LandmarkType, out var field))
+            {
+                perRef[i] = 0;
+                continue;
+            }
+            var p = t.Apply(new WorldCoord(r.WorldX, 0, r.WorldZ));
+            int h = field.GetLength(0), w = field.GetLength(1);
+            if (p.X < 0 || p.Y < 0 || p.X > w - 1 || p.Y > h - 1)
+            {
+                offCrop++;
+                perRef[i] = 0;
+                continue;
+            }
+            var score = IconLikelihoodField.Sample(field, p.X, p.Y);
+            perRef[i] = score;
+            j += score;
+            if (score >= 0.5) aboveHalf++;
+        }
+
+        return new JResult(j, aboveHalf, offCrop, perRef);
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/LocalRefine.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/LocalRefine.cs
@@ -1,0 +1,56 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class LocalRefine
+{
+    /// <summary>
+    /// Hill-climbing ascent on (Tx, Ty, Scale). At each iteration, tries +step in
+    /// each axis (and -step) and takes the move with the best J; halves the step
+    /// when no axis improves. Holds Rot and Mirror fixed (those are discrete
+    /// branches at the grid level).
+    /// </summary>
+    public static CandidateTransform Run(
+        CandidateTransform seed,
+        IReadOnlyDictionary<string, double[,]> fields,
+        IReadOnlyList<ReferencePoint> refs,
+        int maxIter,
+        double stepInit)
+    {
+        var t = seed;
+        double bestJ = JEvaluator.Evaluate(t, fields, refs).J;
+        double stepXY = stepInit;
+        double stepScale = stepInit * Math.Max(1e-6, seed.Scale) * 0.01;
+
+        for (int iter = 0; iter < maxIter; iter++)
+        {
+            var candidates = new (CandidateTransform T, double J)[]
+            {
+                (t with { Tx = t.Tx + stepXY }, 0),
+                (t with { Tx = t.Tx - stepXY }, 0),
+                (t with { Ty = t.Ty + stepXY }, 0),
+                (t with { Ty = t.Ty - stepXY }, 0),
+                (t with { Scale = t.Scale + stepScale }, 0),
+                (t with { Scale = Math.Max(1e-6, t.Scale - stepScale) }, 0),
+            };
+            int bestI = -1;
+            double newBest = bestJ;
+            for (int i = 0; i < candidates.Length; i++)
+            {
+                var j = JEvaluator.Evaluate(candidates[i].T, fields, refs).J;
+                candidates[i] = (candidates[i].T, j);
+                if (j > newBest) { newBest = j; bestI = i; }
+            }
+            if (bestI < 0)
+            {
+                stepXY *= 0.5;
+                stepScale *= 0.5;
+                if (stepXY < 0.01 && stepScale < 1e-6) break;
+            }
+            else
+            {
+                t = candidates[bestI].T;
+                bestJ = newBest;
+            }
+        }
+        return t;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/ProbeReferences.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/ProbeReferences.cs
@@ -1,0 +1,34 @@
+using Mithril.Tools.MapCalibration.Common;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+/// <summary>
+/// Loads <see cref="ReferencePoint"/> entries for a given area by combining
+/// landmarks (Portal / MeditationPillar / TeleportationPlatform) from
+/// <c>landmarks.json</c> and NPC positions from <c>npcs.json</c>.
+/// </summary>
+internal static class ProbeReferences
+{
+    public static IReadOnlyList<ReferencePoint> Load(string landmarksJson, string npcsJson, string area)
+    {
+        var result = new List<ReferencePoint>();
+
+        foreach (var l in LandmarksReader.LoadForArea(landmarksJson, area))
+        {
+            result.Add(new ReferencePoint(l.Name, l.Type, l.World.X, l.World.Z));
+        }
+
+        foreach (var n in NpcsReader.LoadForArea(npcsJson, area))
+        {
+            result.Add(new ReferencePoint(n.Name, n.Type, n.World.X, n.World.Z));
+        }
+
+        return result;
+    }
+
+    /// <summary>Absolute path to the bundled <c>landmarks.json</c> in the repo.</summary>
+    public static string DefaultLandmarksPath() => RepoPaths.LandmarksJsonPath();
+
+    /// <summary>Absolute path to the bundled <c>npcs.json</c> in the repo.</summary>
+    public static string DefaultNpcsPath() => RepoPaths.NpcsJsonPath();
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/RansacSeedsCsv.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/RansacSeedsCsv.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class RansacSeedsCsv
+{
+    public static List<(string Label, CandidateTransform T)> Read(string path)
+    {
+        var rows = new List<(string, CandidateTransform)>();
+        foreach (var line in File.ReadAllLines(path).Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var parts = line.Split(',', 6);
+            if (parts.Length != 6) throw new FormatException($"bad row '{line}' (want label,scale,rot,ox,oy,mirror)");
+            rows.Add((parts[0],
+                new CandidateTransform(
+                    double.Parse(parts[1], CultureInfo.InvariantCulture),
+                    double.Parse(parts[2], CultureInfo.InvariantCulture),
+                    bool.Parse(parts[5]),
+                    double.Parse(parts[3], CultureInfo.InvariantCulture),
+                    double.Parse(parts[4], CultureInfo.InvariantCulture))));
+        }
+        return rows;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/ReferencePoint.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/ReferencePoint.cs
@@ -1,0 +1,3 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal readonly record struct ReferencePoint(string Label, string LandmarkType, double WorldX, double WorldZ);

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Bundle;
 using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
@@ -9,12 +11,93 @@ internal static class SynthesisProbePhase
 {
     public static int Run(CliArgs args)
     {
-        // Prereq guards.
-        if (args.TruthCal is null)
+        // Resolve --bundle-dir into the four file paths if not explicitly overridden.
+        LoadedBundle? loadedBundle = null;
+        string? mapRectJsonPath = args.MapRectJsonPath;
+        string? recoveredCalJsonPath = args.RecoveredCalJsonPath;
+        string? alignedDeviationPath = args.AlignedDeviationPath;
+        string? detectionsJsonPath = args.DetectionsJsonPath;
+
+        if (!string.IsNullOrEmpty(args.BundleDir))
         {
-            Console.Error.WriteLine("--truth-cal required for --phase synthesis-probe");
+            loadedBundle = BundleLoader.Open(args.BundleDir);
+            mapRectJsonPath ??= loadedBundle.Attempt.Files.MapRect is { } mr ? Path.Combine(args.BundleDir, mr) : null;
+            recoveredCalJsonPath ??= loadedBundle.Attempt.Files.RecoveredCalibration is { } rc ? Path.Combine(args.BundleDir, rc) : null;
+            alignedDeviationPath ??= loadedBundle.DeviationPath;
+            detectionsJsonPath ??= loadedBundle.Attempt.Files.Detections is { } d ? Path.Combine(args.BundleDir, d) : null;
+        }
+
+        // Derive truth-cal per precedence:
+        //   1. --truth-cal           (crop-pixel space, wins outright)
+        //   2. --hand-truth-cal      (texture-pixel space + MapRect → conversion)
+        //   3. --recovered-cal-json  (texture-pixel space + MapRect → conversion)
+        CandidateTransform? truth = null;
+
+        if (args.TruthCal is { } tc)
+        {
+            truth = new CandidateTransform(tc.Scale, tc.Rot, tc.Mirror, tc.Ox, tc.Oy);
+        }
+        else if (args.HandTruthCal is { } htc)
+        {
+            if (mapRectJsonPath is null)
+            {
+                Console.Error.WriteLine("[err] --hand-truth-cal requires --maprect-json (directly or via --bundle-dir).");
+                return 2;
+            }
+            var mapRectJson = JsonSerializer.Deserialize(
+                File.ReadAllText(mapRectJsonPath),
+                BundleJsonContext.Default.MapRectJson)!;
+            var mapRect = new MapRect(
+                mapRectJson.OriginX, mapRectJson.OriginY,
+                mapRectJson.Width, mapRectJson.Height,
+                mapRectJson.TextureWidth, mapRectJson.TextureHeight,
+                mapRectJson.AutoDetectScore, mapRectJson.SourceScaleFactor);
+            var handCalJson = new RecoveredCalibrationJson(
+                SchemaVersion: 1,
+                Scale: htc.Scale, RotationRadians: htc.Rot,
+                OriginX: htc.Ox, OriginY: htc.Oy,
+                MirrorNorth: htc.Mirror,
+                CalibrationZoom: 1.0,
+                ResidualPixels: 0.0,
+                ReferenceCount: 0,
+                Source: "HandSupplied",
+                Inliers: System.Array.Empty<InlierJson>());
+            truth = MapRectConversion.FromRecoveredCalibration(handCalJson, mapRect, out var handAnisoPct);
+            if (handAnisoPct > 1.0)
+                Console.Error.WriteLine($"[warn] MapRect resize is anisotropic by {handAnisoPct:0.00}%; using geometric mean.");
+            Console.Error.WriteLine("[truth] using --hand-truth-cal (texture-pixel space → crop-pixel via MapRect).");
+        }
+        else if (mapRectJsonPath is not null && recoveredCalJsonPath is not null)
+        {
+            var mapRectJson = JsonSerializer.Deserialize(
+                File.ReadAllText(mapRectJsonPath),
+                BundleJsonContext.Default.MapRectJson)!;
+            var recoveredCalJson = JsonSerializer.Deserialize(
+                File.ReadAllText(recoveredCalJsonPath),
+                BundleJsonContext.Default.RecoveredCalibrationJson)!;
+            var mapRect = new MapRect(
+                mapRectJson.OriginX, mapRectJson.OriginY,
+                mapRectJson.Width, mapRectJson.Height,
+                mapRectJson.TextureWidth, mapRectJson.TextureHeight,
+                mapRectJson.AutoDetectScore, mapRectJson.SourceScaleFactor);
+            truth = MapRectConversion.FromRecoveredCalibration(recoveredCalJson, mapRect, out var anisoPct);
+            if (anisoPct > 1.0)
+                Console.Error.WriteLine($"[warn] MapRect resize is anisotropic by {anisoPct:0.00}%; using geometric mean.");
+            Console.Error.WriteLine(
+                $"[truth] using --recovered-cal-json (production's recovered cal, residual {recoveredCalJson.ResidualPixels:0.00} px). " +
+                "If production's solve is suspect, override with --hand-truth-cal.");
+        }
+
+        if (truth is null)
+        {
+            Console.Error.WriteLine("[err] No truth-cal: pass --truth-cal, or --hand-truth-cal + --maprect-json, or --bundle-dir/--recovered-cal-json + --maprect-json.");
             return 2;
         }
+
+        // Non-nullable local for use throughout the rest of Run.
+        var truthNn = truth.Value;
+
+        // Prereq guards (unchanged).
         if (string.IsNullOrEmpty(args.ScreenshotPath))
         {
             Console.Error.WriteLine("--screenshot required for --phase synthesis-probe");
@@ -30,16 +113,9 @@ internal static class SynthesisProbePhase
         using var rootSpan = SynthesisProbeTracer.Source.StartActivity("probe.attempt");
         rootSpan?.SetTag("area", args.Area);
         rootSpan?.SetTag("screenshot", args.ScreenshotPath);
-
-        var truth = new CandidateTransform(
-            Scale: args.TruthCal.Value.Scale,
-            RotRadians: args.TruthCal.Value.Rot,
-            Mirror: args.TruthCal.Value.Mirror,
-            Tx: args.TruthCal.Value.Ox,
-            Ty: args.TruthCal.Value.Oy);
-        rootSpan?.SetTag("truth.scale", truth.Scale);
-        rootSpan?.SetTag("truth.rot", truth.RotRadians);
-        rootSpan?.SetTag("truth.mirror", truth.Mirror);
+        rootSpan?.SetTag("truth.scale", truthNn.Scale);
+        rootSpan?.SetTag("truth.rot", truthNn.RotRadians);
+        rootSpan?.SetTag("truth.mirror", truthNn.Mirror);
 
         // Load screenshot + crop to map rect.
         var screenshot = ImageIo.LoadGray(args.ScreenshotPath);
@@ -117,16 +193,35 @@ internal static class SynthesisProbePhase
         }
 
         // Build per-type likelihood fields by sliding each template over the
-        // positive-deviation layer (screenshot minus aligned base).
+        // positive-deviation layer. When --aligned-deviation is provided, load
+        // the pre-computed post-ECC deviation directly (skips screenshot-minus-base
+        // subtraction). Otherwise fall back to Build(screenshotCrop, alignedBase).
         var fieldsByType = new Dictionary<string, double[,]>(StringComparer.Ordinal);
-        foreach (var template in templates)
+        if (alignedDeviationPath is not null)
         {
-            using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
-            fieldSpan?.SetTag("template.type", template.LandmarkType);
-            fieldSpan?.SetTag("template.size_px", Math.Max(template.Gray.Width, template.Gray.Height));
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            fieldsByType[template.LandmarkType] = IconLikelihoodField.Build(screenshotCrop, alignedBase, template);
-            fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
+            var deviation = ImageIo.LoadGray(alignedDeviationPath);
+            foreach (var template in templates)
+            {
+                using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
+                fieldSpan?.SetTag("template.type", template.LandmarkType);
+                fieldSpan?.SetTag("template.size_px", Math.Max(template.Gray.Width, template.Gray.Height));
+                fieldSpan?.SetTag("source", "aligned-deviation");
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                fieldsByType[template.LandmarkType] = IconLikelihoodField.LoadDeviationAsField(deviation, template);
+                fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
+            }
+        }
+        else
+        {
+            foreach (var template in templates)
+            {
+                using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
+                fieldSpan?.SetTag("template.type", template.LandmarkType);
+                fieldSpan?.SetTag("template.size_px", Math.Max(template.Gray.Width, template.Gray.Height));
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                fieldsByType[template.LandmarkType] = IconLikelihoodField.Build(screenshotCrop, alignedBase, template);
+                fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
+            }
         }
 
         // Load reference points (landmarks + NPCs) for the area.
@@ -144,22 +239,25 @@ internal static class SynthesisProbePhase
             writer.WriteFieldPng(type, field);
 
         // E1 — truth score (always).
-        E1_TruthScore.Run(fieldsByType, refs, truth, writer);
+        E1_TruthScore.Run(fieldsByType, refs, truthNn, writer);
 
         // E2 — translation sweep ±2×templateSizePx (always).
-        E2_TranslationSweep.Run(fieldsByType, refs, truth, templateSizePx: renderSizePx, writer);
+        E2_TranslationSweep.Run(fieldsByType, refs, truthNn, templateSizePx: renderSizePx, writer);
 
         // E3 — scale sweep ±25 % in 1 % steps (always).
-        E3_ScaleSweep.Run(fieldsByType, refs, truth, writer);
+        E3_ScaleSweep.Run(fieldsByType, refs, truthNn, writer);
 
         // E4 — RANSAC seed scores (only when a seeds CSV is supplied).
         if (!string.IsNullOrEmpty(args.RansacSeedsCsvPath))
-            E4_RansacSeedScore.Run(fieldsByType, refs, truth, args.RansacSeedsCsvPath, writer);
+            E4_RansacSeedScore.Run(fieldsByType, refs, truthNn, args.RansacSeedsCsvPath, writer);
 
         // E5 — cold-grid global search + local refine (always).
+        // Narrow the scale bracket to ±20% of the expected scale derived from
+        // truth, excluding the tiny-scale degeneracy.
+        var scaleBracket = E5_ColdGrid.BracketAroundExpected(truthNn.Scale, fractionAbove: 0.2);
         E5_ColdGrid.Run(
-            fieldsByType, refs, truth,
-            scaleBracket: (0.1, 2.0),
+            fieldsByType, refs, truthNn,
+            scaleBracket: scaleBracket,
             scaleSamples: 16,
             cropWidth: mw,
             cropHeight: mh,

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
@@ -1,10 +1,153 @@
+using Mithril.MapCalibration;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibration.Common;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;
+
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
 
 internal static class SynthesisProbePhase
 {
     public static int Run(CliArgs args)
     {
-        Console.WriteLine("[synthesis-probe] not yet implemented");
+        // Prereq guards.
+        if (args.TruthCal is null)
+        {
+            Console.Error.WriteLine("--truth-cal required for --phase synthesis-probe");
+            return 2;
+        }
+        if (string.IsNullOrEmpty(args.ScreenshotPath))
+        {
+            Console.Error.WriteLine("--screenshot required for --phase synthesis-probe");
+            return 2;
+        }
+        if (args.MapRect is null)
+        {
+            Console.Error.WriteLine("--map-rect required for --phase synthesis-probe (auto-detect is not reliable enough for the diagnostic)");
+            return 2;
+        }
+
+        using var tracer = SynthesisProbeTracer.Configure(args.TraceConsole, args.OtlpEndpoint);
+        using var rootSpan = SynthesisProbeTracer.Source.StartActivity("probe.attempt");
+        rootSpan?.SetTag("area", args.Area);
+        rootSpan?.SetTag("screenshot", args.ScreenshotPath);
+
+        var truth = new CandidateTransform(
+            Scale: args.TruthCal.Value.Scale,
+            RotRadians: args.TruthCal.Value.Rot,
+            Mirror: args.TruthCal.Value.Mirror,
+            Tx: args.TruthCal.Value.Ox,
+            Ty: args.TruthCal.Value.Oy);
+        rootSpan?.SetTag("truth.scale", truth.Scale);
+        rootSpan?.SetTag("truth.rot", truth.RotRadians);
+        rootSpan?.SetTag("truth.mirror", truth.Mirror);
+
+        // Load screenshot + crop to map rect.
+        var screenshot = ImageIo.LoadGray(args.ScreenshotPath);
+        var (mx, my, mw, mh) = args.MapRect.Value;
+        var screenshotCrop = ImageOps.Crop(screenshot, mx, my, mw, mh);
+        rootSpan?.SetTag("crop.w", mw);
+        rootSpan?.SetTag("crop.h", mh);
+
+        // Locate + load the aligned base texture, resampled to the crop dimensions.
+        var pgInstall = SteamInstall.FindPgInstall();
+        var mapDir = args.MapDir ?? RepoPaths.DefaultMapsCacheDir();
+        var tpkPath = args.TpkPath ?? RepoPaths.DefaultTpkPath();
+        var mapPng = MapTextureExtractor.EnsureExtracted(pgInstall, mapDir, args.Area);
+        var baseTexture = ImageIo.LoadGray(mapPng);
+        var alignedBase = ImageOps.Resize(baseTexture, mw, mh);
+
+        // Load icon templates from the extracted icons cache, scaled to the
+        // requested render size.  IconTemplateExtractor has no LoadAll(dir, size)
+        // method — build IconTemplate objects manually from the IconIndex.
+        var iconsDir = args.IconsDir ?? RepoPaths.DefaultIconsCacheDir();
+        IconTemplateExtractor.EnsureExtracted(pgInstall, iconsDir, tpkPath);
+        var iconIndex = IconTemplateExtractor.Load(iconsDir);
+
+        int renderSizePx = args.IconRenderSize > 0 ? args.IconRenderSize : 16;
+        var templates = new List<IconTemplate>();
+        foreach (var meta in iconIndex.Icons)
+        {
+            var iconPath = Path.Combine(iconsDir, meta.File);
+            if (!File.Exists(iconPath))
+            {
+                Console.WriteLine($"  ! template file missing: {iconPath} (skipping)");
+                continue;
+            }
+            var (gray, alpha) = ImageIo.LoadGrayAndAlpha(iconPath);
+            // Scale so the largest source dimension lands at renderSizePx — same
+            // logic ScreenshotCalibrator uses when icon templates are large artwork.
+            int maxDim = Math.Max(gray.Width, gray.Height);
+            int rw = Math.Max(1, gray.Width * renderSizePx / maxDim);
+            int rh = Math.Max(1, gray.Height * renderSizePx / maxDim);
+            var grayR = (rw == gray.Width && rh == gray.Height) ? gray : ImageOps.Resize(gray, rw, rh);
+            var alphaR = (rw == alpha.Width && rh == alpha.Height) ? alpha : ImageOps.Resize(alpha, rw, rh);
+            templates.Add(new IconTemplate(
+                Name: meta.Name,
+                LandmarkType: meta.LandmarkType,
+                PivotX: meta.PivotX,
+                PivotY: meta.PivotY,
+                Gray: grayR,
+                Alpha: alphaR));
+        }
+
+        if (templates.Count == 0)
+        {
+            Console.Error.WriteLine("no icon templates loaded — run --phase extract-icons first");
+            return 1;
+        }
+
+        // Build per-type likelihood fields by sliding each template over the
+        // positive-deviation layer (screenshot minus aligned base).
+        var fieldsByType = new Dictionary<string, double[,]>(StringComparer.Ordinal);
+        foreach (var template in templates)
+        {
+            using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
+            fieldSpan?.SetTag("template.type", template.LandmarkType);
+            fieldSpan?.SetTag("template.size_px", Math.Max(template.Gray.Width, template.Gray.Height));
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            fieldsByType[template.LandmarkType] = IconLikelihoodField.Build(screenshotCrop, alignedBase, template);
+            fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
+        }
+
+        // Load reference points (landmarks + NPCs) for the area.
+        var refs = ProbeReferences.Load(
+            args.LandmarksPath ?? ProbeReferences.DefaultLandmarksPath(),
+            args.NpcsPath ?? ProbeReferences.DefaultNpcsPath(),
+            args.Area);
+
+        // Output directory + writer.
+        var outDir = Path.Combine(RepoPaths.RepoRoot(), "study", "synthesis-probe", args.Area);
+        using var writer = new SynthesisProbeWriter(outDir);
+
+        // Dump field PNGs — one per landmark type.
+        foreach (var (type, field) in fieldsByType)
+            writer.WriteFieldPng(type, field);
+
+        // E1 — truth score (always).
+        E1_TruthScore.Run(fieldsByType, refs, truth, writer);
+
+        // E2 — translation sweep ±2×templateSizePx (always).
+        E2_TranslationSweep.Run(fieldsByType, refs, truth, templateSizePx: renderSizePx, writer);
+
+        // E3 — scale sweep ±25 % in 1 % steps (always).
+        E3_ScaleSweep.Run(fieldsByType, refs, truth, writer);
+
+        // E4 — RANSAC seed scores (only when a seeds CSV is supplied).
+        if (!string.IsNullOrEmpty(args.RansacSeedsCsvPath))
+            E4_RansacSeedScore.Run(fieldsByType, refs, truth, args.RansacSeedsCsvPath, writer);
+
+        // E5 — cold-grid global search + local refine (always).
+        E5_ColdGrid.Run(
+            fieldsByType, refs, truth,
+            scaleBracket: (0.1, 2.0),
+            scaleSamples: 16,
+            cropWidth: mw,
+            cropHeight: mh,
+            gridStepPx: renderSizePx,
+            templateSizePx: renderSizePx,
+            writer);
+
+        Console.WriteLine($"[synthesis-probe] artifacts written to {outDir}");
         return 0;
     }
 }

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
@@ -27,6 +27,20 @@ internal static class SynthesisProbePhase
             detectionsJsonPath ??= loadedBundle.Attempt.Files.Detections is { } d ? Path.Combine(args.BundleDir, d) : null;
         }
 
+        // Local helper: deserialise + materialise a MapRect from the bundle's
+        // 04-maprect.json. Used by both texture-pixel-space truth-cal branches.
+        MapRect LoadMapRectJson(string path)
+        {
+            var j = JsonSerializer.Deserialize(
+                File.ReadAllText(path),
+                BundleJsonContext.Default.MapRectJson)!;
+            return new MapRect(
+                j.OriginX, j.OriginY,
+                j.Width, j.Height,
+                j.TextureWidth, j.TextureHeight,
+                j.AutoDetectScore, j.SourceScaleFactor);
+        }
+
         // Derive truth-cal per precedence:
         //   1. --truth-cal           (crop-pixel space, wins outright)
         //   2. --hand-truth-cal      (texture-pixel space + MapRect → conversion)
@@ -44,14 +58,7 @@ internal static class SynthesisProbePhase
                 Console.Error.WriteLine("[err] --hand-truth-cal requires --maprect-json (directly or via --bundle-dir).");
                 return 2;
             }
-            var mapRectJson = JsonSerializer.Deserialize(
-                File.ReadAllText(mapRectJsonPath),
-                BundleJsonContext.Default.MapRectJson)!;
-            var mapRect = new MapRect(
-                mapRectJson.OriginX, mapRectJson.OriginY,
-                mapRectJson.Width, mapRectJson.Height,
-                mapRectJson.TextureWidth, mapRectJson.TextureHeight,
-                mapRectJson.AutoDetectScore, mapRectJson.SourceScaleFactor);
+            var mapRect = LoadMapRectJson(mapRectJsonPath);
             var handCalJson = new RecoveredCalibrationJson(
                 SchemaVersion: 1,
                 Scale: htc.Scale, RotationRadians: htc.Rot,
@@ -69,17 +76,10 @@ internal static class SynthesisProbePhase
         }
         else if (mapRectJsonPath is not null && recoveredCalJsonPath is not null)
         {
-            var mapRectJson = JsonSerializer.Deserialize(
-                File.ReadAllText(mapRectJsonPath),
-                BundleJsonContext.Default.MapRectJson)!;
+            var mapRect = LoadMapRectJson(mapRectJsonPath);
             var recoveredCalJson = JsonSerializer.Deserialize(
                 File.ReadAllText(recoveredCalJsonPath),
                 BundleJsonContext.Default.RecoveredCalibrationJson)!;
-            var mapRect = new MapRect(
-                mapRectJson.OriginX, mapRectJson.OriginY,
-                mapRectJson.Width, mapRectJson.Height,
-                mapRectJson.TextureWidth, mapRectJson.TextureHeight,
-                mapRectJson.AutoDetectScore, mapRectJson.SourceScaleFactor);
             truth = MapRectConversion.FromRecoveredCalibration(recoveredCalJson, mapRect, out var anisoPct);
             if (anisoPct > 1.0)
                 Console.Error.WriteLine($"[warn] MapRect resize is anisotropic by {anisoPct:0.00}%; using geometric mean.");
@@ -218,6 +218,7 @@ internal static class SynthesisProbePhase
                 using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
                 fieldSpan?.SetTag("template.type", template.LandmarkType);
                 fieldSpan?.SetTag("template.size_px", Math.Max(template.Gray.Width, template.Gray.Height));
+                fieldSpan?.SetTag("source", "screenshot-minus-base");
                 var sw = System.Diagnostics.Stopwatch.StartNew();
                 fieldsByType[template.LandmarkType] = IconLikelihoodField.Build(screenshotCrop, alignedBase, template);
                 fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
@@ -50,11 +50,31 @@ internal static class SynthesisProbePhase
 
         // Locate + load the aligned base texture, resampled to the crop dimensions.
         var pgInstall = SteamInstall.FindPgInstall();
-        var mapDir = args.MapDir ?? RepoPaths.DefaultMapsCacheDir();
         var tpkPath = args.TpkPath ?? RepoPaths.DefaultTpkPath();
-        var mapPng = MapTextureExtractor.EnsureExtracted(pgInstall, mapDir, args.Area);
-        var baseTexture = ImageIo.LoadGray(mapPng);
-        var alignedBase = ImageOps.Resize(baseTexture, mw, mh);
+        GrayImage alignedBase;
+        if (!string.IsNullOrEmpty(args.AlignedBasePath))
+        {
+            if (!File.Exists(args.AlignedBasePath))
+            {
+                Console.Error.WriteLine($"--aligned-base file not found: {args.AlignedBasePath}");
+                return 2;
+            }
+            alignedBase = ImageIo.LoadGray(args.AlignedBasePath);
+            if (alignedBase.Width != mw || alignedBase.Height != mh)
+            {
+                Console.Error.WriteLine(
+                    $"--aligned-base dimensions {alignedBase.Width}x{alignedBase.Height} " +
+                    $"don't match --map-rect crop dims {mw}x{mh}");
+                return 2;
+            }
+        }
+        else
+        {
+            var mapDir = args.MapDir ?? RepoPaths.DefaultMapsCacheDir();
+            var mapPng = MapTextureExtractor.EnsureExtracted(pgInstall, mapDir, args.Area);
+            var baseTexture = ImageIo.LoadGray(mapPng);
+            alignedBase = ImageOps.Resize(baseTexture, mw, mh);
+        }
 
         // Load icon templates from the extracted icons cache, scaled to the
         // requested render size.  IconTemplateExtractor has no LoadAll(dir, size)

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
@@ -1,0 +1,10 @@
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class SynthesisProbePhase
+{
+    public static int Run(CliArgs args)
+    {
+        Console.WriteLine("[synthesis-probe] not yet implemented");
+        return 0;
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeTracer.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeTracer.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal static class SynthesisProbeTracer
+{
+    public const string ActivitySourceName = "Mithril.Tools.MapCalibrationSynthesisProbe";
+    public static readonly ActivitySource Source = new(ActivitySourceName);
+
+    public static TracerProvider? Configure(bool traceConsole, string? otlpEndpoint)
+    {
+        if (!traceConsole && otlpEndpoint is null) return null;
+
+        var builder = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MapCalibrationSynthesisProbe"))
+            .AddSource(ActivitySourceName);
+
+        if (traceConsole) builder.AddConsoleExporter();
+        if (otlpEndpoint is not null)
+            builder.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));
+
+        return builder.Build();
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeWriter.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeWriter.cs
@@ -1,0 +1,85 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+
+internal sealed class SynthesisProbeWriter : IDisposable
+{
+    private readonly StreamWriter _csv;
+    private readonly string _outDir;
+
+    public SynthesisProbeWriter(string outDir)
+    {
+        Directory.CreateDirectory(outDir);
+        _outDir = outDir;
+        _csv = new StreamWriter(Path.Combine(outDir, "synthesis_probe.csv"));
+        _csv.WriteLine("experiment,label,scale,rot,mirror,tx,ty,J,refs_above_0.5,dominance_vs_runner_up");
+    }
+
+    public void AppendCsvRow(string experiment, string label, CandidateTransform t, JResult jr, double dominanceVsRunnerUp)
+    {
+        _csv.Write(experiment); _csv.Write(',');
+        _csv.Write(label); _csv.Write(',');
+        _csv.Write(t.Scale.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(t.RotRadians.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(t.Mirror ? "true" : "false"); _csv.Write(',');
+        _csv.Write(t.Tx.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(t.Ty.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(jr.J.ToString("R", CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.Write(jr.RefsAboveHalf.ToString(CultureInfo.InvariantCulture)); _csv.Write(',');
+        _csv.WriteLine(double.IsNaN(dominanceVsRunnerUp) ? "" : dominanceVsRunnerUp.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    public void WriteFieldPng(string type, double[,] field) =>
+        WriteScalarPng(Path.Combine(_outDir, $"field_{type}.png"), field, vmin: -1.0, vmax: 1.0);
+
+    public void WriteLandscapePng(string label, double[,] landscape) =>
+        WriteScalarPng(Path.Combine(_outDir, $"grid_landscape_{label}.png"), landscape, vmin: Min(landscape), vmax: Max(landscape));
+
+    private static void WriteScalarPng(string path, double[,] field, double vmin, double vmax)
+    {
+        int h = field.GetLength(0), w = field.GetLength(1);
+        double span = (vmax - vmin) > 1e-9 ? (vmax - vmin) : 1.0;
+        using var bmp = new Bitmap(w, h, PixelFormat.Format24bppRgb);
+        var rect = new Rectangle(0, 0, w, h);
+        var data = bmp.LockBits(rect, ImageLockMode.WriteOnly, PixelFormat.Format24bppRgb);
+        try
+        {
+            int stride = data.Stride;
+            byte[] row = new byte[stride];
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    double v = (field[y, x] - vmin) / span;
+                    v = Math.Clamp(v, 0, 1);
+                    byte g = (byte)Math.Round(v * 255);
+                    row[x * 3 + 0] = g;
+                    row[x * 3 + 1] = g;
+                    row[x * 3 + 2] = g;
+                }
+                Marshal.Copy(row, 0, data.Scan0 + y * stride, stride);
+            }
+        }
+        finally { bmp.UnlockBits(data); }
+        bmp.Save(path, ImageFormat.Png);
+    }
+
+    private static double Min(double[,] f)
+    {
+        double m = double.PositiveInfinity;
+        foreach (var v in f) if (v < m) m = v;
+        return m;
+    }
+
+    private static double Max(double[,] f)
+    {
+        double m = double.NegativeInfinity;
+        foreach (var v in f) if (v > m) m = v;
+        return m;
+    }
+
+    public void Dispose() => _csv.Dispose();
+}


### PR DESCRIPTION
## Summary

Wires the synthesis-probe diagnostic (`tools/MapCalibrationFromScreenshot --phase synthesis-probe`) to consume the per-attempt calibration diagnostic bundles produced by [#985](https://github.com/moumantai-gg/mithril/pull/985)'s `AutoCalibrationEngine`. Six new CLI flags (`--bundle-dir`, `--maprect-json`, `--recovered-cal-json`, `--aligned-deviation`, `--detections-json`, `--hand-truth-cal`), a bundle data layer (DTOs + Loader + texture↔aligned-pair MapRect conversion), `IconLikelihoodField.LoadDeviationAsField`, and an `E5_ColdGrid.BracketAroundExpected` helper that narrows the scale search to ±20% around the MapRect-implied scale (excluding the tiny-scale degeneracy by construction).

Spec + plan committed in this branch:

- [`docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md`](docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md) — the brainstorming output and the bundle-driven Results section.
- [`docs/superpowers/plans/2026-06-02-synthesis-probe-bundle-consumption.md`](docs/superpowers/plans/2026-06-02-synthesis-probe-bundle-consumption.md) — the implementation plan executed by SDD across three task blocks.

## Architectural verdict: Proposal B (RANSAC seed + synthesis re-rank), with ECC quality as prerequisite

Three real bundles, all AreaEltibule:

| Bundle | Production | E1 J(truth) | E1 refs ≥ 0.5 | E3 J_best | E5 cold-grid finds truth? |
|---|---|---|---|---|---|
| **A** 031105-069 accepted (10 inliers, 0.79 px) | clean accept | **19.02** | **21 / 38** | 19.02 (= truth, sharp) | no — 542 px off |
| **B** 031130-122 wrong-fit accept (4 inliers, 4.03 px) — hand-truth | wrong cal | **−2.76** | **0 / 38** | 4.99 | no — 335 px off |
| **B** — production-recovered | wrong cal | +0.39 | 2 / 38 | 3.22 | no — 65 px off |
| **C** 031004-908 rejected (3 inliers, NPC starvation) — hand-truth | rejected | **13.96** | **13 / 38** | 13.96 (= truth, sharp) | no — 290 px off |

- **A** (positive control) — synthesis correctly scores truth as the dominant local peak (J=19.02, sharp in E2/E3), but cold-grid + LM refine misses by 542 px because at 16-px grid stride no sample lands within the ~6 px refine basin around truth. Re-rank wins; cold doesn't.
- **B** (wrong-fit accept) — degraded ECC alignment, deviation map contaminated by terrain noise. Hand-truth gets J=−2.76 because no ref projects onto a deviation peak. Production's wrong-recovered cal scores +0.39 only because its 4 inliers picked positions consistent with the noisy field. No solver can rescue this; failure is **upstream** of where either solver intervenes. (Bundle B was a clobber-replace of Bundle A's good calibration 25 s later — see follow-up §1.)
- **C** (rejected → would-be-rescued) — production rejected with "only 3 inliers" because the more-zoomed-out 688×683 view starved NPC-template NCC of all 17 Eltibule NPCs. Synthesis evaluates truth correctly (J=13.96, 13/38 refs, sharp E3 peak) because it aggregates *weak* `L_t(T·r)` across all 38 refs without a per-type discrete threshold. Cold-grid still misses by 290 px (same spacing-vs-peak-width trap as A). A synthesis-J re-rank layered on any near-truth seed source would have accepted Bundle C where production rejected it.

Cold synthesis (Proposal A) is not warranted by this evidence — E5 misses on every bundle, including the positive control. The MapRect-bracketed scale span already excluded the tiny-scale degeneracy; the residual failure is the 16-px grid stride being wider than the LM refine basin, and seeding is the cleaner fix than narrowing the grid.

## Follow-ups (separate issues)

1. **Acceptance-gate monotonicity** in `AutoCalibrationEngine` — Bundle A was a clean 0.79 px accept at 03:11:05; Bundle B's 4.03 px wrong-fit was accepted at 03:11:30, replacing A's good calibration. Reject new fits when J (or residual) is meaningfully worse than the currently-stored area calibration.
2. **MapRect height clamp** — Bundle B's `04-maprect.json` records `height=999` but the engine ran at 986 (clamped to the 1047-tall screenshot). The recorded MapRect should be the clamped height.
3. **Zoom-aware NPC NCC threshold** — Bundle C had 0/17 NPCs detected because the zoomed-out view dropped them below the 0.90 same-type NCC floor. Synthesis re-rank makes this moot, but the detection-side tweak is independently useful.

## Test plan

- [x] 47/47 unit tests passing in `tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests` (`dotnet test … --no-build` — 608 ms).
- [x] `dotnet build tools/MapCalibrationFromScreenshot -c Release` — 0 warnings, 0 errors.
- [x] Real-bundle smoke runs against three live-engine bundles (results recorded under `study/synthesis-probe/run-bundle-{a,b,c}/` locally; verdict summarized in spec doc).
- [ ] Reviewer eyeball on the bundle-driven Results section of the spec doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
