### PR TITLE
feat(map-calibration): surface coarse locator score on map-not-located reject

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -259,15 +259,29 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         _logger?.LogInformation(
             "Auto-calibration {Area}: locating the map within the captured frame (texture registration)…", area);
         var refineStart = Stopwatch.GetTimestamp();
-        MapRect? mapRect;
+        MapRegionRefineResult refineResult;
         using (var refineAct = MithrilActivitySources.MapCalibration.StartActivity("calibration.refine"))
         {
-            mapRect = _refiner.Refine(gray, baseTexture, RefineMinScore);
-            refineAct?.SetTag("map.located", mapRect is not null);
+            refineResult = _refiner.Refine(gray, baseTexture, RefineMinScore);
+            refineAct?.SetTag("map.located", refineResult.AcceptedRect is not null);
+            if (refineResult.BestCoarseRect?.AutoDetectScore is { } coarseScore)
+            {
+                refineAct?.SetTag("locator.best_score", coarseScore);
+            }
         }
+        // Surface the coarse best-rung rect on EITHER branch — the diagnostic bundle
+        // reads this so a future rejected-map-not-located is self-triaging.
+        attempt.LocatorBestRect = refineResult.BestCoarseRect;
+        var mapRect = refineResult.AcceptedRect;
         if (mapRect is null)
         {
             attempt.Outcome = OutcomeVocabulary.RejectedMapNotLocated;
+            if (refineResult.BestCoarseRect is { AutoDetectScore: { } bestScore } best)
+            {
+                _logger?.LogInformation(
+                    "Auto-calibration {Area}: locate rejected — best coarse NCC = {Score:F3} (need >= {MinScore:F2}), factor = {Factor:F3}, origin = ({X}, {Y}).",
+                    area, bestScore, RefineMinScore, best.SourceScaleFactor ?? double.NaN, best.OriginX, best.OriginY);
+            }
             return Fail(area, "couldn't locate the map in the captured frame — zoom the in-game map all the way out and draw the capture box tightly around the map");
         }
         attempt.MapRect = mapRect;

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
@@ -25,6 +25,14 @@ public sealed class CalibrationAttemptContext
     public GrayImage? GrayCapture { get; set; }
     public GrayImage? BaseTextureResampled { get; set; }
     public MapRect? MapRect { get; set; }
+    /// <summary>
+    /// The locator's coarse best-rung rect (with <see cref="MapRect.AutoDetectScore"/>
+    /// + <see cref="MapRect.SourceScaleFactor"/> populated) regardless of whether
+    /// it cleared the engine's accept threshold. Set on both accept and
+    /// <c>rejected-map-not-located</c> outcomes so the bundle/log makes future
+    /// close-miss vs catastrophic-mismatch self-triaging.
+    /// </summary>
+    public MapRect? LocatorBestRect { get; set; }
     public GrayImage? AlignedCrop { get; set; }
     public GrayImage? AlignedTexture { get; set; }
     public IReadOnlyList<LandmarkReference>? References { get; set; }

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs
@@ -11,7 +11,12 @@ public sealed record AttemptJson(
     string Outcome,
     string? RejectReason,
     string EngineVersion,
-    AttemptFilesJson Files);
+    AttemptFilesJson Files,
+    // Coarse locator's best-rung rect (score, factor, origin, size). Populated on both
+    // accept and rejected-map-not-located so the bundle is self-triaging for future
+    // close-miss-vs-catastrophic-mismatch rejections. Null when the locator never ran
+    // (early pre-locate rejects) or the captured frame had no viable rung.
+    MapRectJson? LocatorBest = null);
 
 public sealed record AttemptFilesJson(
     string? RawScreenshot,

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
@@ -234,11 +234,21 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
                 Outcome: ctx.Outcome,
                 RejectReason: ctx.Result?.RejectReason ?? ctx.ExceptionInfo,
                 EngineVersion: AssemblyVersion,
-                Files: files);
+                Files: files,
+                LocatorBest: ToMapRectJson(ctx.LocatorBestRect));
             WriteJson(dir, "01-attempt.json", dto, CalibrationBundleJsonContext.Default.AttemptJson);
         }
         catch (Exception ex) { _logger?.LogWarning(ex, "01-attempt.json header write failed for {Outcome}", ctx.Outcome); }
     }
