### PR TITLE
fix(map-calibration): record clamped bundle MapRect (#989) + add accept monotonicity gate (#988)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -295,6 +295,13 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             return Fail(area, "the located map rect fell outside the captured frame — redraw the capture box tightly around the in-game map");
         }
 
+        // #989: the bundle sink reads attempt.MapRect to write 04-maprect.json.
+        // The detect→solve pipeline below operates on the CLAMPED rect (crop,
+        // alignedTexture, alignedRect all derive from `clamped`), so the bundle
+        // JSON must describe the same dims the deviation/aligned/base-texture
+        // images carry — not the pre-clamp ECC value that overshoots the frame.
+        attempt.MapRect = clamped;
+
         var crop = ImageOps.Crop(gray, clamped.OriginX, clamped.OriginY, clamped.Width, clamped.Height);
         var alignedTexture = ImageOps.Resize(baseTexture, clamped.Width, clamped.Height);
         var alignedRect = new MapRect(0, 0, clamped.Width, clamped.Height, clamped.TextureWidth, clamped.TextureHeight);

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -60,6 +60,16 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         MinArea: 12, MaxIconArea: 900, MinSolidity: 0.35, MaxAspect: 2.5, MinPeak: 0.7);
     private const double RefineMinScore = 0.5;
 
+    // #988 monotonicity gate: when a stored calibration exists for the area,
+    // a new fit must not regress quality by more than these tolerances.
+    // Tuned from the Eltibule 03:11:05 (0.79 px / 10 inliers, GOOD) vs
+    // 03:11:30 (4.03 px / 4 inliers, WRONG) pair surfaced by PR #986: ratio
+    // 2.0× catches the 5× residual blow-up; delta 2 catches the 6-inlier
+    // drop. Both gates conservative on the cold-start floor (4 inliers /
+    // residual already <12 px) so a marginal-but-correct re-fit still wins.
+    private const double MonotonicResidualRatio = 2.0;
+    private const int MonotonicInlierDelta = 2;
+
     private readonly IAreaState _areaState;
     private readonly IGameWindowLocator _windowLocator;
     private readonly IMapCaptureRegionProvider _region;
@@ -357,8 +367,29 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
 
         // Gate-accept: persist through the user store stamped AutoCapture, which
         // inherits user-store precedence by construction (Task 20).
-        attempt.Outcome = OutcomeVocabulary.Accepted;
         var stamped = result.Calibration with { Source = CalibrationSource.AutoCapture };
