### PR TITLE
docs(planning): flip arda-state-snapshot-and-ui-dispatch to shipped

### DIFF
--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -29,7 +29,7 @@ When you create a new slug folder, append a row to the table below: `slug | stat
 
 | Slug | Status | Issue/PR | Description |
 |------|--------|----------|-------------|
-| [arda-state-snapshot-and-ui-dispatch](arda-state-snapshot-and-ui-dispatch/) | active | [#1011](https://github.com/moumantai-gg/mithril/issues/1011) | Fix Palantir pin-enum crash; `MapPins.Pins` snapshot + new `Arda.Wpf` `IUiEventSubscriber` + `WpfMapPinPresenter` |
+| [arda-state-snapshot-and-ui-dispatch](arda-state-snapshot-and-ui-dispatch/) | shipped | [#1011](https://github.com/moumantai-gg/mithril/issues/1011) · [#1013](https://github.com/moumantai-gg/mithril/issues/1013) | Fix Palantir pin-enum crash; `MapPins.Pins` snapshot + new `Arda.Wpf` `IUiEventSubscriber` + `WpfMapPinPresenter` |
 | [gandalf-164-in-game-clock-alarm](gandalf-164-in-game-clock-alarm/) | shipped | [#164](https://github.com/moumantai-gg/mithril/issues/164) | Gandalf: fire timers at PG in-game time-of-day |
 | [legolas-wizard](legolas-wizard/) | shipped | [#111](https://github.com/moumantai-gg/mithril/issues/111) · [#112](https://github.com/moumantai-gg/mithril/issues/112) · [#113](https://github.com/moumantai-gg/mithril/issues/113) | Legolas wizard view + dashboard rework + Motherlode wizard depth |
 | [quest-discovery-module](quest-discovery-module/) | deferred | _no issue_ | Quest browser / eligibility surface (separate from Gandalf) |


### PR DESCRIPTION
Post-merge status flip; trivial docs-only change. PR-A (#1012) and PR-B (#1014) both merged; flipping the INDEX row's status from `active` to `shipped` and linking both Issue-A (#1011) and Issue-B (#1013).