### PR TITLE
feat(map-calibration): synthesis-J re-rank in Shadow mode [PR-2]

### DIFF
--- a/docs/perf-trace-schema.md
+++ b/docs/perf-trace-schema.md
@@ -63,7 +63,8 @@ Once `TelemetrySettings.EnableOtlpExport` is enabled (Settings → Diagnostics �
 | `arda_dispatch` | [`DispatchTable.Dispatch`](../src/Arda/Arda.Dispatch/DispatchTable.cs) (L2) | Per dispatched line; gated on `Activity.Current` so zero-cost when no recording session |
 | `arda_compose` | [`DomainEventBus.Publish`](../src/Arda/Arda.Dispatch/DomainEventBus.cs) (L4 and below) | One span per subscriber-callback per published event; gated on `ActivitySource.HasListeners()` |
 | `overlay_project` | [`OverlayWindowService.OnSurfaceRender`](../src/Mithril.Overlay/Internal/OverlayWindowService.cs) (#835) | One span per per-tick projection; tag `area`, `marker_count`. Scaffold-only — fires only after a migration PR shows the overlay. |
-| `meter_counter` | All `Meter`-counter producers (Arda lines/verb-unmatched/grammar-break, reference fetch_outcome, domain-event-published, overlay projection.latency_ms + frame.markers) | Sums per (instrument, tag-set) flushed once per second |
+| `calibration_synthesis_rerank` | Map auto-calibration Detection layer (synthesis-J re-rank) via [`MapCalibrationDiagnostics`](../src/Mithril.MapCalibration/Diagnostics/MapCalibrationDiagnostics.cs) | One span per solve carrying the synthesis-J re-rank outcome. Tag list TBD per Task 16 of the synthesis-rerank plan. Scaffold-only — producer wiring lands in Task 16. |
+| `meter_counter` | All `Meter`-counter producers (Arda lines/verb-unmatched/grammar-break, reference fetch_outcome, domain-event-published, overlay projection.latency_ms + frame.markers, map-calibration synthesis-J histograms + disagree counter) | Sums per (instrument, tag-set) flushed once per second |
 | `scope` | _ad-hoc_ | Fallback record kind for any `Mithril.*` Activity that doesn't match a dedicated dispatch arm. Reaches via the `scope` arm until a dedicated `overlay_*` dispatch arm lands in `PerfFileExporter`. |
 
 If you read a trace and a kind you expected is missing, check the producer column first.
@@ -287,9 +288,27 @@ Companion `Mithril.Overlay` meter instruments emitted in `meter_counter` records
 
 Scaffold-only — fires only after a Migration step 2+ PR registers Legolas drawers and shows the overlay. A clean scaffold-only build emits zero overlay records.
 
+### `calibration_synthesis_rerank` (synthesis-J scaffold)
+
+Per-solve span emitted from the Map auto-calibration Detection layer (`Mithril.MapCalibration.Detection` ActivitySource) carrying the synthesis-J re-rank outcome for a single solve. The catalog lives in [`Mithril.MapCalibration.Diagnostics.MapCalibrationDiagnostics`](../src/Mithril.MapCalibration/Diagnostics/MapCalibrationDiagnostics.cs) — *local* to `Mithril.MapCalibration` rather than the Shared catalog because `Mithril.MapCalibration.csproj` deliberately doesn't reference `Mithril.Shared` (it must stay consumable by Shared peers without depending up the layering). This mirrors Arda's pattern with [`ArdaActivitySources`](../src/Arda/Arda.Abstractions/Diagnostics/ArdaActivitySources.cs) / [`ArdaMeters`](../src/Arda/Arda.Abstractions/Diagnostics/ArdaMeters.cs). Pointer comments in `MithrilActivitySources` + `MithrilMeters` document the split so future contributors don't reflexively add a duplicate `MapCalibration` static and create a vocabulary fork.
+
+The parent `calibration.solve` span lives on the Capture-layer source [`MithrilActivitySources.MapCalibration`](../src/Mithril.Shared/Diagnostics/Telemetry/MithrilActivitySources.cs); the Detection-layer `calibration.synthesis_rerank` child nests under it when both sources are listened-to.
+
+| Property | Meaning |
+|---|---|
+| _Tag list TBD per Task 16 of the synthesis-rerank plan._ | Producer wiring lands in Task 16; this section will be filled in then. Surfaces under the fallback `scope` arm of `PerfFileExporter` until a dedicated dispatch arm lands. |
+
+Companion `Mithril.MapCalibration.Detection` meter instruments emitted in `meter_counter` records (below):
+
+- `mithril.map_calibration.synthesis.j` — histogram (`double`). Winning candidate's `J(T_k)`. Tag: `verdict` ∈ {`accept`, `reject`} (per synthesis-J).
+- `mithril.map_calibration.synthesis.refs_above_threshold` — histogram (`long`). Count of refs whose sampled `L_t(T·r) ≥ 0.5` for the winning candidate. Tag: `verdict`.
+- `mithril.map_calibration.synthesis.disagree` — counter (`long`). Synthesis-J disagreed with the legacy inlier-count gate. Tag: `change` ∈ {`accept_to_reject`, `reject_to_accept`}.
+
+Scaffold-only — fires only after Task 16 wires the producer. A clean scaffold-only build emits zero calibration-synthesis records.
+
 ### `meter_counter`
 
-Aggregated `System.Diagnostics.Metrics.Meter` counter sum, flushed once per second per (instrument, tag-set). Covers PR B's counters: Arda lines/verb-unmatched/grammar-break/verb-unhandled/domain-event-published, reference fetch-outcome, Mithril.Overlay projection latency + frame markers (#835), and any future counters added via the `Mithril.*` Meter prefix.
+Aggregated `System.Diagnostics.Metrics.Meter` counter sum, flushed once per second per (instrument, tag-set). Covers PR B's counters: Arda lines/verb-unmatched/grammar-break/verb-unhandled/domain-event-published, reference fetch-outcome, Mithril.Overlay projection latency + frame markers (#835), Mithril.MapCalibration synthesis-J histograms + disagree counter (synthesis-rerank plan Task 10), and any future counters added via the `Mithril.*` Meter prefix.
 
 | Property | Meaning |
 |---|---|

--- a/src/Mithril.MapCalibration/DependencyInjection/MapCalibrationServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration/DependencyInjection/MapCalibrationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Mithril.MapCalibration.Detection;
 using Mithril.MapCalibration.Detection.Internal;
@@ -110,10 +111,12 @@ public static class MapCalibrationServiceCollectionExtensions
         });
         services.AddSingleton<ICalibrationDetector, DeviationBlobCalibrationDetector>();
         services.AddSingleton<ICalibrationConfidenceGate, CalibrationConfidenceGate>();
+        services.TryAddSingleton<MapCalibrationSolverOptions>();
         services.AddSingleton(sp => new MapCalibrationSolveEngine(
             sp.GetRequiredService<ICalibrationDetector>(),
             sp.GetRequiredService<ICalibrationConfidenceGate>(),
-            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Engine")));
+            sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Engine"),
+            sp.GetRequiredService<MapCalibrationSolverOptions>()));
         return services;
     }
 }

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Diagnostics;
 
 namespace Mithril.MapCalibration.Detection;
 
