### PR TITLE
feat(map-calibration): cache ORB descriptors alongside base texture [PR-2] (#1009)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -98,6 +98,37 @@ public static partial class CaptureServiceCollectionExtensions
         services.AddSingleton<IMapRegionRefiner, TextureRegistrationRefiner>();
         services.AddSingleton<CaptureValidation>();
 
+        // PR-2 Task 11: ORB descriptor cache infrastructure. Registered now so
+        // PR-4 can pick them up when it swaps FeatureMatchingRefiner in as the
+        // production refiner. Both reader + writer share the same asset cache
+        // dir as the base-texture cache (sibling files
+        // map-texture-<area>.orb.{json,bin}) and the same orb-params hash
+        // derived from MapCalibrationLocateOptions.
+        //
+        // MapCalibrationLocateOptions is registered here as a singleton (POCO
+        // with INotifyPropertyChanged so a future settings UI can bind without
+        // re-resolving the graph). TryAdd so a shell-side settings surface can
+        // pre-register a user-tunable instance.
+        services.TryAddSingleton<MapCalibrationLocateOptions>();
+
+        services.TryAddSingleton<Internal.CachedOrbDescriptorProvider>(sp =>
+        {
+            var opts = sp.GetRequiredService<MapCalibrationLocateOptions>();
+            return new Internal.CachedOrbDescriptorProvider(
+                cacheDir: assetCacheDir,
+                orbParamsHash: ComputeOrbParamsHash(opts),
+                logger: sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.OrbCache"));
+        });
+
+        services.TryAddSingleton<Internal.OrbDescriptorWriter>(sp =>
+        {
+            var opts = sp.GetRequiredService<MapCalibrationLocateOptions>();
+            return new Internal.OrbDescriptorWriter(
+                cacheDir: assetCacheDir,
+                orbParamsHash: ComputeOrbParamsHash(opts),
+                logger: sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Capture.OrbCache"));
+        });
+
         // #966 Task 3: capture-frame debug-dump options (OFF by default). Registered
         // only if the shell hasn't already supplied one, so a settings surface can
         // override by registering its own instance first.
@@ -222,4 +253,23 @@ public static partial class CaptureServiceCollectionExtensions
     /// </summary>
     internal static ICalibrationConfidenceGate BuildConfidenceGate(GameConfig cfg) =>
         new CalibrationConfidenceGate(cfg.CalibrationGoodResidualPx, CalibrationConfidenceGate.DefaultInlierFloor);
+
+    /// <summary>
+    /// Canonical SHA-256 of the locate options that affect the ORB-descriptor
+    /// cache identity. The descriptors are only reusable when these params
+    /// match — change any of them and the manifest's <c>OrbParamsHash</c>
+    /// mismatches the cache key, invalidating the on-disk pair so the next
+    /// refine recomputes (then rewrites) the cache.
+    /// <para>Culture-invariant formatting so the same params hash identically
+    /// across locales; canonical key=value ordering so future param additions
+    /// can extend the suffix without churning existing entries.</para>
+    /// </summary>
+    private static string ComputeOrbParamsHash(MapCalibrationLocateOptions opts)
+    {
+        var s = string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"orb-v1|nFeatures={opts.OrbNFeatures}|loweRatio={opts.LoweRatio:F4}|ransacPx={opts.RansacReprojectionThresholdPx:F4}");
+        var bytes = System.Text.Encoding.UTF8.GetBytes(s);
+        return System.Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes));
+    }
 }

--- a/src/Mithril.MapCalibration.Capture/FeatureMatchingRefiner.cs
+++ b/src/Mithril.MapCalibration.Capture/FeatureMatchingRefiner.cs
@@ -1,4 +1,6 @@
+using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
+using Mithril.MapCalibration.Capture.Internal;
 using Mithril.MapCalibration.Detection;
 using OpenCvSharp;
 
