### PR TITLE
test(map-calibration): park MapBboxDrawController test windows off-screen (#996)

### DIFF
--- a/tests/Mithril.MapCalibration.Capture.Tests/MapCaptureRegionProviderTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/MapCaptureRegionProviderTests.cs
@@ -70,15 +70,7 @@ public sealed class MapCaptureRegionProviderTests
     [Fact]
     public void BeginDraw_with_a_confirmed_snip_persists_physical_to_the_store() => RunOnSta(() =>
     {
-        var window = new Window
-        {
-            WindowStyle = WindowStyle.None,
-            ShowInTaskbar = false,
-            Left = 0,
-            Top = 0,
-            Width = 10,
-            Height = 10,
-        };
+        var window = CreateOffscreenBorderlessWindow();
         try
         {
             window.Show();
@@ -109,15 +101,7 @@ public sealed class MapCaptureRegionProviderTests
     [Fact]
     public void BeginDraw_persists_scaled_physical_rect_distinct_from_diu_mirror() => RunOnSta(() =>
     {
-        var window = new Window
-        {
-            WindowStyle = WindowStyle.None,
-            ShowInTaskbar = false,
-            Left = 0,
-            Top = 0,
-            Width = 10,
-            Height = 10,
-        };
+        var window = CreateOffscreenBorderlessWindow();
         try
         {
             window.Show();
@@ -145,15 +129,7 @@ public sealed class MapCaptureRegionProviderTests
     [Fact]
     public void BeginDraw_with_a_cancelled_snip_does_not_touch_the_store() => RunOnSta(() =>
     {
-        var window = new Window
-        {
-            WindowStyle = WindowStyle.None,
-            ShowInTaskbar = false,
-            Left = 33,
-            Top = 44,
-            Width = 55,
-            Height = 66,
-        };
+        var window = CreateOffscreenBorderlessWindow();
         try
         {
             window.Show();
@@ -167,7 +143,7 @@ public sealed class MapCaptureRegionProviderTests
             DrainDispatcher();
 
             store.Value.Should().BeNull("a cancelled snip persists nothing");
-            window.Left.Should().Be(33);
+            window.Left.Should().Be(OffScreenLeft, "a cancelled snip leaves the window's initial Left untouched");
         }
         finally { window.Close(); }
     });
@@ -175,15 +151,7 @@ public sealed class MapCaptureRegionProviderTests
     [Fact]
     public void BeginDraw_with_no_physical_rect_does_not_persist_but_still_mirrors() => RunOnSta(() =>
     {
-        var window = new Window
-        {
-            WindowStyle = WindowStyle.None,
-            ShowInTaskbar = false,
-            Left = 0,
-            Top = 0,
-            Width = 10,
-            Height = 10,
-        };
+        var window = CreateOffscreenBorderlessWindow();
         try
         {
             window.Show();
@@ -241,6 +209,23 @@ public sealed class MapCaptureRegionProviderTests
         window.Left.Should().Be(5);
         window.Width.Should().Be(7);
     });
+
+    // mithril#996: Tests that call Show() on a real Window flash briefly in the top-left
+    // of the primary monitor when the suite runs in the background. Parking the window
+    // at large negative coordinates keeps it off every realistic monitor while still
+    // realizing the HWND, the dispatcher, and the layout pass that the SUT exercises.
+    private const double OffScreenLeft = -10000;
+    private const double OffScreenTop = -10000;
+
+    private static Window CreateOffscreenBorderlessWindow() => new()
+    {
+        WindowStyle = WindowStyle.None,
+        ShowInTaskbar = false,
+        Left = OffScreenLeft,
+        Top = OffScreenTop,
+        Width = 10,
+        Height = 10,
+    };
 
     private static void DrainDispatcher() =>
         System.Windows.Threading.Dispatcher.CurrentDispatcher.Invoke(

--- a/tests/Mithril.Overlay.Tests/OverlayWindowBindingTests.cs
+++ b/tests/Mithril.Overlay.Tests/OverlayWindowBindingTests.cs
@@ -51,8 +51,15 @@ public sealed class OverlayWindowBindingTests
             // Realize the visual tree. Show() + Hide() is the minimum that
             // forces template expansion + binding resolution; Measure/Arrange
             // alone leave a Window in a partially-realized state.
+            //
+            // mithril#996: WindowStyle.None + AllowsTransparency bypass DWM,
+            // so WindowState.Minimized isn't fully reliable at Show() time —
+            // park the window off-screen too so a brief flash before the
+            // minimize state takes effect can't reach the visible desktop.
             window.WindowState = WindowState.Minimized;
             window.ShowInTaskbar = false;
+            window.Left = -10000;
+            window.Top = -10000;
             window.Show();
             try
             {


### PR DESCRIPTION
## Summary

- Closes [mithril#996](https://github.com/moumantai-gg/mithril/issues/996): the `MapBboxDrawController` tests that needed a real WPF `Window` were created at `(0, 0)` (one at `(33, 44)`) and called `Show()`, so each run flashed a brief borderless rectangle in the top-left of the primary monitor.
- Route the four `Show()`-calling tests in [tests/Mithril.MapCalibration.Capture.Tests/MapCaptureRegionProviderTests.cs](https://github.com/moumantai-gg/mithril/blob/claude/quizzical-brattain-0fe354/tests/Mithril.MapCalibration.Capture.Tests/MapCaptureRegionProviderTests.cs) through a new `CreateOffscreenBorderlessWindow()` helper that parks the window at `(-10000, -10000)`. The HWND, dispatcher, and layout pass still run — only the rendered position moves off every realistic monitor, so the SUT (`MapBboxDrawController`) is unchanged.
- The `Apply_seam_*` tests never call `Show()`, so they're left alone.
- The cancelled-snip test still asserts "initial `Left` unchanged", now via the new `OffScreenLeft` constant.

## Test plan

- [x] `dotnet test tests/Mithril.MapCalibration.Capture.Tests --filter "FullyQualifiedName~MapCaptureRegionProviderTests"` → 11 passed, 0 failed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