+
+    private static MapRectJson? ToMapRectJson(MapRect? rect) =>
+        rect is null
+            ? null
+            : new MapRectJson(1,
+                rect.OriginX, rect.OriginY,
+                rect.Width, rect.Height,
+                rect.TextureWidth, rect.TextureHeight,
+                rect.AutoDetectScore, rect.SourceScaleFactor);
 
     private static string WritePng(string dir, string name, BitmapSource src)
     {

--- a/src/Mithril.MapCalibration.Capture/IMapRegionRefiner.cs
+++ b/src/Mithril.MapCalibration.Capture/IMapRegionRefiner.cs
@@ -11,8 +11,12 @@ public interface IMapRegionRefiner
 {
     /// <summary>
     /// Find where <paramref name="baseTexture"/> sits inside
-    /// <paramref name="capturedGray"/>, or <see langword="null"/> on a weak/no
-    /// match (below <paramref name="minScore"/>).
+    /// <paramref name="capturedGray"/>. The returned
+    /// <see cref="MapRegionRefineResult"/> always preserves the coarse locator's
+    /// best rung (when one was viable), even when the score fell below
+    /// <paramref name="minScore"/> — engine logs and the diagnostic bundle read
+    /// the score from <see cref="MapRegionRefineResult.BestCoarseRect"/> on
+    /// rejection so close-miss vs catastrophic-mismatch is observable.
     /// </summary>
-    MapRect? Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore);
+    MapRegionRefineResult Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore);
 }

--- a/src/Mithril.MapCalibration.Capture/MapRegionRefineResult.cs
+++ b/src/Mithril.MapCalibration.Capture/MapRegionRefineResult.cs
@@ -1,0 +1,25 @@
+using Mithril.MapCalibration.Detection;
+
+namespace Mithril.MapCalibration.Capture;
+
+/// <summary>
+/// Outcome of <see cref="IMapRegionRefiner.Refine"/>. Always populated when the
+/// locator ran — the score is preserved on rejection so the engine can log it
+/// and the diagnostic bundle can record it. Lets a future "map-not-located"
+/// outcome self-triage close-miss (score 0.47, threshold tweak) vs catastrophic
+/// (score 0.05, structural mismatch).
+/// </summary>
+/// <param name="AcceptedRect">The ECC-refined rect when the coarse locator's
+/// score met the caller's threshold; <see langword="null"/> when the score was
+/// below threshold OR no rung was viable.</param>
+/// <param name="BestCoarseRect">The best-rung rect from the coarse NCC scale
+/// ladder, with <see cref="MapRect.AutoDetectScore"/> and
+/// <see cref="MapRect.SourceScaleFactor"/> populated. Available whether or not
+/// the score met threshold; <see langword="null"/> only when the ladder had no
+/// viable rung (degenerate input — capture smaller than every candidate
+/// template).</param>
+public sealed record MapRegionRefineResult(MapRect? AcceptedRect, MapRect? BestCoarseRect)
+{
+    /// <summary>Degenerate result — the locator had no viable rung.</summary>
+    public static MapRegionRefineResult None { get; } = new(null, null);
+}

--- a/src/Mithril.MapCalibration.Capture/TextureRegistrationRefiner.cs
+++ b/src/Mithril.MapCalibration.Capture/TextureRegistrationRefiner.cs
@@ -41,13 +41,24 @@ public sealed class TextureRegistrationRefiner : IMapRegionRefiner
     private const double Epsilon = 1e-6;
     private const int GaussFiltSize = 5;
 