@@ -33,7 +35,15 @@ public sealed class FeatureMatchingRefiner : IMapRegionRefiner
 {
     private readonly MapCalibrationLocateOptions _options;
     private readonly ILogger? _logger;
+    private readonly CachedOrbDescriptorProvider? _cachedDescriptors;
+    private readonly OrbDescriptorWriter? _writer;
+    private string? _currentAreaKey;
 
+    /// <summary>
+    /// PR-1 backward-compatible constructor. No on-disk ORB descriptor cache
+    /// — every Refine recomputes texture-side ORB. Existing tests + the (not
+    /// yet shipped) production DI path use this overload.
+    /// </summary>
     public FeatureMatchingRefiner(
         MapCalibrationLocateOptions options,
         ILogger<FeatureMatchingRefiner>? logger = null)
@@ -42,6 +52,43 @@ public sealed class FeatureMatchingRefiner : IMapRegionRefiner
         _logger = logger;
     }
 
+    /// <summary>
+    /// PR-2 cache-aware constructor. The reader + writer types are internal
+    /// to <c>Mithril.MapCalibration.Capture</c> (their on-disk format is a
+    /// private implementation detail), so this overload is internal too — the
+    /// DI extension method registers the refiner via this ctor; tests reach
+    /// it through <see cref="InternalsVisibleToAttribute"/>.
+    /// </summary>
+    internal FeatureMatchingRefiner(
+        MapCalibrationLocateOptions options,
+        ILogger<FeatureMatchingRefiner>? logger,
+        CachedOrbDescriptorProvider? cachedDescriptors,
+        OrbDescriptorWriter? writer)
+    {
+        _options = options;
+        _logger = logger;
+        _cachedDescriptors = cachedDescriptors;
+        _writer = writer;
+    }
+
+    /// <summary>
+    /// Set the area-key context for the next <see cref="Refine"/> call. The
+    /// engine (PR-4) calls this before each attempt; the refiner uses the
+    /// area key for the on-disk ORB descriptor cache filename
+    /// (<c>map-texture-&lt;areaKey&gt;.orb.{json,bin}</c>).
+    ///
+    /// <para>Not thread-safe. Calibration runs single-attempt-per-hotkey-press
+    /// so single-threaded by construction (spec §"Risks and open questions").
+    /// If a future surface needs multiple concurrent refiners, switch to a
+    /// per-attempt arg on the interface (deferred until then).</para>
+    ///
+    /// <para>Cache integration is opt-in: when the cache reader+writer were
+    /// supplied to the constructor AND <see cref="_currentAreaKey"/> is
+    /// non-null, the cache consults/populates on each Refine. Otherwise the
+    /// behaviour is identical to PR-1 (always compute texture-side ORB).</para>
+    /// </summary>
+    public void SetAreaKey(string? areaKey) => _currentAreaKey = areaKey;
+
     public MapRegionRefineResult Refine(GrayImage capturedGray, GrayImage baseTexture, double minScore)
     {
         // The minScore arg is a leftover from the NCC interface and is
@@ -49,6 +96,13 @@ public sealed class FeatureMatchingRefiner : IMapRegionRefiner
         // The gate that matters lives in _options.
         _ = minScore;
 
+        // texDescriptors lifetime is conditional: when we read from the cache
+        // OrbDescriptorBundle.Dispose owns the Mat; when we compute fresh we
+        // own it. Tracked by texDescriptorsOwned + cachedBundle below, freed
+        // in the outer finally so neither path leaks.
+        Mat? texDescriptors = null;
+        bool texDescriptorsOwned = true;
+        OrbDescriptorBundle? cachedBundle = null;
         try
         {
             using var orb = ORB.Create(nFeatures: _options.OrbNFeatures);
@@ -56,9 +110,39 @@ public sealed class FeatureMatchingRefiner : IMapRegionRefiner
             using var texMat = ToMat8U(baseTexture);
 
             using var capDescriptors = new Mat();
-            using var texDescriptors = new Mat();
             orb.DetectAndCompute(capMat, null, out var capKeypoints, capDescriptors);
-            orb.DetectAndCompute(texMat, null, out var texKeypoints, texDescriptors);
+
+            // ===== begin: cache integration (opt-in) =====
+            KeyPoint[] texKeypoints;
+            string? textureSha = null;
+            bool cacheEligible =
+                _cachedDescriptors is not null
+                && _writer is not null
+                && !string.IsNullOrEmpty(_currentAreaKey);
+
+            if (cacheEligible)
+            {
+                textureSha = Convert.ToHexStringLower(SHA256.HashData(baseTexture.Pixels));
+                cachedBundle = _cachedDescriptors!.TryRead(_currentAreaKey!, textureSha);
+            }
+
+            if (cachedBundle is not null)
+            {
+                texKeypoints = cachedBundle.Keypoints;
+                texDescriptors = cachedBundle.Descriptors;
+                texDescriptorsOwned = false;  // OrbDescriptorBundle.Dispose owns it
+            }
+            else
+            {
+                var computedTexDescriptors = new Mat();
+                orb.DetectAndCompute(texMat, null, out texKeypoints, computedTexDescriptors);
+                texDescriptors = computedTexDescriptors;
+                if (cacheEligible && texKeypoints.Length > 0)
+                {
+                    _writer!.Write(_currentAreaKey!, texKeypoints, texDescriptors, textureSha!, pgVersion: null);
+                }
+            }
+            // ===== end: cache integration =====
 
             if (capDescriptors.Rows < 2 || texDescriptors.Rows < 2)
             {
@@ -172,6 +256,14 @@ public sealed class FeatureMatchingRefiner : IMapRegionRefiner
         {
             _logger?.LogWarning(ex, "Feature-matching locate: OpenCV failure. Safe-degrade.");
             return MapRegionRefineResult.None;
+        }
+        finally
+        {
+            // Dispose the texture descriptors only when we own them (fresh
+            // compute path). On a cache hit the OrbDescriptorBundle owns the
+            // Mat and disposing it here would double-dispose via cachedBundle.
+            if (texDescriptorsOwned) texDescriptors?.Dispose();
+            cachedBundle?.Dispose();
         }
     }
 

--- a/src/Mithril.MapCalibration.Capture/Internal/CachedOrbDescriptorProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/Internal/CachedOrbDescriptorProvider.cs
@@ -1,0 +1,167 @@
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OpenCvSharp;
+
+namespace Mithril.MapCalibration.Capture.Internal;
+
+/// <summary>
+/// Reads cached ORB descriptors for a per-area base texture. Returns null
+/// on any miss, mismatch, or corruption — caller is responsible for
+/// computing+writing them via <c>OrbDescriptorWriter</c>.
+/// </summary>
+internal sealed class CachedOrbDescriptorProvider
+{
+    private readonly string _cacheDir;
+    private readonly string _orbParamsHash;
+    private readonly ILogger? _logger;
+
+    public CachedOrbDescriptorProvider(string cacheDir, string orbParamsHash, ILogger? logger = null)
+    {
+        _cacheDir = cacheDir;
+        _orbParamsHash = orbParamsHash;
+        _logger = logger;
+    }
+
+    public OrbDescriptorBundle? TryRead(string areaKey, string expectedTexturePixelSha256)
+    {
+        if (string.IsNullOrWhiteSpace(_cacheDir) || !Directory.Exists(_cacheDir)) return null;
+
+        var manifestPath = Path.Combine(_cacheDir, $"map-texture-{areaKey}.orb.json");
+        var blobPath     = Path.Combine(_cacheDir, $"map-texture-{areaKey}.orb.bin");
+        if (!File.Exists(manifestPath) || !File.Exists(blobPath)) return null;
+
+        OrbDescriptorManifest? manifest;
+        try
+        {
+            using var s = File.OpenRead(manifestPath);
+            manifest = JsonSerializer.Deserialize(s, CaptureJsonContext.Default.OrbDescriptorManifest);
+        }
+        catch (JsonException ex)
+        {
+            _logger?.LogWarning(ex, "ORB descriptor manifest {Path} unparseable — rebuild.", manifestPath);
+            return null;
+        }
+        if (manifest is null) return null;
+
+        if (manifest.OrbParamsHash != _orbParamsHash
+            || manifest.PixelSha256 != expectedTexturePixelSha256
+            || manifest.SchemaVersion != 1
+            || manifest.DescriptorDim != 32)
+        {
+            _logger?.LogInformation("ORB descriptor cache for {Area} stale — rebuild.", areaKey);
+            return null;
+        }
+
+        byte[] blob;
+        try
+        {
+            using var stream = File.OpenRead(blobPath);
+            using var deflate = new DeflateStream(stream, CompressionMode.Decompress);
+            using var ms = new MemoryStream();
+            deflate.CopyTo(ms);
+            blob = ms.ToArray();
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger?.LogWarning(ex, "ORB descriptor blob {Path} corrupt — rebuild.", blobPath);
+            return null;
+        }
+
+        var actualBlobHash = Convert.ToHexStringLower(SHA256.HashData(blob));
+        if (actualBlobHash != manifest.BlobSha256)
+        {
+            _logger?.LogWarning(
+                "ORB descriptor blob hash mismatch for {Area} (manifest {Expected}, blob {Actual}) — rebuild.",
+                areaKey, manifest.BlobSha256, actualBlobHash);
+            return null;
+        }
+
+        return OrbDescriptorBundle.Decode(blob, manifest);
+    }
+}
+
+/// <summary>
+/// Wire format of the .orb.bin blob: per-keypoint header + 32-byte
+/// descriptor row. See <see cref="Encode"/> / <see cref="Decode"/> for the
+/// concrete layout — the format is private to PR-2's reader + writer.
+/// </summary>
+internal sealed class OrbDescriptorBundle : IDisposable
+{
+    public KeyPoint[] Keypoints { get; }
+    public Mat Descriptors { get; }   // CV_8UC1, rows = KeypointCount, cols = 32
+
+    private OrbDescriptorBundle(KeyPoint[] keypoints, Mat descriptors)
+    {
+        Keypoints = keypoints;
+        Descriptors = descriptors;
+    }
+
+    public void Dispose()
+    {
+        Descriptors.Dispose();
+    }
+
+    public static OrbDescriptorBundle Decode(byte[] blob, OrbDescriptorManifest manifest)
+    {
+        // Format:
+        //   uint32  keypointCount
+        //   per keypoint (24 bytes):
+        //     float32 x, float32 y, float32 size, float32 angle,
+        //     float32 response, int32 octave
+        //   then keypointCount × 32 bytes of descriptor data
+        if (blob.Length < 4) throw new InvalidDataException("blob too small");
+        int n = BitConverter.ToInt32(blob, 0);
+        if (n != manifest.KeypointCount)
+            throw new InvalidDataException($"blob keypointCount {n} != manifest {manifest.KeypointCount}");
+
+        var keypoints = new KeyPoint[n];
+        int offset = 4;
+        for (int i = 0; i < n; i++)
+        {
+            float x        = BitConverter.ToSingle(blob, offset + 0);
+            float y        = BitConverter.ToSingle(blob, offset + 4);
+            float size     = BitConverter.ToSingle(blob, offset + 8);
+            float angle    = BitConverter.ToSingle(blob, offset + 12);
+            float response = BitConverter.ToSingle(blob, offset + 16);
+            int   octave   = BitConverter.ToInt32 (blob, offset + 20);
+            keypoints[i] = new KeyPoint(new Point2f(x, y), size, angle, response, octave, ClassId: -1);
+            offset += 24;
+        }
+
+        var descriptors = new Mat(n, 32, MatType.CV_8UC1);
+        for (int i = 0; i < n; i++)
+        {
+            for (int j = 0; j < 32; j++)
+            {
+                descriptors.Set(i, j, blob[offset + i * 32 + j]);
+            }
+        }
+        return new OrbDescriptorBundle(keypoints, descriptors);
+    }
+
+    public static byte[] Encode(KeyPoint[] keypoints, Mat descriptors)
+    {
+        if (descriptors.Cols != 32 || descriptors.Type() != MatType.CV_8UC1)
+            throw new ArgumentException("expected 32-col CV_8UC1 ORB descriptors", nameof(descriptors));
+
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+        bw.Write(keypoints.Length);
+        foreach (var kp in keypoints)
+        {
+            bw.Write(kp.Pt.X);
+            bw.Write(kp.Pt.Y);
+            bw.Write(kp.Size);
+            bw.Write(kp.Angle);
+            bw.Write(kp.Response);
+            bw.Write(kp.Octave);
+        }
+        for (int i = 0; i < keypoints.Length; i++)
+            for (int j = 0; j < 32; j++)
+                bw.Write(descriptors.At<byte>(i, j));
+        return ms.ToArray();
+    }
+}

--- a/src/Mithril.MapCalibration.Capture/Internal/CachedOrbDescriptorProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/Internal/CachedOrbDescriptorProvider.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -131,13 +132,15 @@ internal sealed class OrbDescriptorBundle : IDisposable
             offset += 24;
         }
 
+        // Bulk-copy descriptors via Marshal.Copy into the freshly-allocated
+        // (and therefore contiguous) Mat backing buffer — beats the
+        // 256k-iteration p/invoke loop (descriptors.Set per byte) by ~3
+        // orders of magnitude on the cache-hit hot path.
         var descriptors = new Mat(n, 32, MatType.CV_8UC1);
-        for (int i = 0; i < n; i++)
+        int byteCount = n * 32;
+        if (byteCount > 0)
         {
-            for (int j = 0; j < 32; j++)
-            {
-                descriptors.Set(i, j, blob[offset + i * 32 + j]);
-            }
+            Marshal.Copy(blob, offset, descriptors.Data, byteCount);
         }
         return new OrbDescriptorBundle(keypoints, descriptors);
     }

