### PR TITLE
docs(planning): flip arda-state-snapshot-and-ui-dispatch to shipped

### DIFF
--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -29,7 +29,7 @@ When you create a new slug folder, append a row to the table below: `slug | stat
 
 | Slug | Status | Issue/PR | Description |
 |------|--------|----------|-------------|
-| [arda-state-snapshot-and-ui-dispatch](arda-state-snapshot-and-ui-dispatch/) | active | [#1011](https://github.com/moumantai-gg/mithril/issues/1011) | Fix Palantir pin-enum crash; `MapPins.Pins` snapshot + new `Arda.Wpf` `IUiEventSubscriber` + `WpfMapPinPresenter` |
+| [arda-state-snapshot-and-ui-dispatch](arda-state-snapshot-and-ui-dispatch/) | shipped | [#1011](https://github.com/moumantai-gg/mithril/issues/1011) · [#1013](https://github.com/moumantai-gg/mithril/issues/1013) | Fix Palantir pin-enum crash; `MapPins.Pins` snapshot + new `Arda.Wpf` `IUiEventSubscriber` + `WpfMapPinPresenter` |
 | [gandalf-164-in-game-clock-alarm](gandalf-164-in-game-clock-alarm/) | shipped | [#164](https://github.com/moumantai-gg/mithril/issues/164) | Gandalf: fire timers at PG in-game time-of-day |
 | [legolas-wizard](legolas-wizard/) | shipped | [#111](https://github.com/moumantai-gg/mithril/issues/111) · [#112](https://github.com/moumantai-gg/mithril/issues/112) · [#113](https://github.com/moumantai-gg/mithril/issues/113) | Legolas wizard view + dashboard rework + Motherlode wizard depth |
 | [quest-discovery-module](quest-discovery-module/) | deferred | _no issue_ | Quest browser / eligibility surface (separate from Gandalf) |

--- a/src/Arda/Arda.Wpf/Arda.Wpf.csproj
+++ b/src/Arda/Arda.Wpf/Arda.Wpf.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Arda.Wpf.Tests" />

--- a/src/Arda/Arda.Wpf/SyncUiEventSubscriber.cs
+++ b/src/Arda/Arda.Wpf/SyncUiEventSubscriber.cs
@@ -1,0 +1,21 @@
+using Arda.Contracts;
+
+namespace Arda.Wpf;
+
+/// <summary>
+/// Synchronous <see cref="IUiEventSubscriber"/> — handlers run on whatever
+/// thread <see cref="IDomainEventPublisher.Publish{T}"/> is called from.
+/// Intended for unit tests (replaces the legacy <c>Action&lt;Action&gt;</c>
+/// sync dispatcher pattern) and headless integration smoke tests; do NOT
+/// register this in the WPF shell — pin updates would land on the Arda
+/// ingest thread instead of the UI thread.
+/// </summary>
+public sealed class SyncUiEventSubscriber : IUiEventSubscriber
+{
+    private readonly IDomainEventSubscriber _inner;
+
+    public SyncUiEventSubscriber(IDomainEventSubscriber inner) => _inner = inner;
+
+    public IDisposable Subscribe<T>(Action<T> handler) where T : struct
+        => _inner.Subscribe(handler);
+}

--- a/src/Arda/Arda.Wpf/UiEventSubscriber.cs
+++ b/src/Arda/Arda.Wpf/UiEventSubscriber.cs
@@ -1,0 +1,82 @@
+using System.Windows.Threading;
+using Arda.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace Arda.Wpf;
+
+/// <summary>
+/// UI-thread-affined wrapper over <see cref="IDomainEventSubscriber"/>.
+/// Subscribers receive their handlers on the WPF Dispatcher thread,
+/// inside a try/catch that logs (rather than crashing via the finalizer
+/// thread when an unobserved <see cref="DispatcherOperation"/> Task captures
+/// the exception).
+///
+/// <para>Non-UI subscribers should continue to depend on
+/// <see cref="IDomainEventSubscriber"/> directly — their lock-based
+/// coordination relies on synchronous handler firing on the Arda ingest
+/// thread, which this wrapper deliberately breaks.</para>
+///
+/// <para>Determinism note: this wrapper sits at the consumer edge, *after*
+/// <c>bus.Publish</c> returns. It does not affect Arda's producer-side
+/// determinism. Headless contexts (replay tests, world-sim driver) do not
+/// reference Arda.Wpf and never see this type.</para>
+/// </summary>
+public interface IUiEventSubscriber
+{
+    /// <summary>Subscribe to domain events of type <typeparamref name="T"/>.
+    /// The handler runs on the WPF Dispatcher thread, inside a try/catch that
+    /// logs handler exceptions instead of crashing the process.</summary>
+    IDisposable Subscribe<T>(Action<T> handler) where T : struct;
+}
+
+/// <summary>
+/// Production <see cref="IUiEventSubscriber"/> backed by a WPF
+/// <see cref="Dispatcher"/>. See the interface doc for the determinism /
+/// non-UI-subscriber boundary.
+/// </summary>
+public sealed class WpfUiEventSubscriber : IUiEventSubscriber
+{
+    private readonly IDomainEventSubscriber _inner;
+    private readonly Dispatcher _dispatcher;
+    private readonly ILogger<WpfUiEventSubscriber> _logger;
+
+    public WpfUiEventSubscriber(
+        IDomainEventSubscriber inner,
+        Dispatcher dispatcher,
+        ILogger<WpfUiEventSubscriber> logger)
+    {
+        _inner = inner;
+        _dispatcher = dispatcher;
+        _logger = logger;
+    }
+
+    public IDisposable Subscribe<T>(Action<T> handler) where T : struct
+        => _inner.Subscribe<T>(evt => _dispatcher.InvokeAsync(
+            () => UiEventSubscriber.SafeInvoke(handler, evt, _logger)));
+}
+
+/// <summary>
+/// Shared static helpers exposed so unit tests can drive the exception-swallow
+/// path without needing an STA-affinitised <see cref="Dispatcher"/>.
+/// </summary>
+public static class UiEventSubscriber
+{
+    /// <summary>
+    /// Invoke <paramref name="handler"/> on <paramref name="evt"/>; if it
+    /// throws, log the exception via <paramref name="logger"/> and swallow it.
+    /// The contract: this method MUST NOT propagate exceptions (that's the
+    /// whole point — keep them off the finalizer thread).
+    /// </summary>
+    public static void SafeInvoke<T>(Action<T> handler, T evt, ILogger logger)
+        where T : struct
+    {
+        try { handler(evt); }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "UI handler for {Event} threw on the dispatcher; suppressed " +
+                "to prevent finalizer-thread crash.",
+                typeof(T).Name);
+        }
+    }
+}

--- a/src/Arda/Arda.Wpf/WpfMapPinPresenter.cs
+++ b/src/Arda/Arda.Wpf/WpfMapPinPresenter.cs
@@ -1,0 +1,105 @@
+using System.Collections.ObjectModel;
+using Arda.Contracts;
+using Arda.World.Player;
+using Arda.World.Player.Events;
+
+namespace Arda.Wpf;
+
+/// <summary>
+/// Bindable presenter over the active map pins. Maintains an
+/// <see cref="ObservableCollection{MapPinEntry}"/> synchronized with the
+/// player's current-area pins via domain events.
+///
+/// <para>On construction, seeds from <see cref="IMapPinState.Pins"/>, then
+/// subscribes to <see cref="MapPinAdded"/>, <see cref="MapPinRemoved"/>, and
+/// <see cref="AreaChanged"/> events. The collection is cleared when the player
+/// transitions to a new area.</para>
+///
+/// <para>Coordinates are keyed by their centi-unit rounded values (rounding to
+/// 2 decimal places) to match the <c>MapPins</c> event handler's 0.01 tolerance.</para>
+/// </summary>
+public sealed class WpfMapPinPresenter : IDisposable
+{
+    private readonly Dictionary<(long X, long Z), MapPinEntry> _byCoord = new();
+    private IDisposable? _addedSub;
+    private IDisposable? _removedSub;
+    private IDisposable? _areaChangedSub;
+
+    public ObservableCollection<MapPinEntry> Pins { get; } = new();
+
+    public WpfMapPinPresenter(IMapPinState state, IUiEventSubscriber bus)
+    {
+        // Seed from initial state
+        foreach (var pin in state.Pins)
+        {
+            Pins.Add(pin);
+            var key = Key(pin.X, pin.Z);
+            _byCoord[key] = pin;
+        }
+
+        // Subscribe to events
+        _addedSub = bus.Subscribe<MapPinAdded>(OnAdded);
+        _removedSub = bus.Subscribe<MapPinRemoved>(OnRemoved);
+        _areaChangedSub = bus.Subscribe<AreaChanged>(OnAreaChanged);
+    }
+
+    /// <summary>
+    /// Round coordinates to centi-units (0.01 tolerance) to produce the keying
+    /// function. Matches the MapPins event handler's tolerance.
+    /// </summary>
+    private static (long X, long Z) Key(double x, double z)
+    {
+        return ((long)Math.Round(x * 100), (long)Math.Round(z * 100));
+    }
+
+    private void Upsert(MapPinEntry pin, bool addToCollection)
+    {
+        var key = Key(pin.X, pin.Z);
+
+        if (_byCoord.TryGetValue(key, out var existing))
+        {
+            // Replace in place
+            var idx = Pins.IndexOf(existing);
+            if (idx >= 0)
+            {
+                Pins[idx] = pin;
+            }
+        }
+        else if (addToCollection)
+        {
+            // New coordinate
+            Pins.Add(pin);
+        }
+
+        _byCoord[key] = pin;
+    }
+
+    private void OnAdded(MapPinAdded e)
+    {
+        var pin = new MapPinEntry(e.X, e.Z, e.Label, e.Shape, e.Color);
+        Upsert(pin, addToCollection: true);
+    }
+
+    private void OnRemoved(MapPinRemoved e)
+    {
+        var key = Key(e.X, e.Z);
+        if (_byCoord.TryGetValue(key, out var pin))
+        {
+            Pins.Remove(pin);
+            _byCoord.Remove(key);
+        }
+    }
+
+    private void OnAreaChanged(AreaChanged _)
+    {
+        Pins.Clear();
+        _byCoord.Clear();
+    }
+
+    public void Dispose()
+    {
+        _addedSub?.Dispose();
+        _removedSub?.Dispose();
+        _areaChangedSub?.Dispose();
+    }
+}

--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -216,6 +216,25 @@ public sealed class FontSizeTimesConverter : IValueConverter
 }
 
 /// <summary>
+/// Returns <see cref="IValueConverter.Convert"/>'s parameter (cast to string) when the
+/// input is null, empty, or all-whitespace; otherwise returns the input value unchanged.
+/// Used as the WPF fallback for binding to string properties whose empty-string value
+/// should display a placeholder (WPF's <c>TargetNullValue</c> only fires for null, not
+/// for <c>""</c>).
+/// </summary>
+public sealed class EmptyStringFallbackConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string s && !string.IsNullOrWhiteSpace(s)) return s;
+        return parameter as string ?? string.Empty;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
 /// Two-way converter between an enum value and <c>bool</c> for radio-button bindings.
 /// Usage: <c>IsChecked="{Binding Foo, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=SomeEnumValue}"</c>.
 /// </summary>

--- a/src/Mithril.Shared.Wpf/Converters.xaml
+++ b/src/Mithril.Shared.Wpf/Converters.xaml
@@ -13,4 +13,5 @@
     <c:LinkGlyphToLucideKindConverter x:Key="LinkGlyphToLucideKind"/>
     <c:LinkGlyphToVisibilityConverter x:Key="LinkGlyphToVis"/>
     <c:FontSizeTimesConverter x:Key="FontSizeTimes"/>
+    <c:EmptyStringFallbackConverter x:Key="EmptyStringFallback"/>
 </ResourceDictionary>

--- a/src/Palantir.Module/PalantirModule.cs
+++ b/src/Palantir.Module/PalantirModule.cs
@@ -21,6 +21,12 @@ public sealed class PalantirModule : IMithrilModule
 
     public void Register(IServiceCollection services)
     {
+        services.AddSingleton<Arda.Wpf.IUiEventSubscriber>(sp => new Arda.Wpf.WpfUiEventSubscriber(
+            sp.GetRequiredService<Arda.Contracts.IDomainEventSubscriber>(),
+            System.Windows.Application.Current.Dispatcher,
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Arda.Wpf.WpfUiEventSubscriber>>()));
+        services.AddSingleton<Arda.Wpf.WpfMapPinPresenter>();
+
         services.AddSingleton<LiveInventoryViewModel>();
         services.AddSingleton<WorldStateViewModel>();
         services.AddSingleton<WorldHealthViewModel>();

--- a/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
+++ b/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
@@ -1,8 +1,8 @@
-using System.Collections.ObjectModel;
 using System.Globalization;
 using Arda.Contracts;
 using Arda.World.Player;
 using Arda.World.Player.Events;
+using Arda.Wpf;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Reference;
@@ -14,10 +14,13 @@ namespace Palantir.ViewModels;
 /// celestial (moon phase), and weather. State is read from Arda state
 /// interfaces (<see cref="IPositionState"/>, <see cref="IAreaState"/>, etc.)
 /// and kept current via domain event subscriptions through
-/// <see cref="IDomainEventSubscriber"/>.
+/// <see cref="IUiEventSubscriber"/> — every handler runs on the WPF
+/// Dispatcher thread inside a SafeInvoke try/catch, so a misbehaving
+/// handler cannot crash the process via an unobserved-task finalizer
+/// rethrow.
 ///
-/// <para>All event handlers fire on the Arda dispatch thread, so every handler
-/// marshals through <see cref="_dispatch"/> before touching bound state.</para>
+/// <para>Pin rendering is delegated to <see cref="WpfMapPinPresenter"/>;
+/// the VM only carries the count + observed-at timestamp for display.</para>
 /// </summary>
 public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
 {
@@ -27,7 +30,7 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     private readonly ICelestialState _celestial;
     private readonly IWeatherState _weather;
     private readonly IReferenceDataService? _refData;
-    private readonly Action<Action> _dispatch;
+    private readonly WpfMapPinPresenter _pinPresenter;
 
     private IDisposable? _positionSub;
     private IDisposable? _areaSub;
@@ -35,6 +38,7 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     private IDisposable? _pinRemovedSub;
     private IDisposable? _celestialSub;
     private IDisposable? _weatherSub;
+    private readonly System.Collections.Specialized.NotifyCollectionChangedEventHandler _pinsChangedHandler;
 
     [ObservableProperty] private string _areaKey = "(unknown)";
     [ObservableProperty] private string _areaFriendlyName = "(area not yet known)";
@@ -46,8 +50,6 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     [ObservableProperty] private string _measuredAtText = "—";
     [ObservableProperty] private string _positionSourceText = "—";
 
-    [ObservableProperty] private int _pinCount;
-    [ObservableProperty] private bool _hasPins;
     [ObservableProperty] private string _pinsObservedAtText = "—";
 
     [ObservableProperty] private bool _hasMoonPhase;
@@ -59,9 +61,12 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     [ObservableProperty] private string _weatherConditionText = "(weather unknown for this map)";
     [ObservableProperty] private string _weatherObservedAtText = "—";
 
-    /// <summary>The current area's pins as presentation rows. Mutated only
-    /// on the dispatched (UI) thread.</summary>
-    public ObservableCollection<MapPinRow> Pins { get; } = [];
+    /// <summary>The presenter's UI-thread <see cref="WpfMapPinPresenter.Pins"/>.
+    /// XAML binds directly; the VM no longer rebuilds a parallel collection.</summary>
+    public System.Collections.ObjectModel.ObservableCollection<MapPinEntry> Pins => _pinPresenter.Pins;
+
+    public int PinCount => Pins.Count;
+    public bool HasPins => Pins.Count > 0;
 
     public WorldStateViewModel(
         IPositionState position,
@@ -69,24 +74,9 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         IMapPinState pins,
         ICelestialState celestial,
         IWeatherState weather,
-        IDomainEventSubscriber bus,
+        IUiEventSubscriber bus,
+        WpfMapPinPresenter pinPresenter,
         IReferenceDataService? refData = null)
-        : this(position, area, pins, celestial, weather, bus, refData, dispatch: null)
-    { }
-
-    /// <summary>
-    /// Test-friendly ctor: inject a synchronous dispatcher so unit tests
-    /// don't need an STA Application running.
-    /// </summary>
-    public WorldStateViewModel(
-        IPositionState position,
-        IAreaState area,
-        IMapPinState pins,
-        ICelestialState celestial,
-        IWeatherState weather,
-        IDomainEventSubscriber bus,
-        IReferenceDataService? refData,
-        Action<Action>? dispatch)
     {
         _position = position;
         _area = area;
@@ -94,7 +84,7 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         _celestial = celestial;
         _weather = weather;
         _refData = refData;
-        _dispatch = dispatch ?? DefaultDispatch;
+        _pinPresenter = pinPresenter;
 
         SeedFromState();
 
@@ -104,12 +94,19 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         _pinRemovedSub = bus.Subscribe<MapPinRemoved>(OnPinRemoved);
         _celestialSub = bus.Subscribe<CelestialInfoChanged>(OnCelestial);
         _weatherSub = bus.Subscribe<WeatherChanged>(OnWeather);
+
+        // Pin count/HasPins shadow the presenter's collection; flip change
+        // notification when its size changes. Handler stored in a field so
+        // Dispose can unsubscribe — the presenter is a singleton, so leaving
+        // the inline lambda subscribed would pin the VM in memory.
+        _pinsChangedHandler = (_, _) =>
+        {
+            OnPropertyChanged(nameof(PinCount));
+            OnPropertyChanged(nameof(HasPins));
+        };
+        _pinPresenter.Pins.CollectionChanged += _pinsChangedHandler;
     }
 
-    /// <summary>
-    /// Reads current state from the Arda state interfaces to seed the UI
-    /// (replay may already have run before the VM is constructed).
-    /// </summary>
     private void SeedFromState()
     {
         RefreshArea();
@@ -119,8 +116,6 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
             HasPosition = true;
             PositionText = FormatPosition(_position.X.Value, _position.Y ?? 0, _position.Z ?? 0);
         }
-
-        RefreshPins();
 
         if (_celestial.Phase != MoonPhase.Unknown || _celestial.CurrentPhaseRaw is not null)
         {
@@ -139,7 +134,7 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         }
     }
 
-    private void OnPosition(PlayerPositionChanged e) => _dispatch(() =>
+    private void OnPosition(PlayerPositionChanged e)
     {
         HasPosition = true;
         PositionText = FormatPosition(e.X, e.Y, e.Z);
@@ -151,23 +146,15 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
             _ => e.Source.ToString(),
         };
         RefreshArea();
-    });
+    }
 
-    private void OnAreaChanged(AreaChanged e) => _dispatch(RefreshArea);
+    private void OnAreaChanged(AreaChanged e) => RefreshArea();
 
-    private void OnPinAdded(MapPinAdded e) => _dispatch(() =>
-    {
-        PinsObservedAtText = FormatTimestamp(e.Metadata.Timestamp);
-        RefreshPins();
-    });
+    private void OnPinAdded(MapPinAdded e) => PinsObservedAtText = FormatTimestamp(e.Metadata.Timestamp);
 
-    private void OnPinRemoved(MapPinRemoved e) => _dispatch(() =>
-    {
-        PinsObservedAtText = FormatTimestamp(e.Metadata.Timestamp);
-        RefreshPins();
-    });
+    private void OnPinRemoved(MapPinRemoved e) => PinsObservedAtText = FormatTimestamp(e.Metadata.Timestamp);
 
-    private void OnCelestial(CelestialInfoChanged e) => _dispatch(() =>
+    private void OnCelestial(CelestialInfoChanged e)
     {
         HasMoonPhase = true;
         MoonPhaseText = e.DisplayName;
@@ -175,21 +162,17 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
             ? $"{e.RawPhase} (unrecognised token)"
             : e.RawPhase;
         MoonMeasuredAtText = FormatTimestamp(e.Metadata.Timestamp);
-    });
+    }
 
-    private void OnWeather(WeatherChanged e) => _dispatch(() =>
+    private void OnWeather(WeatherChanged e)
     {
         HasWeather = e.Current is not null;
         WeatherConditionText = e.Current ?? "(weather unknown for this map)";
         WeatherObservedAtText = FormatTimestamp(e.Metadata.Timestamp);
-    });
+    }
 
     [RelayCommand]
-    private void Refresh() => _dispatch(() =>
-    {
-        RefreshArea();
-        RefreshPins();
-    });
+    private void Refresh() => RefreshArea();
 
     private void RefreshArea()
     {
@@ -220,33 +203,15 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         }
     }
 
-    /// <summary>
-    /// Rebuilds the pin list from <see cref="IMapPinState.Pins"/>. The set is
-    /// tiny (a handful per area), so clear-and-refill is simpler than diffing.
-    /// </summary>
-    private void RefreshPins()
-    {
-        Pins.Clear();
-        foreach (var pin in _pinState.Pins)
-            Pins.Add(MapPinRow.From(pin));
-        PinCount = Pins.Count;
-        HasPins = Pins.Count > 0;
-    }
-
     public void Dispose()
     {
-        _positionSub?.Dispose();
-        _positionSub = null;
-        _areaSub?.Dispose();
-        _areaSub = null;
-        _pinAddedSub?.Dispose();
-        _pinAddedSub = null;
-        _pinRemovedSub?.Dispose();
-        _pinRemovedSub = null;
-        _celestialSub?.Dispose();
-        _celestialSub = null;
-        _weatherSub?.Dispose();
-        _weatherSub = null;
+        _pinPresenter.Pins.CollectionChanged -= _pinsChangedHandler;
+        _positionSub?.Dispose(); _positionSub = null;
+        _areaSub?.Dispose(); _areaSub = null;
+        _pinAddedSub?.Dispose(); _pinAddedSub = null;
+        _pinRemovedSub?.Dispose(); _pinRemovedSub = null;
+        _celestialSub?.Dispose(); _celestialSub = null;
+        _weatherSub?.Dispose(); _weatherSub = null;
     }
 
     private static string FormatPosition(double x, double y, double z) =>
@@ -254,40 +219,4 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
 
     private static string FormatTimestamp(DateTimeOffset? ts) =>
         ts?.UtcDateTime.ToString("u", CultureInfo.InvariantCulture) ?? "—";
-
-    private static void DefaultDispatch(Action action)
-    {
-        var d = System.Windows.Application.Current?.Dispatcher;
-        if (d is null || d.CheckAccess()) action();
-        else d.InvokeAsync(action);
-    }
-}
-
-/// <summary>
-/// Presentation-only projection of a <see cref="MapPinEntry"/> for the World
-/// State debug list — formatting lives here, not in the XAML.
-/// </summary>
-/// <param name="Label">The pin label.</param>
-/// <param name="Appearance">Friendly shape+color description (e.g. "red dot").</param>
-/// <param name="Coords">Signed engine-unit ground-plane coordinate.</param>
-/// <param name="Detail">Raw shape/color values — debug-surface extra.</param>
-public sealed record MapPinRow(string Label, string Appearance, string Coords, string Detail)
-{
-    public static MapPinRow From(MapPinEntry p) => new(
-        string.IsNullOrEmpty(p.Label) ? "Unnamed pin" : p.Label,
-        FormatAppearance(p.Shape, p.Color),
-        string.Format(CultureInfo.InvariantCulture, "X {0:0.00}   Z {1:0.00}", p.X, p.Z),
-        $"Color {p.Color} · Shape {p.Shape}");
-
-    private static string FormatAppearance(int shape, int color)
-    {
-        var c = color switch
-        {
-            0 => "white", 1 => "red", 2 => "orange", 3 => "yellow",
-            4 => "green", 5 => "cyan", 6 => "blue", 7 => "purple",
-            8 => "pink", 9 => "black", _ => ""
-        };
-        var s = shape switch { 0 => "dot", 1 => "square", _ => "pin" };
-        return string.IsNullOrEmpty(c) ? s : $"{c} {s}";
-    }
 }

--- a/src/Palantir.Module/Views/WorldStateView.xaml
+++ b/src/Palantir.Module/Views/WorldStateView.xaml
@@ -143,32 +143,22 @@
                                   Visibility="{Binding HasPins, Converter={StaticResource BoolToVis}}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Background="#FF2E2E2E" CornerRadius="3"
-                                        Padding="10,7" Margin="0,0,0,5">
-                                    <StackPanel>
-                                        <DockPanel>
-                                            <TextBlock HorizontalAlignment="Right"
-                                                       Text="{Binding Appearance}"
-                                                       Foreground="#CCFFFFFF"
-                                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                                       VerticalAlignment="Center"/>
-                                            <TextBlock Text="{Binding Label}"
-                                                       Foreground="#FFFFFFFF"
-                                                       FontWeight="SemiBold"
-                                                       TextTrimming="CharacterEllipsis"/>
-                                        </DockPanel>
-                                        <DockPanel Margin="0,3,0,0">
-                                            <TextBlock HorizontalAlignment="Right"
-                                                       Text="{Binding Detail}"
-                                                       Foreground="#66FFFFFF"
-                                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                                       VerticalAlignment="Center"/>
-                                            <TextBlock Text="{Binding Coords}"
-                                                       FontFamily="{DynamicResource AppMonoFontFamily}"
-                                                       Foreground="#88FFFFFF"/>
-                                        </DockPanel>
-                                    </StackPanel>
-                                </Border>
+                                <StackPanel Orientation="Horizontal" Margin="0,2">
+                                    <TextBlock Text="{Binding Label, FallbackValue='Unnamed pin', TargetNullValue='Unnamed pin'}"
+                                               FontWeight="SemiBold" Margin="0,0,8,0"/>
+                                    <TextBlock>
+                                        <Run Text="X "/>
+                                        <Run Text="{Binding X, StringFormat={}{0:0.00}, Mode=OneWay}"/>
+                                        <Run Text="   Z "/>
+                                        <Run Text="{Binding Z, StringFormat={}{0:0.00}, Mode=OneWay}"/>
+                                    </TextBlock>
+                                    <TextBlock Margin="8,0,0,0" Opacity="0.6">
+                                        <Run Text="Color "/>
+                                        <Run Text="{Binding Color, Mode=OneWay}"/>
+                                        <Run Text=" · Shape "/>
+                                        <Run Text="{Binding Shape, Mode=OneWay}"/>
+                                    </TextBlock>
+                                </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Palantir.Module/Views/WorldStateView.xaml
+++ b/src/Palantir.Module/Views/WorldStateView.xaml
@@ -144,7 +144,7 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="0,2">
-                                    <TextBlock Text="{Binding Label, FallbackValue='Unnamed pin', TargetNullValue='Unnamed pin'}"
+                                    <TextBlock Text="{Binding Label, Converter={StaticResource EmptyStringFallback}, ConverterParameter='Unnamed pin'}"
                                                FontWeight="SemiBold" Margin="0,0,8,0"/>
                                     <TextBlock>
                                         <Run Text="X "/>

--- a/tests/Arda.Wpf.Tests/UiEventSubscriberTests.cs
+++ b/tests/Arda.Wpf.Tests/UiEventSubscriberTests.cs
@@ -1,0 +1,125 @@
+using Arda.Contracts;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Arda.Wpf.Tests;
+
+public sealed class UiEventSubscriberTests
+{
+    [Fact]
+    public void SafeInvoke_HandlerSucceeds_RunsAndDoesNotLog()
+    {
+        var logger = new RecordingLogger();
+        var ran = false;
+
+        UiEventSubscriber.SafeInvoke<TestEvent>(_ => ran = true, new TestEvent(42), logger);
+
+        ran.Should().BeTrue();
+        logger.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SafeInvoke_HandlerThrows_LogsError_DoesNotPropagate()
+    {
+        var logger = new RecordingLogger();
+        Exception? thrown = null;
+
+        try
+        {
+            UiEventSubscriber.SafeInvoke<TestEvent>(
+                _ => throw new InvalidOperationException("boom"),
+                new TestEvent(1),
+                logger);
+        }
+        catch (Exception ex) { thrown = ex; }
+
+        thrown.Should().BeNull("SafeInvoke must swallow handler exceptions to keep them off the finalizer thread");
+        logger.Errors.Should().ContainSingle()
+            .Which.Exception.Should().BeOfType<InvalidOperationException>()
+            .Which.Message.Should().Be("boom");
+    }
+
+    [Fact]
+    public void SyncUiEventSubscriber_DeliversEvents_OnPublishingThread()
+    {
+        var bus = new TestBus();
+        var sub = new SyncUiEventSubscriber(bus);
+        var seen = new List<TestEvent>();
+
+        using var _ = sub.Subscribe<TestEvent>(seen.Add);
+        bus.Publish(new TestEvent(7));
+        bus.Publish(new TestEvent(8));
+
+        seen.Should().HaveCount(2);
+        seen[0].Value.Should().Be(7);
+        seen[1].Value.Should().Be(8);
+    }
+
+    [Fact]
+    public void SyncUiEventSubscriber_Dispose_StopsDelivery()
+    {
+        var bus = new TestBus();
+        var sub = new SyncUiEventSubscriber(bus);
+        var seen = new List<TestEvent>();
+        var token = sub.Subscribe<TestEvent>(seen.Add);
+
+        bus.Publish(new TestEvent(1));
+        token.Dispose();
+        bus.Publish(new TestEvent(2));
+
+        seen.Should().ContainSingle().Which.Value.Should().Be(1);
+    }
+
+    private readonly record struct TestEvent(int Value);
+
+    private sealed class TestBus : IDomainEventPublisher, IDomainEventSubscriber
+    {
+        private readonly Dictionary<Type, List<Delegate>> _handlers = new();
+
+        public void Publish<T>(T evt) where T : struct
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list)) return;
+            foreach (var d in list.ToArray()) ((Action<T>)d).Invoke(evt);
+        }
+
+        public IDisposable Subscribe<T>(Action<T> handler) where T : struct
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list))
+                _handlers[typeof(T)] = list = new();
+            list.Add(handler);
+            return new Sub(() => list.Remove(handler));
+        }
+
+        private sealed class Sub(Action onDispose) : IDisposable
+        {
+            private Action? _onDispose = onDispose;
+            public void Dispose()
+            {
+                _onDispose?.Invoke();
+                _onDispose = null;
+            }
+        }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, Exception? Exception, string Message)> Errors { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+                Errors.Add((logLevel, exception, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/Arda.Wpf.Tests/WpfMapPinPresenterTests.cs
+++ b/tests/Arda.Wpf.Tests/WpfMapPinPresenterTests.cs
@@ -1,0 +1,152 @@
+using Arda.Abstractions.Logs;
+using Arda.Contracts;
+using Arda.World.Player;
+using Arda.World.Player.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Arda.Wpf.Tests;
+
+public sealed class WpfMapPinPresenterTests
+{
+    private static readonly DateTimeOffset T =
+        new(2026, 5, 18, 10, 45, 47, TimeSpan.Zero);
+
+    private static LogLineMetadata Meta() => new(T, T, IsReplay: false);
+
+    [Fact]
+    public void Seeds_FromInitialPinState_OnConstruction()
+    {
+        var state = new FakePinState(
+            new MapPinEntry(100, 200, "alpha", Shape: 0, Color: 1),
+            new MapPinEntry(300, 400, "beta", Shape: 1, Color: 4));
+        var bus = new TestBus();
+
+        using var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        presenter.Pins.Should().HaveCount(2);
+        presenter.Pins.Select(p => p.Label).Should().BeEquivalentTo("alpha", "beta");
+    }
+
+    [Fact]
+    public void MapPinAdded_NewCoord_AppendsRow()
+    {
+        var state = new FakePinState();
+        var bus = new TestBus();
+        using var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        bus.Publish(new MapPinAdded(150, 250, "gamma", Shape: 0, Color: 2, Meta()));
+
+        presenter.Pins.Should().ContainSingle()
+            .Which.Label.Should().Be("gamma");
+    }
+
+    [Fact]
+    public void MapPinAdded_ExistingCoord_ReplacesInPlace()
+    {
+        var state = new FakePinState();
+        var bus = new TestBus();
+        using var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        bus.Publish(new MapPinAdded(150, 250, "old-label", Shape: 0, Color: 2, Meta()));
+        bus.Publish(new MapPinAdded(150.001, 250.001, "new-label", Shape: 0, Color: 3, Meta()));
+        // 150.001 / 250.001 are within MapPins' 0.01 coord tolerance — same key.
+
+        presenter.Pins.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new
+            {
+                Label = "new-label",
+                Color = 3,
+            });
+    }
+
+    [Fact]
+    public void MapPinRemoved_KnownCoord_DropsRow()
+    {
+        var state = new FakePinState();
+        var bus = new TestBus();
+        using var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        bus.Publish(new MapPinAdded(150, 250, "gamma", 0, 2, Meta()));
+        bus.Publish(new MapPinRemoved(150, 250, "gamma", Meta()));
+
+        presenter.Pins.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MapPinRemoved_UnknownCoord_IsNoOp()
+    {
+        var state = new FakePinState();
+        var bus = new TestBus();
+        using var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        bus.Publish(new MapPinAdded(150, 250, "gamma", 0, 2, Meta()));
+        bus.Publish(new MapPinRemoved(999, 999, "ghost", Meta()));
+
+        presenter.Pins.Should().ContainSingle()
+            .Which.Label.Should().Be("gamma");
+    }
+
+    [Fact]
+    public void AreaChanged_ClearsAllPins()
+    {
+        var state = new FakePinState();
+        var bus = new TestBus();
+        using var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        bus.Publish(new MapPinAdded(150, 250, "a", 0, 2, Meta()));
+        bus.Publish(new MapPinAdded(350, 450, "b", 1, 4, Meta()));
+        bus.Publish(new AreaChanged(PreviousArea: "AreaSerbule", CurrentArea: "AreaKur", Metadata: Meta()));
+
+        presenter.Pins.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesAndStopsDeliveringEvents()
+    {
+        var state = new FakePinState();
+        var bus = new TestBus();
+        var presenter = new WpfMapPinPresenter(state, new SyncUiEventSubscriber(bus));
+
+        bus.Publish(new MapPinAdded(150, 250, "before-dispose", 0, 2, Meta()));
+        presenter.Pins.Should().ContainSingle();
+
+        presenter.Dispose();
+        bus.Publish(new MapPinAdded(350, 450, "after-dispose", 1, 4, Meta()));
+
+        presenter.Pins.Should().ContainSingle()
+            .Which.Label.Should().Be("before-dispose");
+    }
+
+    private sealed class FakePinState : IMapPinState
+    {
+        private readonly List<MapPinEntry> _pins;
+        public FakePinState(params MapPinEntry[] seed) => _pins = new(seed);
+        public IReadOnlyList<MapPinEntry> Pins => _pins.ToArray();
+    }
+
+    private sealed class TestBus : IDomainEventPublisher, IDomainEventSubscriber
+    {
+        private readonly Dictionary<Type, List<Delegate>> _handlers = new();
+
+        public void Publish<T>(T evt) where T : struct
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list)) return;
+            foreach (var d in list.ToArray()) ((Action<T>)d).Invoke(evt);
+        }
+
+        public IDisposable Subscribe<T>(Action<T> handler) where T : struct
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list))
+                _handlers[typeof(T)] = list = new();
+            list.Add(handler);
+            return new Sub(() => list.Remove(handler));
+        }
+
+        private sealed class Sub(Action onDispose) : IDisposable
+        {
+            private Action? _onDispose = onDispose;
+            public void Dispose() { _onDispose?.Invoke(); _onDispose = null; }
+        }
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/EmptyStringFallbackConverterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/EmptyStringFallbackConverterTests.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Coverage for <see cref="EmptyStringFallbackConverter"/> — the display-layer fix for
+/// the Palantir unlabeled-pin regression introduced when PR-B removed the
+/// <c>MapPinRow.From</c> projection that previously substituted "Unnamed pin" for
+/// empty/null labels. WPF's <c>TargetNullValue</c> fires only for null, not for
+/// empty string, so a converter is needed to cover all three cases.
+/// </summary>
+public sealed class EmptyStringFallbackConverterTests
+{
+    private static readonly EmptyStringFallbackConverter Sut = new();
+
+    private static object? Convert(object? value, object? parameter)
+        => Sut.Convert(value, typeof(string), parameter, CultureInfo.InvariantCulture);
+
+    [Fact]
+    public void Convert_NullInput_ReturnsParameter()
+    {
+        Convert(null, "Unnamed pin").Should().Be("Unnamed pin");
+    }
+
+    [Fact]
+    public void Convert_EmptyInput_ReturnsParameter()
+    {
+        Convert("", "Unnamed pin").Should().Be("Unnamed pin");
+    }
+
+    [Fact]
+    public void Convert_WhitespaceInput_ReturnsParameter()
+    {
+        Convert("   ", "Unnamed pin").Should().Be("Unnamed pin");
+    }
+
+    [Fact]
+    public void Convert_NonEmptyInput_ReturnsInputUnchanged()
+    {
+        Convert("Tomb portal", "Unnamed pin").Should().Be("Tomb portal");
+    }
+
+    [Fact]
+    public void Convert_NullParameter_ReturnsEmptyString()
+    {
+        Convert("", null).Should().Be("");
+    }
+
+    [Fact]
+    public void ConvertBack_IsNotSupported()
+    {
+        var act = () => Sut.ConvertBack("anything", typeof(string), null, CultureInfo.InvariantCulture);
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Palantir.Tests/WorldStateViewModelTests.cs
+++ b/tests/Palantir.Tests/WorldStateViewModelTests.cs
@@ -173,7 +173,7 @@ public sealed class WorldStateViewModelTests
     }
 
     [Fact]
-    public void Dispose_stops_observing_pins()
+    public void Dispose_stops_updating_PinsObservedAtText()
     {
         var pins = new FakeMapPinState();
         using var vm = NewVm(out var bus, pins: pins);

--- a/tests/Palantir.Tests/WorldStateViewModelTests.cs
+++ b/tests/Palantir.Tests/WorldStateViewModelTests.cs
@@ -133,14 +133,14 @@ public sealed class WorldStateViewModelTests
         var pins = new FakeMapPinState();
         using var vm = NewVm(out var bus, pins: pins);
 
-        pins.Set([new MapPinEntry(123.4, -567.8, "Camp", 2, 3)]);
         bus.Fire(new MapPinAdded(123.4, -567.8, "Camp", 2, 3, Meta()));
 
         vm.HasPins.Should().BeTrue();
         vm.PinCount.Should().Be(1);
         var row = vm.Pins.Single();
         row.Label.Should().Be("Camp");
-        row.Coords.Should().Be("X 123.40   Z -567.80");
+        row.X.Should().BeApproximately(123.4, 0.001);
+        row.Z.Should().BeApproximately(-567.8, 0.001);
         vm.PinsObservedAtText.Should().Be("2026-05-18 10:45:47Z");
     }
 
@@ -151,7 +151,6 @@ public sealed class WorldStateViewModelTests
         var pins = new FakeMapPinState([new MapPinEntry(1, 1, "A", 0, 0), b]);
         using var vm = NewVm(out var bus, pins: pins);
 
-        pins.Set([b]);
         bus.Fire(new MapPinRemoved(1, 1, "A", Meta()));
 
         vm.Pins.Select(r => r.Label).Should().ContainSingle().Which.Should().Be("B");
@@ -163,12 +162,14 @@ public sealed class WorldStateViewModelTests
         var pins = new FakeMapPinState();
         using var vm = NewVm(out var bus, pins: pins);
 
-        pins.Set([new MapPinEntry(-3.14, 0, "", 0, 0)]);
         bus.Fire(new MapPinAdded(-3.14, 0, "", 0, 0, Meta()));
 
         var row = vm.Pins.Single();
-        row.Label.Should().Be("Unnamed pin");
-        row.Coords.Should().Be("X -3.14   Z 0.00");
+        // The "Unnamed pin" display fallback lives in the XAML DataTemplate
+        // (FallbackValue/TargetNullValue); the MapPinEntry stores the raw label.
+        row.Label.Should().Be("");
+        row.X.Should().BeApproximately(-3.14, 0.001);
+        row.Z.Should().BeApproximately(0, 0.001);
     }
 
     [Fact]
@@ -178,10 +179,14 @@ public sealed class WorldStateViewModelTests
         using var vm = NewVm(out var bus, pins: pins);
         vm.Dispose();
 
-        pins.Set([new MapPinEntry(9, 9, "Late", 0, 0)]);
         bus.Fire(new MapPinAdded(9, 9, "Late", 0, 0, Meta()));
 
-        vm.HasPins.Should().BeFalse("the disposed VM must unsubscribe from pins");
+        // After dispose, the VM's own pin-timestamp subscription must be silent.
+        // (The presenter is a separate singleton in production — not co-disposed
+        // with the VM — so vm.Pins / HasPins reflect the presenter's state; the
+        // VM's own observable, PinsObservedAtText, must stay at its default.)
+        vm.PinsObservedAtText.Should().Be("—",
+            "the disposed VM must unsubscribe its own OnPinAdded handler");
     }
 
     // --- Moon phase ---------------------------------------------------------
@@ -285,53 +290,56 @@ public sealed class WorldStateViewModelTests
 
     private static WorldStateViewModel NewVm(
         out FakeBus bus,
-        FakePositionState? position = null,
-        FakeAreaState? area = null,
-        FakeMapPinState? pins = null,
-        FakeCelestialState? celestial = null,
-        FakeWeatherState? weather = null,
+        IPositionState? position = null,
+        IAreaState? area = null,
+        IMapPinState? pins = null,
+        ICelestialState? celestial = null,
+        IWeatherState? weather = null,
         IReferenceDataService? refData = null)
     {
         bus = new FakeBus();
+        var pinState = pins ?? new FakeMapPinState();
+        var subscriber = new Arda.Wpf.SyncUiEventSubscriber(bus);
+        var presenter = new Arda.Wpf.WpfMapPinPresenter(pinState, subscriber);
+
         return new WorldStateViewModel(
             position ?? new FakePositionState(),
             area ?? new FakeAreaState(),
-            pins ?? new FakeMapPinState(),
+            pinState,
             celestial ?? new FakeCelestialState(),
             weather ?? new FakeWeatherState(),
-            bus,
-            refData,
-            dispatch: a => a());
+            subscriber,
+            presenter,
+            refData);
     }
 
     // --- Fakes --------------------------------------------------------------
 
-    internal sealed class FakeBus : IDomainEventSubscriber
+    internal sealed class FakeBus : IDomainEventPublisher, IDomainEventSubscriber
     {
         private readonly Dictionary<Type, List<Delegate>> _handlers = new();
 
+        public void Publish<T>(T evt) where T : struct
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list)) return;
+            foreach (var d in list.ToArray()) ((Action<T>)d).Invoke(evt);
+        }
+
         public IDisposable Subscribe<T>(Action<T> handler) where T : struct
         {
-            var type = typeof(T);
-            if (!_handlers.TryGetValue(type, out var list))
-            {
-                list = [];
-                _handlers[type] = list;
-            }
+            if (!_handlers.TryGetValue(typeof(T), out var list))
+                _handlers[typeof(T)] = list = new();
             list.Add(handler);
             return new Sub(() => list.Remove(handler));
         }
 
-        public void Fire<T>(T evt) where T : struct
-        {
-            if (_handlers.TryGetValue(typeof(T), out var list))
-                foreach (var h in list.ToArray())
-                    ((Action<T>)h)(evt);
-        }
+        /// <summary>Fire an event synchronously — test helper alias for Publish.</summary>
+        public void Fire<T>(T evt) where T : struct => Publish(evt);
 
         private sealed class Sub(Action onDispose) : IDisposable
         {
-            public void Dispose() => onDispose();
+            private Action? _onDispose = onDispose;
+            public void Dispose() { _onDispose?.Invoke(); _onDispose = null; }
         }
     }
 


### PR DESCRIPTION
Post-merge status flip; trivial docs-only change. PR-A (#1012) and PR-B (#1014) both merged; flipping the INDEX row's status from `active` to `shipped` and linking both Issue-A (#1011) and Issue-B (#1013).