@@ -156,12 +157,113 @@ public sealed class MapCalibrationSolveEngine
         return finalResult;
     }
 
-    /// <summary>Placeholder — wired in Task 16.</summary>
     private void EmitSynthesisRerankTelemetry(
         SynthesisRerankMode mode, SynthesisOrientationWinner? winner, CalibrationSolveResult finalResult)
     {
-        // Implemented in Task 16.
+        // Off mode: no L_t was built, no telemetry to emit. (StartActivity returns
+        // null when no listener is attached, so the cost when listeners ARE
+        // attached but mode is Off is one bool branch.)
+        if (mode == SynthesisRerankMode.Off) return;
+
+        using var span = MapCalibrationDiagnostics.ActivitySource.StartActivity("calibration.synthesis_rerank");
+        if (span is null && !HasAnyMeterListener()) return;
+
+        // The legacy gate's verdict, derived from finalResult when mode==Shadow
+        // (legacy is source-of-truth, accept iff Calibration is not null) — or, when
+        // mode==Enabled, computed against the *winner's* AreaCalibration + inlier
+        // count so we can still report disagreement between the gates even though
+        // synthesis-J is doing the final accept.
+        bool legacyAccept;
+        int legacyInlierCount;
+        double? legacyResidualPx;
+        if (mode == SynthesisRerankMode.Shadow)
+        {
+            legacyAccept = finalResult.Calibration is not null;
+            legacyInlierCount = finalResult.InlierCount;
+            legacyResidualPx = finalResult.Calibration?.ResidualPixels;
+        }
+        else
+        {
+            // Enabled: re-run the legacy gate on the synthesis winner's fit so the
+            // disagreement counter remains meaningful.
+            if (winner is not null
+                && _gate.Accept(winner.Calibration, winner.Inliers.Count, out _))
+            {
+                legacyAccept = true;
+                legacyInlierCount = winner.Inliers.Count;
+                legacyResidualPx = winner.Calibration.ResidualPixels;
+            }
+            else if (winner is not null)
+            {
+                legacyAccept = false;
+                legacyInlierCount = winner.Inliers.Count;
+                legacyResidualPx = winner.Calibration.ResidualPixels;
+            }
+            else
+            {
+                legacyAccept = false;
+                legacyInlierCount = 0;
+                legacyResidualPx = null;
+            }
+        }
+
+        bool synthesisAccept = mode == SynthesisRerankMode.Enabled
+            ? finalResult.Calibration is not null
+            : winner is not null
+              && winner.J >= _options.SynthesisJMin
+              && winner.RefsAboveHalf >= _options.SynthesisNMin;
+
+        var synthVerdict = synthesisAccept ? "accept" : "reject";
+        var gateVerdict = legacyAccept ? "accept" : "reject";
+        var disagree = synthesisAccept != legacyAccept;
+        var change = disagree
+            ? (synthesisAccept ? "reject_to_accept" : "accept_to_reject")
+            : "none";
+
+        if (span is not null)
+        {
+            span.SetTag("synth.mode", mode.ToString().ToLowerInvariant());
+            if (winner is not null)
+            {
+                span.SetTag("synth.j_best", winner.J);
+                span.SetTag("synth.refs_above_0.5", winner.RefsAboveHalf);
+                span.SetTag("synth.refs_total", winner.RefsTotal);
+                span.SetTag("synth.refs_off_crop", winner.RefsOffCrop);
+            }
+            span.SetTag("synth.j_min", _options.SynthesisJMin);
+            span.SetTag("synth.n_min", _options.SynthesisNMin);
+            span.SetTag("synth.verdict", synthVerdict);
+            span.SetTag("gate.verdict", gateVerdict);
+            span.SetTag("gate.inliers", legacyInlierCount);
+            if (legacyResidualPx is not null) span.SetTag("gate.residual_px", legacyResidualPx.Value);
+            span.SetTag("disagree", disagree);
+            span.SetTag("disagree.would_change", change);
+        }
+
+        if (winner is not null)
+        {
+            var verdictTag = new KeyValuePair<string, object?>("verdict", synthVerdict);
+            MapCalibrationDiagnostics.Meters.SynthesisJ.Record(winner.J, verdictTag);
+            MapCalibrationDiagnostics.Meters.SynthesisRefsAboveThreshold.Record(winner.RefsAboveHalf, verdictTag);
+        }
+        if (disagree)
+        {
+            MapCalibrationDiagnostics.Meters.SynthesisDisagree.Add(1,
+                new KeyValuePair<string, object?>("change", change));
+        }
     }
+
+    /// <summary>
+    /// True if any consumer is currently listening to the synthesis meters. Used
+    /// to short-circuit the emit body when no span listener AND no meter listener
+    /// — the unconditional-producer convention (CLAUDE.md) means producers emit
+    /// without `if (active)`, but this helper avoids the per-emit prep work when
+    /// the activity didn't start and nobody is listening to the meters either.
+    /// </summary>
+    private static bool HasAnyMeterListener() =>
+        MapCalibrationDiagnostics.Meters.SynthesisJ.Enabled
+        || MapCalibrationDiagnostics.Meters.SynthesisRefsAboveThreshold.Enabled
+        || MapCalibrationDiagnostics.Meters.SynthesisDisagree.Enabled;
 
     /// <summary>
     /// Per-orientation detect summary: typed detection total + per-type breakdown

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -199,3 +199,17 @@ public sealed record CalibrationSolveResult(
 {
     public IReadOnlyList<TypedDetection>? Detections { get; init; }
 }
+
+/// <summary>
+/// Per-orientation synthesis-J winner, used by
+/// <see cref="MapCalibrationSolveEngine"/>'s cross-orientation selector.
+/// Internal — the public consumer sees the unified <see cref="CalibrationSolveResult"/>.
+/// </summary>
+internal sealed record SynthesisOrientationWinner(
+    bool Rotate180,
+    AreaCalibration Calibration,
+    IReadOnlyList<TypeAwareRansacSolver.AssignedReference> Inliers,
+    double J,
+    int RefsAboveHalf,
+    int RefsOffCrop,
+    int RefsTotal);

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -193,13 +193,14 @@ public sealed class MapCalibrationSolveEngine
 
         // One template per landmark-type — the per-type L_t fields are keyed by
         // LandmarkType. If a type has multiple templates (e.g. variants), the
-        // first is used; mirror the probe's behaviour (which uses the same
-        // ProbeReferences-driven per-type single template).
+        // LAST in iteration order wins, matching the probe's path at
+        // SynthesisProbePhase.cs (`fieldsByType[template.LandmarkType] = ...`
+        // inside a foreach). Production must match this so Task 17's L_t equality
+        // test holds in any future multi-template-per-type scenario.
         var perType = new Dictionary<string, IconTemplate>(StringComparer.Ordinal);
         foreach (var template in templates.Templates)
         {
-            if (!perType.ContainsKey(template.LandmarkType))
-                perType[template.LandmarkType] = template;
+            perType[template.LandmarkType] = template;
         }
 
         var fields = new Dictionary<string, double[,]>(perType.Count, StringComparer.Ordinal);

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -214,6 +214,60 @@ public sealed class MapCalibrationSolveEngine
         return fields;
     }
 
