### PR TITLE
chore(github): refresh issue-template area dropdowns + regression/perf flags (#1024)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -35,7 +35,7 @@ body:
     id: module
     attributes:
       label: Module
-      description: Which module is affected? Adds the matching `module:*` label.
+      description: Which module is affected? After create, apply the matching `module:*` label manually (no auto-applier wired yet — see #1024).
       options:
         - shell
         - samwise
@@ -60,16 +60,30 @@ body:
     id: area
     attributes:
       label: Area
-      description: Which cross-cutting area, if any?
+      description: Which cross-cutting area, if any? After create, apply the matching `area:*` label manually.
       options:
         - none
-        - parser
-        - ui
+        - arda
         - ci
         - docs
+        - gamestate-services
+        - map-calibration
+        - parser
+        - performance
+        - telemetry
         - test
+        - ui
     validations:
       required: false
+
+  - type: checkboxes
+    id: flags
+    attributes:
+      label: Flags
+      description: Tick any that apply. After create, apply the corresponding labels manually (`regression`, `area:performance`).
+      options:
+        - label: Regression — previously-working behavior broke from a known change
+        - label: Performance issue — slowness, stalls, regressions in wall-clock or resource use
 
   - type: textarea
     id: context

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -34,7 +34,7 @@ body:
     id: module
     attributes:
       label: Module
-      description: Which module owns this work? Adds the matching `module:*` label.
+      description: Which module owns this work? After create, apply the matching `module:*` label manually (no auto-applier wired yet — see #1024).
       options:
         - shell
         - samwise
@@ -59,14 +59,19 @@ body:
     id: area
     attributes:
       label: Area
-      description: Which cross-cutting area, if any?
+      description: Which cross-cutting area, if any? After create, apply the matching `area:*` label manually.
       options:
         - none
-        - parser
-        - ui
+        - arda
         - ci
         - docs
+        - gamestate-services
+        - map-calibration
+        - parser
+        - performance
+        - telemetry
         - test
+        - ui
     validations:
       required: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Project knowledge is split across four tiers. Route new content by what it is:
 
 | If you're writing… | Put it… |
 |---|---|
-| A pending unit of work (bug, feature, chore) | A GitHub Issue. Use the bug/feature template; the dropdowns auto-apply `module:*` and `area:*` labels. For behavior that was working and broke as a consequence of a known change, also add the `regression` label (the template doesn't surface it yet — apply manually). The issue body can be a brief description that refers to the relevant spec/plan in `docs/planning/<slug>/`. |
+| A pending unit of work (bug, feature, chore) | A GitHub Issue. Use the bug/feature template. The module + area dropdowns and the regression / performance checkboxes are guides — apply the matching `module:*` / `area:*` / `regression` labels manually after create (no auto-applier workflow exists yet — see #1024). The issue body can be a brief description that refers to the relevant spec/plan in `docs/planning/<slug>/`. |
 | Roadmap / prioritisation state | `docs/roadmaps/` in this repo (one file per module/area). The [**Mithril Roadmap** Project](https://github.com/orgs/moumantai-gg/projects/1) (org-level, replaced the legacy user-level board 2026-05-21) is still the queryable board; custom fields: `Status`, `Priority`, `Module`. Don't add inline checklists to roadmap docs — the doc holds *why*, the issue holds *what*. |
 | Stable reference, process, how-to, user guide | The [wiki](https://github.com/moumantai-gg/mithril/wiki). Stable content; doesn't co-evolve with code. |
 | Design rationale that co-evolves with code | `docs/` in this repo. Architecture decisions, design notebooks, cross-cutting concerns. |


### PR DESCRIPTION
Closes #1024.

## Summary

- Refreshed the `area` dropdown in both `bug.yml` and `feature.yml` to include every existing `area:*` label (was missing `arda`, `gamestate-services`, `map-calibration`, `performance`, `telemetry`).
- Added a `Flags` checkboxes block to `bug.yml` so filers can flag `regression` and `area:performance` issues without remembering the label names.
- Corrected CLAUDE.md's "Where does new content go?" row — the previous text claimed the dropdowns auto-apply labels, which has always been false (no label-applier workflow exists in `.github/workflows/`).

## What this PR does NOT do

The issue body for #1024 asked to "investigate before adding more surface" re: a label-applier workflow. Investigation result: no such workflow exists today; the dropdowns have always been decorative. Wiring an actual auto-applier (parsing the form output and applying labels via `gh issue edit`) is deferred — small additional scope but a real new moving part. If manual-application proves too lossy in practice, a follow-up issue covers it; for now the template descriptions and CLAUDE.md both honestly say "apply manually after create."

## Test plan

- [x] `bug.yml` and `feature.yml` are valid YAML / GitHub Issue Forms schema (visible from PR-side rendering)
- [ ] Once merged, file a throwaway test issue via the bug template; confirm the new dropdown options + checkboxes render correctly. (Manual; I can't preview Issue Forms from a PR branch.)
- [x] CLAUDE.md line still renders as a single table row

🤖 Generated with [Claude Code](https://claude.com/claude-code)