-    public MapRect? Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore)
+    public MapRegionRefineResult Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore)
     {
-        var seed = MapRectLocator.AutoDetect(
-            capturedGray, baseTexture, minScore, MapRectLocator.DefaultWorkingLongEdgePx);
+        // Always run the threshold-free locator so the coarse score is preserved on
+        // both accept and reject; the threshold gate is applied here, NOT in the
+        // locator. Without this seam the rejection branch loses the score and the
+        // engine can't tell a close miss from a catastrophic mismatch.
+        var seed = MapRectLocator.AutoDetectBest(
+            capturedGray, baseTexture, MapRectLocator.DefaultWorkingLongEdgePx);
         if (seed is null)
         {
-            return null; // coarse locate failed → nothing to refine
+            return MapRegionRefineResult.None; // no viable rung — degenerate input
+        }
+
+        // Below threshold → don't pay the ECC refine, but still report what the
+        // locator found so the engine/bundle can record the score+factor+origin.
+        if (seed.AutoDetectScore is null || seed.AutoDetectScore < minScore)
+        {
+            return new MapRegionRefineResult(AcceptedRect: null, BestCoarseRect: seed);
         }
 
         int sw = seed.Width, sh = seed.Height;
@@ -71,19 +82,25 @@ public sealed class TextureRegistrationRefiner : IMapRegionRefiner
             double scaleX = Math.Sqrt((double)a * a + (double)c * c);
             double scaleY = Math.Sqrt((double)b * b + (double)d * d);
 
-            return new MapRect(
+            // Carry the coarse seed's AutoDetectScore + SourceScaleFactor through the
+            // ECC-refined rect so the accept log + bundle both see the score (today
+            // they print empty because the new MapRect drops both fields).
+            var refined = new MapRect(
                 OriginX: (int)Math.Round(tx),
                 OriginY: (int)Math.Round(ty),
                 Width: (int)Math.Round(sw * scaleX),
                 Height: (int)Math.Round(sh * scaleY),
                 TextureWidth: baseTexture.Width,
-                TextureHeight: baseTexture.Height);
+                TextureHeight: baseTexture.Height,
+                AutoDetectScore: seed.AutoDetectScore,
+                SourceScaleFactor: seed.SourceScaleFactor);
+            return new MapRegionRefineResult(AcceptedRect: refined, BestCoarseRect: seed);
         }
         catch (OpenCVException)
         {
             // Non-convergence (and any other OpenCV-internal failure): fall back to
             // the coarse seed so the engine sees no worse than the pre-#978 behaviour.
-            return seed;
+            return new MapRegionRefineResult(AcceptedRect: seed, BestCoarseRect: seed);
         }
     }
 

--- a/src/Mithril.MapCalibration/Detection/MapRectLocator.cs
+++ b/src/Mithril.MapCalibration/Detection/MapRectLocator.cs
@@ -56,6 +56,28 @@ public static class MapRectLocator
     /// </summary>
     public static MapRect? AutoDetect(GrayImage screenshot, GrayImage texture, double minScore)
     {
+        var best = AutoDetectBest(screenshot, texture);
+        if (best is null || best.AutoDetectScore is null || best.AutoDetectScore < minScore) return null;
+        return best;
+    }
+
+    /// <summary>
+    /// Threshold-free sibling of <see cref="AutoDetect(GrayImage, GrayImage, double)"/>:
+    /// runs the same scale ladder and returns the best-rung rect with
+    /// <see cref="MapRect.AutoDetectScore"/> + <see cref="MapRect.SourceScaleFactor"/>
+    /// populated, regardless of how low the score is. Returns null only when the ladder
+    /// itself has no valid rung (every candidate fails the size filter — a degenerate
+    /// input).
+    ///
+    /// <para><b>Why a separate method.</b> The thresholded overload discards the score
+    /// on rejection, so the caller can't tell a close miss (score 0.47) from a
+    /// catastrophic mismatch (score 0.05) — both look like <c>null</c>. The auto-
+    /// calibration engine and its diagnostic bundle want the score in both branches
+    /// (accept logs it; reject logs it AND writes it to <c>01-attempt.json</c>) so a
+    /// future "map-not-located" outcome is self-triaging.</para>
+    /// </summary>
+    public static MapRect? AutoDetectBest(GrayImage screenshot, GrayImage texture)
+    {
         // Candidate downsample factors for the texture — each gives a different
         // "rendered map size" hypothesis. The match's score peak picks the
         // closest hypothesis. Fractional factors are essential when the user
@@ -99,7 +121,7 @@ public static class MapRectLocator
             }
         }
 
-        if (bestRect is null || bestScore < minScore) return null;
+        if (bestRect is null) return null;
 
         // Task 2 (#966): the discrete ladder quantises SourceScaleFactor to ±2.5–5%.
         // Fit a parabola through the best rung and its two ladder neighbours on the
