### PR TITLE
feat(synthesis-probe): apply DeviationFlood rim mask in bundle-consumed deviation

### DIFF
--- a/src/Mithril.MapCalibration/Detection/DeviationBlobDetector.cs
+++ b/src/Mithril.MapCalibration/Detection/DeviationBlobDetector.cs
@@ -47,26 +47,8 @@ public static class DeviationBlobDetector
 
         if (rim == RimMaskMode.DeviationFlood)
         {
-            // Edge-connected deviation flood: the rim is the foreground component
-            // that touches the image edge; interior icons are isolated foreground
-            // islands, and the matching interior terrain isn't foreground at all.
-            // So this drops the rim without eating the interior the colour
-            // BorderMask over-masks (mithril#897 — Eltibule 11.3% vs colour 67.6%).
-            var rimMask = new bool[n];
-            var q = new Queue<int>();
-            void Enq(int x, int y)
-            {
-                if (x < 0 || x >= w || y < 0 || y >= h) return;
-                int k = y * w + x;
-                if (fg[k] && !rimMask[k]) { rimMask[k] = true; q.Enqueue(k); }
-            }
-            for (int x = 0; x < w; x++) { Enq(x, 0); Enq(x, h - 1); }
-            for (int y = 0; y < h; y++) { Enq(0, y); Enq(w - 1, y); }
-            while (q.Count > 0)
-            {
-                int k = q.Dequeue(); int x = k % w, y = k / w;
-                Enq(x - 1, y); Enq(x + 1, y); Enq(x, y - 1); Enq(x, y + 1);
-            }
+            // Edge-connected deviation flood: see DeviationFloodRimMask docs.
+            var rimMask = DeviationFloodRimMask.Build(dev, w, h, devThr);
             for (int i = 0; i < n; i++) if (rimMask[i]) fg[i] = false;
         }
 

--- a/src/Mithril.MapCalibration/Detection/DeviationFloodRimMask.cs
+++ b/src/Mithril.MapCalibration/Detection/DeviationFloodRimMask.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace Mithril.MapCalibration.Detection;
+
+/// <summary>
+/// Edge-connected flood mask over a deviation array: returns true for any
+/// pixel reachable from the image edge through 4-connected pixels whose
+/// deviation is above the threshold. The PG rocky rim around outdoor zones
+/// is the foreground component that touches the image edge; interior
+/// icons are isolated foreground islands, so this mask cleanly excises the
+/// rim without eating interior signal. See mithril#897 gate study (Eltibule
+/// 11.3% vs colour-flood 67.6%).
+///
+/// <para>This is the helper shape extracted from <see cref="DeviationBlobDetector.DetectIconBlobs"/>'s
+/// inline <see cref="RimMaskMode.DeviationFlood"/> branch (formerly lines 48-71).
+/// Used by both production's blob detector and the synthesis-probe tool's
+/// <c>IconLikelihoodField.LoadDeviationAsField</c> so they compute on the
+/// same masked input.</para>
+/// </summary>
+public static class DeviationFloodRimMask
+{
+    /// <summary>
+    /// Build the edge-connected foreground rim mask.
+    /// </summary>
+    /// <param name="dev">Deviation values, row-major (length = <paramref name="w"/> * <paramref name="h"/>).</param>
+    /// <param name="w">Image width in pixels.</param>
+    /// <param name="h">Image height in pixels.</param>
+    /// <param name="devThr">Threshold: pixels with <c>dev[i] &gt;= devThr</c> are foreground.</param>
+    /// <returns>A boolean array, same length as <paramref name="dev"/>, with true at each rim pixel.</returns>
+    public static bool[] Build(float[] dev, int w, int h, double devThr)
+    {
+        int n = w * h;
+        var rim = new bool[n];
+        var q = new Queue<int>();
+        void Enq(int x, int y)
+        {
+            if (x < 0 || x >= w || y < 0 || y >= h) return;
+            int k = y * w + x;
+            if (dev[k] >= devThr && !rim[k]) { rim[k] = true; q.Enqueue(k); }
+        }
+        for (int x = 0; x < w; x++) { Enq(x, 0); Enq(x, h - 1); }
+        for (int y = 0; y < h; y++) { Enq(0, y); Enq(w - 1, y); }
+        while (q.Count > 0)
+        {
+            int k = q.Dequeue(); int x = k % w, y = k / w;
+            Enq(x - 1, y); Enq(x + 1, y); Enq(x, y - 1); Enq(x, y + 1);
+        }
+        return rim;
+    }
+}