--- a/src/Mithril.MapCalibration.Capture/Internal/CaptureJsonContext.cs
+++ b/src/Mithril.MapCalibration.Capture/Internal/CaptureJsonContext.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Mithril.MapCalibration.Capture.Internal;
+
+/// <summary>
+/// Source-generated JSON context for internal capture-side records (ORB
+/// descriptor cache manifest, etc). Kept separate from
+/// <see cref="Mithril.MapCalibration.Capture.Diagnostics.CalibrationBundleJsonContext"/>
+/// (which is for user-facing diagnostic bundle output) so the two concerns
+/// don't bleed.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+[JsonSerializable(typeof(OrbDescriptorManifest))]
+internal partial class CaptureJsonContext : JsonSerializerContext;

--- a/src/Mithril.MapCalibration.Capture/Internal/OrbDescriptorManifest.cs
+++ b/src/Mithril.MapCalibration.Capture/Internal/OrbDescriptorManifest.cs
@@ -1,0 +1,28 @@
+namespace Mithril.MapCalibration.Capture.Internal;
+
+/// <summary>
+/// Per-area ORB descriptor cache manifest. Sits alongside
+/// <c>map-texture-&lt;area&gt;.json</c>; the descriptor payload is the
+/// DeflateStream-compressed sibling <c>map-texture-&lt;area&gt;.orb.bin</c>.
+///
+/// <para><b>Cache key.</b> A cached pair is valid iff:</para>
+/// <list type="bullet">
+/// <item><c>SchemaVersion</c> matches what the current binary expects.</item>
+/// <item><c>PixelSha256</c> matches the sibling source texture's manifest
+/// <c>PixelSha256</c> — cache invalidates whenever the texture is
+/// rebuilt.</item>
+/// <item><c>OrbParamsHash</c> matches the SHA-256 of the canonical ORB
+/// param struct — cache invalidates whenever any param changes.</item>
+/// <item>The actual <c>.orb.bin</c>'s SHA-256 matches
+/// <c>BlobSha256</c> — guards against truncation / corruption.</item>
+/// </list>
+/// </summary>
+internal sealed record OrbDescriptorManifest(
+    int SchemaVersion,
+    string Area,
+    string? PgVersion,
+    int KeypointCount,
+    int DescriptorDim,        // 32 for ORB
+    string OrbParamsHash,
+    string PixelSha256,
+    string BlobSha256);