@@ -127,12 +149,27 @@ public static class MapRectLocator
     public static MapRect? AutoDetect(
         GrayImage screenshot, GrayImage texture, double minScore, int workingLongEdgePx)
     {
+        var best = AutoDetectBest(screenshot, texture, workingLongEdgePx);
+        if (best is null || best.AutoDetectScore is null || best.AutoDetectScore < minScore) return null;
+        return best;
+    }
+
+    /// <summary>
+    /// Threshold-free downsampling overload — pairs with
+    /// <see cref="AutoDetectBest(GrayImage, GrayImage)"/> the way the four-arg
+    /// <see cref="AutoDetect(GrayImage, GrayImage, double, int)"/> pairs with the
+    /// native three-arg form. Live callers use this so the auto-calibration engine
+    /// can always observe the score, even when it's below the production threshold.
+    /// </summary>
+    public static MapRect? AutoDetectBest(
+        GrayImage screenshot, GrayImage texture, int workingLongEdgePx)
+    {
         if (workingLongEdgePx <= 0) throw new ArgumentOutOfRangeException(nameof(workingLongEdgePx));
 
         var (workScreenshot, captureRatio) = DownsampleToLongEdge(screenshot, workingLongEdgePx);
         var (workTexture, _) = DownsampleToLongEdge(texture, workingLongEdgePx);
 
-        var rect = AutoDetect(workScreenshot, workTexture, minScore);
+        var rect = AutoDetectBest(workScreenshot, workTexture);
         if (rect is null) return null;
 
         // Unscale origin/size from working-capture pixels back to full-capture

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -355,7 +355,7 @@ public sealed class AutoCalibrationEngineTests
         // Refiner returns null → map-not-located reject (everything upstream succeeds).
         var h = new EngineHarness
         {
-            Refiner = new FakeRefiner(null),
+            Refiner = new FakeRefiner(MapRegionRefineResult.None),
             SinkSelector = selector,
         };
 
@@ -363,6 +363,39 @@ public sealed class AutoCalibrationEngineTests
 
         captured.Should().HaveCount(1);
         captured[0].Outcome.Should().Be(OutcomeVocabulary.RejectedMapNotLocated);
+    }
+
+    /// <summary>
+    /// Observability: a sub-threshold locate must still surface what the locator
+    /// found (score, factor, origin) via <see cref="CalibrationAttemptContext.LocatorBestRect"/>
+    /// so the diagnostic bundle records it and a future close-miss vs catastrophic
+    /// rejection is self-triaging.
+    /// </summary>
+    [Fact]
+    public async Task TryCalibrate_map_not_located_surfaces_LocatorBestRect_to_attempt()
+    {
+        var captured = new List<CalibrationAttemptContext>();
+        var selector = MakeSinkSelector(new CapturingSink(captured));
+        // Below-threshold coarse seed: AcceptedRect=null, BestCoarseRect carries the
+        // score (≈0.42, the kind of close-miss the live Kur Mountains attempt hit).
+        var coarseBest = new MapRect(192, 100, 909, 909, 2048, 2048,
+            AutoDetectScore: 0.4729, SourceScaleFactor: 1.47);
+        var h = new EngineHarness
+        {
+            Refiner = new FakeRefiner(new MapRegionRefineResult(AcceptedRect: null, BestCoarseRect: coarseBest)),
+            SinkSelector = selector,
+        };
+
+        await h.Engine().TryCalibrateCurrentAreaAsync(default);
+
+        captured.Should().HaveCount(1);
+        captured[0].Outcome.Should().Be(OutcomeVocabulary.RejectedMapNotLocated);
+        captured[0].LocatorBestRect.Should().NotBeNull();
+        var best = captured[0].LocatorBestRect!;
+        best.AutoDetectScore.Should().Be(0.4729);
+        best.SourceScaleFactor.Should().Be(1.47);
+        best.OriginX.Should().Be(192);
+        best.OriginY.Should().Be(100);
     }
 
     [Fact]

--- a/tests/Mithril.MapCalibration.Capture.Tests/Diagnostics/CalibrationAttemptBundleSinkTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Diagnostics/CalibrationAttemptBundleSinkTests.cs
@@ -141,6 +141,38 @@ public sealed class CalibrationAttemptBundleSinkTests : IDisposable
         attempt.Files.Detections.Should().Be("10-detections.json");  // detections list was present
     }
 