--- a/src/Mithril.MapCalibration/Detection/DeviationFloodRimMask.cs
+++ b/src/Mithril.MapCalibration/Detection/DeviationFloodRimMask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Mithril.MapCalibration.Detection;
@@ -22,14 +23,21 @@ public static class DeviationFloodRimMask
     /// <summary>
     /// Build the edge-connected foreground rim mask.
     /// </summary>
-    /// <param name="dev">Deviation values, row-major (length = <paramref name="w"/> * <paramref name="h"/>).</param>
+    /// <param name="dev">Deviation values, row-major. Must have length exactly <paramref name="w"/> * <paramref name="h"/>.</param>
     /// <param name="w">Image width in pixels.</param>
     /// <param name="h">Image height in pixels.</param>
     /// <param name="devThr">Threshold: pixels with <c>dev[i] &gt;= devThr</c> are foreground.</param>
     /// <returns>A boolean array, same length as <paramref name="dev"/>, with true at each rim pixel.</returns>
     public static bool[] Build(float[] dev, int w, int h, double devThr)
     {
+        if (dev is null) throw new ArgumentNullException(nameof(dev));
+        if (w <= 0) throw new ArgumentOutOfRangeException(nameof(w), w, "width must be positive");
+        if (h <= 0) throw new ArgumentOutOfRangeException(nameof(h), h, "height must be positive");
         int n = w * h;
+        if (dev.Length != n)
+            throw new ArgumentException(
+                $"dev.Length ({dev.Length}) must equal w*h ({n}).", nameof(dev));
+
         var rim = new bool[n];
         var q = new Queue<int>();
         void Enq(int x, int y)

--- a/tests/Mithril.MapCalibration.Tests/Detection/DeviationFloodRimMaskTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/DeviationFloodRimMaskTests.cs
@@ -72,4 +72,19 @@ public sealed class DeviationFloodRimMaskTests
         // Nothing should be masked because no pixel meets the threshold.
         for (int i = 0; i < W * H; i++) rim[i].Should().BeFalse();
     }