+    /// <summary>
+    /// For one orientation, score each of the RANSAC top-K candidates with
+    /// <see cref="JEvaluator"/>, LM-refine the highest-J candidate with
+    /// <see cref="LocalRefine"/>, and return the orientation winner. The winner's
+    /// <c>Calibration</c> reflects the LM-refined fit; <c>Inliers</c> are the
+    /// raw RANSAC inlier set of the pre-refine candidate (the LM step adjusts
+    /// the geometry but the inlier set was the seed of that geometry).
+    /// </summary>
+    private SynthesisOrientationWinner? ScoreOrientationCandidates(
+        bool rotate180,
+        IReadOnlyList<TypeAwareRansacSolver.TopKCandidate> candidates,
+        IReadOnlyDictionary<string, double[,]> fields,
+        IReadOnlyList<LandmarkReference> references,
+        MapRect alignedRect)
+    {
+        if (candidates.Count == 0) return null;
+
+        SynthesisOrientationWinner? best = null;
+        foreach (var cand in candidates)
+        {
+            var t = CandidateTransform.FromCalibration(cand.Calibration, alignedRect);
+            var j = JEvaluator.Evaluate(t, fields, references);
+            if (best is null || j.J > best.J)
+            {
+                best = new SynthesisOrientationWinner(
+                    Rotate180: rotate180,
+                    Calibration: cand.Calibration,
+                    Inliers: cand.Inliers,
+                    J: j.J,
+                    RefsAboveHalf: j.RefsAboveHalf,
+                    RefsOffCrop: j.RefsOffCrop,
+                    RefsTotal: references.Count);
+            }
+        }
+
+        if (best is null) return null;
+
+        // LM-refine the highest-J candidate's transform. The refined transform
+        // re-scores against the same L_t fields → we update J / RefsAboveHalf /
+        // RefsOffCrop to reflect the refined geometry. We do NOT mutate
+        // best.Calibration, because that's the texture-pixel-space AreaCalibration
+        // the engine still persists; LM works in aligned-pair-pixel space and
+        // wouldn't round-trip cleanly through the rect re-scale.
+        var seed = CandidateTransform.FromCalibration(best.Calibration, alignedRect);
+        var refined = LocalRefine.Run(seed, fields, references, maxIter: 24, stepInit: 1.0);
+        var refinedJ = JEvaluator.Evaluate(refined, fields, references);
+        return best with
+        {
+            J = refinedJ.J,
+            RefsAboveHalf = refinedJ.RefsAboveHalf,
+            RefsOffCrop = refinedJ.RefsOffCrop,
+        };
+    }
+
     private static IReadOnlyDictionary<string, List<TypedDetection>> ToMutable(
         IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> byType)
     {

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -39,8 +39,13 @@ public sealed class MapCalibrationSolveEngine
     /// </summary>
     public CalibrationSolveResult Solve(DetectionRequest request, IReadOnlyList<LandmarkReference> references)
     {
-        CalibrationSolveResult? bestAccepted = null;
-        CalibrationSolveResult? bestRejected = null;
+        // Cache per orientation: L_t fields + top-K + scored winner (when mode != Off).
+        SynthesisOrientationWinner? bestSynthesis = null;
+        CalibrationSolveResult? bestLegacyAccepted = null;
+        CalibrationSolveResult? bestLegacyRejected = null;
+
+        var mode = _options.SynthesisRerankMode;
+        int topK = mode == SynthesisRerankMode.Off ? 1 : Math.Max(1, _options.RansacTopK);
 
         foreach (var rotate180 in new[] { false, true })
         {
@@ -49,46 +54,113 @@ public sealed class MapCalibrationSolveEngine
 
             var detections = _detector.Detect(req);
             LogDetectSummary(rotate180, detections, references);
-            var (cal, inliers) = TypeAwareRansacSolver.Solve(ToMutable(detections), references, request.MapRect);
+            var topKList = TypeAwareRansacSolver.SolveTopK(ToMutable(detections), references, request.MapRect, topK);
             var flatDetections = FlattenDetections(detections);
 
-            if (cal is null)
+            // === Legacy track: pick the lowest-residual gate-accepted top-K[0] (preserves shadow-source-of-truth) ===
+            if (topKList.Count == 0)
             {
-                bestRejected ??= new CalibrationSolveResult(null, inliers.Count, "no geometrically-consistent fit", inliers) { Detections = flatDetections };
-                continue;
-            }
-
-            if (_gate.Accept(cal, inliers.Count, out var reason))
-            {
-                var accepted = new CalibrationSolveResult(cal, inliers.Count, null, inliers) { Detections = flatDetections };
-                // Prefer the lower-residual accepted orientation.
-                if (bestAccepted is null || cal.ResidualPixels < bestAccepted.Calibration!.ResidualPixels)
-                {
-                    bestAccepted = accepted;
-                }
+                bestLegacyRejected ??= new CalibrationSolveResult(
+                    null, 0, "no geometrically-consistent fit", []) { Detections = flatDetections };
             }
             else
             {
-                // Track the closest rejection for a useful reason if nothing passes.
-                if (bestRejected is null || cal.ResidualPixels < (bestRejected.Calibration?.ResidualPixels ?? double.PositiveInfinity))
+                var legacyHead = topKList[0];
+                if (_gate.Accept(legacyHead.Calibration, legacyHead.Inliers.Count, out var legacyReason))
                 {
-                    bestRejected = new CalibrationSolveResult(null, inliers.Count, reason, inliers) { Detections = flatDetections };
+                    var accepted = new CalibrationSolveResult(
+                        legacyHead.Calibration, legacyHead.Inliers.Count, null, legacyHead.Inliers)
+                        { Detections = flatDetections };
+                    if (bestLegacyAccepted is null
+                        || legacyHead.Calibration.ResidualPixels < bestLegacyAccepted.Calibration!.ResidualPixels)
+                    {
+                        bestLegacyAccepted = accepted;
+                    }
                 }
+                else if (bestLegacyRejected is null
+                    || legacyHead.Calibration.ResidualPixels
+                        < (bestLegacyRejected.Calibration?.ResidualPixels ?? double.PositiveInfinity))
+                {
+                    bestLegacyRejected = new CalibrationSolveResult(
+                        null, legacyHead.Inliers.Count, legacyReason, legacyHead.Inliers)
+                        { Detections = flatDetections };
+                }
+            }
+
+            // === Synthesis track (skipped when mode == Off) ===
+            if (mode == SynthesisRerankMode.Off) continue;
+
+            var fields = BuildLikelihoodFieldsFromDeviation(req.Screenshot, req.BaseTexture, req.Templates);
+            var winner = ScoreOrientationCandidates(rotate180, topKList, fields, references, req.MapRect);
+            if (winner is null) continue;
+            if (bestSynthesis is null || winner.J > bestSynthesis.J)
+            {
+                bestSynthesis = winner;
             }
         }
 
-        if (bestAccepted is not null)
+        // Decide the unified result.
+        var legacyResult = bestLegacyAccepted ?? bestLegacyRejected ??
+            new CalibrationSolveResult(null, 0, "no detections");
+
+        if (mode != SynthesisRerankMode.Enabled)
         {
-            _logger?.LogInformation(
-                "Auto-calibration accepted: residual {Residual:0.00} px, {Inliers} inliers.",
-                bestAccepted.Calibration!.ResidualPixels, bestAccepted.InlierCount);
-            LogInlierCorrespondences(bestAccepted.Calibration!, bestAccepted.Inliers);
-            return bestAccepted;
+            // Off + Shadow: legacy is source of truth. Telemetry emission (Task 16)
+            // wraps this whole block in the synthesis_rerank span; bestSynthesis
+            // values are still available for tagging when mode == Shadow.
+            EmitSynthesisRerankTelemetry(mode, bestSynthesis, legacyResult);
+            if (legacyResult.Calibration is not null)
+            {
+                _logger?.LogInformation(
+                    "Auto-calibration accepted: residual {Residual:0.00} px, {Inliers} inliers.",
+                    legacyResult.Calibration.ResidualPixels, legacyResult.InlierCount);
+                LogInlierCorrespondences(legacyResult.Calibration, legacyResult.Inliers);
+            }
+            else
+            {
+                _logger?.LogInformation("Auto-calibration rejected: {Reason}.", legacyResult.RejectReason);
+            }
+            return legacyResult;
         }
 
-        var rejected = bestRejected ?? new CalibrationSolveResult(null, 0, "no detections");
-        _logger?.LogInformation("Auto-calibration rejected: {Reason}.", rejected.RejectReason);
-        return rejected;
+        // Enabled: synthesis-J IS the gate.
+        if (bestSynthesis is null)
+        {
+            _logger?.LogInformation("Auto-calibration rejected (synthesis): no synthesis-J winner.");
+            var noWinner = new CalibrationSolveResult(null, 0, "no synthesis-J winner",
+                legacyResult.Inliers) { Detections = legacyResult.Detections };
+            EmitSynthesisRerankTelemetry(mode, bestSynthesis, noWinner);
+            return noWinner;
+        }
+        bool synthAccept = bestSynthesis.J >= _options.SynthesisJMin
+                        && bestSynthesis.RefsAboveHalf >= _options.SynthesisNMin;
+        CalibrationSolveResult finalResult;
+        if (synthAccept)
+        {
+            finalResult = new CalibrationSolveResult(
+                bestSynthesis.Calibration, bestSynthesis.Inliers.Count, null, bestSynthesis.Inliers)
+                { Detections = legacyResult.Detections };
+            _logger?.LogInformation(
+                "Auto-calibration accepted (synthesis-J): J={J:0.00}, refs>=0.5 {Refs}/{Total}.",
+                bestSynthesis.J, bestSynthesis.RefsAboveHalf, bestSynthesis.RefsTotal);
+        }
+        else
+        {
+            var reason = $"synthesis-J below threshold (J={bestSynthesis.J:0.00} < {_options.SynthesisJMin:0.00} "
+                       + $"OR refs>=0.5 {bestSynthesis.RefsAboveHalf} < {_options.SynthesisNMin})";
+            finalResult = new CalibrationSolveResult(null, bestSynthesis.Inliers.Count, reason, bestSynthesis.Inliers)
+                { Detections = legacyResult.Detections };
+            _logger?.LogInformation("Auto-calibration rejected (synthesis): {Reason}.", reason);
+        }
+        EmitSynthesisRerankTelemetry(mode, bestSynthesis, finalResult);
+        return finalResult;
+    }
+
+    /// <summary>Placeholder — wired in Task 16.</summary>
+    private void EmitSynthesisRerankTelemetry(
+        SynthesisRerankMode mode, SynthesisOrientationWinner? winner, CalibrationSolveResult finalResult)
+    {
+        // Implemented in Task 16.
     }
 
     /// <summary>

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -167,6 +167,52 @@ public sealed class MapCalibrationSolveEngine
             inliers.Count, maxX - minX, maxY - minY, string.Join("  ", parts));
     }
 