+
+        // #988 monotonicity gate. When a stored calibration already exists for
+        // this area, the new fit must not regress residual/inlier quality (a
+        // wrong-fit second attempt that clears the cold-start gate would
+        // otherwise replace a good first attempt — see the Eltibule 03:11:05
+        // vs 03:11:30 pair in the originating issue). Cold start (no existing)
+        // takes the same accept path it always did.
+        var existing = _calibrationService.GetCalibration(area);
+        if (existing is not null)
+        {
+            var monotonicReason = CheckMonotonicAccept(existing, stamped, result.InlierCount);
+            if (monotonicReason is not null)
+            {
+                attempt.Outcome = OutcomeVocabulary.RejectedNotMonotonic;
+                _logger?.LogInformation(
+                    "Auto-calibration rejected for {Area}: monotonicity gate — {Reason}. Prior calibration kept (residual {PriorResidual:0.00}px, refs {PriorRefs}).",
+                    area, monotonicReason, existing.ResidualPixels, existing.ReferenceCount);
+                return new AutoCalibrationOutcome(Persisted: false, AreaKey: area, RejectReason: monotonicReason);
+            }
+        }
+
+        attempt.Outcome = OutcomeVocabulary.Accepted;
         _calibrationService.SaveUserRefinement(area, stamped);
         _logger?.LogInformation(
             "Auto-calibration persisted for {Area} (residual {Residual:0.00} px, {Inliers} inliers).",
@@ -504,6 +535,33 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     {
         _logger?.LogInformation("Auto-calibration not attempted for {Area}: {Reason}.", string.IsNullOrEmpty(area) ? "<none>" : area, reason);
         return new AutoCalibrationOutcome(Persisted: false, AreaKey: area, RejectReason: reason);
+    }
+
+    /// <summary>
+    /// #988 monotonicity gate. A new fit may REPLACE an existing stored
+    /// calibration only if it isn't meaningfully worse. Rejects when the new
+    /// residual exceeds the existing by <see cref="MonotonicResidualRatio"/>×
+    /// OR the new inlier count is below the existing by more than
+    /// <see cref="MonotonicInlierDelta"/>. Returns null on accept, or a
+    /// human-readable reason on reject.
+    ///
+    /// <para>Cold start (no <paramref name="existing"/>) is the caller's
+    /// problem — this helper is consulted only after the engine looks up a
+    /// prior calibration and finds one. The cold-start accept path is
+    /// unchanged per the issue's out-of-scope list.</para>
+    /// </summary>
+    internal static string? CheckMonotonicAccept(AreaCalibration existing, AreaCalibration candidate, int candidateInlierCount)
+    {
+        if (existing.ResidualPixels > 0
+            && candidate.ResidualPixels > existing.ResidualPixels * MonotonicResidualRatio)
+        {
+            return $"new residual {candidate.ResidualPixels:0.00}px exceeds existing {existing.ResidualPixels:0.00}px × {MonotonicResidualRatio:0.0}";
+        }
+        if (candidateInlierCount < existing.ReferenceCount - MonotonicInlierDelta)
+        {
+            return $"new inlier count {candidateInlierCount} below existing {existing.ReferenceCount} − {MonotonicInlierDelta}";
+        }
+        return null;
     }
 }
 

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/OutcomeVocabulary.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/OutcomeVocabulary.cs
@@ -21,6 +21,7 @@ public static class OutcomeVocabulary
     public const string RejectedSolveNoDetections = "rejected-solve-no-detections";
     public const string RejectedSolveInsufficientInliers = "rejected-solve-insufficient-inliers";
     public const string RejectedSolveResidual = "rejected-solve-residual";
+    public const string RejectedNotMonotonic = "rejected-not-monotonic";
     public const string Error = "error";
 
     private static readonly FrozenSet<string> NoBundleOutcomes = FrozenSet.Create(

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -402,6 +402,89 @@ public sealed class AutoCalibrationEngineTests
         captured[0].Outcome.Should().Be(OutcomeVocabulary.RejectedSolveInsufficientInliers);
     }
 