+    /// <summary>
+    /// Observability: on a <c>rejected-map-not-located</c> outcome the bundle's
+    /// <c>01-attempt.json</c> must carry the coarse locator's best score+factor+origin
+    /// (under <c>LocatorBest</c>), so triaging close-miss vs catastrophic-mismatch is
+    /// just <c>jq .locatorBest.autoDetectScore</c> on the captured bundle.
+    /// </summary>
+    [Fact]
+    public void Writes_locatorBest_on_map_not_located_reject()
+    {
+        var ctx = new CalibrationAttemptContext("AreaKurMountains",
+            new DateTimeOffset(2026, 6, 2, 17, 15, 30, 866, TimeSpan.Zero));
+        ctx.RawCapture = new CapturedFrame(4, 4, new byte[4 * 4 * 4]);
+        ctx.GrayCapture = new GrayImage(4, 4, new byte[16]);
+        // The locator found a best rung below threshold — preserved on the context.
+        ctx.LocatorBestRect = new MapRect(192, 100, 909, 909, 2048, 2048,
+            AutoDetectScore: 0.4729, SourceScaleFactor: 1.47);
+        ctx.Outcome = OutcomeVocabulary.RejectedMapNotLocated;
+
+        NewSink().Write(ctx);
+
+        var dir = Directory.GetDirectories(_root).Single();
+        var attemptJsonPath = Path.Combine(dir, "01-attempt.json");
+        using var fs = File.OpenRead(attemptJsonPath);
+        var attempt = JsonSerializer.Deserialize(fs, CalibrationBundleJsonContext.Default.AttemptJson);
+        attempt.Should().NotBeNull();
+        attempt!.LocatorBest.Should().NotBeNull();
+        attempt.LocatorBest!.AutoDetectScore.Should().Be(0.4729);
+        attempt.LocatorBest.SourceScaleFactor.Should().Be(1.47);
+        attempt.LocatorBest.OriginX.Should().Be(192);
+        attempt.LocatorBest.OriginY.Should().Be(100);
+    }
+
     [Theory]
     [InlineData("rejected-no-area")]
     [InlineData("rejected-pg-not-foreground")]

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -69,9 +69,11 @@ internal sealed class SpyCapture : ICaptureService
 
 internal sealed class FakeRefiner : IMapRegionRefiner
 {
-    private readonly MapRect? _rect;
-    public FakeRefiner(MapRect? rect) => _rect = rect;
-    public MapRect? Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore) => _rect;
+    private readonly MapRegionRefineResult _result;
+    public FakeRefiner(MapRect? rect)
+        => _result = new MapRegionRefineResult(AcceptedRect: rect, BestCoarseRect: rect);
+    public FakeRefiner(MapRegionRefineResult result) => _result = result;
+    public MapRegionRefineResult Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore) => _result;
 }
 
 internal sealed class FakeBaseTextureProvider : IBaseTextureProvider