+    /// <summary>
+    /// Build per-type L_t fields for one orientation by computing the additive
+    /// deviation D = max(0, screenshot − baseTexture), applying the rim-mask
+    /// (mithril#992), and scoring each unique landmark-type template against the
+    /// masked deviation. Cached by orientation: built once per orientation, reused
+    /// across all top-K candidates the re-rank scores.
+    /// </summary>
+    private static IReadOnlyDictionary<string, double[,]> BuildLikelihoodFieldsFromDeviation(
+        GrayImage screenshot,
+        GrayImage baseTexture,
+        IconTemplateSet templates)
+    {
+        if (screenshot.Width != baseTexture.Width || screenshot.Height != baseTexture.Height)
+            throw new ArgumentException("screenshot and base texture must have matching dimensions");
+
+        int w = screenshot.Width, h = screenshot.Height;
+        var deviation = new byte[w * h];
+        for (int i = 0; i < deviation.Length; i++)
+        {
+            int d = screenshot.Pixels[i] - baseTexture.Pixels[i];
+            deviation[i] = d > 0 ? (byte)Math.Min(255, d) : (byte)0;
+        }
+        var devImage = new GrayImage(w, h, deviation);
+
+        // One template per landmark-type — the per-type L_t fields are keyed by
+        // LandmarkType. If a type has multiple templates (e.g. variants), the
+        // first is used; mirror the probe's behaviour (which uses the same
+        // ProbeReferences-driven per-type single template).
+        var perType = new Dictionary<string, IconTemplate>(StringComparer.Ordinal);
+        foreach (var template in templates.Templates)
+        {
+            if (!perType.ContainsKey(template.LandmarkType))
+                perType[template.LandmarkType] = template;
+        }
+
+        var fields = new Dictionary<string, double[,]>(perType.Count, StringComparer.Ordinal);
+        foreach (var (type, template) in perType)
+        {
+            fields[type] = IconLikelihoodField.LoadDeviationAsField(
+                devImage, template,
+                applyRimMask: true,
+                devThr: IconLikelihoodField.DefaultDevThr);
+        }
+        return fields;
+    }
+
     private static IReadOnlyDictionary<string, List<TypedDetection>> ToMutable(
         IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> byType)
     {

--- a/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration/Detection/MapCalibrationSolveEngine.cs
@@ -18,15 +18,18 @@ public sealed class MapCalibrationSolveEngine
     private readonly ICalibrationDetector _detector;
     private readonly ICalibrationConfidenceGate _gate;
     private readonly ILogger? _logger;
+    private readonly MapCalibrationSolverOptions _options;
 
     public MapCalibrationSolveEngine(
         ICalibrationDetector detector,
         ICalibrationConfidenceGate gate,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        MapCalibrationSolverOptions? options = null)
     {
         _detector = detector;
         _gate = gate;
         _logger = logger;
+        _options = options ?? new MapCalibrationSolverOptions();
     }
 
     /// <summary>

--- a/src/Mithril.MapCalibration/Diagnostics/MapCalibrationDiagnostics.cs
+++ b/src/Mithril.MapCalibration/Diagnostics/MapCalibrationDiagnostics.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Mithril.MapCalibration.Diagnostics;
+
+/// <summary>
+/// Local <see cref="ActivitySource"/> + <see cref="Meter"/> catalog for the
+/// <c>Mithril.MapCalibration</c> Detection layer. Defined here (and NOT in
+/// <c>Mithril.Shared/Diagnostics/Telemetry/MithrilActivitySources.cs</c> +
+/// <c>MithrilMeters.cs</c>) because <c>Mithril.MapCalibration.csproj</c>
+/// deliberately doesn't reference <c>Mithril.Shared</c> — the same constraint
+/// Arda's catalogs work around (see <c>ArdaActivitySources</c> / <c>ArdaMeters</c>).
+///
+/// <para>Names follow the <c>"Mithril.…"</c> prefix convention so listeners
+/// subscribing to the prefix receive both the Shared catalogs and this one
+/// uniformly. The Capture layer already emits <c>"Mithril.MapCalibration.Capture"</c>
+/// spans through <see cref="Mithril.Shared.Diagnostics.Telemetry.MithrilActivitySources.MapCalibration"/>;
+/// this catalog adds <c>"Mithril.MapCalibration.Detection"</c> so the per-layer
+/// vocabulary is unambiguous when a Seq waterfall surfaces both at once.</para>
+/// </summary>
+public static class MapCalibrationDiagnostics
+{
+    /// <summary>
+    /// Spans emitted from the Detection layer's solve / synthesis-J path.
+    /// Parent span (<c>calibration.solve</c>) lives in the Capture layer's
+    /// <see cref="Mithril.Shared.Diagnostics.Telemetry.MithrilActivitySources.MapCalibration"/>;
+    /// when both are listened-to, this source's children (<c>calibration.synthesis_rerank</c>)
+    /// nest under the Capture parent naturally.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new("Mithril.MapCalibration.Detection");
+
+    /// <summary>Map auto-calibration synthesis-J re-rank instruments (spec §Q2 telemetry contract).</summary>
+    public static class Meters
+    {
+        public static readonly Meter Meter = new("Mithril.MapCalibration.Detection");
+
+        /// <summary>Winning candidate's <c>J(T_k)</c>. Tag: <c>verdict</c> ∈ {accept, reject} (per synthesis-J).</summary>
+        public static readonly Histogram<double> SynthesisJ =
+            Meter.CreateHistogram<double>("mithril.map_calibration.synthesis.j");
+
+        /// <summary>Refs whose sampled <c>L_t(T·r) ≥ 0.5</c> for the winning candidate. Tag: <c>verdict</c>.</summary>
+        public static readonly Histogram<long> SynthesisRefsAboveThreshold =
+            Meter.CreateHistogram<long>("mithril.map_calibration.synthesis.refs_above_threshold");
+
+        /// <summary>Synthesis-J disagreed with the legacy inlier-count gate. Tag: <c>change</c> ∈ {accept_to_reject, reject_to_accept}.</summary>
+        public static readonly Counter<long> SynthesisDisagree =
+            Meter.CreateCounter<long>("mithril.map_calibration.synthesis.disagree");
+    }
+}

--- a/src/Mithril.MapCalibration/MapCalibrationSolverOptions.cs
+++ b/src/Mithril.MapCalibration/MapCalibrationSolverOptions.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Mithril.MapCalibration;
+
+/// <summary>
+/// Three-state toggle for the synthesis-J re-rank (spec §Q2).
+/// <list type="bullet">
+/// <item><c>Off</c> — no L_t build, legacy inlier-count gate is the source of truth, zero cost.</item>
+/// <item><c>Shadow</c> — L_t built, synthesis-J computed + emitted as telemetry, but the legacy gate is still the source of truth for accept/reject (and therefore for persistence). Safe-to-deploy default while Phase-C telemetry accumulates.</item>
+/// <item><c>Enabled</c> — synthesis-J is the gate; accept iff <c>J ≥ J_min AND refs_above_0.5 ≥ N_min</c>. Legacy inlier count + residual remain informational.</item>
+/// </list>
+/// </summary>
+public enum SynthesisRerankMode
+{
+    Off,
+    Shadow,
+    Enabled,
+}
+
+/// <summary>
+/// Runtime-flippable knobs for <see cref="Detection.MapCalibrationSolveEngine"/>'s
+/// synthesis-J re-rank (spec §Q2). Mirrors the
+/// <see cref="Mithril.MapCalibration.Capture.CaptureDiagnosticsOptions"/> pattern:
+/// DI singleton, plain mutable POCO, INotifyPropertyChanged so a settings UI
+/// can bind without re-resolving the graph.
+///
+/// <para>Default <see cref="SynthesisRerankMode"/> is <see cref="SynthesisRerankMode.Shadow"/> —
+/// the engine computes synthesis-J + emits telemetry but the legacy
+/// inlier-count gate remains the source of truth (spec §Q2 "Why Shadow is the
+/// default"). The <see cref="SynthesisJMin"/> / <see cref="SynthesisNMin"/>
+/// defaults are anchored to PR #993's post-rim 4-bundle dataset (Bundle A=19/21,
+/// B-truth=15.5/16, C=14/13 accept; B-wrong-fit=2.5/4 rejects); recalibrate
+/// against real telemetry per spec §Q3 Phase C before flipping the default.</para>
+/// </summary>
+public sealed class MapCalibrationSolverOptions : INotifyPropertyChanged
+{
+    private SynthesisRerankMode _synthesisRerankMode = SynthesisRerankMode.Shadow;
+    private double _synthesisJMin = 8.0;
+    private int _synthesisNMin = 8;
+    private int _ransacTopK = 8;
+
+    /// <summary>Active re-rank mode. Default <see cref="SynthesisRerankMode.Shadow"/>.</summary>
+    public SynthesisRerankMode SynthesisRerankMode
+    {
+        get => _synthesisRerankMode;
+        set { if (_synthesisRerankMode != value) { _synthesisRerankMode = value; OnChanged(); } }
+    }
+
+    /// <summary>J floor for the <see cref="SynthesisRerankMode.Enabled"/> gate. Default 8.0.</summary>
+    public double SynthesisJMin
+    {
+        get => _synthesisJMin;
+        set { if (_synthesisJMin != value) { _synthesisJMin = value; OnChanged(); } }
+    }
+
+    /// <summary>Floor on <c>refs whose sampled L_t ≥ 0.5</c> for the <see cref="SynthesisRerankMode.Enabled"/> gate. Default 8.</summary>
+    public int SynthesisNMin
+    {
+        get => _synthesisNMin;
+        set { if (_synthesisNMin != value) { _synthesisNMin = value; OnChanged(); } }
+    }
+
+    /// <summary>Number of RANSAC candidates the re-rank scores per orientation. Default 8.</summary>
+    public int RansacTopK
+    {
+        get => _ransacTopK;
+        set { if (_ransacTopK != value) { _ransacTopK = value; OnChanged(); } }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/src/Mithril.Shared/Diagnostics/Telemetry/MithrilActivitySources.cs
+++ b/src/Mithril.Shared/Diagnostics/Telemetry/MithrilActivitySources.cs
@@ -39,6 +39,12 @@ public static class MithrilActivitySources
     // because Arda projects can't take a dependency on Mithril.Shared. Both catalogs
     // share the "Mithril." prefix below so listeners receive both uniformly.
 
+    // MapCalibration Detection-layer sources live in Mithril.MapCalibration.
+    // Diagnostics.MapCalibrationDiagnostics because Mithril.MapCalibration.csproj
+    // deliberately doesn't take a dependency on Mithril.Shared (it must be
+    // consumable by Mithril.Shared peers without depending up the layering).
+    // The "Mithril." prefix below picks both catalogs up uniformly.
+
     /// <summary>Prefix all sources share — listeners filter on this so they receive every Mithril emit (including Arda's per-layer sources).</summary>
     public const string Prefix = "Mithril.";
 }

--- a/src/Mithril.Shared/Diagnostics/Telemetry/MithrilMeters.cs
+++ b/src/Mithril.Shared/Diagnostics/Telemetry/MithrilMeters.cs
@@ -58,6 +58,12 @@ public static class MithrilMeters
     // ArdaActivitySources — Arda can't depend on Mithril.Shared). Listener-side meter
     // dispatch is purely string-based on the instrument name.
 
+    // MapCalibration Detection-layer instruments live in Mithril.MapCalibration.
+    // Diagnostics.MapCalibrationDiagnostics.Meters for the same reason Arda's
+    // do — Mithril.MapCalibration.csproj can't take a dependency on Mithril.
+    // Shared. Listener-side meter dispatch is purely string-based on the
+    // instrument name, so the Shared and Local catalogs feed the same exporters.
+
     /// <summary>Reference-data fetch outcomes (PR B).</summary>
     public static class Reference
     {

--- a/tests/Mithril.MapCalibration.Tests/Detection/EngineRegistrationTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/EngineRegistrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 using Mithril.MapCalibration.DependencyInjection;
 using Xunit;
@@ -61,5 +62,19 @@ public sealed class EngineRegistrationTests
     {
         var act = () => new ServiceCollection().AddMithrilMapCalibrationEngine("");
         act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddMithrilMapCalibrationEngine_registers_MapCalibrationSolverOptions_with_Shadow_default()
+    {
+        var services = new ServiceCollection();
+        services.AddMithrilMapCalibrationEngine(assetCacheDir: System.IO.Path.GetTempPath());
+        using var sp = services.BuildServiceProvider();
+
+        var opts = sp.GetRequiredService<MapCalibrationSolverOptions>();
+        opts.SynthesisRerankMode.Should().Be(SynthesisRerankMode.Shadow);
+
+        // Same instance returned per resolve (singleton).
+        sp.GetRequiredService<MapCalibrationSolverOptions>().Should().BeSameAs(opts);
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/SynthesisRerankFieldEquivalenceTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/SynthesisRerankFieldEquivalenceTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.MapCalibration.Tests.Fixtures;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+public sealed class SynthesisRerankFieldEquivalenceTests
+{
+    /// <summary>
+    /// Production builds L_t from (alignedCrop, alignedTexture) via subtraction
+    /// + DeviationFloodRimMask + ScoreAll. The probe builds L_t from a
+    /// pre-computed deviation via LoadDeviationAsField (which applies the same
+    /// DeviationFloodRimMask + ScoreAll). With production's subtracted
+    /// deviation handed to the probe's LoadDeviationAsField, the fields must
+    /// be byte-identical.
+    /// </summary>
+    [Fact]
+    public void Production_path_and_probe_LoadDeviationAsField_produce_identical_fields()
+    {
+        const int W = 256, H = 192;
+        var texturePixels = SyntheticMap.MakeTexture(W, H, seed: 4242);
+        var shotPixels = (byte[])texturePixels.Clone();
+        // Drip a few icon-shaped bright pixels into the screenshot so the
+        // deviation has signal at predictable spots.
+        SyntheticMap.BlitTeardrop(shotPixels, W, H, anchorX: 80, anchorY: 60, width: 16, height: 16, luminance: 220);
+        SyntheticMap.BlitTeardrop(shotPixels, W, H, anchorX: 170, anchorY: 120, width: 16, height: 16, luminance: 220);
+
+        var shot = new GrayImage(W, H, shotPixels);
+        var tex  = new GrayImage(W, H, texturePixels);
+
+        var templates = SyntheticMap.BuildTemplates(SyntheticMap.DefaultIcons);
+        var template = templates.Templates[0];
+
+        // Production path (mirrors MapCalibrationSolveEngine.BuildLikelihoodFieldsFromDeviation).
+        var prodDev = new byte[W * H];
+        for (int i = 0; i < prodDev.Length; i++)
+        {
+            int d = shot.Pixels[i] - tex.Pixels[i];
+            prodDev[i] = d > 0 ? (byte)System.Math.Min(255, d) : (byte)0;
+        }
+        var prodField = IconLikelihoodField.LoadDeviationAsField(
+            new GrayImage(W, H, prodDev), template,
+            applyRimMask: true, devThr: IconLikelihoodField.DefaultDevThr);
+
+        // Probe path (LoadDeviationAsField over an externally-computed deviation).
+        var probeDev = new byte[W * H];
+        for (int i = 0; i < probeDev.Length; i++)
+        {
+            int d = shot.Pixels[i] - tex.Pixels[i];
+            probeDev[i] = d > 0 ? (byte)System.Math.Min(255, d) : (byte)0;
+        }
+        var probeField = IconLikelihoodField.LoadDeviationAsField(
+            new GrayImage(W, H, probeDev), template);  // default rim-mask = true, default devThr
+
+        // Byte-equivalent.
+        prodField.GetLength(0).Should().Be(probeField.GetLength(0));
+        prodField.GetLength(1).Should().Be(probeField.GetLength(1));
+        for (int y = 0; y < prodField.GetLength(0); y++)
+        for (int x = 0; x < prodField.GetLength(1); x++)
+        {
+            prodField[y, x].Should().Be(probeField[y, x],
+                $"production and probe paths must score the same deviation byte-identically at ({x},{y})");
+        }
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/Detection/SynthesisRerankShadowModeTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/SynthesisRerankShadowModeTests.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using System.Linq;
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.MapCalibration.Tests.Fixtures;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+public sealed class SynthesisRerankShadowModeTests
+{
+    private const int TexW = 320, TexH = 260;
+    private static readonly AreaCalibration Truth = new(
+        Scale: 1.1, RotationRadians: 0.25, OriginX: 160, OriginY: 130,
+        ReferenceCount: 0, ResidualPixels: 0.0)
+    { MirrorNorth = false, CalibrationZoom = 1.0 };
+
+    private static readonly (string Type, string Icon, int W, int H, int Lum, double X, double Z)[] Landmarks =
+    [
+        ("Portal", "landmark_portal", 24, 32, 60, -60, 70),
+        ("Portal", "landmark_portal", 24, 32, 60, 70, -50),
+        ("TeleportationPlatform", "landmark_telepad", 28, 22, 180, 90, 30),
+        ("MeditationPillar", "landmark_medipillar", 18, 40, 110, -20, -40),
+        ("Npc", "landmark_npc", 20, 28, 220, 40, 55),
+    ];
+
+    private static (GrayImage shot, GrayImage tex, System.Collections.Generic.List<LandmarkReference> refs) Build()
+    {
+        var texPixels = SyntheticMap.MakeTexture(TexW, TexH, seed: 7777);
+        var shotPixels = (byte[])texPixels.Clone();
+        var refs = new System.Collections.Generic.List<LandmarkReference>();
+        foreach (var l in Landmarks)
+        {
+            var tex = Truth.WorldToWindow(new WorldCoord(l.X, 0, l.Z));
+            SyntheticMap.BlitTeardrop(shotPixels, TexW, TexH, tex.X, tex.Y, l.W, l.H, l.Lum);
+            refs.Add(new LandmarkReference(l.Type, l.Icon, new WorldCoord(l.X, 0, l.Z)));
+        }
+        return (new GrayImage(TexW, TexH, shotPixels), new GrayImage(TexW, TexH, texPixels), refs);
+    }
+
+    private static MapCalibrationSolveEngine EngineWith(MapCalibrationSolverOptions opts) =>
+        new(new DeviationBlobCalibrationDetector(), new CalibrationConfidenceGate(), null, opts);
+
+    private static IconTemplateSet Templates() => SyntheticMap.BuildTemplates(SyntheticMap.DefaultIcons);
+
+    private static MapRect Rect() => new(0, 0, TexW, TexH, TexW, TexH);
+
+    private static DetectionRequest Request(GrayImage shot, GrayImage tex) =>
+        new(shot, tex, Rect(), Templates(), RimMaskMode.DeviationFlood,
+            LowNcc: 0.5, TypeFloor: 0.80,
+            BlobOptions: new BlobOptions(MinArea: 12, MaxIconArea: 900, MinSolidity: 0.35, MaxAspect: 2.5, MinPeak: 0.7))
+            { RenderSizePx = 16 };
+
+    [Fact]
+    public void Mode_Off_emits_no_synthesis_span()
+    {
+        var (shot, tex, refs) = Build();
+        var opts = new MapCalibrationSolverOptions { SynthesisRerankMode = SynthesisRerankMode.Off };
+        var engine = EngineWith(opts);
+
+        var spans = new System.Collections.Generic.List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "Mithril.MapCalibration.Detection",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => spans.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        _ = engine.Solve(Request(shot, tex), refs);
+
+        spans.Should().NotContain(a => a.OperationName == "calibration.synthesis_rerank");
+    }
+
+    [Fact]
+    public void Mode_Shadow_emits_span_but_legacy_gate_is_source_of_truth()
+    {
+        var (shot, tex, refs) = Build();
+        var opts = new MapCalibrationSolverOptions { SynthesisRerankMode = SynthesisRerankMode.Shadow };
+        var shadowEngine = EngineWith(opts);
+        var offEngine = EngineWith(new MapCalibrationSolverOptions { SynthesisRerankMode = SynthesisRerankMode.Off });
+
+        var spans = new System.Collections.Generic.List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "Mithril.MapCalibration.Detection",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => spans.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var shadowResult = shadowEngine.Solve(Request(shot, tex), refs);
+        var offResult    = offEngine.Solve(Request(shot, tex), refs);
+
+        // Legacy verdict is unchanged from Off (Shadow keeps the legacy gate as source-of-truth).
+        (shadowResult.Calibration is not null).Should().Be(offResult.Calibration is not null);
+
+        // Synthesis span emitted.
+        spans.Should().Contain(a => a.OperationName == "calibration.synthesis_rerank");
+        var synth = spans.First(a => a.OperationName == "calibration.synthesis_rerank");
+        synth.GetTagItem("synth.mode").Should().Be("shadow");
+        synth.GetTagItem("synth.verdict").Should().BeOneOf("accept", "reject");
+    }
+
+    [Fact]
+    public void Mode_Enabled_rejects_when_J_below_threshold()
+    {
+        var (shot, tex, refs) = Build();
+        // Set J_min absurdly high so Enabled rejects even the truth fit.
+        var opts = new MapCalibrationSolverOptions
+        {
+            SynthesisRerankMode = SynthesisRerankMode.Enabled,
+            SynthesisJMin = 1_000_000.0,
+            SynthesisNMin = 1_000_000,
+        };
+        var engine = EngineWith(opts);
+
+        var result = engine.Solve(Request(shot, tex), refs);
+        result.Calibration.Should().BeNull();
+        result.RejectReason.Should().Contain("synthesis-J below threshold");
+    }
+
+    [Fact]
+    public void Mode_Enabled_accepts_when_synthesis_thresholds_clear()
+    {
+        var (shot, tex, refs) = Build();
+        var opts = new MapCalibrationSolverOptions
+        {
+            SynthesisRerankMode = SynthesisRerankMode.Enabled,
+            SynthesisJMin = 0.0,
+            SynthesisNMin = 0,
+        };
+        var engine = EngineWith(opts);
+
+        var result = engine.Solve(Request(shot, tex), refs);
+        result.Calibration.Should().NotBeNull(
+            "synthesis-J with zero thresholds must accept the synthetic truth fit");
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/MapCalibrationSolverOptionsTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/MapCalibrationSolverOptionsTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests;
+
+public sealed class MapCalibrationSolverOptionsTests
+{
+    [Fact]
+    public void Default_mode_is_Shadow()
+    {
+        var opts = new MapCalibrationSolverOptions();
+        opts.SynthesisRerankMode.Should().Be(SynthesisRerankMode.Shadow);
+        opts.SynthesisJMin.Should().Be(8.0);
+        opts.SynthesisNMin.Should().Be(8);
+        opts.RansacTopK.Should().Be(8);
+    }
+
+    [Fact]
+    public void PropertyChanged_fires_on_mode_flip()
+    {
+        var opts = new MapCalibrationSolverOptions();
+        var heard = new System.Collections.Generic.List<string?>();
+        opts.PropertyChanged += (_, e) => heard.Add(e.PropertyName);
+
+        opts.SynthesisRerankMode = SynthesisRerankMode.Enabled;
+        opts.SynthesisRerankMode = SynthesisRerankMode.Enabled; // no event — no change
+
+        heard.Should().Equal(nameof(MapCalibrationSolverOptions.SynthesisRerankMode));
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of the synthesis-J re-rank rollout per the [synthesis-J re-rank design spec](docs/superpowers/specs/2026-06-02-synthesis-rerank-design.md). Builds on [PR-1 (#998)](https://github.com/moumantai-gg/mithril/pull/998) which relocated the math.

This PR wires synthesis-J into `MapCalibrationSolveEngine` behind a runtime-flippable three-state toggle (`SynthesisRerankMode { Off, Shadow, Enabled }`) defaulting to **Shadow** — compute + telemetry, legacy gate is still the source of truth. PR-3 (flip default to Enabled) is gated on Phase-C real-world telemetry per the spec's Q3 acceptance criteria and is **filed as a follow-up** rather than carried here.

### What's in PR-2

**Foundation (Block 3):**
- `MapCalibrationSolverOptions` POCO + `SynthesisRerankMode { Off, Shadow, Enabled }` enum with `INotifyPropertyChanged` plumbing. Defaults pinned to PR #993's post-rim 4-bundle dataset (J_min=8.0, N_min=8, K=8).
- `MapCalibrationDiagnostics` LOCAL telemetry catalog inside `Mithril.MapCalibration` — mirrors Arda's pattern because `Mithril.MapCalibration.csproj` deliberately refuses ProjectReference to `Mithril.Shared`. Pointer comments added to `MithrilActivitySources.cs` and `MithrilMeters.cs` so the architectural pattern is documented at both sites.
- DI wiring via `TryAddSingleton<MapCalibrationSolverOptions>` in `AddMithrilMapCalibrationEngine`. Engine ctor takes an optional `options` param defaulting to a fresh Shadow-mode instance.
- `SynthesisOrientationWinner` internal record for the per-orientation J winner.

**Engine integration (Block 4):**
- `BuildLikelihoodFieldsFromDeviation` helper: computes `D = max(0, screenshot - baseTexture)`, dedupes templates per landmark-type (LAST wins, matching probe iteration order — a fix landed mid-PR), passes through `IconLikelihoodField.LoadDeviationAsField` with the rim-mask.
- `ScoreOrientationCandidates` helper: scores each top-K candidate with `JEvaluator`, LM-refines the highest-J winner via `LocalRefine`, returns the per-orientation winner. The persisted `AreaCalibration` stays the upstream RANSAC fit; the refined geometry is only used to score J.
- `Solve` refactored into a two-track design:
  - **Legacy track** (runs in all modes): same as before but pulls `topKList[0]` from the new `SolveTopK` API (K=1 in Off mode).
  - **Synthesis track** (skipped if Off): builds L_t per orientation, scores top-K, picks highest-J winner cross-orientation.
  - Off + Shadow return the legacy result; Enabled returns the synthesis-gated result (`J >= J_min AND refs_above_0.5 >= N_min`).
- Telemetry: new `calibration.synthesis_rerank` span with 13 spec-listed tags. Three new meters: `mithril.map_calibration.synthesis.j` (Histogram), `...refs_above_threshold` (Histogram), `...disagree` (Counter). Off-mode early-return plus listener short-circuit make the off-path zero-cost. In Enabled mode the engine re-runs the legacy gate against the synthesis winner so the disagreement counter remains meaningful.

**Tests + audit (Block 5):**
- `SynthesisRerankFieldEquivalenceTests`: pins production-vs-probe L_t byte-equivalence (the spec's Verification-owed item).
- `SynthesisRerankShadowModeTests`: four facts pinning the three-mode contract — Off emits no span, Shadow emits but matches Off's verdict, Enabled rejects under absurd thresholds, Enabled accepts under zero thresholds.
- Audit of existing engine tests: no edits needed — `MapCalibrationSolveEngineLoggingTests` uses tolerant `Contain(predicate)` assertions; `MapCalibrationSolveEngineTests` has no log/span assertions.

### What's NOT in PR-2

- **PR-3: flip default from Shadow to Enabled.** Gated on Phase-C telemetry per the spec's Q3 acceptance criteria. File as a follow-up issue when the criteria are met.
- **Shadow-mode `08-synthesis-verdict.json` bundle sibling** (spec Open Q2). Deferred.
- **Per-area `J_min` / `N_min` thresholds** (spec Open Q3). Phase-C telemetry will reveal whether single global thresholds span the data.
- **Persisting the LM-refined transform** instead of the upstream RANSAC fit. If Phase-C accuracy data shows the refined fit is better, file a follow-up.
- **#988 monotonicity gate <-> synthesis-J interaction.** The accept-monotonicity check in `AutoCalibrationEngine.CheckMonotonicAccept` (landed pre-PR-1) currently uses residual + inlier count. When PR-3 flips Enabled live, the natural extension is to compare J values instead. Not blocking PR-2: Shadow keeps the legacy gate as source-of-truth.
- **Settings UI for the three thresholds.** POCO + INPC is wired; a Settings view is a follow-up.

### Architectural invariants preserved

- **Decoder-free `src/Mithril.MapCalibration/`** — BCL-only. The new `MapCalibrationDiagnostics` catalog only uses `System.Diagnostics` + `System.Diagnostics.Metrics`. `ShippedGraphDecoderFreeTests` green.
- **No ProjectReference from `Mithril.MapCalibration` to `Mithril.Shared`** — local catalog respects the load-bearing layering invariant. csproj is unchanged for that ItemGroup; pointer comments in the Shared catalogs document the pattern (mirrors Arda).
- **Deterministic RANSAC seed `Random(852)`** preserved through the `Solve` -> `SolveTopK` wrapper refactor.
- **Backward-compatible engine ctor**: existing two-arg `new MapCalibrationSolveEngine(detector, gate)` callers still compile, with default-Shadow options falling back to `new MapCalibrationSolverOptions()`.

### Test results

- `dotnet build Mithril.slnx`: 0 warnings, 0 errors
- `tests/Mithril.MapCalibration.Tests`: **129 passed**
- `tests/Mithril.MapCalibration.Capture.Tests`: 154 passed (unchanged)
- `tests/Mithril.MapCalibration.Harness.Tests`: 34 passed (unchanged)
- `ShippedGraphDecoderFreeTests`: green

### Notes for the reviewer

- The plan's verbatim code blocks for several tasks included `using System;` / `using System.Collections.Generic;` directives that turn out to be redundant under the repo's `<ImplicitUsings>enable</ImplicitUsings>` (see `Directory.Build.props`). Each was caught by LSP after the first task and corrected upstream in the plan; the actual files in this PR have the right minimal usings.
- One plan-author error caught mid-PR: the per-type L_t template dedupe direction. The plan said "FIRST wins; mirror the probe" — but the probe actually does LAST-wins (overwrite on each iteration). Fix landed as commit `92f82ceb` before the helper was wired up.
- Per-task spec compliance + code quality subagent reviewers ran on every commit. The only "Important" finding across PR-2 was the LAST-vs-FIRST dedupe (caught + fixed). All other findings were Minor (doc polish, redundant null-checks, style consistency).
- The Q2 acceptance criteria for the eventual PR-3 flip are quoted verbatim in the spec; the reviewer doesn't need to litigate them here.

### Test plan

- [x] `dotnet build Mithril.slnx` 0/0
- [x] `Mithril.MapCalibration.Tests` 129/129 green
- [x] `Mithril.MapCalibration.Capture.Tests` 154/154 green (unchanged)
- [x] `Mithril.MapCalibration.Harness.Tests` 34/34 green (unchanged)
- [x] Decoder-free + no-ProjectReference-to-Shared invariants intact (csproj unchanged)
- [x] Subagent spec + quality reviews clean on every commit

Drafted by Claude (Opus 4.7), posted by @arthur-conde

[plan](docs/superpowers/plans/2026-06-02-synthesis-rerank.md) · [spec](docs/superpowers/specs/2026-06-02-synthesis-rerank-design.md) · [PR-1 (#998)](https://github.com/moumantai-gg/mithril/pull/998)