+    // ── #988 monotonicity gate (engine-level) ────────────────────────────────
+
+    [Fact]
+    public async Task Replaces_existing_when_new_fit_is_better()
+    {
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, MakeCal(residual: 3.0, refs: 6));
+        var h = new EngineHarness { Solve = Accepted(residual: 0.65, inliers: 8), Service = svc };
+
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeTrue();
+        svc.Saved.Should().ContainKey(Area);
+        svc.Saved[Area].ResidualPixels.Should().Be(0.65);
+    }
+
+    [Fact]
+    public async Task Rejects_when_new_residual_blows_up_vs_existing()
+    {
+        // Mirrors the PR #986 Eltibule case: existing residual 0.79 px, new 4.03 px.
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, MakeCal(residual: 0.79, refs: 10));
+        var h = new EngineHarness { Solve = Accepted(residual: 4.03, inliers: 4), Service = svc };
+
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("residual");
+        svc.Saved.Should().NotContainKey(Area); // existing untouched
+    }
+
+    [Fact]
+    public async Task Rejects_when_new_inlier_count_drops_vs_existing()
+    {
+        var svc = new FakeCalibrationService();
+        svc.Seed(Area, MakeCal(residual: 1.0, refs: 10));
+        var h = new EngineHarness { Solve = Accepted(residual: 1.0, inliers: 4), Service = svc };
+
+        var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Contain("inlier");
+        svc.Saved.Should().NotContainKey(Area);
+    }
+
+    // ── #988 monotonicity gate (helper-level) ────────────────────────────────
+
+    [Fact]
+    public void Monotonicity_helper_accepts_better_residual_and_same_inliers()
+    {
+        var existing = MakeCal(residual: 2.0, refs: 8);
+        var candidate = MakeCal(residual: 1.0, refs: 8);
+        AutoCalibrationEngine.CheckMonotonicAccept(existing, candidate, candidateInlierCount: 8)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Monotonicity_helper_rejects_residual_blowup_beyond_ratio()
+    {
+        var existing = MakeCal(residual: 1.0, refs: 8);
+        var candidate = MakeCal(residual: 3.0, refs: 8); // 3× > 2× threshold
+        AutoCalibrationEngine.CheckMonotonicAccept(existing, candidate, candidateInlierCount: 8)
+            .Should().Contain("residual");
+    }
+
+    [Fact]
+    public void Monotonicity_helper_rejects_inlier_drop_beyond_delta()
+    {
+        var existing = MakeCal(residual: 1.0, refs: 10);
+        var candidate = MakeCal(residual: 1.0, refs: 10); // ReferenceCount on the cal is metadata
+        AutoCalibrationEngine.CheckMonotonicAccept(existing, candidate, candidateInlierCount: 4) // 10 − 4 = 6 > delta 2
+            .Should().Contain("inlier");
+    }
+
+    [Fact]
+    public void Monotonicity_helper_accepts_marginal_within_tolerances()
+    {
+        var existing = MakeCal(residual: 1.0, refs: 8);
+        var candidate = MakeCal(residual: 1.8, refs: 8); // 1.8 < 1.0 × 2.0
+        AutoCalibrationEngine.CheckMonotonicAccept(existing, candidate, candidateInlierCount: 7) // 8 − 7 = 1 ≤ delta 2
+            .Should().BeNull();
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static CalibrationAttemptBundleSinkSelector MakeSinkSelector(ICalibrationAttemptBundleSink sink) =>
@@ -428,6 +511,10 @@ public sealed class AutoCalibrationEngineTests
 
     private static AreaCalibration SomeBaseline() =>
         new(1.0, 0, 50, 50, 4, 3.0) { Source = CalibrationSource.BundledBaseline };
+
+    private static AreaCalibration MakeCal(double residual, int refs) => new(
+        Scale: 1.0, RotationRadians: 0.0, OriginX: 0.0, OriginY: 0.0,
+        ReferenceCount: refs, ResidualPixels: residual);
 
     /// <summary>
     /// Mutable harness: each property has a sensible "happy path" default; a test

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -183,6 +183,62 @@ public sealed class AutoCalibrationEngineTests
     // ── Bundle-sink (#984 Block D) ───────────────────────────────────────────
 
     [Fact]
+    public async Task Recorded_MapRect_height_matches_clamped_height_when_ECC_rect_overshoots_frame()
+    {
+        // #989: per-attempt bundle's 04-maprect.json must record the height the
+        // engine actually used (the clamped height), not the pre-clamp ECC-located
+        // height — otherwise the JSON disagrees with the deviation/aligned/
+        // base-texture image dims in the same bundle. Reproduce the overshoot:
+        // a 100×100 captured frame + an ECC rect that asks for 150 rows starting
+        // at row 50 (would extend to row 200; clamps to row 100, i.e. height 50).
+        var capture = new GrayImage(100, 100, new byte[100 * 100]);
+        var baseTex = new GrayImage(200, 200, new byte[200 * 200]);
+        var overshootingRect = new MapRect(
+            OriginX: 0, OriginY: 50, Width: 100, Height: 150,
+            TextureWidth: 200, TextureHeight: 200,
+            AutoDetectScore: 0.9, SourceScaleFactor: 1.0);
+
+        var captured = new List<CalibrationAttemptContext>();
+        var selector = MakeSinkSelector(new CapturingSink(captured));
+        var h = new EngineHarness
+        {
+            BaseTexture = baseTex,
+            Refiner = new FakeRefiner(overshootingRect),
+            Solve = Accepted(residual: 0.65, inliers: 5),
+            SinkSelector = selector,
+        };
+        // Override the default 64×64 SpyCapture with a 100×100 one matching the
+        // overshoot scenario. EngineHarness.Capture is get-only, but a fresh
+        // harness with the right capture isn't expressible without constructing
+        // the engine directly (Capture is initialized in the field initializer).
+        // So construct the engine inline using the same shape as the harness.
+        var captureSpy = new SpyCapture(capture);
+        var solver = new SpySolver(h.Solve);
+        var engine = new AutoCalibrationEngine(
+            new FakeAreaState(Area),
+            new FakeWindowLocator(h.GameWindow),
+            new FakeRegionProvider(h.Bbox),
+            captureSpy,
+            h.Refiner,
+            new FakeBaseTextureProvider(baseTex),
+            new FakeAreaRefs(new[] { new LandmarkReference("landmark_npc", "x", new WorldCoord(1, 0, 1)) }),
+            solver,
+            h.IconProvider,
+            h.Service,
+            logger: null,
+            sinkSelector: selector);
+
+        await engine.TryCalibrateCurrentAreaAsync(default);
+
+        captured.Should().HaveCount(1);
+        var ctx = captured[0];
+        ctx.MapRect.Should().NotBeNull();
+        ctx.MapRect!.Height.Should().Be(50,
+            "the engine clamped 150→50 to stay within the 100-row frame; the bundle must record the height it actually used");
+        ctx.MapRect.OriginY.Should().Be(50, "OriginY is in-bounds and untouched by the clamp");
+    }
+
+    [Fact]
     public async Task TryCalibrate_passes_populated_context_to_sink_on_accept()
     {
         var captured = new List<CalibrationAttemptContext>();


### PR DESCRIPTION
## Summary

Two related fixes to `AutoCalibrationEngine` surfaced by PR #986's bundle-driven synthesis-probe study of the Eltibule 2026-06-02 03:11 session:

- **#989** — the per-attempt diagnostic bundle's `04-maprect.json` recorded the *requested* MapRect height. When the engine clamped the ECC-located rect to the screenshot bottom edge, the JSON disagreed with the deviation/aligned/base-texture image files in the same bundle (concretely: `height=999` in JSON vs 986-row image files on the Eltibule 03:11:30 attempt). Reassign `attempt.MapRect = clamped` immediately after `ClampToFrame` so the bundle JSON describes the same rect every downstream consumer used.
- **#988** — a wrong-fit second attempt (residual 4.03 px, 4 inliers, rotated 117° off truth) replaced a clean first attempt (residual 0.79 px, 10 inliers) 25 seconds later because both cleared the cold-start gate (inliers ≥ 4). Add a monotonicity gate on the accept path: when a stored calibration exists, the new fit must clear residual ratio ≤ 2× *and* inlier delta ≤ 2. Cold start (no prior) is unchanged. Rejections tag the bundle `rejected-not-monotonic` and log the prior's residual + refs so post-hoc audit can answer "what was kept and why."

Both fixes localize to `AutoCalibrationEngine` + its `OutcomeVocabulary`. Thresholds (`MonotonicResidualRatio = 2.0`, `MonotonicInlierDelta = 2`) are first-pass guesses tuned to catch the Eltibule pair; tighten as data accumulates.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors (warnings-as-errors enabled).
- [x] `dotnet test Mithril.slnx` — all green; calibration suite went 147 → 154 tests with 8 net new (1 for #989, 4 helper + 3 engine for #988).
- [x] Regression sentinel for #989: `Recorded_MapRect_height_matches_clamped_height_when_ECC_rect_overshoots_frame` constructs a 100×100 capture + a 150-row rect at OriginY=50; asserts the bundle context records `Height==50` (clamp), would have read 150 without the fix.
- [x] Regression sentinel for #988: `Rejects_when_new_residual_blows_up_vs_existing` mirrors the Eltibule pair verbatim (seed 0.79/10, new 4.03/4) and asserts `Persisted=false` + prior untouched.
- [x] Existing `Persists_with_AutoCapture_source_on_accept` (cold-start) and `Keeps_prior_calibration_when_the_gate_rejects` (solver-reject) both still pass — the new gate only fires when a prior exists, so cold start is genuinely unchanged.

## Known follow-ups (non-blocking, from code review)

- The `existing.ResidualPixels > 0` guard in `CheckMonotonicAccept` defends against a sentinel-zero baseline residual. Real solver output is always > 0; if no baselines stamp a literal zero, this guard can be removed (project's "no speculative guards" rule).
- Boundary-condition tests (`candidate.Residual == existing.Residual * 2.0` exactly accepts; `candidateInlierCount == existing.ReferenceCount - 2` exactly accepts) would lock the strict-vs-non-strict comparison semantics. Low-risk for floating point, trivial to add.

Closes #988, closes #989.

— drafted by Claude (Opus 4.7), posted by @arthur-conde