+
+    [Fact]
+    public void Build_ThrowsOnMismatchedLength()
+    {
+        var act = () => DeviationFloodRimMask.Build(new float[10], w: 4, h: 4, devThr: 0.5);
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*dev.Length*must equal*");
+    }
+
+    [Fact]
+    public void Build_ThrowsOnNonPositiveDimensions()
+    {
+        var act = () => DeviationFloodRimMask.Build(new float[0], w: 0, h: 4, devThr: 0.5);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/DeviationFloodRimMaskTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/DeviationFloodRimMaskTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+public sealed class DeviationFloodRimMaskTests
+{
+    [Fact]
+    public void Build_EdgeFloodMasksEdgeTouchingForeground()
+    {
+        // 8x8 deviation. An L-shape foreground (all 1.0) touches the left edge
+        // at column 0. devThr = 0.5 → fg = the L-shape pixels.
+        const int W = 8, H = 8;
+        var dev = new float[W * H];
+        // L-shape: top-left corner cells (0,0)-(0,4) vertical + (0,4)-(3,4) horizontal.
+        for (int y = 0; y < 5; y++) dev[y * W + 0] = 1f;       // left column 0..4
+        for (int x = 0; x < 4; x++) dev[4 * W + x] = 1f;       // row 4, x=0..3
+        // Add one interior "noise" foreground pixel that does NOT touch the edge
+        // and is NOT 4-connected to any L-shape pixel.
+        // L-shape occupies: (0,0)..(0,4) + (1,4)..(3,4). (5,2) is fully interior.
+        dev[2 * W + 5] = 1f;  // (5, 2) — isolated, NOT 4-connected to the L
+
+        var rim = DeviationFloodRimMask.Build(dev, W, H, devThr: 0.5);
+
+        // Every L-shape pixel should be in the rim.
+        for (int y = 0; y < 5; y++) rim[y * W + 0].Should().BeTrue($"L vertical at (0,{y})");
+        for (int x = 0; x < 4; x++) rim[4 * W + x].Should().BeTrue($"L horizontal at ({x},4)");
+
+        // The isolated interior pixel must NOT be in the rim.
+        rim[2 * W + 5].Should().BeFalse("interior pixel not 4-connected to edge");
+    }
+
+    [Fact]
+    public void Build_IsolatedInteriorForegroundNotMasked()
+    {
+        // 8x8: a 2x2 high-deviation blob in the dead center + a separate
+        // edge-touching strip on the right.
+        const int W = 8, H = 8;
+        var dev = new float[W * H];
+        // Interior 2x2 at (3,3)..(4,4):
+        dev[3 * W + 3] = 1f; dev[3 * W + 4] = 1f;
+        dev[4 * W + 3] = 1f; dev[4 * W + 4] = 1f;
+        // Right-edge strip at column 7, rows 1..3:
+        dev[1 * W + 7] = 1f; dev[2 * W + 7] = 1f; dev[3 * W + 7] = 1f;
+
+        var rim = DeviationFloodRimMask.Build(dev, W, H, devThr: 0.5);
+
+        // Interior 2x2 NOT masked.
+        rim[3 * W + 3].Should().BeFalse();
+        rim[3 * W + 4].Should().BeFalse();
+        rim[4 * W + 3].Should().BeFalse();
+        rim[4 * W + 4].Should().BeFalse();
+        // Right-edge strip IS masked.
+        rim[1 * W + 7].Should().BeTrue();
+        rim[2 * W + 7].Should().BeTrue();
+        rim[3 * W + 7].Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_BelowThresholdNotMasked()
+    {
+        // Same shapes as the previous test but at deviation 0.3, below threshold.
+        const int W = 8, H = 8;
+        var dev = new float[W * H];
+        dev[3 * W + 3] = 0.3f; dev[3 * W + 4] = 0.3f;
+        dev[4 * W + 3] = 0.3f; dev[4 * W + 4] = 0.3f;
+        dev[1 * W + 7] = 0.3f; dev[2 * W + 7] = 0.3f; dev[3 * W + 7] = 0.3f;
+
+        var rim = DeviationFloodRimMask.Build(dev, W, H, devThr: 0.5);
+
+        // Nothing should be masked because no pixel meets the threshold.
+        for (int i = 0; i < W * H; i++) rim[i].Should().BeFalse();
+    }
+}

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/CliArgsBundleFlagsTests.cs
@@ -91,4 +91,27 @@ public class CliArgsBundleFlagsTests
             .WithMessage("*--hand-truth-cal*")
             .Which.Message.Should().NotContain("--truth-cal wants");
     }
+
+    [Fact]
+    public void Parses_no_rim_mask_flag()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+            "--no-rim-mask",
+        })!;
+
+        args.SkipRimMask.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parses_default_rim_mask_on()
+    {
+        var args = CliArgs.Parse(new[]
+        {
+            "--phase", "synthesis-probe", "--area", "AreaEltibule",
+        })!;
+
+        args.SkipRimMask.Should().BeFalse();
+    }
 }

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationRimMaskTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationRimMaskTests.cs
@@ -8,30 +8,41 @@ namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
 public class IconLikelihoodFieldLoadDeviationRimMaskTests
 {
     [Fact]
-    public void LoadDeviationAsField_RimMaskZerosFieldUnderRim()
+    public void LoadDeviationAsField_RimMaskAffectsScoredColumnAdjacentToEdge()
     {
-        // 64x64 deviation: an edge-touching strip on the right + an interior
-        // cross-shaped icon-like blob. Rim mask should zero the right strip
-        // (peak score there must be 0) but leave the interior blob scoreable.
+        // 64x64 deviation with an edge-touching strip at column 63 (right edge),
+        // rows 10-15, value 200 (above the 0.5 * 255 = 127.5 threshold). Plus an
+        // interior cross at (32, 32) far from any edge.
+        //
+        // ScoreAll only writes field[y, cx] where (cx - ax) + tw <= W. For a 5x5
+        // template with ax = Math.Round(0.5 * 5) = 2 (banker's rounding), the
+        // last scored column is cx = 61 (window spans columns 59-63). The
+        // template's opaque pixel at (ty=2, tx=4) reads source pixel (cy, 63).
+        // So scoring at cx = 61 INCLUDES the rim-strip pixel; masking it
+        // changes the field value there. cx = 62, 63 are never scored, so any
+        // assertion at those columns would be a no-op (would pass even with
+        // applyRimMask: false). That's why we assert at cx = 61.
         const int W = 64, H = 64;
         var devBytes = new byte[W * H];
-        // Right-edge strip: column 63, rows 10..15, value 200.
         for (int y = 10; y <= 15; y++) devBytes[y * W + (W - 1)] = 200;
-        // Interior cross at (32, 32): 5x5 plus pattern.
         StampCross(devBytes, W, cx: 32, cy: 32);
         var deviation = new GrayImage(W, H, devBytes);
 
         var template = MakeCrossTemplate();
-        var fieldMasked = IconLikelihoodField.LoadDeviationAsField(
+
+        var raw = IconLikelihoodField.LoadDeviationAsField(
+            deviation, template, applyRimMask: false, devThr: IconLikelihoodField.DefaultDevThr);
+        var masked = IconLikelihoodField.LoadDeviationAsField(
             deviation, template, applyRimMask: true, devThr: IconLikelihoodField.DefaultDevThr);
 
-        // Field score directly UNDER the right strip's pixels must be zero
-        // (rim was zeroed → NCC over an all-zero window has zero std → field=0).
-        fieldMasked[12, W - 1].Should().Be(0.0);
-        fieldMasked[13, W - 1].Should().Be(0.0);
+        // At cx=61, the window spans cols 59-63 and the template reads (cy, 63).
+        // raw includes the rim pixel (value 200); masked zeros it.
+        masked[12, 61].Should().NotBe(raw[12, 61],
+            "masking the rim pixel at (12, 63) must change the score at the adjacent scored column cx=61");
 
-        // Interior cross's peak score must be high.
-        fieldMasked[32, 32].Should().BeGreaterThan(0.8);
+        // The interior cross peak must still score high under masking (the flood
+        // shouldn't reach inland from any edge).
+        masked[32, 32].Should().BeGreaterThan(0.8);
     }
 
     [Fact]

--- a/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationRimMaskTests.cs
+++ b/tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests/IconLikelihoodFieldLoadDeviationRimMaskTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;
+using Xunit;
+
+namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Tests;
+
+public class IconLikelihoodFieldLoadDeviationRimMaskTests
+{
+    [Fact]
+    public void LoadDeviationAsField_RimMaskZerosFieldUnderRim()
+    {
+        // 64x64 deviation: an edge-touching strip on the right + an interior
+        // cross-shaped icon-like blob. Rim mask should zero the right strip
+        // (peak score there must be 0) but leave the interior blob scoreable.
+        const int W = 64, H = 64;
+        var devBytes = new byte[W * H];
+        // Right-edge strip: column 63, rows 10..15, value 200.
+        for (int y = 10; y <= 15; y++) devBytes[y * W + (W - 1)] = 200;
+        // Interior cross at (32, 32): 5x5 plus pattern.
+        StampCross(devBytes, W, cx: 32, cy: 32);
+        var deviation = new GrayImage(W, H, devBytes);
+
+        var template = MakeCrossTemplate();
+        var fieldMasked = IconLikelihoodField.LoadDeviationAsField(
+            deviation, template, applyRimMask: true, devThr: IconLikelihoodField.DefaultDevThr);
+
+        // Field score directly UNDER the right strip's pixels must be zero
+        // (rim was zeroed → NCC over an all-zero window has zero std → field=0).
+        fieldMasked[12, W - 1].Should().Be(0.0);
+        fieldMasked[13, W - 1].Should().Be(0.0);
+
+        // Interior cross's peak score must be high.
+        fieldMasked[32, 32].Should().BeGreaterThan(0.8);
+    }
+
+    [Fact]
+    public void LoadDeviationAsField_RimMaskDisabled_MatchesScoreAll()
+    {
+        // With the rim mask disabled, the overload should return exactly
+        // the same field as ScoreAll on the raw deviation.
+        const int W = 64, H = 64;
+        var devBytes = new byte[W * H];
+        for (int y = 10; y <= 15; y++) devBytes[y * W + (W - 1)] = 200;
+        StampCross(devBytes, W, cx: 32, cy: 32);
+        var deviation = new GrayImage(W, H, devBytes);
+
+        var template = MakeCrossTemplate();
+        var fieldUnmasked = IconLikelihoodField.LoadDeviationAsField(
+            deviation, template, applyRimMask: false, devThr: IconLikelihoodField.DefaultDevThr);
+        var fieldScoreAll = IconLikelihoodField.ScoreAll(deviation, template);
+
+        // The two fields must be element-wise equal.
+        for (int y = 0; y < H; y++)
+            for (int x = 0; x < W; x++)
+                fieldUnmasked[y, x].Should().Be(fieldScoreAll[y, x]);
+    }
+
+    private static void StampCross(byte[] pixels, int width, int cx, int cy)
+    {
+        for (int dy = -2; dy <= 2; dy++)
+            pixels[(cy + dy) * width + cx] = 200;
+        for (int dx = -2; dx <= 2; dx++)
+            pixels[cy * width + (cx + dx)] = 200;
+        pixels[cy * width + cx] = 255;
+    }
+
+    private static IconTemplate MakeCrossTemplate()
+    {
+        var gray = new byte[]   { 0,0,200,0,0,  0,0,200,0,0,  200,200,255,200,200,  0,0,200,0,0,  0,0,200,0,0 };
+        var alpha = new byte[]  { 0,0,255,0,0,  0,0,255,0,0,  255,255,255,255,255,  0,0,255,0,0,  0,0,255,0,0 };
+        return new IconTemplate(
+            Name: "x", LandmarkType: "Portal", PivotX: 0.5, PivotY: 0.5,
+            Gray: new GrayImage(5, 5, gray),
+            Alpha: new GrayImage(5, 5, alpha));
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/CliArgs.cs
+++ b/tools/MapCalibrationFromScreenshot/CliArgs.cs
@@ -46,7 +46,8 @@ internal sealed record CliArgs(
     string? RecoveredCalJsonPath,
     string? AlignedDeviationPath,
     string? DetectionsJsonPath,
-    (double Scale, double Rot, double Ox, double Oy, bool Mirror)? HandTruthCal)
+    (double Scale, double Rot, double Ox, double Oy, bool Mirror)? HandTruthCal,
+    bool SkipRimMask)
 {
     public static CliArgs? Parse(string[] argv)
     {
@@ -90,6 +91,7 @@ internal sealed record CliArgs(
         string? alignedDeviationPath = null;
         string? detectionsJsonPath = null;
         (double, double, double, double, bool)? handTruthCal = null;
+        bool skipRimMask = false;
 
         for (int i = 0; i < argv.Length; i++)
         {
@@ -200,6 +202,9 @@ internal sealed record CliArgs(
                     }
                     break;
                 }
+                case "--no-rim-mask":
+                    skipRimMask = true;
+                    break;
                 case "-h" or "--help":
                     return null;
                 default:
@@ -285,7 +290,8 @@ internal sealed record CliArgs(
             RecoveredCalJsonPath: recoveredCalJsonPath,
             AlignedDeviationPath: alignedDeviationPath,
             DetectionsJsonPath: detectionsJsonPath,
-            HandTruthCal: handTruthCal);
+            HandTruthCal: handTruthCal,
+            SkipRimMask: skipRimMask);
     }
 
     private static (double, double, double, double, bool) ParseSeed(string s)
@@ -517,6 +523,12 @@ internal sealed record CliArgs(
                                                      recovered cal is known-wrong, e.g. the 2026-06-02 4-inlier
                                                      residual-4-px solves; supply the hand-verified entry from
                                                      src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json).
+              --no-rim-mask                         disable the edge-connected DeviationFlood rim mask that
+                                                     the probe applies by default when consuming a bundle's
+                                                     deviation. Use to compare rim-masked vs raw scores for
+                                                     diagnostic purposes; production's RANSAC detector always
+                                                     applies this mask, so the default-on matches what
+                                                     production sees.
             """);
     }
 }

--- a/tools/MapCalibrationFromScreenshot/README.md
+++ b/tools/MapCalibrationFromScreenshot/README.md
@@ -237,6 +237,12 @@ E5's scale bracket auto-narrows to ±20% of the expected aligned-pair-pixel scal
 
 Override any auto-resolved flag by passing it explicitly — the explicit flag wins.
 
+### Rim masking
+
+When `--aligned-deviation` (or `--bundle-dir`) is the field source, the probe applies the same edge-connected rim flood production's detector uses (`RimMaskMode.DeviationFlood`), zeroing the rocky rim of outdoor zones before NCC. This matches what production's RANSAC inlier pool sees, so the probe's J numbers reflect production's actual scoring surface.
+
+Pass `--no-rim-mask` to disable for diagnostic comparisons (e.g., when measuring how much of the J drop on a wrong-fit attempt comes from the rim vs from interior topographic ghosting).
+
 Flags specific to this phase: `--truth-cal`, `--ransac-seeds-csv`, `--trace-console`, `--otlp`. The full flag table near the top of this README documents each.
 
 ## Out of scope (v1)

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/IconLikelihoodField.cs
@@ -34,15 +34,49 @@ internal static class IconLikelihoodField
     }
 
     /// <summary>
+    /// Default deviation threshold used by <see cref="LoadDeviationAsField(GrayImage, IconTemplate, bool, double)"/>'s
+    /// rim-mask path. Matches the CLI's <c>--detection-threshold</c> default; production's
+    /// <c>DeviationBlobDetector</c> derives <c>devThr = 1 - lowNcc</c> with the same 0.5 baseline.
+    /// </summary>
+    public const double DefaultDevThr = 0.5;
+
+    /// <summary>
     /// Build a field from a pre-computed deviation map. Skips the screenshot-minus-
     /// aligned-base subtraction step that <see cref="Build"/> performs; equivalent
     /// to calling <see cref="ScoreAll"/> directly with a deviation supplied by the
     /// caller. Used by the bundle-consumption path where the live engine has
     /// already produced a post-ECC deviation via #978's ECC refiner.
+    ///
+    /// <para>This default overload applies <see cref="DeviationFloodRimMask"/> so the
+    /// probe's J numbers reflect what production's RANSAC pool sees (rim-masked
+    /// deviation, mithril#897 gate-study balance). Pass the 4-arg overload with
+    /// <c>applyRimMask: false</c> to disable for diagnostic comparisons.</para>
     /// </summary>
     /// <returns>Same row-major [H, W] layout as <see cref="ScoreAll"/>.</returns>
     public static double[,] LoadDeviationAsField(GrayImage deviation, IconTemplate template)
-        => ScoreAll(deviation, template);
+        => LoadDeviationAsField(deviation, template, applyRimMask: true, devThr: DefaultDevThr);
+
+    /// <summary>
+    /// Overload with explicit rim-mask control. Set <paramref name="applyRimMask"/>
+    /// to false to score the raw deviation (used by tests and diagnostic CLI runs).
+    /// </summary>
+    public static double[,] LoadDeviationAsField(
+        GrayImage deviation, IconTemplate template, bool applyRimMask, double devThr)
+    {
+        if (!applyRimMask) return ScoreAll(deviation, template);
+
+        int n = deviation.Width * deviation.Height;
+        var dev = new float[n];
+        for (int i = 0; i < n; i++) dev[i] = deviation.Pixels[i] / 255f;
+
+        var rim = DeviationFloodRimMask.Build(dev, deviation.Width, deviation.Height, devThr);
+
+        var maskedPixels = new byte[n];
+        for (int i = 0; i < n; i++) maskedPixels[i] = rim[i] ? (byte)0 : deviation.Pixels[i];
+
+        var masked = new GrayImage(deviation.Width, deviation.Height, maskedPixels);
+        return ScoreAll(masked, template);
+    }
 
     /// <summary>
     /// Bicubic interpolation of <paramref name="field"/> at sub-pixel position

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbePhase.cs
@@ -200,14 +200,17 @@ internal static class SynthesisProbePhase
         if (alignedDeviationPath is not null)
         {
             var deviation = ImageIo.LoadGray(alignedDeviationPath);
+            bool applyRimMask = !args.SkipRimMask;
             foreach (var template in templates)
             {
                 using var fieldSpan = SynthesisProbeTracer.Source.StartActivity("field.build");
                 fieldSpan?.SetTag("template.type", template.LandmarkType);
                 fieldSpan?.SetTag("template.size_px", Math.Max(template.Gray.Width, template.Gray.Height));
                 fieldSpan?.SetTag("source", "aligned-deviation");
+                fieldSpan?.SetTag("rim_masked", applyRimMask);
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                fieldsByType[template.LandmarkType] = IconLikelihoodField.LoadDeviationAsField(deviation, template);
+                fieldsByType[template.LandmarkType] = IconLikelihoodField.LoadDeviationAsField(
+                    deviation, template, applyRimMask, IconLikelihoodField.DefaultDevThr);
                 fieldSpan?.SetTag("duration_ms", sw.ElapsedMilliseconds);
             }
         }


### PR DESCRIPTION
## Summary

Two commits. Independent of PR #987 (auto-fill); branch is based on `main`.

| SHA | Type | What |
|---|---|---|
| `5009616d` | refactor | Extract inline edge-flood rim-mask logic from `DeviationBlobDetector` into a standalone `DeviationFloodRimMask` helper. **Byte-identical** — existing `DeviationFloodRimTests` is the regression proof. |
| `9cdd86b6` | fix | Validate `DeviationFloodRimMask.Build` preconditions (null/non-positive dims/length mismatch). Public production-API surface; clear `ArgumentException` beats a deep `IndexOutOfRangeException`. |
| `19e3708c` | feat | `IconLikelihoodField.LoadDeviationAsField` now applies the rim mask by default. `--no-rim-mask` CLI flag disables for diagnostics. `field.build` span carries a `rim_masked` tag. README documents the production-parity rationale. |
| `6f737a52` | test | Tighten the rim-mask test — original assertion was at column 63 which `ScoreAll` never writes (border exclusion based on template width + pivot), so it would have passed even with `applyRimMask:false`. Rewrite to compare raw vs masked at `cx=61` (the last scored column whose 5×5 window reaches the rim pixel), proving the masking changes the field. Add parse-round-trip tests for `--no-rim-mask`. |

## Why

The synthesis-probe consumes `07-deviation.png` raw, but production's `DeviationBlobDetector` zeroes the edge-connected rim foreground (`RimMaskMode.DeviationFlood`) before any NCC. So the probe and production were computing on different inputs — minor in isolation, but load-bearing once we use accumulated probe-on-bundles to calibrate production accept-gate thresholds. The mithril#897 gate study measured this rim flood at Eltibule 11.3% pixel coverage (vs ColourFlood's 67.6%) — surgical rather than over-masking.

## Test plan

- [x] `dotnet build Mithril.slnx -c Release` — 0 warnings, 0 errors.
- [x] `dotnet test tools/MapCalibrationFromScreenshot.SynthesisProbe.Tests -c Release` — **51/51 passing** (47 baseline + 2 rim-mask + 2 parse-round-trip).
- [x] `dotnet test tests/Mithril.MapCalibration.Tests -c Release` — **113/113 passing** (108 baseline + 3 helper unit tests + 2 precondition-guard tests).
- [x] Byte-identical regression: pre-existing `DeviationFloodRimTests` (2 facts in `tests/Mithril.MapCalibration.Tests/Detection/`) was NOT modified and still passes after the extraction refactor.
- [x] Smoke: `--phase synthesis-probe --no-rim-mask` parses without error (still hits the truth-cal precedence check first).
- [ ] User to re-run the three Eltibule bundles (A/B/C) and update [`docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md`](docs/superpowers/specs/2026-06-01-synthesis-probe-diagnostic-design.md) with the rim-masked J numbers alongside the existing unmasked ones. Expected per the plan: A ≈ 18-20 (rim doesn't materially affect interior refs), B remains negative (interior topographic ghosting, not rim-driven), C the biggest gain (14.5-17, vs current 13.96). Architectural verdict (Proposal B) doesn't change; the table just gets sharper.

## Out of scope (per the plan)

- **No changes to production's `AutoCalibrationEngine`.** Probe-side only — production already applies `DeviationFlood`.
- **No changes to `07-deviation.png` writing.** Bundle's deviation visualization stays raw by design so humans inspecting bundles see exactly what ECC produced.
- **No threshold-tuning experiment.** `DefaultDevThr = 0.5` matches the CLI's `--detection-threshold` default and production's `1 - lowNcc` derivation; if a future study suggests a different threshold for the probe, that's a separate change.
- **No interior-residue masking.** Bundle C's interior topographic ghosting is an ECC-residual problem `DeviationFlood` can't help with — it only handles edge-connected components.
- **Spec-doc J-number addendum.** Deferred to the user post-real-bundle run (we don't fabricate measurements).

## API notes

- `DeviationFloodRimMask.Build` accepts `float[]` (not `ReadOnlySpan<float>` as the plan originally suggested). The implementer noted a local-function ref-struct capture concern that's actually resolvable in C# 11+, but `float[]` works for all current callers (production passes `float[]`, the new probe caller materializes a `float[]` from the deviation byte array). Future need for slice/stack-allocation callers can revisit.
- `IconLikelihoodField.LoadDeviationAsField` now has two overloads: 2-arg (always rim-masks, matches production) and 4-arg (`applyRimMask`, `devThr` controllable). Two-overload API picked over a single 1-arg method with a `bool` so the default path reads cleanly at call sites; the diagnostic path is explicit.

## Cross-references

- #987 — synthesis-probe `--bundle-dir` auto-fill (independent; not blocking this PR).
- #897 — gate study that measured `DeviationFlood` masking coverage on Eltibule.
- #985 — calibration diagnostic bundle (produces `07-deviation.png`).
- #978 — ECC refiner that produces the post-aligned deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)