### PR TITLE
docs(claude.md): note manual regression label in issue workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Project knowledge is split across four tiers. Route new content by what it is:
 
 | If you're writing… | Put it… |
 |---|---|
-| A pending unit of work (bug, feature, chore) | A GitHub Issue. Use the bug/feature template; the dropdowns auto-apply `module:*` and `area:*` labels. The issue body can be a brief description that refers to the relevant spec/plan in `docs/planning/<slug>/`. |
+| A pending unit of work (bug, feature, chore) | A GitHub Issue. Use the bug/feature template; the dropdowns auto-apply `module:*` and `area:*` labels. For behavior that was working and broke as a consequence of a known change, also add the `regression` label (the template doesn't surface it yet — apply manually). The issue body can be a brief description that refers to the relevant spec/plan in `docs/planning/<slug>/`. |
 | Roadmap / prioritisation state | `docs/roadmaps/` in this repo (one file per module/area). The [**Mithril Roadmap** Project](https://github.com/orgs/moumantai-gg/projects/1) (org-level, replaced the legacy user-level board 2026-05-21) is still the queryable board; custom fields: `Status`, `Priority`, `Module`. Don't add inline checklists to roadmap docs — the doc holds *why*, the issue holds *what*. |
 | Stable reference, process, how-to, user guide | The [wiki](https://github.com/moumantai-gg/mithril/wiki). Stable content; doesn't co-evolve with code. |
 | Design rationale that co-evolves with code | `docs/` in this repo. Architecture decisions, design notebooks, cross-cutting concerns. |


### PR DESCRIPTION
## Summary

- Notes in CLAUDE.md's "Where does new content go?" table that the `regression` label exists but isn't surfaced by the bug template yet, so it needs manual application at file time.

Filed alongside [#1024](https://github.com/moumantai-gg/mithril/issues/1024) which tracks the template refresh itself. Once that lands, this CLAUDE.md note can be slimmed down to "the template surfaces it" instead of "apply manually."

Context: [#1022](https://github.com/moumantai-gg/mithril/issues/1022) was the first issue to want this label — a synthesis-J Shadow-mode perf regression introduced by #999. While I was applying labels by hand, the gap in the template became obvious.

## Test plan

- [x] Doc-only change; no code, no tests
- [x] CLAUDE.md renders correctly in GitHub's markdown preview