--- a/src/Mithril.MapCalibration.Capture/Internal/OrbDescriptorWriter.cs
+++ b/src/Mithril.MapCalibration.Capture/Internal/OrbDescriptorWriter.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OpenCvSharp;
+
+namespace Mithril.MapCalibration.Capture.Internal;
+
+/// <summary>
+/// Writes per-area ORB descriptors to disk as a sibling pair of
+/// <c>map-texture-&lt;area&gt;.orb.json</c> (manifest) +
+/// <c>map-texture-&lt;area&gt;.orb.bin</c> (DeflateStream-compressed blob)
+/// so subsequent runs can skip the texture-side ORB compute. Reader is
+/// <see cref="CachedOrbDescriptorProvider"/>; format owner is
+/// <see cref="OrbDescriptorBundle.Encode"/>.
+///
+/// <para>Fail-soft: any <see cref="IOException"/> on write is logged at
+/// Warning and swallowed — the locate path already has the descriptors in
+/// memory for this attempt, so a failed cache write only costs a recompute
+/// on the next run.</para>
+/// </summary>
+internal sealed class OrbDescriptorWriter
+{
+    private readonly string _cacheDir;
+    private readonly string _orbParamsHash;
+    private readonly ILogger? _logger;
+
+    public OrbDescriptorWriter(string cacheDir, string orbParamsHash, ILogger? logger = null)
+    {
+        _cacheDir = cacheDir;
+        _orbParamsHash = orbParamsHash;
+        _logger = logger;
+    }
+
+    public void Write(
+        string areaKey, KeyPoint[] keypoints, Mat descriptors,
+        string texturePixelSha256, string? pgVersion)
+    {
+        var blob = OrbDescriptorBundle.Encode(keypoints, descriptors);
+        var blobSha = Convert.ToHexStringLower(SHA256.HashData(blob));
+        var manifest = new OrbDescriptorManifest(
+            SchemaVersion: 1,
+            Area: areaKey,
+            PgVersion: pgVersion,
+            KeypointCount: keypoints.Length,
+            DescriptorDim: 32,
+            OrbParamsHash: _orbParamsHash,
+            PixelSha256: texturePixelSha256,
+            BlobSha256: blobSha);
+
+        try
+        {
+            Directory.CreateDirectory(_cacheDir);
+            var manifestPath = Path.Combine(_cacheDir, $"map-texture-{areaKey}.orb.json");
+            var blobPath     = Path.Combine(_cacheDir, $"map-texture-{areaKey}.orb.bin");
+
+            using (var s = File.Create(manifestPath))
+            {
+                JsonSerializer.Serialize(s, manifest, CaptureJsonContext.Default.OrbDescriptorManifest);
+            }
+            using (var s = File.Create(blobPath))
+            using (var deflate = new DeflateStream(s, CompressionLevel.Optimal))
+            {
+                deflate.Write(blob, 0, blob.Length);
+            }
+            _logger?.LogInformation(
+                "Wrote ORB descriptor cache for {Area}: {Count} keypoints, {BlobBytes} bytes deflate-compressed payload.",
+                areaKey, keypoints.Length, blob.Length);
+        }
+        catch (IOException ex)
+        {
+            _logger?.LogWarning(ex, "Failed to write ORB descriptor cache for {Area}; locate will recompute on next run.", areaKey);
+        }
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/CachedOrbDescriptorProviderTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CachedOrbDescriptorProviderTests.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture.Internal;
+using OpenCvSharp;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+public sealed class CachedOrbDescriptorProviderTests : IDisposable
+{
+    private readonly string _tmpDir = Path.Combine(Path.GetTempPath(), "mithril-orb-cache-" + Guid.NewGuid());
+    private const string ParamsHash = "deadbeef";
+    private const string PixelHash = "facefeed";
+
+    public CachedOrbDescriptorProviderTests() => Directory.CreateDirectory(_tmpDir);
+    public void Dispose() { if (Directory.Exists(_tmpDir)) Directory.Delete(_tmpDir, recursive: true); }
+
+    [Fact]
+    public void Round_trips_write_then_read()
+    {
+        var (kp, desc) = SampleDescriptors(count: 8);
+        new OrbDescriptorWriter(_tmpDir, ParamsHash).Write("X", kp, desc, PixelHash, pgVersion: "test");
+
+        using var bundle = new CachedOrbDescriptorProvider(_tmpDir, ParamsHash).TryRead("X", PixelHash);
+
+        bundle.Should().NotBeNull();
+        bundle!.Keypoints.Length.Should().Be(8);
+        bundle.Descriptors.Rows.Should().Be(8);
+        bundle.Descriptors.Cols.Should().Be(32);
+    }
+
+    [Fact]
+    public void Returns_null_on_blob_corruption()
+    {
+        var (kp, desc) = SampleDescriptors(count: 4);
+        new OrbDescriptorWriter(_tmpDir, ParamsHash).Write("X", kp, desc, PixelHash, pgVersion: null);
+
+        // Flip a byte in the deflate-compressed blob (almost certainly breaks decompression OR hash).
+        var blobPath = Path.Combine(_tmpDir, "map-texture-X.orb.bin");
+        var bytes = File.ReadAllBytes(blobPath);
+        bytes[bytes.Length / 2] ^= 0xFF;
+        File.WriteAllBytes(blobPath, bytes);
+
+        var bundle = new CachedOrbDescriptorProvider(_tmpDir, ParamsHash).TryRead("X", PixelHash);
+        bundle.Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_on_orb_params_hash_mismatch()
+    {
+        var (kp, desc) = SampleDescriptors(count: 4);
+        new OrbDescriptorWriter(_tmpDir, ParamsHash).Write("X", kp, desc, PixelHash, pgVersion: null);
+
+        var bundle = new CachedOrbDescriptorProvider(_tmpDir, "different-params-hash").TryRead("X", PixelHash);
+        bundle.Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_on_pixel_sha_mismatch()
+    {
+        var (kp, desc) = SampleDescriptors(count: 4);
+        new OrbDescriptorWriter(_tmpDir, ParamsHash).Write("X", kp, desc, PixelHash, pgVersion: null);
+
+        var bundle = new CachedOrbDescriptorProvider(_tmpDir, ParamsHash).TryRead("X", "different-pixel-sha");
+        bundle.Should().BeNull();
+    }
+
+    private static (KeyPoint[] kp, Mat desc) SampleDescriptors(int count)
+    {
+        var kp = new KeyPoint[count];
+        for (int i = 0; i < count; i++)
+            kp[i] = new KeyPoint(new Point2f(i * 10, i * 10), 7f, 0f, 1f, 0, -1);
+
+        var desc = new Mat(count, 32, MatType.CV_8UC1);
+        for (int i = 0; i < count; i++)
+            for (int j = 0; j < 32; j++)
+                desc.Set(i, j, (byte)((i * 31 + j * 17) & 0xFF));
+        return (kp, desc);
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of the 4-PR feature-matching locate plan for [#1009](https://github.com/moumantai-gg/mithril/issues/1009). Adds an on-disk ORB descriptor cache alongside the existing base-texture cache + lazy-populate integration in `FeatureMatchingRefiner`. Stacked on [#1015](https://github.com/moumantai-gg/mithril/pull/1015) (PR-1).

## What landed

| Task | Commit | Scope |
|---|---|---|
| 9  | `8eea07d4` | `OrbDescriptorManifest` record + new `CaptureJsonContext` for capture-side cache metadata serialization (separate from `CalibrationBundleJsonContext` per concern separation) |
| 10 | `8bc21eef` | `CachedOrbDescriptorProvider` (manifest + SHA-256 + DeflateStream blob reader) + `OrbDescriptorBundle` (Encode/Decode wire format: 4-byte count + 24 bytes/kp + N×32 descriptor bytes). Reader returns null on any miss/mismatch — caller rebuilds. |
| 11 | `85be7519` | `OrbDescriptorWriter` + lazy-populate integration in `FeatureMatchingRefiner` (cache opt-in via internal ctor + `SetAreaKey()` mutator) + DI wiring of all three new types + `MapCalibrationLocateOptions` registration. Also folds in a perf fix: `OrbDescriptorBundle.Decode` switched from per-byte `Mat.Set` to a single `Marshal.Copy` (256k p/invoke → one memcpy on the cache-hit hot path). |
| 12 | `67a9f0d2` | Cache integrity tests: round-trip, blob corruption, params-hash mismatch, pixel-sha mismatch (4 facts) |

## Cache format

- `map-texture-<area>.orb.json` — manifest with `SchemaVersion=1`, `Area`, `PgVersion?`, `KeypointCount`, `DescriptorDim=32`, `OrbParamsHash` (SHA-256 of the canonical params struct), `PixelSha256` (links to source texture's pixel hash), `BlobSha256` (integrity over `.orb.bin`)
- `map-texture-<area>.orb.bin` — DeflateStream-compressed binary blob: `uint32 keypointCount` + N × 24-byte keypoint header (`x, y, size, angle, response, octave`) + N × 32-byte ORB descriptor row

**Invalidation:** cache is valid iff SchemaVersion=1, DescriptorDim=32, OrbParamsHash matches, PixelSha256 matches, and the actual blob SHA-256 matches `BlobSha256`. Any mismatch returns null → caller computes + writes fresh.

## DI shape

- `MapCalibrationLocateOptions` — singleton (was missing; added)
- `CachedOrbDescriptorProvider` — singleton, factory captures the asset cache dir + an `OrbParamsHash` derived from the live options
- `OrbDescriptorWriter` — singleton, same factory pattern
- `FeatureMatchingRefiner` — **still not registered as `IMapRegionRefiner`**. PR-1's public ctor is the active path; the new internal cache-aware ctor exists for the eventual PR-4 swap (production engine calls `SetAreaKey()` before each `Refine`).

## Test results

- New facts: **4 cache integrity tests** + 0 changes to the 166 PR-1 tests
- Full Capture.Tests suite: **170/170** green
- Full MapCalibration.Tests: **130/130** green

## Notes for the reviewer

1. **Cache is opt-in by construction.** The PR-1 public `FeatureMatchingRefiner` constructor (no cache args) is preserved verbatim; the cache-aware ctor is `internal`. The 166 PR-1 tests confirm that the cache integration is invisible when cache args are null. PR-4 will switch the DI registration to use the cache-aware ctor.

2. **`OrbDescriptorBundle.Decode` perf fix.** Task 11 also folds in a fix flagged by Task 10's reviewer: the per-byte `descriptors.Set(i, j, blob[...])` loop was replaced with `Marshal.Copy(blob, offset, descriptors.Data, n * 32)`. Safe because `new Mat(rows, cols, type)` allocates a contiguous buffer. ~256k p/invoke calls → 1 memcpy on the cache-hit path.

3. **Known follow-up (not in this PR):** `OrbParamsHash` is captured into the provider at DI resolution time. If a settings UI ever ships that mutates `MapCalibrationLocateOptions.OrbNFeatures` (or similar) at runtime, the cache won't auto-invalidate until the singleton is re-resolved (shell restart). Two clean fixes when needed: subscribe to `INPC`, or recompute the hash per-call. No settings UI ships today so this is latent.

4. **Known minor (filed for follow-up):** the `OrbParamsHash` format includes `LoweRatio` and `RansacReprojectionThresholdPx`, which aren't ORB descriptor params (they affect matching/RANSAC, not the descriptors themselves). Including them over-invalidates the cache on Lowe/RANSAC tuning. The spec's design table (§Descriptor caching) listed only true ORB params; the plan body included the others. Per-spec correction is a one-line cleanup.

## Test plan

- [x] 4 new cache-integrity tests green (round-trip, corruption, 2 cache-key mismatches)
- [x] All 166 PR-1 tests still green (cache opt-in proven)
- [x] Full Capture.Tests 170/170
- [x] Full MapCalibration.Tests 130/130
- [ ] **Reviewer** confirms the Marshal.Copy perf fix is acceptable as a drive-by improvement vs filing as a follow-up
- [ ] **Reviewer** notes the two known follow-ups (stale-hash on live settings; over-invalidation on Lowe/RANSAC tuning) for the issue tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)