--- a/tests/Mithril.MapCalibration.Capture.Tests/TextureRegistrationRefinerTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/TextureRegistrationRefinerTests.cs
@@ -20,10 +20,33 @@ public sealed class TextureRegistrationRefinerTests
     {
         var tex = SyntheticMap.NoisyTexture(seed: 3, w: 64, h: 64);
         var frame = SyntheticMap.PasteInto(tex, canvasW: 160, canvasH: 120, atX: 40, atY: 30);
-        var rect = new TextureRegistrationRefiner().Refine(frame, tex, minScore: 0.5);
-        rect.Should().NotBeNull();
-        rect!.OriginX.Should().BeCloseTo(40, 3);
-        rect.OriginY.Should().BeCloseTo(30, 3);
+        var result = new TextureRegistrationRefiner().Refine(frame, tex, minScore: 0.5);
+        result.AcceptedRect.Should().NotBeNull();
+        result.AcceptedRect!.OriginX.Should().BeCloseTo(40, 3);
+        result.AcceptedRect.OriginY.Should().BeCloseTo(30, 3);
+    }
+
+    /// <summary>
+    /// Observability seam: when the coarse score falls below the engine's threshold,
+    /// the refiner must still surface what the locator found — the bundle/log
+    /// downstream wants the score and origin even on a "couldn't locate" outcome,
+    /// so future close-miss vs catastrophic-miss is self-triaging.
+    /// </summary>
+    [Fact]
+    public void Refine_surfaces_BestCoarseRect_when_below_minScore()
+    {
+        var tex = SyntheticMap.NoisyTexture(seed: 3, w: 64, h: 64);
+        var frame = SyntheticMap.PasteInto(tex, canvasW: 160, canvasH: 120, atX: 40, atY: 30);
+        // minScore > 1.0 forces rejection without engineering a deliberately-poor
+        // input; the embedded texture's match still scores ~1.0.
+        var result = new TextureRegistrationRefiner().Refine(frame, tex, minScore: 1.5);
+
+        result.AcceptedRect.Should().BeNull("score is below the impossible threshold");
+        result.BestCoarseRect.Should().NotBeNull("the locator did find a best rung — surface it");
+        result.BestCoarseRect!.AutoDetectScore.Should().NotBeNull();
+        result.BestCoarseRect.AutoDetectScore!.Value.Should().BeGreaterThan(0.5);
+        result.BestCoarseRect.OriginX.Should().BeCloseTo(40, 3);
+        result.BestCoarseRect.OriginY.Should().BeCloseTo(30, 3);
     }
 
     /// <summary>
@@ -59,7 +82,7 @@ public sealed class TextureRegistrationRefinerTests
         var capture = new GrayImage(captureW, captureH, shot);
 
         var sw = Stopwatch.StartNew();
-        var rect = new TextureRegistrationRefiner().Refine(capture, texture, minScore: 0.3);
+        var result = new TextureRegistrationRefiner().Refine(capture, texture, minScore: 0.3);
         sw.Stop();
 
         _output.WriteLine($"seam Refine at live resolution: {sw.ElapsedMilliseconds} ms");
@@ -69,8 +92,9 @@ public sealed class TextureRegistrationRefinerTests
         // NOT the 384px working size), and the texture dims are the FULL texture — never
         // the working-resolution copy. The ~4× capture box-average leaves ≲ one working
         // pixel (≈4 full px) of origin quantisation plus the discrete-rung scale slop.
-        rect.Should().NotBeNull("the embedded texture must be locatable through the seam");
-        rect!.OriginX.Should().BeCloseTo(padX, 35);
+        result.AcceptedRect.Should().NotBeNull("the embedded texture must be locatable through the seam");
+        var rect = result.AcceptedRect!;
+        rect.OriginX.Should().BeCloseTo(padX, 35);
         rect.OriginY.Should().BeCloseTo(padY, 35);
         rect.Width.Should().BeGreaterThan(MapRectLocator.DefaultWorkingLongEdgePx,
             "the rect must be unscaled back to full-capture pixels, not left at working resolution");

--- a/tests/Mithril.MapCalibration.Tests/Detection/MapRectLocatorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/MapRectLocatorTests.cs
@@ -279,4 +279,43 @@ public sealed class MapRectLocatorTests
         sw.ElapsedMilliseconds.Should().BeLessThan(30_000,
             "the #966 downsample must keep live-resolution AutoDetect far below the minutes-long brute-force regression, even under a contended Debug CI run");
     }
+
+    /// <summary>
+    /// Observability seam: the threshold-applying <see cref="MapRectLocator.AutoDetect(GrayImage, GrayImage, double)"/>
+    /// returns <c>null</c> on a sub-threshold match, throwing away the score we'd need
+    /// to triage close-miss-vs-catastrophic. <see cref="MapRectLocator.AutoDetectBest(GrayImage, GrayImage)"/>
+    /// always returns the best rung's rect with <see cref="MapRect.AutoDetectScore"/>
+    /// populated so the engine can log it and the bundle can record it.
+    /// </summary>
+    [Fact]
+    public void AutoDetectBest_returns_rect_with_score_even_when_below_typical_threshold()
+    {
+        // The embedded-texture pair scores ~1.0 on the matching rung; using a
+        // minScore > 1.0 on the threshold-applying overload guarantees rejection
+        // without engineering a deliberately-poor input.
+        const int tw = 120, th = 90;
+        var texture = NoisyTexture(tw, th, 1234);
+        const int padX = 20, padY = 35;
+        int sw = tw + padX + 30, sh = th + padY + 25;
+        var shot = new byte[sw * sh];
+        Array.Fill(shot, (byte)40);
+        for (int y = 0; y < th; y++)
+            Buffer.BlockCopy(texture.Pixels, y * tw, shot, (y + padY) * sw + padX, tw);
+        var screenshot = new GrayImage(sw, sh, shot);
+
+        // Thresholded overload rejects (no rect returned — score is hidden).
+        MapRectLocator.AutoDetect(screenshot, texture, minScore: 1.5).Should().BeNull();
+
+        // Best-rect overload surfaces the score regardless of threshold.
+        var best = MapRectLocator.AutoDetectBest(screenshot, texture);
+
+        best.Should().NotBeNull();
+        best!.AutoDetectScore.Should().NotBeNull();
+        best.AutoDetectScore!.Value.Should().BeInRange(0.0, 1.0);
+        // The match really did succeed — score is meaningfully high; threshold gate
+        // is the *only* reason AutoDetect dropped it.
+        best.AutoDetectScore!.Value.Should().BeGreaterThan(0.5);
+        best.OriginX.Should().BeCloseTo(padX, 3);
+        best.OriginY.Should().BeCloseTo(padY, 3);
+    }
 }


### PR DESCRIPTION
## Why

Live Kur Mountains calibration hit `rejected-map-not-located` twice this session. The bundle's `01-attempt.json` recorded the outcome but no signal on WHY — coarse NCC score, factor, and origin were dropped on the floor when the refiner returned null. To learn the score was **0.4729** (a close miss of the 0.50 gate, not a catastrophic mismatch) I had to write a one-off test rig against the captured screenshot + cached texture.

Future `map-not-located` rejections should be self-triaging from the bundle alone.

## What

Threads the coarse locator's best-rung rect (score, factor, origin, size) through to the diagnostic bundle and the engine log, on **both** accept and `rejected-map-not-located` outcomes:

- **`MapRectLocator.AutoDetectBest(...)`** — threshold-free sibling of `AutoDetect` that always returns the best-rung rect with `AutoDetectScore` + `SourceScaleFactor` populated. Existing `AutoDetect` is now a thin wrapper that applies the threshold over the new method, so callers can observe what the locator found even when the gate rejects.
- **`IMapRegionRefiner.Refine` → `MapRegionRefineResult`** (AcceptedRect + BestCoarseRect) instead of nullable `MapRect`. `TextureRegistrationRefiner` applies the threshold itself and carries the coarse seed's score/factor through the ECC-refined rect — incidentally fixing a side-bug where the accept log line printed `AutoDetectScore = , SourceScaleFactor = ` empty.
- **Engine** sets `CalibrationAttemptContext.LocatorBestRect` on both branches; reject branch also logs `best coarse NCC = X.XXX (need >= 0.50), factor = X.XXX, origin = (X, Y)`.
- **`AttemptJson` gains a `locatorBest` block** (origin/size/score/factor). Future triage is `jq .locatorBest.autoDetectScore < 01-attempt.json`.

No threshold tweak — observability first, then decide what to do about the 0.47-vs-0.50 close miss.

## Test plan

- [x] `MapRectLocatorTests.AutoDetectBest_returns_rect_with_score_even_when_below_typical_threshold`
- [x] `TextureRegistrationRefinerTests.Refine_surfaces_BestCoarseRect_when_below_minScore`
- [x] `AutoCalibrationEngineTests.TryCalibrate_map_not_located_surfaces_LocatorBestRect_to_attempt`
- [x] `CalibrationAttemptBundleSinkTests.Writes_locatorBest_on_map_not_located_reject`
- [x] `dotnet test tests/Mithril.MapCalibration.Tests` — 130 passed
- [x] `dotnet test tests/Mithril.MapCalibration.Capture.Tests` — 157 passed
- [x] `dotnet build Mithril.slnx` — clean
- [ ] Rerun Kur Mountains calibration live; confirm bundle's `01-attempt.json` carries `locatorBest` and the rejection log line includes the score

🤖 Generated with [Claude Code](https://claude.com/claude-code)