### PR TITLE
feat(map-calibration): per-scene calibration keying (closes #1021)

### DIFF
--- a/docs/perf-trace-schema.md
+++ b/docs/perf-trace-schema.md
@@ -306,6 +306,16 @@ Companion `Mithril.MapCalibration.Detection` meter instruments emitted in `meter
 
 Scaffold-only — fires only after Task 16 wires the producer. A clean scaffold-only build emits zero calibration-synthesis records.
 
+The canonical map-calibration *attempt-outcome* string vocabulary lives in [`OutcomeVocabulary`](../src/Mithril.MapCalibration.Capture/Diagnostics/OutcomeVocabulary.cs) — it's the per-attempt diagnostic-bundle subdir suffix today, and is the value set any future `mithril.map_calibration.attempts` counter's `outcome` tag will draw from (fixed-vocabulary string, Safe / no scrubbing). Known values:
+
+- `accepted` — solve persisted a transform.
+- `rejected-no-area` / `rejected-pg-not-foreground` / `rejected-no-bbox` — pre-capture refusals; no bundle written.
+- `rejected-capture-failed` / `rejected-no-base-texture` / `rejected-map-not-located` / `rejected-clamp-degenerate` — capture / locate / clamp stage refusals.
+- `rejected-solve` / `rejected-solve-no-detections` / `rejected-solve-insufficient-inliers` / `rejected-solve-residual` — solver-stage refusals (free-form `RejectReason` is mapped to a fixed sub-category by `OutcomeVocabulary.RejectSolveSubcategory`).
+- `rejected-not-monotonic` — post-solve monotonicity gate refusal.
+- `map_asset_not_known` — autocal invoked before any `Downloading Map` line was observed in this session (no per-scene asset key known). Added with #1021's per-scene keying; the user-facing hint is "change zones once or restart while in this scene."
+- `error` — unexpected exception in the attempt pipeline.
+
 ### `meter_counter`
 
 Aggregated `System.Diagnostics.Metrics.Meter` counter sum, flushed once per second per (instrument, tag-set). Covers PR B's counters: Arda lines/verb-unmatched/grammar-break/verb-unhandled/domain-event-published, reference fetch-outcome, Mithril.Overlay projection latency + frame markers (#835), Mithril.MapCalibration synthesis-J histograms + disagree counter (synthesis-rerank plan Task 10), and any future counters added via the `Mithril.*` Meter prefix.

--- a/src/Arda/Arda.Contracts/Events/Player/MapAssetChanged.cs
+++ b/src/Arda/Arda.Contracts/Events/Player/MapAssetChanged.cs
@@ -1,0 +1,20 @@
+using Arda.Abstractions.Logs;
+
+namespace Arda.World.Player.Events;
+
+/// <summary>
+/// Emitted when PG's asset loader fetches a per-scene map texture
+/// (the unbracketed "Downloading Map [GUID] ... runtime key GUID[Map_&lt;X&gt;]"
+/// Player.log line). Carries both the literal Unity Texture2D name
+/// (<paramref name="CurrentMapAsset"/>, including the <c>Map_</c> prefix)
+/// and the sub-zone-level friendly name from the same line
+/// (<paramref name="CurrentSceneFriendlyName"/>, matching npcs.json's
+/// <c>AreaFriendlyName</c>). For aggregator <c>AreaX</c> entries (e.g.
+/// <c>AreaCave1</c>), <see cref="CurrentSceneFriendlyName"/> identifies the
+/// specific sub-scene where the parent area's <c>FriendlyName</c> would not.
+/// </summary>
+public readonly record struct MapAssetChanged(
+    string? PreviousMapAsset,
+    string? CurrentMapAsset,
+    string? CurrentSceneFriendlyName,
+    LogLineMetadata Metadata);

--- a/src/Arda/Arda.Contracts/State/Player/IMapState.cs
+++ b/src/Arda/Arda.Contracts/State/Player/IMapState.cs
@@ -3,10 +3,11 @@ using Arda.World.Player.Events;
 namespace Arda.World.Player;
 
 /// <summary>
-/// Flat read-only view of all map-scoped state: area, position, weather, pins.
+/// Flat read-only view of all map-scoped state: area, map asset, position, weather, pins.
 /// Consumers needing change notifications subscribe to the corresponding domain
-/// events (<see cref="AreaChanged"/>, <see cref="PlayerPositionChanged"/>,
-/// <see cref="WeatherChanged"/>, <see cref="MapPinAdded"/>, <see cref="MapPinRemoved"/>)
+/// events (<see cref="AreaChanged"/>, <see cref="MapAssetChanged"/>,
+/// <see cref="PlayerPositionChanged"/>, <see cref="WeatherChanged"/>,
+/// <see cref="MapPinAdded"/>, <see cref="MapPinRemoved"/>)
 /// via <see cref="Arda.Contracts.IDomainEventSubscriber"/>.
 /// </summary>
 public interface IMapState

--- a/src/Arda/Arda.Contracts/State/Player/IMapState.cs
+++ b/src/Arda/Arda.Contracts/State/Player/IMapState.cs
@@ -22,6 +22,21 @@ public interface IMapState
     /// <summary>Timestamp of the most recent area transition.</summary>
     DateTimeOffset? TransitionedAt { get; }
 
+    // --- Map asset (per-Unity-scene texture identity) ---
+
+    /// <summary>Literal Unity Texture2D name for the currently-displayed map texture (e.g. <c>"Map_HogansKeepBasement"</c>),
+    /// including the <c>Map_</c> prefix. Source: Player.log's <c>Downloading Map ... runtime key ...[Map_&lt;X&gt;]</c> line.
+    /// <c>null</c> until the first such line is observed in this session.</summary>
+    string? CurrentMapAsset { get; }
+
+    /// <summary>Sub-zone-level friendly area name from the same line (e.g. <c>"Hogan's Basement"</c>), which for
+    /// aggregator areas (<c>AreaCave1</c>, etc.) differs from <see cref="IMapState.CurrentArea"/>'s parent FriendlyName.
+    /// Matches the per-NPC <c>AreaFriendlyName</c> field in npcs.json.</summary>
+    string? CurrentSceneFriendlyName { get; }
+
+    /// <summary>Timestamp of the most recent <c>Downloading Map</c> line.</summary>
+    DateTimeOffset? MapAssetMeasuredAt { get; }
+
     // --- Position ---
 
     /// <summary>Engine X coordinate (ground plane), or <c>null</c> before first observation.</summary>

--- a/src/Arda/Arda.Dispatch/VerbExtractor.cs
+++ b/src/Arda/Arda.Dispatch/VerbExtractor.cs
@@ -60,6 +60,10 @@ internal static class VerbExtractor
         if (log.StartsWith("!!! Initializing area!"))
             return new ParsedVerb(Verbs.InitializingArea, ReadOnlySpan<char>.Empty);
 
+        // Asset loader: "Downloading Map [hash] GUID hash for area X runtime key hash[Map_<X>]"
+        if (log.StartsWith("Downloading Map "))
+            return new ParsedVerb(Verbs.DownloadingMap, log["Downloading Map ".Length..]);
+
         // Chat: login banner — "**** Logged In As ..."
         if (log.StartsWith(ChatLoginBannerPrefix))
             return new ParsedVerb(Verbs.ChatLoginBanner, log);

--- a/src/Arda/Arda.Dispatch/Verbs.cs
+++ b/src/Arda/Arda.Dispatch/Verbs.cs
@@ -12,6 +12,9 @@ public static class Verbs
     /// <summary>Synthetic verb for "!!! Initializing area! (id): AreaKey" system lines.</summary>
     public const string InitializingArea = "InitializingArea";
 
+    /// <summary>Synthetic verb for the unbracketed "Downloading Map [GUID] ... runtime key GUID[Map_&lt;X&gt;]" asset-loader line.</summary>
+    public const string DownloadingMap = "DownloadingMap";
+
     // Standard LocalPlayer: Process* verbs (literal text from log)
     public const string ProcessAddItem = "ProcessAddItem";
     public const string ProcessDeleteItem = "ProcessDeleteItem";

--- a/src/Arda/Arda.World.Player/Internal/MapAssetLoader.cs
+++ b/src/Arda/Arda.World.Player/Internal/MapAssetLoader.cs
@@ -1,0 +1,77 @@
+using Arda.Abstractions.Logs;
+using Arda.Contracts;
+using Arda.Dispatch;
+using Arda.World.Player.Events;
+
+namespace Arda.World.Player.Internal;
+
+/// <summary>
+/// Parses the unbracketed Player.log "Downloading Map [GUID] GUID GUID for
+/// area &lt;FriendlyAreaName&gt; runtime key GUID[&lt;AssetName&gt;]" line (synthetic
+/// verb <see cref="Verbs.DownloadingMap"/>) into per-scene map state. The
+/// asset name in the runtime-key bracket is the literal Unity Texture2D
+/// name (including the <c>Map_</c> prefix) and is the calibration key
+/// downstream consumers use.
+/// </summary>
+/// <remarks>
+/// <para>Malformed lines (missing <c>for area </c>, missing the runtime-key
+/// bracket, empty args) are silently skipped — no state mutation, no event
+/// published. The dispatch table doesn't inspect return values; safe-degrade
+/// is the established Arda parser pattern.</para>
+///
+/// <para>Idempotent: a re-parse of the same line is a no-op event (state
+/// changes once; subsequent identical parses don't fire <see cref="MapAssetChanged"/>).</para>
+/// </remarks>
+internal sealed class MapAssetLoader : IFrameHandler
+{
+    private readonly IDomainEventPublisher _bus;
+
+    public MapAssetLoader(IDomainEventPublisher bus)
+    {
+        _bus = bus;
+    }
+
+    public string? CurrentMapAsset { get; private set; }
+    public string? CurrentSceneFriendlyName { get; private set; }
+    public DateTimeOffset? MapAssetMeasuredAt { get; private set; }
+
+    public void Handle(ReadOnlySpan<char> args, ReadOnlySpan<char> verb, string sourceLog, LogLineMetadata metadata)
+    {
+        const string ForArea = "for area ";
+        const string RuntimeKey = " runtime key ";
+
+        var forAreaIdx = args.IndexOf(ForArea);
+        if (forAreaIdx < 0) return;
+
+        var friendlyStart = forAreaIdx + ForArea.Length;
+        var runtimeKeyRelIdx = args[friendlyStart..].IndexOf(RuntimeKey);
+        if (runtimeKeyRelIdx < 0) return;
+
+        var friendlyName = args.Slice(friendlyStart, runtimeKeyRelIdx).ToString();
+
+        // The asset-name bracket MUST come after the " runtime key " marker; the
+        // earlier [GUID] at args-head is also a bracket pair, so guarding against
+        // it ensures malformed lines (missing close bracket on the runtime-key
+        // bracket) don't silently fall back to the head-GUID bracket.
+        var runtimeKeyAbsIdx = friendlyStart + runtimeKeyRelIdx + RuntimeKey.Length;
+        var lastOpen = args.LastIndexOf('[');
+        var lastClose = args.LastIndexOf(']');
+        if (lastOpen < runtimeKeyAbsIdx) return;
+        if (lastClose <= lastOpen + 1) return;
+
+        var mapAsset = args.Slice(lastOpen + 1, lastClose - lastOpen - 1).ToString();
+
+        // Idempotent: only mutate + publish on actual change.
+        if (string.Equals(mapAsset, CurrentMapAsset, StringComparison.Ordinal)
+            && string.Equals(friendlyName, CurrentSceneFriendlyName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var previous = CurrentMapAsset;
+        CurrentMapAsset = mapAsset;
+        CurrentSceneFriendlyName = friendlyName;
+        MapAssetMeasuredAt = metadata.Timestamp ?? metadata.ReadOn;
+        _bus.Publish(new MapAssetChanged(previous, CurrentMapAsset, CurrentSceneFriendlyName, metadata));
+    }
+}

--- a/src/Arda/Arda.World.Player/Internal/MapScope.cs
+++ b/src/Arda/Arda.World.Player/Internal/MapScope.cs
@@ -5,14 +5,24 @@ namespace Arda.World.Player.Internal;
 /// <summary>
 /// Composite that implements <see cref="IMapState"/> by delegating to the
 /// individual map-scoped handlers (<see cref="Map"/>, <see cref="Position"/>,
-/// <see cref="Weather"/>, <see cref="MapPins"/>). Registered as a singleton;
-/// consumers inject <see cref="IMapState"/> for a flat view of all map state.
+/// <see cref="Weather"/>, <see cref="MapPins"/>, <see cref="MapAssetLoader"/>).
+/// Registered as a singleton; consumers inject <see cref="IMapState"/> for a
+/// flat view of all map state.
 /// </summary>
-internal sealed class MapScope(Map map, Position position, Weather weather, MapPins pins) : IMapState
+internal sealed class MapScope(
+    Map map,
+    Position position,
+    Weather weather,
+    MapPins pins,
+    MapAssetLoader mapAsset) : IMapState
 {
     public string? CurrentArea => map.CurrentArea;
     public string? PreviousArea => map.PreviousArea;
     public DateTimeOffset? TransitionedAt => map.TransitionedAt;
+
+    public string? CurrentMapAsset => mapAsset.CurrentMapAsset;
+    public string? CurrentSceneFriendlyName => mapAsset.CurrentSceneFriendlyName;
+    public DateTimeOffset? MapAssetMeasuredAt => mapAsset.MapAssetMeasuredAt;
 
     public double? X => position.X;
     public double? Y => position.Y;

--- a/src/Arda/Arda.World.Player/PlayerWorldExtensions.cs
+++ b/src/Arda/Arda.World.Player/PlayerWorldExtensions.cs
@@ -127,12 +127,20 @@ public static class PlayerWorldExtensions
         });
         builder.Services.AddSingleton<IMapPinState>(sp => sp.GetRequiredService<MapPins>());
 
+        // --- Map asset loader handler (Downloading Map line) ---
+        builder.Services.AddSingleton(sp =>
+        {
+            var bus = sp.GetRequiredService<IDomainEventPublisher>();
+            return new MapAssetLoader(bus);
+        });
+
         // --- Map scope composite (flat IMapState over all map-scoped handlers) ---
         builder.Services.AddSingleton<IMapState>(sp => new MapScope(
             sp.GetRequiredService<Map>(),
             sp.GetRequiredService<Position>(),
             sp.GetRequiredService<Weather>(),
-            sp.GetRequiredService<MapPins>()));
+            sp.GetRequiredService<MapPins>(),
+            sp.GetRequiredService<MapAssetLoader>()));
 
         // --- Effects handler ---
         builder.Services.AddSingleton(sp =>
@@ -184,6 +192,9 @@ public static class PlayerWorldExtensions
             var map = sp.GetRequiredService<Map>();
             RegisterHandler(registry, Verbs.LoadingLevel, map);
             RegisterHandler(registry, Verbs.InitializingArea, map);
+
+            var mapAsset = sp.GetRequiredService<MapAssetLoader>();
+            RegisterHandler(registry, Verbs.DownloadingMap, mapAsset);
 
             var inventory = sp.GetRequiredService<Inventory>();
             var player = sp.GetRequiredService<Internal.Player>();

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -78,7 +78,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     /// </summary>
     private const double ScaleRegimeRelTolerance = 0.02;
 
-    private readonly IAreaState _areaState;
+    private readonly IMapState _mapState;
     private readonly IGameWindowLocator _windowLocator;
     private readonly IMapCaptureRegionProvider _region;
     private readonly ICaptureService _capture;
@@ -100,7 +100,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     private readonly string? _pgVersion;
 
     public AutoCalibrationEngine(
-        IAreaState areaState,
+        IMapState mapState,
         IGameWindowLocator windowLocator,
         IMapCaptureRegionProvider region,
         ICaptureService capture,
@@ -117,7 +117,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         string? assetCacheDir = null,
         string? pgVersion = null)
     {
-        _areaState = areaState;
+        _mapState = mapState;
         _windowLocator = windowLocator;
         _region = region;
         _capture = capture;
@@ -159,8 +159,28 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     /// </summary>
     public async Task<AutoCalibrationOutcome> TryCalibrateCurrentAreaAsync(CancellationToken ct)
     {
-        var area = _areaState.CurrentArea ?? string.Empty;
-        var attempt = new CalibrationAttemptContext(area, DateTimeOffset.UtcNow);
+        // Strict gate (mithril#1021 D3): refuse outright when the per-scene
+        // Map_<X> asset name isn't known yet (no Downloading Map line observed
+        // in this session). No fallback to a synthesised key — keying texture
+        // + reference lookups on a guess would silently mis-calibrate aggregator
+        // sub-zones. Fires BEFORE any side effect (no bundle write, no attempt
+        // context, no texture/solver invocation).
+        if (string.IsNullOrEmpty(_mapState.CurrentMapAsset))
+        {
+            _logger?.LogInformation(
+                "Auto-calibration refused: per-scene map asset not yet known (Area={Area}); change zones once or restart while in this scene.",
+                _mapState.CurrentArea ?? "<none>");
+            return new AutoCalibrationOutcome(
+                Persisted: false,
+                AreaKey: _mapState.CurrentArea ?? string.Empty,
+                RejectReason: OutcomeVocabulary.MapAssetNotYetKnown,
+                OutcomeCategory: OutcomeVocabulary.MapAssetNotYetKnown);
+        }
+
+        // From here on, CurrentMapAsset is the authoritative per-scene key
+        // (#1021): texture lookup, sidecar requests, attempt-bundle naming.
+        var assetKey = _mapState.CurrentMapAsset;
+        var attempt = new CalibrationAttemptContext(assetKey, DateTimeOffset.UtcNow);
         var sink = _sinkSelector.Resolve();
         try
         {
@@ -201,7 +221,14 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         // step is slow.
         using var actSpan = MithrilActivitySources.MapCalibration.StartActivity("calibration.attempt");
 
-        var area = attempt.Area;
+        // #1021: the bundle/log "Area" tag in attempt.Area is the per-scene asset
+        // key (the bundle subfolder + 01-attempt.json read it). The parent
+        // area-key and sub-zone friendly name source from IMapState so the
+        // reference filter scopes NPC lookups to the right sub-zone for
+        // aggregator scenes.
+        var assetKey = attempt.Area;
+        var area = _mapState.CurrentArea ?? string.Empty;
+        var sceneRef = new MapSceneRef(area, _mapState.CurrentSceneFriendlyName);
         if (string.IsNullOrWhiteSpace(area))
         {
             attempt.Outcome = OutcomeVocabulary.RejectedNoArea;
@@ -250,9 +277,9 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         var gray = captureResult.Gray;
 
         _logger?.LogInformation(
-            "Auto-calibration {Area}: captured {Width}x{Height} frame; resolving base texture…",
-            area, gray.Width, gray.Height);
-        var baseTexture = await ResolveBaseTextureAsync(area, ct).ConfigureAwait(false);
+            "Auto-calibration {Area} ({MapAsset}): captured {Width}x{Height} frame; resolving base texture…",
+            area, assetKey, gray.Width, gray.Height);
+        var baseTexture = await ResolveBaseTextureAsync(assetKey, ct).ConfigureAwait(false);
         if (baseTexture is null)
         {
             attempt.Outcome = OutcomeVocabulary.RejectedNoBaseTexture;
@@ -314,14 +341,16 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             "Auto-calibration {Area}: map sub-rect located ({MapRect}) in {ElapsedMs:0} ms.",
             area, mapRect, Stopwatch.GetElapsedTime(refineStart).TotalMilliseconds);
 
-        // Task 15 (mithril#1021) will replace this with the strict (Map_<X>, SceneFriendlyName)
-        // pair from IMapState. For now, keep the build green by lifting the area
-        // string into a directly-registered MapSceneRef (SceneFriendlyName = null
-        // → area-only filter, same behaviour as pre-#1021).
-        var references = _references.ForArea(new MapSceneRef(area, SceneFriendlyName: null));
+        // #1021: scene-aware reference lookup. ParentAreaKey scopes landmarks
+        // (landmarks.json has no sub-zone field) and the NPC parent filter;
+        // SceneFriendlyName further narrows the NPC filter for aggregator
+        // scenes (e.g. AreaCave1 → Hogan's Basement) so the solver doesn't
+        // pair the captured Texture2D against every NPC under the aggregator.
+        var references = _references.ForArea(sceneRef);
         attempt.References = references;
         _logger?.LogInformation(
-            "Auto-calibration {Area}: {ReferenceCount} landmark reference(s) for this area.", area, references.Count);
+            "Auto-calibration {Area} ({MapAsset}, scene={Scene}): {ReferenceCount} landmark reference(s).",
+            area, assetKey, sceneRef.SceneFriendlyName ?? "<none>", references.Count);
 
         // Resolve icon templates per attempt (#949). On a fresh icon cache the
         // provider returns Empty; if a sidecar is wired, demand-trigger its --icons
@@ -461,10 +490,14 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
     /// Task-21 policy. Resolve the base texture from the #931 provider; on a
     /// cache-miss, optionally trigger the sidecar once to populate the cache,
     /// then retry. Fail-soft to null on any path.
+    ///
+    /// <para>Keyed on the per-scene <paramref name="assetKey"/> (mithril#1021):
+    /// the literal Unity Texture2D name observed in the Player.log
+    /// <c>Downloading Map … runtime key …[Map_&lt;X&gt;]</c> line.</para>
     /// </summary>
-    private async Task<GrayImage?> ResolveBaseTextureAsync(string area, CancellationToken ct)
+    private async Task<GrayImage?> ResolveBaseTextureAsync(string assetKey, CancellationToken ct)
     {
-        var tex = _baseTextures.TryGetBaseTexture(area);
+        var tex = _baseTextures.TryGetBaseTexture(assetKey);
         if (tex is not null) return tex;
 
         if (_assetExtractor is null || _gameConfig is null
@@ -473,46 +506,46 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             return null; // no extractor wired → safe-degrade (caller surfaces "preparing map assets…")
         }
 
-        _logger?.LogInformation("Base texture cache-miss for {Area}; invoking asset-extractor sidecar.", area);
+        _logger?.LogInformation("Base texture cache-miss for {MapAsset}; invoking asset-extractor sidecar.", assetKey);
         try
         {
             var request = new ExtractRequest(
                 InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Texture,
-                MapAssetName: area,
+                MapAssetName: assetKey,
                 ExpectPgVersion: _pgVersion,
                 TpkPath: ResolveTpkPath());
             var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);
             if (!extract.Ok)
             {
                 _logger?.LogWarning(
-                    "Asset-extractor sidecar failed for {Area} (exit {Exit}): {Error}. Safe-degrade.",
-                    area, extract.ExitCode, extract.Error);
+                    "Asset-extractor sidecar failed for {MapAsset} (exit {Exit}): {Error}. Safe-degrade.",
+                    assetKey, extract.ExitCode, extract.Error);
                 return null;
             }
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Asset-extractor sidecar threw for {Area}. Safe-degrade.", area);
+            _logger?.LogWarning(ex, "Asset-extractor sidecar threw for {MapAsset}. Safe-degrade.", assetKey);
             return null;
         }
 
-        var retried = _baseTextures.TryGetBaseTexture(area); // retry after populate
+        var retried = _baseTextures.TryGetBaseTexture(assetKey); // retry after populate
         if (retried is null)
         {
             // The extractor reported success but the provider still has no usable
-            // texture for this area. Distinguish this from a plain transient
+            // texture for this asset. Distinguish this from a plain transient
             // cache-miss: it usually means an asset-shape change or a
             // canonical-hash-gate mismatch (the extracted bytes don't match the
             // gated hash), which a future PG patch can introduce silently.
             // Behaviour is unchanged (still fail-soft); this just makes the
             // gate/shape mismatch visible instead of looking like a cache hiccup.
             _logger?.LogWarning(
-                "Asset-extractor reported success for {Area} but no usable base texture is available after retry "
+                "Asset-extractor reported success for {MapAsset} but no usable base texture is available after retry "
                 + "(possible asset-shape change or canonical-hash-gate mismatch, not a transient cache-miss). Safe-degrade.",
-                area);
+                assetKey);
         }
         return retried;
     }

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -480,7 +480,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
                 InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Texture,
-                AreaKey: area,
+                MapAssetName: area,
                 ExpectPgVersion: _pgVersion,
                 TpkPath: ResolveTpkPath());
             var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);
@@ -542,7 +542,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
                 InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir!,
                 Kind: ExtractKind.Icons,
-                AreaKey: null,
+                MapAssetName: null,
                 ExpectPgVersion: _pgVersion,
                 TpkPath: ResolveTpkPath());
             var extract = await _assetExtractor.ExtractAsync(request, ct).ConfigureAwait(false);

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -314,7 +314,11 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             "Auto-calibration {Area}: map sub-rect located ({MapRect}) in {ElapsedMs:0} ms.",
             area, mapRect, Stopwatch.GetElapsedTime(refineStart).TotalMilliseconds);
 
-        var references = _references.ForArea(area);
+        // Task 15 (mithril#1021) will replace this with the strict (Map_<X>, SceneFriendlyName)
+        // pair from IMapState. For now, keep the build green by lifting the area
+        // string into a directly-registered MapSceneRef (SceneFriendlyName = null
+        // → area-only filter, same behaviour as pre-#1021).
+        var references = _references.ForArea(new MapSceneRef(area, SceneFriendlyName: null));
         attempt.References = references;
         _logger?.LogInformation(
             "Auto-calibration {Area}: {ReferenceCount} landmark reference(s) for this area.", area, references.Count);

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -455,7 +455,9 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         // RenderSizePx-16 typed-detection bar). When the regimes differ (or either
         // side has no stamped factor — pre-#1005 legacy records, or a refiner
         // returning null Metrics), skip the comparison and accept.
-        var existing = _calibrationService.GetCalibration(area);
+        // #1021: persistence is keyed on the per-scene assetKey (Map_<X>) post-migration —
+        // baseline.json + UserRefinementStore both store under the asset key.
+        var existing = _calibrationService.GetCalibration(assetKey);
         if (existing is not null
             && IsSameScaleRegime(existing.LocatorScale, stamped.LocatorScale))
         {
@@ -475,7 +477,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         }
 
         attempt.Outcome = OutcomeVocabulary.Accepted;
-        _calibrationService.SaveUserRefinement(area, stamped);
+        _calibrationService.SaveUserRefinement(assetKey, stamped);
         _logger?.LogInformation(
             "Auto-calibration persisted for {Area} (residual {Residual:0.00} px, {Inliers} inliers).",
             area, stamped.ResidualPixels, result.InlierCount);

--- a/src/Mithril.MapCalibration.Capture/CalibrationStatusFormatter.cs
+++ b/src/Mithril.MapCalibration.Capture/CalibrationStatusFormatter.cs
@@ -41,6 +41,11 @@ public static class CalibrationStatusFormatter
         OutcomeVocabulary.RejectedNotMonotonic =>
             "Calibration unchanged: the new fit was worse than the saved one. "
             + "To force-replace, clear the saved calibration for this area.",
+        // #1021: per-scene calibration keying — autocal fired before any
+        // Downloading Map line was observed in this session, so the per-scene
+        // Map_<X> asset name is unknown. Tell the user how to recover.
+        OutcomeVocabulary.MapAssetNotYetKnown =>
+            "Map asset not yet known — change zones once or restart while in this scene.",
         // Other categories deliberately not routed here yet — they fall through
         // to the substring path so today's wording is preserved by default.
         _ => null,

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -47,7 +47,9 @@ public static partial class CaptureServiceCollectionExtensions
     /// registered the cross-cutting singletons it consumes: <see cref="GameConfig"/>,
     /// <see cref="Mithril.Overlay.IOverlayWindow"/>,
     /// <see cref="Arda.Contracts.IDomainEventSubscriber"/>,
-    /// <see cref="Arda.World.Player.IAreaState"/>, and
+    /// <see cref="Arda.World.Player.IMapState"/> (the engine reads
+    /// <c>CurrentMapAsset</c> / <c>CurrentSceneFriendlyName</c> for per-scene
+    /// keying, #1021), and
     /// <see cref="Mithril.Shared.Reference.IReferenceDataService"/>.
     ///
     /// <para>#947: the capture region is a SHELL-persisted desktop rect, sourced
@@ -57,6 +59,15 @@ public static partial class CaptureServiceCollectionExtensions
     /// consumes it optionally so the graph still builds in test setups without the
     /// shell. The overlay's own <c>WindowLayoutBinder</c> (→ <c>LegolasSettings</c>)
     /// is untouched; full overlay-reads-shell-store consolidation is a follow-up.</para>
+    ///
+    /// <para>#1021: the engine now resolves
+    /// <see cref="Arda.World.Player.IMapState"/> instead of
+    /// <see cref="Arda.World.Player.IAreaState"/> so the per-scene
+    /// <c>CurrentMapAsset</c> + <c>CurrentSceneFriendlyName</c> drive texture
+    /// + reference lookups (texture is keyed on <c>Map_&lt;X&gt;</c>, NPC
+    /// filtering is sub-zone-aware). The shell registers
+    /// <see cref="Arda.World.Player.IMapState"/> via
+    /// <c>PlayerWorldExtensions.AddArdaPlayerWorld</c>.</para>
     /// </summary>
     public static IServiceCollection AddMithrilMapCalibrationCapture(
         this IServiceCollection services,
@@ -146,7 +157,7 @@ public static partial class CaptureServiceCollectionExtensions
         // The orchestrator. Resolved as both the concrete type (for the hotkey +
         // DI test) and the narrow IAutoCalibrationRunner seam.
         services.AddSingleton<AutoCalibrationEngine>(sp => new AutoCalibrationEngine(
-            sp.GetRequiredService<Arda.World.Player.IAreaState>(),
+            sp.GetRequiredService<Arda.World.Player.IMapState>(),
             sp.GetRequiredService<IGameWindowLocator>(),
             sp.GetRequiredService<IMapCaptureRegionProvider>(),
             sp.GetRequiredService<ICaptureService>(),

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/OutcomeVocabulary.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/OutcomeVocabulary.cs
@@ -22,6 +22,13 @@ public static class OutcomeVocabulary
     public const string RejectedSolveInsufficientInliers = "rejected-solve-insufficient-inliers";
     public const string RejectedSolveResidual = "rejected-solve-residual";
     public const string RejectedNotMonotonic = "rejected-not-monotonic";
+
+    /// <summary>
+    /// Refusal: autocal was invoked before any Downloading Map line was observed
+    /// in this session, so the per-scene Map_&lt;X&gt; asset name is unknown. The user
+    /// hint surfaces in the toast + Palantir debug surface.
+    /// </summary>
+    public const string MapAssetNotYetKnown = "map_asset_not_known";
     public const string Error = "error";
 
     private static readonly FrozenSet<string> NoBundleOutcomes = FrozenSet.Create(

--- a/src/Mithril.MapCalibration.Capture/IAreaReferenceProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/IAreaReferenceProvider.cs
@@ -5,16 +5,23 @@ namespace Mithril.MapCalibration.Capture;
 
 /// <summary>
 /// Supplies the landmark/NPC world-anchor reference points the solver pairs
-/// detections against, for one area. Decoupled behind an interface so the
+/// detections against, for one scene. Decoupled behind an interface so the
 /// orchestrator depends on a seam (testable with a fake) rather than the
 /// reference-data service directly.
 /// </summary>
 public interface IAreaReferenceProvider
 {
     /// <summary>
-    /// The <see cref="LandmarkReference"/> set for <paramref name="areaKey"/>
-    /// (e.g. <c>"AreaSerbule"</c>). Empty when the area is unknown or carries no
-    /// mappable references — which fail-soft yields no inliers → the gate rejects.
+    /// Landmark + NPC references for the scene identified by
+    /// <paramref name="sceneRef"/>. NPCs are filtered on
+    /// <c>(AreaName == ParentAreaKey)</c>, further narrowed by
+    /// <c>AreaFriendlyName == SceneFriendlyName</c> when the latter is non-null.
+    /// Landmarks are filtered on <c>ParentAreaKey</c> alone (landmarks.json
+    /// has no sub-zone field). For directly-registered areas
+    /// (<see cref="MapSceneRef.SceneFriendlyName"/> null) the filter collapses
+    /// to the legacy area-only behaviour. Empty when the scene is unknown or
+    /// carries no mappable references — which fail-soft yields no inliers →
+    /// the gate rejects.
     /// </summary>
-    IReadOnlyList<LandmarkReference> ForArea(string areaKey);
+    IReadOnlyList<LandmarkReference> ForArea(MapSceneRef sceneRef);
 }

--- a/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
+++ b/src/Mithril.MapCalibration.Capture/IconTemplateBootstrap.cs
@@ -127,7 +127,7 @@ public sealed class IconTemplateBootstrap : IHostedService, IDisposable
                 InstallRoot: _gameConfig.InstallRoot,
                 OutDir: _assetCacheDir,
                 Kind: ExtractKind.Icons,
-                AreaKey: null,
+                MapAssetName: null,
                 ExpectPgVersion: _pgVersion,
                 TpkPath: ResolveTpkPath());
             var result = await _extractor.ExtractAsync(request, ct).ConfigureAwait(false);

--- a/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
+++ b/src/Mithril.MapCalibration.Capture/ReferenceDataAreaReferenceProvider.cs
@@ -46,8 +46,9 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
         _logger = logger;
     }
 
-    public IReadOnlyList<LandmarkReference> ForArea(string areaKey)
+    public IReadOnlyList<LandmarkReference> ForArea(MapSceneRef sceneRef)
     {
+        var areaKey = sceneRef.ParentAreaKey;
         if (string.IsNullOrWhiteSpace(areaKey)) return Array.Empty<LandmarkReference>();
 
         var result = new List<LandmarkReference>();
@@ -59,6 +60,10 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
         // never a calibration reference and is not a shape regression.
         var malformedCoords = 0;
 
+        // Landmarks: area-only filter (no sub-zone field on landmarks.json — partial
+        // coverage for aggregator scenes is documented in spec mithril#1021;
+        // the RANSAC solver tolerates the cross-scene noise via type-constrained
+        // pairing + the inlier ratio gate).
         if (_refData.Landmarks.TryGetValue(areaKey, out var landmarks))
         {
             foreach (var lm in landmarks)
@@ -88,10 +93,15 @@ public sealed class ReferenceDataAreaReferenceProvider : IAreaReferenceProvider
             }
         }
 
+        // NPCs: (AreaName, AreaFriendlyName) pair when SceneFriendlyName is set
+        // (aggregator scene narrowed to one sub-zone — mithril#1021), else
+        // area-only (back-compat for directly-registered areas).
         foreach (var npc in _refData.NpcsByInternalName.Values)
         {
             if (npc is null) continue;
             if (!string.Equals(npc.AreaName, areaKey, StringComparison.Ordinal)) continue;
+            if (sceneRef.SceneFriendlyName is { } sub
+                && !string.Equals(npc.AreaFriendlyName, sub, StringComparison.Ordinal)) continue;
             if (string.IsNullOrWhiteSpace(npc.Pos)) continue; // positionless entry — skip, not a shape change
             if (TryParseWorld(npc.Pos, out var world))
             {

--- a/src/Mithril.MapCalibration.Detection/IBaseTextureProvider.cs
+++ b/src/Mithril.MapCalibration.Detection/IBaseTextureProvider.cs
@@ -23,8 +23,14 @@ namespace Mithril.MapCalibration;
 public interface IBaseTextureProvider
 {
     /// <summary>
-    /// The base texture for <paramref name="areaKey"/> (e.g. <c>"AreaSerbule"</c>),
+    /// The base texture for <paramref name="mapAssetKey"/> (e.g. <c>"Map_AreaSerbule"</c>),
     /// or <c>null</c> if it can't be loaded + verified.
+    ///
+    /// <para>The key is the <b>literal Unity Texture2D name</b> (with the
+    /// <c>Map_</c> prefix), as observed in the Player.log
+    /// <c>Downloading Map ... runtime key ...[Map_&lt;X&gt;]</c> line. See
+    /// <see href="https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#map-asset-loads-per-scene-map-textures">
+    /// Player-Log-Signals § Map asset loads</see>.</para>
     /// </summary>
-    GrayImage? TryGetBaseTexture(string areaKey);
+    GrayImage? TryGetBaseTexture(string mapAssetKey);
 }

--- a/src/Mithril.MapCalibration.Detection/Internal/CachedBaseTextureProvider.cs
+++ b/src/Mithril.MapCalibration.Detection/Internal/CachedBaseTextureProvider.cs
@@ -48,33 +48,33 @@ internal sealed class CachedBaseTextureProvider : IBaseTextureProvider
         _logger = logger;
     }
 
-    public GrayImage? TryGetBaseTexture(string areaKey)
+    public GrayImage? TryGetBaseTexture(string mapAssetKey)
     {
-        if (string.IsNullOrWhiteSpace(areaKey))
+        if (string.IsNullOrWhiteSpace(mapAssetKey))
             return null;
         if (string.IsNullOrWhiteSpace(_cacheDir) || !Directory.Exists(_cacheDir))
         {
             _logger?.LogInformation(
-                "Base-texture cache dir {CacheDir} absent — no base texture for {Area} (safe-degrade).",
-                _cacheDir, areaKey);
+                "Base-texture cache dir {CacheDir} absent — no base texture for {MapAsset} (safe-degrade).",
+                _cacheDir, mapAssetKey);
             return null;
         }
 
-        var manifestPath = Path.Combine(_cacheDir, $"map-texture-{areaKey}.json");
-        var blobPath = Path.Combine(_cacheDir, $"map-texture-{areaKey}.bin");
+        var manifestPath = Path.Combine(_cacheDir, $"map-texture-{mapAssetKey}.json");
+        var blobPath = Path.Combine(_cacheDir, $"map-texture-{mapAssetKey}.bin");
 
-        var manifest = ReadManifest(manifestPath, areaKey);
+        var manifest = ReadManifest(manifestPath, mapAssetKey);
         if (manifest is null) return null;
 
-        var pixels = ReadDecompressedPixels(blobPath, areaKey);
+        var pixels = ReadDecompressedPixels(blobPath, mapAssetKey);
         if (pixels is null) return null;
 
         var actualHash = Convert.ToHexStringLower(SHA256.HashData(pixels));
         if (!string.Equals(actualHash, manifest.PixelSha256, StringComparison.OrdinalIgnoreCase))
         {
             _logger?.LogWarning(
-                "Base-texture pixel hash mismatch for {Area} (manifest {Expected}, blob {Actual}) — base texture rejected (safe-degrade).",
-                areaKey, manifest.PixelSha256, actualHash);
+                "Base-texture pixel hash mismatch for {MapAsset} (manifest {Expected}, blob {Actual}) — base texture rejected (safe-degrade).",
+                mapAssetKey, manifest.PixelSha256, actualHash);
             return null;
         }
 
@@ -82,8 +82,8 @@ internal sealed class CachedBaseTextureProvider : IBaseTextureProvider
         if (count <= 0 || pixels.Length != count)
         {
             _logger?.LogWarning(
-                "Base-texture blob length {Len} != width*height={Expected} for {Area} — base texture rejected (safe-degrade).",
-                pixels.Length, count, areaKey);
+                "Base-texture blob length {Len} != width*height={Expected} for {MapAsset} — base texture rejected (safe-degrade).",
+                pixels.Length, count, mapAssetKey);
             return null;
         }
 
@@ -91,26 +91,26 @@ internal sealed class CachedBaseTextureProvider : IBaseTextureProvider
         // the within-cache integrity check above + lean on the confidence gate.
         if (_hashGate is not null)
         {
-            var verdict = _hashGate.Check(_pgVersion, areaKey, manifest.PixelSha256);
+            var verdict = _hashGate.Check(_pgVersion, mapAssetKey, manifest.PixelSha256);
             if (!verdict.Accepted)
             {
                 _logger?.LogWarning(
-                    "Base-texture for {Area} rejected by canonical-hash gate: {Reason} — base texture rejected (safe-degrade).",
-                    areaKey, verdict.Reason);
+                    "Base-texture for {MapAsset} rejected by canonical-hash gate: {Reason} — base texture rejected (safe-degrade).",
+                    mapAssetKey, verdict.Reason);
                 return null;
             }
         }
 
-        _logger?.LogInformation("Loaded base texture for {Area} ({W}x{H}) from {CacheDir} (pixelSha256 verified).",
-            areaKey, manifest.Width, manifest.Height, _cacheDir);
+        _logger?.LogInformation("Loaded base texture for {MapAsset} ({W}x{H}) from {CacheDir} (pixelSha256 verified).",
+            mapAssetKey, manifest.Width, manifest.Height, _cacheDir);
         return new GrayImage(manifest.Width, manifest.Height, pixels);
     }
 
-    private MapTextureManifest? ReadManifest(string manifestPath, string areaKey)
+    private MapTextureManifest? ReadManifest(string manifestPath, string mapAssetKey)
     {
         if (!File.Exists(manifestPath))
         {
-            _logger?.LogInformation("Base-texture manifest {Path} not found — no base texture for {Area} (safe-degrade).", manifestPath, areaKey);
+            _logger?.LogInformation("Base-texture manifest {Path} not found — no base texture for {MapAsset} (safe-degrade).", manifestPath, mapAssetKey);
             return null;
         }
         try
@@ -119,28 +119,28 @@ internal sealed class CachedBaseTextureProvider : IBaseTextureProvider
             var manifest = JsonSerializer.Deserialize(stream, DetectionJsonContext.Default.MapTextureManifest);
             if (manifest is null || string.IsNullOrEmpty(manifest.PixelSha256) || manifest.Width <= 0 || manifest.Height <= 0)
             {
-                _logger?.LogWarning("Base-texture manifest {Path} empty/malformed — no base texture for {Area} (safe-degrade).", manifestPath, areaKey);
+                _logger?.LogWarning("Base-texture manifest {Path} empty/malformed — no base texture for {MapAsset} (safe-degrade).", manifestPath, mapAssetKey);
                 return null;
             }
             return manifest;
         }
         catch (JsonException ex)
         {
-            _logger?.LogWarning(ex, "Base-texture manifest {Path} failed to parse — no base texture for {Area} (safe-degrade).", manifestPath, areaKey);
+            _logger?.LogWarning(ex, "Base-texture manifest {Path} failed to parse — no base texture for {MapAsset} (safe-degrade).", manifestPath, mapAssetKey);
             return null;
         }
         catch (IOException ex)
         {
-            _logger?.LogWarning(ex, "Base-texture manifest {Path} failed to read — no base texture for {Area} (safe-degrade).", manifestPath, areaKey);
+            _logger?.LogWarning(ex, "Base-texture manifest {Path} failed to read — no base texture for {MapAsset} (safe-degrade).", manifestPath, mapAssetKey);
             return null;
         }
     }
 
-    private byte[]? ReadDecompressedPixels(string blobPath, string areaKey)
+    private byte[]? ReadDecompressedPixels(string blobPath, string mapAssetKey)
     {
         if (!File.Exists(blobPath))
         {
-            _logger?.LogInformation("Base-texture blob {Path} not found — no base texture for {Area} (safe-degrade).", blobPath, areaKey);
+            _logger?.LogInformation("Base-texture blob {Path} not found — no base texture for {MapAsset} (safe-degrade).", blobPath, mapAssetKey);
             return null;
         }
         try
@@ -153,12 +153,12 @@ internal sealed class CachedBaseTextureProvider : IBaseTextureProvider
         }
         catch (InvalidDataException ex)
         {
-            _logger?.LogWarning(ex, "Base-texture blob {Path} failed to decompress — no base texture for {Area} (safe-degrade).", blobPath, areaKey);
+            _logger?.LogWarning(ex, "Base-texture blob {Path} failed to decompress — no base texture for {MapAsset} (safe-degrade).", blobPath, mapAssetKey);
             return null;
         }
         catch (IOException ex)
         {
-            _logger?.LogWarning(ex, "Base-texture blob {Path} failed to read — no base texture for {Area} (safe-degrade).", blobPath, areaKey);
+            _logger?.LogWarning(ex, "Base-texture blob {Path} failed to read — no base texture for {MapAsset} (safe-degrade).", blobPath, mapAssetKey);
             return null;
         }
     }

--- a/src/Mithril.MapCalibration.Detection/Internal/ProcessAssetExtractor.cs
+++ b/src/Mithril.MapCalibration.Detection/Internal/ProcessAssetExtractor.cs
@@ -82,18 +82,18 @@ public sealed class ProcessAssetExtractor : IAssetExtractor
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
             _logger?.LogWarning(
-                "Asset-extractor sidecar timed out after {Timeout} ({Kind} {Area}) — child killed (safe-degrade).",
+                "Asset-extractor sidecar timed out after {Timeout} ({Kind} {MapAsset}) — child killed (safe-degrade).",
                 _timeout, request.Kind, request.MapAssetName);
             return ExtractResult.Failure(ExitTimeout, $"sidecar timed out after {_timeout}");
         }
         catch (OperationCanceledException)
         {
-            _logger?.LogInformation("Asset-extractor sidecar cancelled by caller ({Kind} {Area}).", request.Kind, request.MapAssetName);
+            _logger?.LogInformation("Asset-extractor sidecar cancelled by caller ({Kind} {MapAsset}).", request.Kind, request.MapAssetName);
             throw;
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Asset-extractor sidecar failed to launch ({Kind} {Area}) — safe-degrade.", request.Kind, request.MapAssetName);
+            _logger?.LogWarning(ex, "Asset-extractor sidecar failed to launch ({Kind} {MapAsset}) — safe-degrade.", request.Kind, request.MapAssetName);
             return ExtractResult.Failure(ExitLaunchFailed, $"sidecar launch failed: {ex.Message}");
         }
 

--- a/src/Mithril.MapCalibration.Detection/Internal/ProcessAssetExtractor.cs
+++ b/src/Mithril.MapCalibration.Detection/Internal/ProcessAssetExtractor.cs
@@ -83,17 +83,17 @@ public sealed class ProcessAssetExtractor : IAssetExtractor
         {
             _logger?.LogWarning(
                 "Asset-extractor sidecar timed out after {Timeout} ({Kind} {Area}) — child killed (safe-degrade).",
-                _timeout, request.Kind, request.AreaKey);
+                _timeout, request.Kind, request.MapAssetName);
             return ExtractResult.Failure(ExitTimeout, $"sidecar timed out after {_timeout}");
         }
         catch (OperationCanceledException)
         {
-            _logger?.LogInformation("Asset-extractor sidecar cancelled by caller ({Kind} {Area}).", request.Kind, request.AreaKey);
+            _logger?.LogInformation("Asset-extractor sidecar cancelled by caller ({Kind} {Area}).", request.Kind, request.MapAssetName);
             throw;
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Asset-extractor sidecar failed to launch ({Kind} {Area}) — safe-degrade.", request.Kind, request.AreaKey);
+            _logger?.LogWarning(ex, "Asset-extractor sidecar failed to launch ({Kind} {Area}) — safe-degrade.", request.Kind, request.MapAssetName);
             return ExtractResult.Failure(ExitLaunchFailed, $"sidecar launch failed: {ex.Message}");
         }
 
@@ -157,8 +157,8 @@ public sealed class ProcessAssetExtractor : IAssetExtractor
         }
         else
         {
-            psi.ArgumentList.Add("--area");
-            psi.ArgumentList.Add(request.AreaKey ?? string.Empty);
+            psi.ArgumentList.Add("--asset");
+            psi.ArgumentList.Add(request.MapAssetName ?? string.Empty);
         }
         if (!string.IsNullOrWhiteSpace(request.ExpectPgVersion))
         {
@@ -176,7 +176,7 @@ public sealed class ProcessAssetExtractor : IAssetExtractor
     private static string MapExitCode(int exitCode, ExtractRequest request) => exitCode switch
     {
         2 => $"PG install not found at '{request.InstallRoot}'",
-        3 => $"map bundle missing for area '{request.AreaKey}'",
+        3 => $"map bundle missing for area '{request.MapAssetName}'",
         4 => "asset decode failed",
         5 => $"output dir not writable '{request.OutDir}'",
         _ => $"sidecar exited with code {exitCode}",

--- a/src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json
+++ b/src/Mithril.MapCalibration/BundledData/map-calibration-baseline.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://moumantai-gg.github.io/mithril/map-calibration-baseline-v1.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "anchors": {
-    "AreaSerbule": {
+    "Map_AreaSerbule": {
       "scale": 0.8225888770409359,
       "rotationRadians": 7.088147823900868E-05,
       "originX": -159.67286441908084,
@@ -11,7 +11,7 @@
       "residualPixels": 0.3030622255943075,
       "source": "BundledBaseline"
     },
-    "AreaEltibule": {
+    "Map_AreaEltibule": {
       "scale": 0.7632337115580504,
       "rotationRadians": 3.141276165642632,
       "originX": 2146.21356708398,
@@ -20,7 +20,7 @@
       "residualPixels": 0.650247611982931,
       "source": "BundledBaseline"
     },
-    "AreaKurMountains": {
+    "Map_AreaKurMountains": {
       "scale": 0.5686213259799479,
       "rotationRadians": -3.141467542457235,
       "originX": 2188.818672930765,

--- a/src/Mithril.MapCalibration/IAssetExtractor.cs
+++ b/src/Mithril.MapCalibration/IAssetExtractor.cs
@@ -27,7 +27,7 @@ public interface IAssetExtractor
 /// <param name="InstallRoot">PG install root passed to the sidecar's <c>--install</c>.</param>
 /// <param name="OutDir">Cache directory passed to the sidecar's <c>--out</c>.</param>
 /// <param name="Kind">Icons or a single area's base texture.</param>
-/// <param name="AreaKey">Required when <see cref="Kind"/> is <see cref="ExtractKind.Texture"/>.</param>
+/// <param name="MapAssetName">Required when <see cref="Kind"/> is <see cref="ExtractKind.Texture"/>.</param>
 /// <param name="ExpectPgVersion">Optional <c>--expect-pg-version</c> assertion.</param>
 /// <param name="TpkPath">Optional explicit <c>--tpk</c> path to the UABEA
 /// <c>classdata.tpk</c> the icon decoder needs (#960). When set, the sidecar
@@ -37,7 +37,7 @@ public sealed record ExtractRequest(
     string InstallRoot,
     string OutDir,
     ExtractKind Kind,
-    string? AreaKey,
+    string? MapAssetName,
     string? ExpectPgVersion,
     string? TpkPath = null);
 

--- a/src/Mithril.MapCalibration/Internal/UserRefinementStore.cs
+++ b/src/Mithril.MapCalibration/Internal/UserRefinementStore.cs
@@ -176,47 +176,101 @@ internal sealed class UserRefinementStore
             // individually so a single poisoned entry is skipped+warned while every
             // other area survives. Durable against any future additive enum/field
             // change, not just AutoCapture.
-            using var stream = File.OpenRead(_filePath);
-            using var doc = JsonDocument.Parse(stream);
             var loaded = new Dictionary<string, AreaCalibration>(StringComparer.Ordinal);
+            bool needsMigration;
 
-            if (doc.RootElement.ValueKind != JsonValueKind.Object ||
-                !doc.RootElement.TryGetProperty("calibrations", out var calibrations) ||
-                calibrations.ValueKind != JsonValueKind.Object)
+            // Open + parse + walk the JSON inside a tight scope so the read
+            // stream is released BEFORE any migration Persist() runs — otherwise
+            // the File.Replace in Persist hits a sharing violation on the
+            // destination and the outer catch wipes the store. The doc/stream
+            // are not needed past the dictionary population.
+            using (var stream = File.OpenRead(_filePath))
+            using (var doc = JsonDocument.Parse(stream))
             {
-                // No (or malformed) calibrations object → nothing to load. An empty
-                // store is the correct result; a structurally-broken file is caught
-                // below by JsonDocument.Parse throwing.
-                _refinements = loaded;
-                return;
-            }
-
-            foreach (var entry in calibrations.EnumerateObject())
-            {
-                try
+                // Detect file-level schema version. Absent → v1 (legacy shape that
+                // predates this field, written by builds before #1021). v1 keyed
+                // refinements by bare area name (e.g. "AreaSerbule"); v2+ uses the
+                // per-scene Map_<X> grammar from the asset-load log (e.g.
+                // "Map_AreaSerbule"). See docs/planning/per-scene-calibration-keying/.
+                var schemaVersion = 1;
+                if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                    doc.RootElement.TryGetProperty("schemaVersion", out var verProp) &&
+                    verProp.ValueKind == JsonValueKind.Number &&
+                    verProp.TryGetInt32(out var v))
                 {
-                    var cal = entry.Value.Deserialize(MapCalibrationJsonContext.Default.AreaCalibration);
-                    if (cal is null) continue;
-                    // Stamp Source on every surviving entry; lifted records from
-                    // older shapes may not carry it explicitly and the default on
-                    // the record is UserRefinement, which matches this store's
-                    // contents — but be defensive in case a future shape change
-                    // reorders defaults.
-                    loaded[entry.Name] = cal with { Source = CalibrationSource.UserRefinement };
+                    schemaVersion = v;
                 }
-                catch (JsonException ex)
+                needsMigration = schemaVersion < 2;
+
+                if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+                    !doc.RootElement.TryGetProperty("calibrations", out var calibrations) ||
+                    calibrations.ValueKind != JsonValueKind.Object)
                 {
-                    // One unparseable entry (unknown future enum NAME / added field
-                    // an older build can't read) — skip it, keep the rest. This is
-                    // the durable downgrade-window degrade: the area re-runs
-                    // calibration; no other area's data is touched.
-                    _logger?.LogWarning(ex,
-                        "Skipping unparseable user refinement entry {Area} in {Path} — {Reason}.",
-                        entry.Name, _filePath, ex.Message);
+                    // No (or malformed) calibrations object → nothing to load. An empty
+                    // store is the correct result; a structurally-broken file is caught
+                    // below by JsonDocument.Parse throwing. Do NOT persist here — an
+                    // empty migration writes nothing back (idempotence + no spurious
+                    // rewrite of a malformed-but-readable file).
+                    _refinements = loaded;
+                    return;
+                }
+
+                foreach (var entry in calibrations.EnumerateObject())
+                {
+                    try
+                    {
+                        var cal = entry.Value.Deserialize(MapCalibrationJsonContext.Default.AreaCalibration);
+                        if (cal is null) continue;
+                        // v1→v2 key migration: prefix bare area keys with "Map_". A
+                        // pathological v1 file whose key ALREADY starts with "Map_"
+                        // is kept verbatim (defensive — never double-prefix).
+                        var key = entry.Name;
+                        if (needsMigration && !key.StartsWith("Map_", StringComparison.Ordinal))
+                        {
+                            key = "Map_" + key;
+                        }
+                        // Stamp Source on every surviving entry; lifted records from
+                        // older shapes may not carry it explicitly and the default on
+                        // the record is UserRefinement, which matches this store's
+                        // contents — but be defensive in case a future shape change
+                        // reorders defaults.
+                        loaded[key] = cal with { Source = CalibrationSource.UserRefinement };
+                    }
+                    catch (JsonException ex)
+                    {
+                        // One unparseable entry (unknown future enum NAME / added field
+                        // an older build can't read) — skip it, keep the rest. This is
+                        // the durable downgrade-window degrade: the area re-runs
+                        // calibration; no other area's data is touched.
+                        _logger?.LogWarning(ex,
+                            "Skipping unparseable user refinement entry {Area} in {Path} — {Reason}.",
+                            entry.Name, _filePath, ex.Message);
+                    }
                 }
             }
 
             _refinements = loaded;
+
+            // Persist immediately on a v1→v2 migration so subsequent boots are
+            // no-op loads (idempotence) and so the file on disk reflects the
+            // new key grammar before any consumer mutates the store. Use the
+            // existing transactional Persist; if it throws, roll the in-memory
+            // state back to empty (i.e. behave as though the load failed) so
+            // we never end up with v2 keys in memory while v1 keys remain on
+            // disk — that asymmetry is the silent data-loss path Save() guards
+            // against, and the same invariant applies here.
+            if (needsMigration && _refinements.Count > 0)
+            {
+                _logger?.LogInformation(
+                    "Migrated {Count} user refinement(s) at {Path} to v2 (Map_<X> keying).",
+                    _refinements.Count, _filePath);
+                try { Persist(); }
+                catch
+                {
+                    _refinements = new Dictionary<string, AreaCalibration>(StringComparer.Ordinal);
+                    throw;
+                }
+            }
         }
         catch (Exception ex) when (ex is IOException or JsonException)
         {
@@ -242,7 +296,7 @@ internal sealed class UserRefinementStore
     /// </summary>
     private void Persist()
     {
-        var file = new UserRefinementFile(SchemaVersion: 1, Calibrations: _refinements);
+        var file = new UserRefinementFile(SchemaVersion: 2, Calibrations: _refinements);
         var json = JsonSerializer.Serialize(file, MapCalibrationJsonContext.Default.UserRefinementFile);
         // Atomic-ish write: temp file then move. Defends against a crash
         // mid-write turning the store into garbage.

--- a/src/Mithril.MapCalibration/Internal/UserRefinementStore.cs
+++ b/src/Mithril.MapCalibration/Internal/UserRefinementStore.cs
@@ -191,7 +191,7 @@ internal sealed class UserRefinementStore
                 // predates this field, written by builds before #1021). v1 keyed
                 // refinements by bare area name (e.g. "AreaSerbule"); v2+ uses the
                 // per-scene Map_<X> grammar from the asset-load log (e.g.
-                // "Map_AreaSerbule"). See docs/planning/per-scene-calibration-keying/.
+                // "Map_AreaSerbule"). See docs/planning/map-calibration-1021-per-scene-keying/.
                 var schemaVersion = 1;
                 if (doc.RootElement.ValueKind == JsonValueKind.Object &&
                     doc.RootElement.TryGetProperty("schemaVersion", out var verProp) &&

--- a/src/Mithril.MapCalibration/MapSceneRef.cs
+++ b/src/Mithril.MapCalibration/MapSceneRef.cs
@@ -1,0 +1,21 @@
+namespace Mithril.MapCalibration;
+
+/// <summary>
+/// Composite identifier for a single Unity scene's calibration scope.
+/// <see cref="ParentAreaKey"/> is the areas.json key (always non-null in
+/// practice — Arda surfaces it from <c>!!! Initializing area! </c>).
+/// <see cref="SceneFriendlyName"/> is the sub-zone-level npcs.json
+/// <c>AreaFriendlyName</c>; <c>null</c> for directly-registered areas,
+/// set for aggregator-area sub-zones (e.g. for the Hogan's Keep basement
+/// scene under <c>AreaCave1</c>, <c>SceneFriendlyName</c> is
+/// <c>"Hogan's Basement"</c>).
+/// </summary>
+/// <remarks>
+/// Used by <c>Mithril.MapCalibration.Capture.IAreaReferenceProvider.ForArea</c> to scope
+/// NPC lookups to the right sub-zone. Landmarks.json has no sub-zone field,
+/// so the landmark filter uses <see cref="ParentAreaKey"/> alone — partial
+/// coverage for aggregator scenes is documented in the spec (mithril#1021).
+/// </remarks>
+public readonly record struct MapSceneRef(
+    string ParentAreaKey,
+    string? SceneFriendlyName);

--- a/tests/Arda.Dispatch.Tests/VerbExtractorTests.cs
+++ b/tests/Arda.Dispatch.Tests/VerbExtractorTests.cs
@@ -30,6 +30,25 @@ public class VerbExtractorTests
         result.Verb.ToString().Should().Be(Verbs.InitializingArea);
     }
 
+    [Fact]
+    public void Parse_DownloadingMap_ReturnsSyntheticKey()
+    {
+        var line = "Downloading Map [0e88b64bdd834cc41a23b8357802f254] GUID 0e88b64bdd834cc41a23b8357802f254 for area Kur Mountains runtime key 0e88b64bdd834cc41a23b8357802f254[Map_AreaKurMountains]";
+        var result = VerbExtractor.Parse(line.AsSpan());
+        result.Verb.ToString().Should().Be(Verbs.DownloadingMap);
+        result.Args.ToString().Should().Be(
+            "[0e88b64bdd834cc41a23b8357802f254] GUID 0e88b64bdd834cc41a23b8357802f254 for area Kur Mountains runtime key 0e88b64bdd834cc41a23b8357802f254[Map_AreaKurMountains]");
+    }
+
+    [Fact]
+    public void Parse_DownloadingMapAlone_ReturnsEmpty()
+    {
+        // Defensive: bare "Downloading Map" without a space-prefixed body should not match;
+        // it's a line shape we've never observed and shouldn't synthesize.
+        var result = VerbExtractor.Parse("Downloading Map".AsSpan());
+        result.IsEmpty.Should().BeTrue();
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("some random text")]

--- a/tests/Arda.World.Player.Tests/MapAssetLoaderTests.cs
+++ b/tests/Arda.World.Player.Tests/MapAssetLoaderTests.cs
@@ -1,0 +1,131 @@
+using Arda.Abstractions.Logs;
+using Arda.Contracts;
+using Arda.Dispatch;
+using Arda.World.Player.Events;
+using Arda.World.Player.Internal;
+using FluentAssertions;
+using Xunit;
+
+namespace Arda.World.Player.Tests;
+
+public class MapAssetLoaderTests
+{
+    private readonly SpyEventBus _bus = new();
+    private readonly MapAssetLoader _handler;
+
+    public MapAssetLoaderTests()
+    {
+        _handler = new MapAssetLoader(_bus);
+    }
+
+    private static LogLineMetadata Meta(bool isReplay = false) =>
+        new(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, isReplay);
+
+    /// <summary>Simulates what the DispatchTable does for a DownloadingMap verb:
+    /// args is everything after "Downloading Map " in the source line.</summary>
+    private void Dispatch(string friendlyArea, string mapAsset, LogLineMetadata? meta = null)
+    {
+        var source =
+            $"Downloading Map [44d50fb35fa65dd4cbb84e3af49ca0a4] GUID 44d50fb35fa65dd4cbb84e3af49ca0a4 "
+            + $"for area {friendlyArea} runtime key 44d50fb35fa65dd4cbb84e3af49ca0a4[{mapAsset}]";
+        var args = source["Downloading Map ".Length..].AsSpan();
+        _handler.Handle(args, default, source, meta ?? Meta());
+    }
+
+    [Fact]
+    public void Parses_HogansBasement_HappyPath()
+    {
+        Dispatch("Hogan's Basement", "Map_HogansKeepBasement");
+
+        _handler.CurrentMapAsset.Should().Be("Map_HogansKeepBasement");
+        _handler.CurrentSceneFriendlyName.Should().Be("Hogan's Basement");
+        _handler.MapAssetMeasuredAt.Should().NotBeNull();
+
+        var changed = _bus.Published<MapAssetChanged>().Should().ContainSingle().Subject;
+        changed.PreviousMapAsset.Should().BeNull();
+        changed.CurrentMapAsset.Should().Be("Map_HogansKeepBasement");
+        changed.CurrentSceneFriendlyName.Should().Be("Hogan's Basement");
+    }
+
+    [Theory]
+    [InlineData("Hogan's Basement", "Map_HogansKeepBasement")]
+    [InlineData("Caves Beneath Kur Mountains", "Map_AreaKurCaves")]
+    [InlineData("Serbule", "Map_AreaSerbule")]
+    [InlineData("Anagoge Island", "Map_AreaNewbieIsland")]
+    public void Parses_VariousFriendlyAndAssetForms(string friendly, string asset)
+    {
+        Dispatch(friendly, asset);
+        _handler.CurrentMapAsset.Should().Be(asset);
+        _handler.CurrentSceneFriendlyName.Should().Be(friendly);
+    }
+
+    [Fact]
+    public void Idempotent_ReParse_DoesNotRepublish()
+    {
+        Dispatch("Hogan's Basement", "Map_HogansKeepBasement");
+        Dispatch("Hogan's Basement", "Map_HogansKeepBasement");
+        _bus.Published<MapAssetChanged>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Transition_PopulatesPreviousMapAsset()
+    {
+        Dispatch("Serbule", "Map_AreaSerbule");
+        Dispatch("Hogan's Basement", "Map_HogansKeepBasement");
+
+        var events = _bus.Published<MapAssetChanged>().ToList();
+        events.Should().HaveCount(2);
+        events[1].PreviousMapAsset.Should().Be("Map_AreaSerbule");
+        events[1].CurrentMapAsset.Should().Be("Map_HogansKeepBasement");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("[GUID] no for-area no runtime-key")]
+    [InlineData("[GUID] for area X but no runtime key delimiter")]
+    [InlineData("[GUID] for area X runtime key GUID no_close_bracket")]
+    [InlineData("[GUID] for area X runtime key GUID[]")]
+    public void Malformed_SilentSkip_NoStateMutation_NoEvent(string args)
+    {
+        _handler.Handle(args.AsSpan(), default, "Downloading Map " + args, Meta());
+        _handler.CurrentMapAsset.Should().BeNull();
+        _handler.CurrentSceneFriendlyName.Should().BeNull();
+        _bus.Published<MapAssetChanged>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LastBracketWins_NotTheArgsHeadGuidBracket()
+    {
+        Dispatch("Test Area", "Map_TestScene");
+        _handler.CurrentMapAsset.Should().Be("Map_TestScene");
+        _handler.CurrentMapAsset.Should().NotStartWith("44d50fb"); // not the GUID
+    }
+
+    private sealed class SpyEventBus : IDomainEventSubscriber, IDomainEventPublisher
+    {
+        private readonly Dictionary<Type, List<object>> _published = [];
+
+        public IDisposable Subscribe<T>(Action<T> handler) where T : struct => new NoopDisposable();
+
+        public void Publish<T>(T domainEvent) where T : struct
+        {
+            if (!_published.TryGetValue(typeof(T), out var list))
+            {
+                list = [];
+                _published[typeof(T)] = list;
+            }
+            list.Add(domainEvent);
+        }
+
+        public List<T> Published<T>() where T : struct
+        {
+            if (_published.TryGetValue(typeof(T), out var list))
+                return list.Cast<T>().ToList();
+            return [];
+        }
+
+        public void Clear() => _published.Clear();
+
+        private sealed class NoopDisposable : IDisposable { public void Dispose() { } }
+    }
+}

--- a/tests/Arda.World.Player.Tests/MapAssetLoaderTests.cs
+++ b/tests/Arda.World.Player.Tests/MapAssetLoaderTests.cs
@@ -68,6 +68,18 @@ public class MapAssetLoaderTests
     }
 
     [Fact]
+    public void Replay_LastDownloadingMapLineWins()
+    {
+        Dispatch("Serbule", "Map_AreaSerbule", Meta(isReplay: true));
+        Dispatch("Eltibule", "Map_AreaEltibule", Meta(isReplay: true));
+        Dispatch("Hogan's Basement", "Map_HogansKeepBasement", Meta(isReplay: true));
+
+        _handler.CurrentMapAsset.Should().Be("Map_HogansKeepBasement");
+        _handler.CurrentSceneFriendlyName.Should().Be("Hogan's Basement");
+        _bus.Published<MapAssetChanged>().Should().HaveCount(3);
+    }
+
+    [Fact]
     public void Transition_PopulatesPreviousMapAsset()
     {
         Dispatch("Serbule", "Map_AreaSerbule");

--- a/tests/Mithril.MapCalibration.Capture.Tests/AreaReferenceProviderTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AreaReferenceProviderTests.cs
@@ -28,7 +28,7 @@ public sealed class AreaReferenceProviderTests
                 new Landmark { Name = "Teleport Circle", Loc = "x:1 y:0 z:2", Type = "TeleportationPlatform" })
             .WithNpc("AreaSerbule", "Marna", pos: "x:30 y:0 z:40");
 
-        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
+        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea(new MapSceneRef("AreaSerbule", null));
 
         // mithril#974: Type carries the raw PG vocabulary (the same the detector
         // keys IconTemplate.LandmarkType by); the landmark_* sprite strings are
@@ -48,7 +48,7 @@ public sealed class AreaReferenceProviderTests
                 new Landmark { Name = "NoLoc", Loc = null, Type = "Portal" },
                 new Landmark { Name = "Garbage", Loc = "not a position", Type = "Portal" });
 
-        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
+        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea(new MapSceneRef("AreaSerbule", null));
 
         refs.Should().ContainSingle(r => r.Type == "Portal");
         refs.Should().OnlyContain(r => r.Name == "Good");
@@ -67,7 +67,7 @@ public sealed class AreaReferenceProviderTests
             .WithPositionlessNpc("AreaEltibule", "Sacrificial Bowl");
 
         var logger = new ListLogger();
-        var refs = new ReferenceDataAreaReferenceProvider(refData, logger).ForArea("AreaEltibule");
+        var refs = new ReferenceDataAreaReferenceProvider(refData, logger).ForArea(new MapSceneRef("AreaEltibule", null));
 
         refs.Should().ContainSingle(r => r.Type == "Npc" && r.Name == "Braigon");
         logger.Warnings.Should().NotContain(m => m.Contains("coord", StringComparison.OrdinalIgnoreCase));
@@ -84,7 +84,7 @@ public sealed class AreaReferenceProviderTests
                 new Landmark { Name = "Garbage", Loc = "not a position", Type = "Portal" });
 
         var logger = new ListLogger();
-        new ReferenceDataAreaReferenceProvider(refData, logger).ForArea("AreaSerbule");
+        new ReferenceDataAreaReferenceProvider(refData, logger).ForArea(new MapSceneRef("AreaSerbule", null));
 
         logger.Warnings.Should().ContainSingle(m =>
             m.Contains("malformed coords") && m.Contains("1"));
@@ -100,12 +100,12 @@ public sealed class AreaReferenceProviderTests
             .WithLandmarks("AreaSerbule",
                 new Landmark { Name = "Mystery", Loc = "x:1 y:0 z:1", Type = "SomeFutureLandmark" });
 
-        new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule").Should().BeEmpty();
+        new ReferenceDataAreaReferenceProvider(refData).ForArea(new MapSceneRef("AreaSerbule", null)).Should().BeEmpty();
     }
 
     [Fact]
     public void Unknown_area_yields_empty()
-        => new ReferenceDataAreaReferenceProvider(new FakeAreaReferenceData()).ForArea("AreaNope").Should().BeEmpty();
+        => new ReferenceDataAreaReferenceProvider(new FakeAreaReferenceData()).ForArea(new MapSceneRef("AreaNope", null)).Should().BeEmpty();
 
     [Fact]
     public void Emitted_types_are_a_subset_of_the_canonical_vocabulary()
@@ -121,10 +121,57 @@ public sealed class AreaReferenceProviderTests
                 new Landmark { Name = "T", Loc = "x:3 y:0 z:3", Type = "TeleportationPlatform" })
             .WithNpc("AreaSerbule", "Marna", pos: "x:4 y:0 z:4");
 
-        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea("AreaSerbule");
+        var refs = new ReferenceDataAreaReferenceProvider(refData).ForArea(new MapSceneRef("AreaSerbule", null));
 
         refs.Select(r => r.Type).Distinct().Should().OnlyContain(t => CanonicalLandmarkTypes.All.Contains(t));
         refs.Should().NotBeEmpty();
+    }
+
+    // ── mithril#1021 per-scene keying: composite (ParentAreaKey, SceneFriendlyName?) ──
+
+    [Fact]
+    public void ForArea_AggregatorSceneFriendlyName_NarrowsNpcsToThatSubzone()
+    {
+        // AreaCave1 is an aggregator under which multiple sub-zones live; the
+        // SceneFriendlyName narrows NPCs to the matching AreaFriendlyName only.
+        var refData = new FakeAreaReferenceData()
+            .WithNpc("AreaCave1", "Hogan's Basement", "Gorvessa", pos: "x:100 y:0 z:200")
+            .WithNpc("AreaCave1", "Goblin Dungeon", "Goblin", pos: "x:300 y:0 z:400");
+
+        var refs = new ReferenceDataAreaReferenceProvider(refData)
+            .ForArea(new MapSceneRef("AreaCave1", "Hogan's Basement"));
+
+        refs.Should().ContainSingle(r => r.Name == "Gorvessa");
+        refs.Should().NotContain(r => r.Name == "Goblin");
+    }
+
+    [Fact]
+    public void ForArea_NullSceneFriendlyName_CollapsesToAreaOnlyFilter()
+    {
+        // Back-compat: a directly-registered area passes SceneFriendlyName = null,
+        // so the filter collapses to AreaName-only (pre-#1021 behaviour).
+        var refData = new FakeAreaReferenceData()
+            .WithNpc("AreaSerbule", "Serbule", "A", pos: "x:1 y:0 z:1")
+            .WithNpc("AreaSerbule", "Serbule", "B", pos: "x:2 y:0 z:2");
+
+        var refs = new ReferenceDataAreaReferenceProvider(refData)
+            .ForArea(new MapSceneRef("AreaSerbule", SceneFriendlyName: null));
+
+        refs.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ForArea_AggregatorWithoutMatchingFriendlyName_ReturnsEmpty()
+    {
+        // Aggregator scene whose SceneFriendlyName matches no NPC's
+        // AreaFriendlyName → empty NPC set (the gate then rejects on no inliers).
+        var refData = new FakeAreaReferenceData()
+            .WithNpc("AreaCave1", "Goblin Dungeon", "X", pos: "x:1 y:0 z:1");
+
+        var refs = new ReferenceDataAreaReferenceProvider(refData)
+            .ForArea(new MapSceneRef("AreaCave1", "Hogan's Basement"));
+
+        refs.Should().BeEmpty();
     }
 
     /// <summary>Minimal <see cref="ILogger"/> that collects Warning messages for assertions.</summary>

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineFeatureMatchingTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineFeatureMatchingTests.cs
@@ -93,8 +93,12 @@ public sealed class AutoCalibrationEngineFeatureMatchingTests
         // origin is arbitrary (capture is faked).
         var bbox = new CaptureRect(0, 0, capture.Width, capture.Height);
 
+        // #1021: the engine now reads IMapState. The Kur fixture's texture is
+        // keyed on the area name (legacy fixture naming), so we set
+        // CurrentMapAsset = Area to match — both pre- and post-#1021 the lookup
+        // key for this fixture is "AreaKurMountains".
         var engine = new AutoCalibrationEngine(
-            new FakeAreaState(Area),
+            new FakeMapState { CurrentArea = Area, CurrentMapAsset = Area },
             new FakeWindowLocator(new GameWindow(1, new CaptureRect(0, 0, 1920, 1080))),
             new FakeRegionProvider(bbox),
             new SpyCapture(capture),

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineOutcomeCategoryTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineOutcomeCategoryTests.cs
@@ -18,6 +18,8 @@ namespace Mithril.MapCalibration.Capture.Tests;
 public sealed class AutoCalibrationEngineOutcomeCategoryTests
 {
     private const string Area = EngineHarness.DefaultArea;
+    // #1021: calibration store keys are per-scene asset keys (Map_<X>).
+    private const string AssetKey = EngineHarness.DefaultAssetKey;
 
     [Fact]
     public async Task Accept_outcome_carries_Accepted_category()
@@ -79,7 +81,7 @@ public sealed class AutoCalibrationEngineOutcomeCategoryTests
     public async Task Monotonicity_reject_outcome_carries_RejectedNotMonotonic_category()
     {
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, TestHelpers.SomeBaseline() with { LocatorScale = 0.408, ResidualPixels = 0.79, ReferenceCount = 10 });
+        svc.Seed(AssetKey, TestHelpers.SomeBaseline() with { LocatorScale = 0.408, ResidualPixels = 0.79, ReferenceCount = 10 });
 
         var h = new EngineHarness
         {

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -20,6 +20,11 @@ namespace Mithril.MapCalibration.Capture.Tests;
 public sealed class AutoCalibrationEngineTests
 {
     private const string Area = EngineHarness.DefaultArea;
+    // #1021: the engine persists + looks up calibration under the per-scene
+    // asset key (Map_<X>), not the bare area key. Tests that read/write the
+    // calibration store use this constant; tests that read CurrentArea, error
+    // strings, or AreaKey on the outcome still use Area.
+    private const string AssetKey = EngineHarness.DefaultAssetKey;
 
     [Fact]
     public async Task Persists_with_AutoCapture_source_on_accept()
@@ -31,22 +36,22 @@ public sealed class AutoCalibrationEngineTests
 
         outcome.Persisted.Should().BeTrue();
         outcome.AreaKey.Should().Be(Area);
-        svc.Saved.Should().ContainKey(Area);
-        svc.Saved[Area].Source.Should().Be(CalibrationSource.AutoCapture);
+        svc.Saved.Should().ContainKey(AssetKey);
+        svc.Saved[AssetKey].Source.Should().Be(CalibrationSource.AutoCapture);
     }
 
     [Fact]
     public async Task Keeps_prior_calibration_when_the_gate_rejects()
     {
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, SomeBaseline());
+        svc.Seed(AssetKey, SomeBaseline());
         var h = new EngineHarness { Solve = Rejected("residual 25.00 px exceeds threshold 12.00 px"), Service = svc };
 
         var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
 
         outcome.Persisted.Should().BeFalse();
         outcome.RejectReason.Should().Contain("residual");
-        svc.Saved.Should().NotContainKey(Area); // prior untouched (no Save call)
+        svc.Saved.Should().NotContainKey(AssetKey); // prior untouched (no Save call)
     }
 
     [Fact]
@@ -455,14 +460,14 @@ public sealed class AutoCalibrationEngineTests
     public async Task Replaces_existing_when_new_fit_is_better()
     {
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, MakeCal(residual: 3.0, refs: 6));
+        svc.Seed(AssetKey, MakeCal(residual: 3.0, refs: 6));
         var h = new EngineHarness { Solve = Accepted(residual: 0.65, inliers: 8), Service = svc };
 
         var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
 
         outcome.Persisted.Should().BeTrue();
-        svc.Saved.Should().ContainKey(Area);
-        svc.Saved[Area].ResidualPixels.Should().Be(0.65);
+        svc.Saved.Should().ContainKey(AssetKey);
+        svc.Saved[AssetKey].ResidualPixels.Should().Be(0.65);
     }
 
     [Fact]
@@ -472,7 +477,7 @@ public sealed class AutoCalibrationEngineTests
         // Both sides must be at the same LocatorScale regime (#1005) for the
         // monotonicity gate to fire — same in-game zoom is the original #988 case.
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, MakeCal(residual: 0.79, refs: 10) with { LocatorScale = 0.408 });
+        svc.Seed(AssetKey, MakeCal(residual: 0.79, refs: 10) with { LocatorScale = 0.408 });
         var h = new EngineHarness
         {
             Solve = Accepted(residual: 4.03, inliers: 4),
@@ -486,7 +491,7 @@ public sealed class AutoCalibrationEngineTests
 
         outcome.Persisted.Should().BeFalse();
         outcome.RejectReason.Should().Contain("residual");
-        svc.Saved.Should().NotContainKey(Area); // existing untouched
+        svc.Saved.Should().NotContainKey(AssetKey); // existing untouched
     }
 
     [Fact]
@@ -495,7 +500,7 @@ public sealed class AutoCalibrationEngineTests
         // Same in-game zoom (matching LocatorScale) so the #1005 regime predicate
         // does NOT skip the gate; the inlier-delta arm is then free to fire.
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, MakeCal(residual: 1.0, refs: 10) with { LocatorScale = 0.408 });
+        svc.Seed(AssetKey, MakeCal(residual: 1.0, refs: 10) with { LocatorScale = 0.408 });
         var h = new EngineHarness
         {
             Solve = Accepted(residual: 1.0, inliers: 4),
@@ -509,7 +514,7 @@ public sealed class AutoCalibrationEngineTests
 
         outcome.Persisted.Should().BeFalse();
         outcome.RejectReason.Should().Contain("inlier");
-        svc.Saved.Should().NotContainKey(Area);
+        svc.Saved.Should().NotContainKey(AssetKey);
     }
 
     // ── #988 monotonicity gate (helper-level) ────────────────────────────────
@@ -571,7 +576,7 @@ public sealed class AutoCalibrationEngineTests
         var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
 
         outcome.Persisted.Should().BeTrue();
-        svc.Saved[Area].LocatorScale.Should().Be(0.408);
+        svc.Saved[AssetKey].LocatorScale.Should().Be(0.408);
     }
 
     [Fact]
@@ -579,7 +584,7 @@ public sealed class AutoCalibrationEngineTests
     {
         var svc = new FakeCalibrationService();
         // Seed an EXISTING calibration at scale 0.408 with high quality.
-        svc.Seed(Area, SomeBaseline() with { LocatorScale = 0.408, ResidualPixels = 0.5, ReferenceCount = 10 });
+        svc.Seed(AssetKey, SomeBaseline() with { LocatorScale = 0.408, ResidualPixels = 0.5, ReferenceCount = 10 });
 
         // Capture at scale 0.800 (different regime) with a WORSE-looking fit
         // (would trip both monotonicity arms: residual much higher, inliers much lower).
@@ -597,7 +602,7 @@ public sealed class AutoCalibrationEngineTests
 
         outcome.Persisted.Should().BeTrue();
         outcome.RejectReason.Should().BeNull();
-        svc.Saved[Area].LocatorScale.Should().Be(0.800);
+        svc.Saved[AssetKey].LocatorScale.Should().Be(0.800);
     }
 
     [Fact]
@@ -607,7 +612,7 @@ public sealed class AutoCalibrationEngineTests
         // attempt seconds later. LocatorScale values match within tolerance,
         // gate fires, prior calibration kept.
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, SomeBaseline() with { LocatorScale = 0.408, ResidualPixels = 0.79, ReferenceCount = 10 });
+        svc.Seed(AssetKey, SomeBaseline() with { LocatorScale = 0.408, ResidualPixels = 0.79, ReferenceCount = 10 });
 
         var h = new EngineHarness
         {
@@ -627,7 +632,7 @@ public sealed class AutoCalibrationEngineTests
         // arm first (checked before inlier-delta), but either arm is the same
         // monotonicity-reject outcome from a router POV.
         outcome.OutcomeCategory.Should().Be(OutcomeVocabulary.RejectedNotMonotonic);
-        svc.Saved.Should().NotContainKey(Area); // prior preserved (no Save call)
+        svc.Saved.Should().NotContainKey(AssetKey); // prior preserved (no Save call)
     }
 
     [Fact]
@@ -637,7 +642,7 @@ public sealed class AutoCalibrationEngineTests
         // candidate has a value. IsSameScaleRegime(null, _) → false → gate skipped.
         // First re-capture stamps a value and subsequent comparisons can gate normally.
         var svc = new FakeCalibrationService();
-        svc.Seed(Area, SomeBaseline() with { LocatorScale = null, ResidualPixels = 0.5, ReferenceCount = 10 });
+        svc.Seed(AssetKey, SomeBaseline() with { LocatorScale = null, ResidualPixels = 0.5, ReferenceCount = 10 });
 
         var h = new EngineHarness
         {
@@ -651,7 +656,7 @@ public sealed class AutoCalibrationEngineTests
         var outcome = await h.Engine().TryCalibrateCurrentAreaAsync(default);
 
         outcome.Persisted.Should().BeTrue();
-        svc.Saved[Area].LocatorScale.Should().Be(0.408); // legacy null replaced with stamped value
+        svc.Saved[AssetKey].LocatorScale.Should().Be(0.408); // legacy null replaced with stamped value
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineTests.cs
@@ -161,7 +161,7 @@ public sealed class AutoCalibrationEngineTests
         // Build an engine with a throwing extractor directly to prove fail-soft.
         var solver = new SpySolver(new CalibrationSolveResult(new AreaCalibration(1, 0, 0, 0, 6, 0.5), 6, null));
         var engine = new AutoCalibrationEngine(
-            new FakeAreaState(Area),
+            new FakeMapState { CurrentArea = Area, CurrentMapAsset = "Map_" + Area },
             new FakeWindowLocator(new GameWindow(1, new CaptureRect(0, 0, 1920, 1080))),
             new FakeRegionProvider(new CaptureRect(0, 0, 64, 64)),
             new SpyCapture(new GrayImage(64, 64, new byte[64 * 64])),
@@ -214,7 +214,7 @@ public sealed class AutoCalibrationEngineTests
         var captureSpy = new SpyCapture(capture);
         var solver = new SpySolver(h.Solve);
         var engine = new AutoCalibrationEngine(
-            new FakeAreaState(Area),
+            new FakeMapState { CurrentArea = Area, CurrentMapAsset = "Map_" + Area },
             new FakeWindowLocator(h.GameWindow),
             new FakeRegionProvider(h.Bbox),
             captureSpy,
@@ -314,7 +314,7 @@ public sealed class AutoCalibrationEngineTests
         var captureSpy = new SpyCapture(null);
         var solver = new SpySolver(Accepted(0.5, 4));
         var engine = new AutoCalibrationEngine(
-            new FakeAreaState(Area),
+            new FakeMapState { CurrentArea = Area, CurrentMapAsset = "Map_" + Area },
             new FakeWindowLocator(h.GameWindow),
             new FakeRegionProvider(h.Bbox),
             captureSpy,
@@ -684,5 +684,74 @@ public sealed class AutoCalibrationEngineTests
     private static AreaCalibration MakeCal(double residual, int refs) => new(
         Scale: 1.0, RotationRadians: 0.0, OriginX: 0.0, OriginY: 0.0,
         ReferenceCount: refs, ResidualPixels: residual);
+
+    // ── mithril#1021 strict gate + per-scene keying ─────────────────────────
+
+    /// <summary>
+    /// #1021 D3 (ratified): when <see cref="IMapState.CurrentMapAsset"/> is null
+    /// — autocal fired before any <c>Downloading Map</c> line was observed in
+    /// this session — the engine refuses outright. No fallback to a synthesised
+    /// <c>Map_&lt;area&gt;</c> guess; no texture/solver invocation. The outcome
+    /// surfaces <see cref="OutcomeVocabulary.MapAssetNotYetKnown"/> on BOTH
+    /// <see cref="AutoCalibrationOutcome.RejectReason"/> (legacy substring router)
+    /// AND <see cref="AutoCalibrationOutcome.OutcomeCategory"/> (structural router,
+    /// Task 14), so the status formatter routes the zone-change hint
+    /// deterministically.
+    /// </summary>
+    [Fact]
+    public async Task TryCalibrate_NoCurrentMapAsset_ReturnsRejectWithMapAssetNotYetKnown()
+    {
+        var h = new EngineHarness
+        {
+            CurrentArea = "AreaCave1",     // areas.json key is set…
+            CurrentMapAsset = null,        // …but no Downloading Map line yet
+            CurrentSceneFriendlyName = null,
+        };
+
+        var engine = h.Engine();
+        var outcome = await engine.TryCalibrateCurrentAreaAsync(default);
+
+        outcome.Persisted.Should().BeFalse();
+        outcome.RejectReason.Should().Be(OutcomeVocabulary.MapAssetNotYetKnown);
+        outcome.OutcomeCategory.Should().Be(OutcomeVocabulary.MapAssetNotYetKnown);
+        outcome.AreaKey.Should().Be("AreaCave1"); // context for logs, not a lookup key
+
+        // No side effects: the gate fires before texture resolution or solving.
+        h.BaseTextureProvider.Calls.Should().BeEmpty(
+            "the strict gate refuses outright — no Map_<X> fallback texture lookup");
+        h.Solver.SolveCalls.Should().Be(0,
+            "no detector input → no solve call");
+        h.Capture.Called.Should().BeFalse(
+            "the strict gate fires BEFORE any capture or downstream collaborator");
+    }
+
+    /// <summary>
+    /// #1021: when <see cref="IMapState.CurrentMapAsset"/> + <see cref="IMapState.CurrentSceneFriendlyName"/>
+    /// are set, the literal asset key flows verbatim to <see cref="IBaseTextureProvider.TryGetBaseTexture"/>
+    /// (no Map_-prefix synthesis) and the composite <see cref="MapSceneRef"/>
+    /// (ParentArea + sub-zone) flows to <see cref="IAreaReferenceProvider.ForArea"/>.
+    /// This is the aggregator-sub-zone case the spec calls out
+    /// (<c>AreaCave1</c> + <c>"Hogan's Basement"</c> → <c>Map_HogansKeepBasement</c>).
+    /// </summary>
+    [Fact]
+    public async Task TryCalibrate_CurrentMapAssetSet_PassesLiteralAssetKeyAndSceneRefDownstream()
+    {
+        var h = new EngineHarness
+        {
+            CurrentArea = "AreaCave1",
+            CurrentMapAsset = "Map_HogansKeepBasement",
+            CurrentSceneFriendlyName = "Hogan's Basement",
+            Solve = Accepted(residual: 0.65, inliers: 5),
+        };
+
+        var engine = h.Engine();
+        await engine.TryCalibrateCurrentAreaAsync(default);
+
+        h.BaseTextureProvider.Calls.Should().ContainSingle()
+            .Which.Should().Be("Map_HogansKeepBasement",
+                "the engine MUST pass the literal Unity Texture2D name from IMapState — no Map_<area> synthesis");
+        h.AreaRefs.LastSceneRef.Should().Be(new MapSceneRef("AreaCave1", "Hogan's Basement"),
+            "ParentAreaKey sources from IMapState.CurrentArea; SceneFriendlyName from IMapState.CurrentSceneFriendlyName");
+    }
 
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineZoomChangeRegressionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineZoomChangeRegressionTests.cs
@@ -19,6 +19,9 @@ namespace Mithril.MapCalibration.Capture.Tests;
 public sealed class AutoCalibrationEngineZoomChangeRegressionTests
 {
     private const string Area = EngineHarness.DefaultArea;
+    // #1021: the calibration store is keyed by per-scene asset key (Map_<X>),
+    // not the bare area key.
+    private const string AssetKey = EngineHarness.DefaultAssetKey;
 
     [Fact]
     public async Task User_recalibrates_at_a_different_zoom_and_lands_without_being_told_to_zoom_out()
@@ -39,7 +42,7 @@ public sealed class AutoCalibrationEngineZoomChangeRegressionTests
         first.Persisted.Should().BeTrue();
         first.OutcomeCategory.Should().Be(OutcomeVocabulary.Accepted);
         CalibrationStatusFormatter.ForOutcome(first).Should().BeNull();
-        svc.Saved[Area].LocatorScale.Should().Be(0.408);
+        svc.Saved[AssetKey].LocatorScale.Should().Be(0.408);
 
         // Step 2: user changes the in-game zoom, redraws the bbox, re-captures.
         // The new regime is scale 0.800 — outside the ±2% tolerance. Even though
@@ -61,8 +64,8 @@ public sealed class AutoCalibrationEngineZoomChangeRegressionTests
         CalibrationStatusFormatter.ForOutcome(second).Should().BeNull(); // chip clears
 
         // Saved cal is the NEW one (single-slot storage per #1005; per-scale is #1006).
-        svc.Saved[Area].LocatorScale.Should().Be(0.800);
-        svc.Saved[Area].ResidualPixels.Should().Be(1.2);
+        svc.Saved[AssetKey].LocatorScale.Should().Be(0.800);
+        svc.Saved[AssetKey].ResidualPixels.Should().Be(1.2);
     }
 
     [Fact]
@@ -100,6 +103,6 @@ public sealed class AutoCalibrationEngineZoomChangeRegressionTests
         msg.Should().NotContain("zoom the in-game map all the way out");
 
         // Good first calibration preserved.
-        svc.Saved[Area].ResidualPixels.Should().Be(0.79);
+        svc.Saved[AssetKey].ResidualPixels.Should().Be(0.79);
     }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CalibrationStatusFormatterTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CalibrationStatusFormatterTests.cs
@@ -92,4 +92,20 @@ public sealed class CalibrationStatusFormatterTests
 
         CalibrationStatusFormatter.ForOutcome(outcome).Should().BeNull();
     }
+
+    // ── #1021: per-scene calibration keying — pre-Downloading-Map refusal ──
+
+    [Fact]
+    public void Format_MapAssetNotYetKnown_ReturnsZoneChangeHint()
+    {
+        var outcome = new AutoCalibrationOutcome(
+            Persisted: false,
+            AreaKey: "AreaCave1",
+            RejectReason: OutcomeVocabulary.MapAssetNotYetKnown,
+            OutcomeCategory: OutcomeVocabulary.MapAssetNotYetKnown);
+
+        CalibrationStatusFormatter.ForOutcome(outcome)
+            .Should().Contain("Map asset not yet known")
+            .And.Contain("change zones once or restart while in this scene");
+    }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -136,6 +136,14 @@ public sealed class CaptureDependencyInjectionTests
         services.AddSingleton<IOverlayWindow>(new FakeOverlayWindow());
         services.AddSingleton<IDomainEventSubscriber>(new FakeDomainEventSubscriber());
         services.AddSingleton<IAreaState>(new FakeAreaState("AreaSerbule"));
+        // #1021: the engine now resolves IMapState (per-scene asset + sub-zone)
+        // instead of IAreaState. AutoCalibrationTrigger still consumes IAreaState
+        // (zone-change subscription), so both registrations remain.
+        services.AddSingleton<IMapState>(new FakeMapState
+        {
+            CurrentArea = "AreaSerbule",
+            CurrentMapAsset = "Map_AreaSerbule",
+        });
         services.AddSingleton<IReferenceDataService>(new FakeAreaReferenceData());
         services.AddSingleton<IMapCalibrationService>(new FakeCalibrationService());
 

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -112,9 +112,25 @@ internal sealed class FakeIconTemplateProvider : IIconTemplateProvider
 
 internal sealed class FakeAreaRefs : IAreaReferenceProvider
 {
-    private readonly IReadOnlyList<LandmarkReference> _refs;
-    public FakeAreaRefs(IReadOnlyList<LandmarkReference> refs) => _refs = refs;
-    public IReadOnlyList<LandmarkReference> ForArea(string areaKey) => _refs;
+    public FakeAreaRefs() => References = Array.Empty<LandmarkReference>();
+    public FakeAreaRefs(IReadOnlyList<LandmarkReference> refs) => References = refs;
+
+    /// <summary>References returned by every <see cref="ForArea"/> call. Settable
+    /// so callers may use either the positional constructor or an
+    /// object-initializer (mithril#1021 plan style).</summary>
+    public IReadOnlyList<LandmarkReference> References { get; set; }
+
+    /// <summary>The <see cref="MapSceneRef"/> from the most recent
+    /// <see cref="ForArea"/> call, or <c>null</c> if not yet invoked. Used by
+    /// the per-scene-keying tests (mithril#1021) to assert the composite
+    /// scene identity flows through unmodified.</summary>
+    public MapSceneRef? LastSceneRef { get; private set; }
+
+    public IReadOnlyList<LandmarkReference> ForArea(MapSceneRef sceneRef)
+    {
+        LastSceneRef = sceneRef;
+        return References;
+    }
 }
 
 internal sealed class SpySolver : IMapCalibrationSolver

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Arda.Contracts;
 using Arda.World.Player;
+using Arda.World.Player.Events;
 using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture;
 using Mithril.MapCalibration.Detection;
@@ -35,6 +36,38 @@ internal sealed class FakeAreaState : IAreaState
 {
     public FakeAreaState(string? area) => CurrentArea = area;
     public string? CurrentArea { get; }
+}
+
+/// <summary>
+/// Flat <see cref="IMapState"/> fake for engine tests (mithril#1021). Every
+/// property is a settable init so tests construct what they need with an
+/// object initializer; un-set properties default to <c>null</c> / empty.
+/// </summary>
+internal sealed class FakeMapState : IMapState
+{
+    // --- Area ---
+    public string? CurrentArea { get; set; }
+    public string? PreviousArea { get; set; }
+    public DateTimeOffset? TransitionedAt { get; set; }
+
+    // --- Map asset ---
+    public string? CurrentMapAsset { get; set; }
+    public string? CurrentSceneFriendlyName { get; set; }
+    public DateTimeOffset? MapAssetMeasuredAt { get; set; }
+
+    // --- Position ---
+    public double? X { get; set; }
+    public double? Y { get; set; }
+    public double? Z { get; set; }
+    public DateTimeOffset? PositionMeasuredAt { get; set; }
+    public PositionSource? PositionSource { get; set; }
+
+    // --- Weather ---
+    public string? CurrentWeather { get; set; }
+    public DateTimeOffset? WeatherMeasuredAt { get; set; }
+
+    // --- Pins ---
+    public IReadOnlyList<MapPinEntry> Pins { get; set; } = Array.Empty<MapPinEntry>();
 }
 
 internal sealed class FakeWindowLocator : IGameWindowLocator
@@ -87,9 +120,27 @@ internal sealed class FakeRefiner : IMapRegionRefiner
 
 internal sealed class FakeBaseTextureProvider : IBaseTextureProvider
 {
-    private readonly GrayImage? _tex;
-    public FakeBaseTextureProvider(GrayImage? tex) => _tex = tex;
-    public GrayImage? TryGetBaseTexture(string areaKey) => _tex;
+    /// <summary>
+    /// Parameterless constructor for the mithril#1021 object-initializer style:
+    /// <c>new FakeBaseTextureProvider { ResolveAs = ... }</c>.
+    /// </summary>
+    public FakeBaseTextureProvider() { }
+
+    /// <summary>Legacy positional constructor — pre-#1021 tests pass the texture directly.</summary>
+    public FakeBaseTextureProvider(GrayImage? tex) => ResolveAs = tex;
+
+    /// <summary>The texture this provider returns for any <see cref="TryGetBaseTexture"/> call.</summary>
+    public GrayImage? ResolveAs { get; set; }
+
+    /// <summary>Every <see cref="TryGetBaseTexture"/> key, in call order. The strict-gate test
+    /// (#1021) asserts this is empty when the engine refuses early.</summary>
+    public List<string> Calls { get; } = new();
+
+    public GrayImage? TryGetBaseTexture(string mapAssetKey)
+    {
+        Calls.Add(mapAssetKey);
+        return ResolveAs;
+    }
 }
 
 /// <summary>
@@ -138,9 +189,13 @@ internal sealed class SpySolver : IMapCalibrationSolver
     private readonly CalibrationSolveResult _result;
     public SpySolver(CalibrationSolveResult result) => _result = result;
     public bool Called { get; private set; }
+    /// <summary>Number of <see cref="Solve"/> calls. The mithril#1021 strict-gate
+    /// test asserts this is zero when the engine refuses early.</summary>
+    public int SolveCalls { get; private set; }
     public CalibrationSolveResult Solve(DetectionRequest request, IReadOnlyList<LandmarkReference> references)
     {
         Called = true;
+        SolveCalls++;
         return _result;
     }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineHarness.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineHarness.cs
@@ -22,7 +22,24 @@ internal sealed class EngineHarness
     /// test overrides <see cref="CurrentArea"/>.</summary>
     public const string DefaultArea = "AreaEltibule";
 
+    /// <summary>The default per-scene map-asset key. Mirrors the
+    /// <see cref="DefaultArea"/> in the cosmically-trivial 1:1 case the legacy
+    /// happy-path tests assume (mithril#1021: real aggregator scenes carry a
+    /// distinct asset name).</summary>
+    public const string DefaultMapAsset = "Map_AreaEltibule";
+
     public string? CurrentArea { get; init; } = DefaultArea;
+
+    /// <summary>Per-scene map-asset key for the engine's strict gate (mithril#1021 D3).
+    /// Defaults to <see cref="DefaultMapAsset"/> so the legacy happy-path tests
+    /// don't trip the gate. Set to <c>null</c> to model "Downloading Map line
+    /// not yet observed in this session".</summary>
+    public string? CurrentMapAsset { get; init; } = DefaultMapAsset;
+
+    /// <summary>Sub-zone friendly name for aggregator scenes. Defaults to <c>null</c>
+    /// (directly-registered area).</summary>
+    public string? CurrentSceneFriendlyName { get; init; }
+
     public CaptureRect? Bbox { get; init; } = new CaptureRect(0, 0, 64, 64);
     public GameWindow? GameWindow { get; init; } = new GameWindow(1, new CaptureRect(0, 0, 1920, 1080));
     public GrayImage? BaseTexture { get; init; } = new GrayImage(64, 64, new byte[64 * 64]);
@@ -44,6 +61,17 @@ internal sealed class EngineHarness
     public SpyCapture Capture { get; } = new(new GrayImage(64, 64, new byte[64 * 64]));
     public SpySolver Solver { get; private set; } = null!;
 
+    /// <summary>Base-texture provider. Exposed so #1021 tests can assert
+    /// <see cref="FakeBaseTextureProvider.Calls"/> reflects the per-scene asset
+    /// key the engine looked up. Auto-constructed in <see cref="Engine"/> from
+    /// <see cref="BaseTexture"/>.</summary>
+    public FakeBaseTextureProvider BaseTextureProvider { get; private set; } = null!;
+
+    /// <summary>Reference-data provider. Exposed so #1021 tests can assert
+    /// <see cref="FakeAreaRefs.LastSceneRef"/> carries the composite scene
+    /// identity. Auto-constructed in <see cref="Engine"/>.</summary>
+    public FakeAreaRefs AreaRefs { get; private set; } = null!;
+
     // Refiner stub: defaults to the happy-path rect. Tests can override to:
     //   - new FakeRefiner(null) → drives the engine into the map-not-located path
     //   - a rect with origin >= frame dims → drives the engine into clamp-degenerate
@@ -53,14 +81,22 @@ internal sealed class EngineHarness
     public AutoCalibrationEngine Engine()
     {
         Solver = new SpySolver(Solve);
+        BaseTextureProvider = new FakeBaseTextureProvider(BaseTexture);
+        AreaRefs = new FakeAreaRefs(new[] { new LandmarkReference("landmark_npc", "x", new WorldCoord(1, 0, 1)) });
+        var mapState = new FakeMapState
+        {
+            CurrentArea = CurrentArea,
+            CurrentMapAsset = CurrentMapAsset,
+            CurrentSceneFriendlyName = CurrentSceneFriendlyName,
+        };
         return new AutoCalibrationEngine(
-            new FakeAreaState(CurrentArea),
+            mapState,
             new FakeWindowLocator(GameWindow),
             new FakeRegionProvider(Bbox),
             Capture,
             Refiner,
-            new FakeBaseTextureProvider(BaseTexture),
-            new FakeAreaRefs(new[] { new LandmarkReference("landmark_npc", "x", new WorldCoord(1, 0, 1)) }),
+            BaseTextureProvider,
+            AreaRefs,
             Solver,
             IconProvider,
             Service,

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineHarness.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineHarness.cs
@@ -28,6 +28,13 @@ internal sealed class EngineHarness
     /// distinct asset name).</summary>
     public const string DefaultMapAsset = "Map_AreaEltibule";
 
+    /// <summary>The default per-scene asset key the engine uses for persistence
+    /// + lookup post-#1021. Equal to <see cref="DefaultMapAsset"/>; aliased
+    /// separately so test sites that read/write the calibration store can name
+    /// their intent ("the asset-key the engine persists under") without coupling
+    /// to the texture-load semantics.</summary>
+    public const string DefaultAssetKey = DefaultMapAsset;
+
     public string? CurrentArea { get; init; } = DefaultArea;
 
     /// <summary>Per-scene map-asset key for the engine's strict gate (mithril#1021 D3).

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/FakeAreaReferenceData.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/FakeAreaReferenceData.cs
@@ -34,6 +34,21 @@ internal sealed class FakeAreaReferenceData : IReferenceDataService
         return this;
     }
 
+    /// <summary>Seed an NPC with both <see cref="Npc.AreaName"/> (parent aggregator key) and
+    /// <see cref="Npc.AreaFriendlyName"/> (sub-zone label) — used by the per-scene-keying
+    /// tests (mithril#1021) to scope NPCs to the right sub-zone of an aggregator scene.</summary>
+    public FakeAreaReferenceData WithNpc(string areaKey, string areaFriendlyName, string name, string pos)
+    {
+        _npcsByInternalName["NPC_" + name] = new Npc
+        {
+            Name = name,
+            AreaName = areaKey,
+            AreaFriendlyName = areaFriendlyName,
+            Pos = pos,
+        };
+        return this;
+    }
+
     /// <summary>Seed a positionless table entry (no <see cref="Npc.Pos"/>) — e.g. the
     /// "Work Orders" sign / "Sacrificial Bowl" pedestal that live in npcs.json without
     /// a map position. These must be skipped silently, not counted as a coord-shape change.</summary>

--- a/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/IconTemplateBootstrapTests.cs
@@ -63,7 +63,7 @@ public sealed class IconTemplateBootstrapTests : IDisposable
         call.Kind.Should().Be(ExtractKind.Icons);
         call.InstallRoot.Should().Be(@"C:\Games\PG");
         call.OutDir.Should().Be(_cacheDir);
-        call.AreaKey.Should().BeNull();
+        call.MapAssetName.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Mithril.MapCalibration.Capture.Tests/ReferenceProviderSolverSeamTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/ReferenceProviderSolverSeamTests.cs
@@ -67,7 +67,7 @@ public sealed class ReferenceProviderSolverSeamTests
                      $"z:{npc.Z.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
         }
 
-        var refs = new ReferenceDataAreaReferenceProvider(fake).ForArea("AreaSerbule");
+        var refs = new ReferenceDataAreaReferenceProvider(fake).ForArea(new MapSceneRef("AreaSerbule", null));
         refs.Should().HaveCount(Points.Length);
         // Provider speaks the canonical vocabulary…
         refs.Select(r => r.Type).Distinct().Should().OnlyContain(t => CanonicalLandmarkTypes.All.Contains(t));

--- a/tests/Mithril.MapCalibration.Tests/AutoCaptureCalibrationSourceTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/AutoCaptureCalibrationSourceTests.cs
@@ -57,6 +57,11 @@ public sealed class AutoCaptureCalibrationSourceTests
             // name the converter can't parse (stands in for a future/unknown source
             // name as seen by a build that predates it). The poisoned entry must be
             // dropped while the valid entry survives — NOT a whole-store wipe.
+            //
+            // Note: the file is v1 shape (bare area keys) intentionally — this
+            // exercises BOTH the per-entry resilience (the original fix) AND the
+            // v1→v2 prefix migrator (#1021 Task 18) at once. The survivor is
+            // looked up under its migrated "Map_<X>" key.
             File.WriteAllText(path,
                 "{\"schemaVersion\":1,\"calibrations\":{" +
                 "\"AreaSerbule\":{" +
@@ -73,12 +78,21 @@ public sealed class AutoCaptureCalibrationSourceTests
 
             // The poisoned entry (originX=10) is dropped: never served as a user
             // refinement (a bundled baseline may win, but never the bad transform).
-            var poisoned = service.GetCalibration("AreaSerbule");
-            (poisoned is null || poisoned.OriginX != 10 || poisoned.Source != CalibrationSource.UserRefinement)
-                .Should().BeTrue("the unparseable user-store refinement must not be served");
+            // Check under BOTH the bare v1 key and the migrated v2 key so the
+            // assertion is robust regardless of whether per-entry resilience
+            // skipped it before or after key transformation.
+            foreach (var lookupKey in new[] { "AreaSerbule", "Map_AreaSerbule" })
+            {
+                var poisoned = service.GetCalibration(lookupKey);
+                (poisoned is null || poisoned.OriginX != 10 || poisoned.Source != CalibrationSource.UserRefinement)
+                    .Should().BeTrue($"the unparseable user-store refinement must not be served (key={lookupKey})");
+            }
 
-            // The valid sibling entry SURVIVES — this is the resilience the fix adds.
-            var survivor = service.GetCalibration("AreaEltibule");
+            // The valid sibling entry SURVIVES — this is the resilience the fix
+            // adds. Looked up under the migrated "Map_AreaEltibule" key per the
+            // v1→v2 prefix migrator. Bare "AreaEltibule" is intentionally NOT
+            // resolvable post-migration — that's the new keying contract.
+            var survivor = service.GetCalibration("Map_AreaEltibule");
             survivor.Should().NotBeNull("a poisoned sibling entry must not wipe the whole store");
             survivor!.OriginX.Should().Be(42, "the valid entry's transform is preserved verbatim");
             survivor.OriginY.Should().Be(99);

--- a/tests/Mithril.MapCalibration.Tests/BundledBaselineLoaderTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/BundledBaselineLoaderTests.cs
@@ -26,8 +26,8 @@ public sealed class BundledBaselineLoaderTests
         // turns this red rather than degrading at runtime.
         var baseline = BundledBaselineLoader.Load(logger: null);
 
-        baseline.Should().ContainKeys("AreaSerbule", "AreaEltibule", "AreaKurMountains");
-        baseline["AreaSerbule"].Source.Should().Be(CalibrationSource.BundledBaseline);
+        baseline.Should().ContainKeys("Map_AreaSerbule", "Map_AreaEltibule", "Map_AreaKurMountains");
+        baseline["Map_AreaSerbule"].Source.Should().Be(CalibrationSource.BundledBaseline);
     }
 
     [Fact]
@@ -38,5 +38,23 @@ public sealed class BundledBaselineLoaderTests
         {
             cal.Source.Should().Be(CalibrationSource.BundledBaseline);
         }
+    }
+
+    [Fact]
+    public void Bundled_baseline_v2_keys_have_Map_prefix()
+    {
+        // The v2 schema (#1021) keys calibration entries by the per-scene asset name
+        // (Map_AreaSerbule) rather than the area aggregate (AreaSerbule). This test
+        // catches a regression where someone hand-edits the JSON and forgets the
+        // prefix OR forgets the schemaVersion bump — either of which would silently
+        // re-break the per-scene keying #1021 fixed.
+        var baseline = BundledBaselineLoader.Load(logger: null);
+
+        baseline.Should().ContainKey("Map_AreaSerbule");
+        baseline.Should().ContainKey("Map_AreaEltibule");
+        baseline.Should().ContainKey("Map_AreaKurMountains");
+        baseline.Should().NotContainKey("AreaSerbule");
+        baseline.Should().NotContainKey("AreaEltibule");
+        baseline.Should().NotContainKey("AreaKurMountains");
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ProcessAssetExtractorTests.cs
@@ -78,7 +78,7 @@ public sealed class ProcessAssetExtractorTests : IDisposable
             new ExtractRequest("C:/PG", "C:/cache", ExtractKind.Texture, "AreaSerbule", "1.2.3"), CancellationToken.None);
 
         var args = captured!.ArgumentList;
-        args.Should().ContainInOrder("--area", "AreaSerbule");
+        args.Should().ContainInOrder("--asset", "AreaSerbule");
         args.Should().ContainInOrder("--expect-pg-version", "1.2.3");
         args.Should().NotContain("--icons");
     }

--- a/tests/Mithril.MapCalibration.Tests/Internal/UserRefinementStoreMigrationTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Internal/UserRefinementStoreMigrationTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.MapCalibration.Internal;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Internal;
+
+/// <summary>
+/// Task 18 (#1021): <see cref="UserRefinementStore"/> load-time v1&#8594;v2 prefix
+/// migrator. A v1 file (absent top-level <c>schemaVersion</c> field, bare area
+/// keys like <c>AreaSerbule</c>) loads as <c>Map_</c>-prefixed in memory and is
+/// rewritten with <c>schemaVersion: 2</c>. A v2 file is byte-untouched on disk.
+/// A v1 file whose key is already <c>Map_</c>-prefixed (defensive) is not
+/// double-prefixed. A missing file is a no-op.
+/// </summary>
+public sealed class UserRefinementStoreMigrationTests : IDisposable
+{
+    private readonly string _dir;
+
+    public UserRefinementStoreMigrationTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "mithril-refstore-migrate-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch { /* CI temp dir gets reaped */ }
+    }
+
+    private string Path_ => Path.Combine(_dir, "refinements.json");
+
+    private const string V1Json = """
+        {
+          "calibrations": {
+            "AreaSerbule": {
+              "scale": 0.82, "rotationRadians": 0.0, "originX": 100.0, "originY": 200.0,
+              "referenceCount": 4, "residualPixels": 0.5,
+              "source": "UserRefinement", "schemaVersion": 1, "calibrationZoom": 1.0, "mirrorNorth": false
+            }
+          }
+        }
+        """;
+
+    [Fact]
+    public void Load_V1File_PrefixesKeysWithMapAndPersistsAsV2()
+    {
+        File.WriteAllText(Path_, V1Json);
+
+        var store = new UserRefinementStore(_dir);
+
+        store.TryGet("Map_AreaSerbule", out var cal).Should().BeTrue();
+        cal.Scale.Should().BeApproximately(0.82, 1e-9);
+
+        // File rewritten with schemaVersion 2, Map_-prefixed key.
+        using var doc = JsonDocument.Parse(File.ReadAllText(Path_));
+        doc.RootElement.GetProperty("schemaVersion").GetInt32().Should().Be(2);
+        doc.RootElement.GetProperty("calibrations").EnumerateObject()
+            .Select(p => p.Name).Should().ContainSingle().Which.Should().Be("Map_AreaSerbule");
+    }
+
+    [Fact]
+    public void Load_V2File_NoMutation()
+    {
+        const string v2 = """
+            {
+              "schemaVersion": 2,
+              "calibrations": {
+                "Map_AreaSerbule": {
+                  "scale": 0.82, "rotationRadians": 0.0, "originX": 100.0, "originY": 200.0,
+                  "referenceCount": 4, "residualPixels": 0.5,
+                  "source": "UserRefinement", "schemaVersion": 1, "calibrationZoom": 1.0, "mirrorNorth": false
+                }
+              }
+            }
+            """;
+        File.WriteAllText(Path_, v2);
+        var before = File.ReadAllBytes(Path_);
+
+        var store = new UserRefinementStore(_dir);
+        store.TryGet("Map_AreaSerbule", out _).Should().BeTrue();
+
+        // Idempotent: file unchanged byte-for-byte (no rewrite triggered).
+        File.ReadAllBytes(Path_).Should().Equal(before);
+    }
+
+    [Fact]
+    public void Load_V1FileWithAlreadyPrefixedKey_NotDoublePrefixed()
+    {
+        const string weird = """
+            {
+              "calibrations": {
+                "Map_AreaSerbule": {
+                  "scale": 0.82, "rotationRadians": 0.0, "originX": 100.0, "originY": 200.0,
+                  "referenceCount": 4, "residualPixels": 0.5,
+                  "source": "UserRefinement", "schemaVersion": 1, "calibrationZoom": 1.0, "mirrorNorth": false
+                }
+              }
+            }
+            """;
+        File.WriteAllText(Path_, weird);
+
+        var store = new UserRefinementStore(_dir);
+        store.TryGet("Map_AreaSerbule", out _).Should().BeTrue();
+        store.TryGet("Map_Map_AreaSerbule", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Load_MissingFile_NoMigration_NoCrash()
+    {
+        var store = new UserRefinementStore(_dir);
+        store.All.Should().BeEmpty();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Logging/Fixtures/per-rule/asset-loader-noise.log
+++ b/tests/Mithril.Shared.Tests/Logging/Fixtures/per-rule/asset-loader-noise.log
@@ -18,3 +18,7 @@ UnloadTime: 5.891400 ms
 UnloadTime: 0.486400 ms
 Downloading Map [0e88b64bdd834cc41a23b8357802f254] GUID 0e88b64bdd834cc41a23b8357802f254 for area Kur Mountains runtime key 0e88b64bdd834cc41a23b8357802f254[Map_AreaKurMountains]
 Completed load of [0e88b64bdd834cc41a23b8357802f254]: ChainOperation<IList`1> - Dependencies [Assets/Art/Maps/Map_AreaKurMountains.png, Assets/Art/Maps/Map_AreaKurMountains.png]. Succeeded. 
+Downloading Map [44d50fb35fa65dd4cbb84e3af49ca0a4] GUID 44d50fb35fa65dd4cbb84e3af49ca0a4 for area Hogan's Basement runtime key 44d50fb35fa65dd4cbb84e3af49ca0a4[Map_HogansKeepBasement]
+Completed load of [44d50fb35fa65dd4cbb84e3af49ca0a4]: ChainOperation<IList`1> - Dependencies [Assets/Art/Maps/Map_HogansKeepBasement.png, Assets/Art/Maps/Map_HogansKeepBasement.png]. Succeeded.
+UnloadTime: 0.123400 ms
+>> Map_HogansKeepBasement (UnityEngine.Texture2D) UnityEngine.Texture2D

--- a/tools/Mithril.AssetExtractor/Program.cs
+++ b/tools/Mithril.AssetExtractor/Program.cs
@@ -3,7 +3,13 @@
 // pre-decoded manifest+blob cache the decoder-free app graph reads BCL-only.
 //
 // CLI:
-//   mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>] [--tpk <path>]
+//   mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --asset <Map_<X>>) [--expect-pg-version <v>] [--tpk <path>]
+//
+// --asset takes the literal Unity Texture2D name (e.g. Map_AreaSerbule,
+// Map_HogansKeepBasement) verbatim from the Player.log "Downloading Map" line
+// — see mithril#1021. Renamed from --area in mithril#1021; the caller side
+// (ProcessAssetExtractor in src/Mithril.MapCalibration.Detection) emits the
+// new flag.
 //
 // Outputs: cache files on disk (existing manifest+blob format) + ONE JSON result
 // line on stdout + an exit code. stderr = human diagnostics.
@@ -110,10 +116,23 @@ namespace Mithril.Tools.AssetExtractor
             else
             {
                 var mapDir = Path.Combine(args.OutDir, "maps-src");
+                // --asset is the literal Unity Texture2D name (e.g. Map_AreaSerbule,
+                // Map_HogansKeepBasement). The shared MapTextureExtractor.EnsureExtracted
+                // is also called from the gate-study / WPF / synthesis-probe tools, all
+                // of which pass the bare "<X>" form (e.g. "AreaSerbule"); to avoid
+                // churning those callers, strip the Map_ prefix here at the sidecar
+                // boundary before handing off. The consumer-facing cache (written by
+                // MapTextureCacheEmitter and read by CachedBaseTextureProvider) is keyed
+                // on the full Map_<X> form (#1021 — that's the per-scene cache key the
+                // runtime now expects).
+                var asset = args.MapAssetName!;
+                var bareArea = asset.StartsWith("Map_", StringComparison.Ordinal)
+                    ? asset["Map_".Length..]
+                    : asset;
                 string pngPath;
                 try
                 {
-                    pngPath = MapTextureExtractor.EnsureExtracted(args.InstallRoot, mapDir, args.AreaKey!);
+                    pngPath = MapTextureExtractor.EnsureExtracted(args.InstallRoot, mapDir, bareArea);
                 }
                 catch (UserFacingException ex) when (ex.Message.Contains("no map bundle for area", StringComparison.OrdinalIgnoreCase))
                 {
@@ -121,8 +140,8 @@ namespace Mithril.Tools.AssetExtractor
                     return ExitBundleMissing;
                 }
                 var (manifestPath, sha) = MapTextureCacheEmitter.EmitFromPng(
-                    pngPath, args.AreaKey!, args.OutDir, pgVersion, extractorVersion);
-                artifacts.Add(new ResultArtifact("texture", args.AreaKey, manifestPath, sha));
+                    pngPath, asset, args.OutDir, pgVersion, extractorVersion);
+                artifacts.Add(new ResultArtifact("texture", asset, manifestPath, sha));
             }
 
             EmitResult(pgVersion, extractorVersion, artifacts);
@@ -174,11 +193,11 @@ namespace Mithril.Tools.AssetExtractor
 
     internal enum ExtractKind { Icons, Texture }
 
-    internal sealed record SidecarArgs(string InstallRoot, string OutDir, ExtractKind Kind, string? AreaKey, string? ExpectPgVersion, string? TpkPath)
+    internal sealed record SidecarArgs(string InstallRoot, string OutDir, ExtractKind Kind, string? MapAssetName, string? ExpectPgVersion, string? TpkPath)
     {
         public static SidecarArgs Parse(string[] args)
         {
-            string? install = null, outDir = null, area = null, expect = null, tpk = null;
+            string? install = null, outDir = null, asset = null, expect = null, tpk = null;
             bool icons = false;
             for (int i = 0; i < args.Length; i++)
             {
@@ -187,7 +206,7 @@ namespace Mithril.Tools.AssetExtractor
                     case "--install": install = Next(args, ref i, "--install"); break;
                     case "--out": outDir = Next(args, ref i, "--out"); break;
                     case "--icons": icons = true; break;
-                    case "--area": area = Next(args, ref i, "--area"); break;
+                    case "--asset": asset = Next(args, ref i, "--asset"); break;
                     case "--expect-pg-version": expect = Next(args, ref i, "--expect-pg-version"); break;
                     case "--tpk": tpk = Next(args, ref i, "--tpk"); break;
                     default:
@@ -196,9 +215,9 @@ namespace Mithril.Tools.AssetExtractor
             }
             if (string.IsNullOrWhiteSpace(install)) throw new UserFacingException("--install <pgRoot> is required");
             if (string.IsNullOrWhiteSpace(outDir)) throw new UserFacingException("--out <cacheDir> is required");
-            if (icons && area is not null) throw new UserFacingException("--icons and --area are mutually exclusive");
-            if (!icons && area is null) throw new UserFacingException("one of --icons or --area <AreaKey> is required");
-            return new SidecarArgs(install, outDir, icons ? ExtractKind.Icons : ExtractKind.Texture, area, expect, tpk);
+            if (icons && asset is not null) throw new UserFacingException("--icons and --asset are mutually exclusive");
+            if (!icons && asset is null) throw new UserFacingException("one of --icons or --asset <Map_<X>> is required");
+            return new SidecarArgs(install, outDir, icons ? ExtractKind.Icons : ExtractKind.Texture, asset, expect, tpk);
         }
 
         private static string Next(string[] args, ref int i, string flag)
@@ -210,7 +229,7 @@ namespace Mithril.Tools.AssetExtractor
         public static void PrintUsage()
         {
             Console.Error.WriteLine(
-                "usage: mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>] [--tpk <path>]");
+                "usage: mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --asset <Map_<X>>) [--expect-pg-version <v>] [--tpk <path>]");
         }
     }
 

--- a/tools/Mithril.AssetExtractor/README.md
+++ b/tools/Mithril.AssetExtractor/README.md
@@ -38,15 +38,22 @@ doesn't run.
 ## CLI
 
 ```
-mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --area <AreaKey>) [--expect-pg-version <v>]
+mithril-asset-extract --install <pgRoot> --out <cacheDir> (--icons | --asset <Map_<AssetName>>) [--expect-pg-version <v>]
 ```
 
 - `--icons` — extract the landmark icon templates from `sharedassets0.assets`
   (needs `classdata.tpk` beside the exe or at the Tools default) and write
   `icon-templates.{json,bin}` into `<cacheDir>`.
-- `--area <AreaKey>` — extract that area's `Map_<AreaKey>` base texture from its
-  Addressables bundle and write the gray-only `map-texture-<AreaKey>.{json,bin}`
-  into `<cacheDir>`.
+- `--asset <Map_<AssetName>>` — extract the literal Unity Texture2D named
+  `Map_<AssetName>` (e.g. `Map_AreaSerbule`, `Map_HogansKeepBasement` — the
+  verbatim name from the Player.log "Downloading Map" line — see
+  [mithril#1021](https://github.com/moumantai-gg/mithril/issues/1021))
+  from its Addressables bundle and write the gray-only
+  `map-texture-Map_<AssetName>.{json,bin}` into `<cacheDir>`. Renamed from
+  `--area` in mithril#1021; the prior flag's value was a bare areas.json key
+  (e.g. `AreaSerbule`), which couldn't address aggregator sub-zones whose
+  scenes don't appear in `areas.json` (the ~51 dungeons fronted by an
+  `AreaCave*` parent).
 
 ## Known limitation (v1)
 
@@ -58,8 +65,8 @@ without it). That file is **neither bundled in the csproj nor staged by
 → the app fail-softs (icon templates stay empty → no detections → the confidence
 gate rejects → safe-degrade, never a wrong calibration).
 
-`--area` texture extraction is **unaffected** — area Addressables bundles ship
-inline type trees, so no `classdata.tpk` is required.
+`--asset` texture extraction is **unaffected** — per-scene Addressables bundles
+ship inline type trees, so no `classdata.tpk` is required.
 
 This is an accepted v1 limitation: icon provisioning (staging `classdata.tpk`
 beside the published sidecar, or bundling it) rides with the
@@ -74,8 +81,12 @@ sits beside the exe (or at the Tools default path).
 # icons
 mithril-asset-extract --install "C:\...\Project Gorgon" --out C:\tmp\cache --icons
 
-# one area
-mithril-asset-extract --install "C:\...\Project Gorgon" --out C:\tmp\cache --area AreaSerbule
+# one scene's map texture (direct-area)
+mithril-asset-extract --install "C:\...\Project Gorgon" --out C:\tmp\cache --asset Map_AreaSerbule
+
+# one scene's map texture (aggregator sub-zone — pre-#1021 the bare AreaCave1
+# parent key couldn't address this)
+mithril-asset-extract --install "C:\...\Project Gorgon" --out C:\tmp\cache --asset Map_HogansKeepBasement
 ```
 
 Each run writes the cache files + emits **one JSON result line** on stdout:
@@ -94,10 +105,11 @@ Both reuse the existing deflate manifest+blob shape the runtime loaders verify:
 
 - **icons** (`icon-templates.{json,bin}`): per icon, `w*h` gray bytes then `w*h`
   alpha bytes, Deflate-compressed; `pixelSha256` over the decompressed stream.
-- **texture** (`map-texture-<area>.{json,bin}`): single-entry manifest
+- **texture** (`map-texture-Map_<AssetName>.{json,bin}`): single-entry manifest
   (width, height, pixelSha256) + `w*h` **gray** bytes Deflate-compressed (no
   alpha). The base texture is a single channel the detector diffs the screenshot
-  against.
+  against. Cache key is the literal Unity Texture2D name (with the `Map_`
+  prefix) — see [mithril#1021](https://github.com/moumantai-gg/mithril/issues/1021).
 
 `pgVersion` + `extractorVersion` are stamped into every manifest (the
 cache-invalidation + canonical-hash-gate keys).


### PR DESCRIPTION
## Summary

Implements [mithril#1021](https://github.com/moumantai-gg/mithril/issues/1021) — switches Mithril's calibration store from `areas.json` `AreaX` keys (one per registered area) to **literal per-scene Unity asset names** (`Map_HogansKeepBasement`, `Map_AreaSerbule`, … verbatim from the `Downloading Map [GUID] … runtime key GUID[Map_<X>]` Player.log line). Unblocks autocal for the ~51 aggregator sub-zone scenes that previously fell through the empty-bundle path.

- **Spec:** [`docs/planning/map-calibration-1021-per-scene-keying/spec.md`](docs/planning/map-calibration-1021-per-scene-keying/spec.md) — decisions D1–D8 ratified.
- **Plan:** `docs/planning/map-calibration-1021-per-scene-keying/plan.md` (on branch [`plan/map-calibration-1021-per-scene-keying`](https://github.com/moumantai-gg/mithril/tree/plan/map-calibration-1021-per-scene-keying), PR [#1035](https://github.com/moumantai-gg/mithril/pull/1035)) — 22 tasks across 7 phases, every step TDD-shaped.
- **Closes** [#1021](https://github.com/moumantai-gg/mithril/issues/1021).

## What changed (by phase)

| Phase | Tasks | Net change |
|---|---|---|
| **1. Arda foundation** | 1–7 | New `Verbs.DownloadingMap` const, `VerbExtractor` prefix branch, `MapAssetChanged` event, `MapAssetLoader` handler with full TDD coverage (13 tests; idempotent, last-bracket-wins, 5 malformed-skip cases), `IMapState` extended with `CurrentMapAsset` / `CurrentSceneFriendlyName` / `MapAssetMeasuredAt`, `MapScope` delegation + DI wire-up. |
| **2. Calibration type** | 8 | New `MapSceneRef(ParentAreaKey, SceneFriendlyName?)` record struct. |
| **3. Provider seam** | 9–10 | `IAreaReferenceProvider.ForArea(string)` → `ForArea(MapSceneRef)`; sub-zone-aware NPC filter narrows on `(AreaName, AreaFriendlyName)` when `SceneFriendlyName` is set, collapses to area-only for direct areas. `IBaseTextureProvider.TryGetBaseTexture(areaKey)` → `mapAssetKey` rename + 12 log-property renames. |
| **4. Sidecar contract** | 11–12 | `ExtractRequest.AreaKey` → `MapAssetName`; sidecar CLI `--area <X>` → `--asset <Map_X>`; sidecar internally strips `Map_` at boundary so the existing shared `MapTextureExtractor` (used by 3 out-of-scope callers — gate-study, WPF, SynthesisProbe) is untouched. |
| **5. Autocal cutover (CRITICAL PATH)** | 13–15 | New `OutcomeVocabulary.MapAssetNotYetKnown` const; `CalibrationStatusFormatter` routes to user-facing "Map asset not yet known — change zones once or restart while in this scene." `AutoCalibrationEngine` DI: `IAreaState` → `IMapState`. **Strict gate** (spec D3): `CurrentMapAsset == null` returns `Persisted: false`, `RejectReason: MapAssetNotYetKnown`, **no fallback to `$"Map_{CurrentArea}"`**, no detector/solver/texture-provider invocation. |
| **6. Persistence + telemetry** | 16–21 | `map-calibration-baseline.json` `schemaVersion` 1→2; 3 anchor keys prefixed (`AreaSerbule` → `Map_AreaSerbule`, etc.) with byte-for-byte unchanged values. `UserRefinementStore` load-time v1→v2 migrator: idempotent at the load level (v2 file is byte-untouched on disk), transactional rollback if `Persist()` throws mid-write, defensive no-double-prefix. Telemetry `outcome` vocabulary documented in `docs/perf-trace-schema.md`. New live-capture lines appended to the `asset-loader-noise.log` fixture. Replay-drain ordering test for `MapAssetLoader`. |
| **7. Integration** | 22 | Full-solution build (0 warnings, 0 errors), all tests green. |

## ⚠️ Known regression risk — please read before merging

The user-side persistence migration introduces a key-shape mismatch that **affects existing users** of the 3 directly-registered baseline-anchor areas (`AreaSerbule`, `AreaEltibule`, `AreaKurMountains`):

Post-merge, `MapCalibrationService.GetCalibration(areaKey)` does an exact-key lookup against both stores:
- `_baseline` is now keyed by `Map_<X>` (this PR).
- `_userStore` is migrated to `Map_<X>` on first load (this PR).
- But three callers still pass the **bare** `AreaX` form from `IAreaState.CurrentArea`:
  - `src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs:126`
  - `src/Legolas.Module/Services/AreaCalibrationService.cs:143,170,181`

After this PR lands, an existing Mithril user opening the map in Serbule will see the renderer fall through to "no calibration" because `GetCalibration("AreaSerbule")` misses the now-`Map_AreaSerbule`-keyed baseline. **This is a real regression.** The Checkpoint C and D reviewers both flagged it.

`AutoCalibrationEngine` itself was fixed in this PR (commit [`2f24c2b2`](https://github.com/moumantai-gg/mithril/commit/2f24c2b2)) — it now reads + writes under `assetKey` — so newly-saved user refinements use the right key shape going forward. But that doesn't help the renderer or the trigger.

**Follow-up issue filed:** [#1041](https://github.com/moumantai-gg/mithril/issues/1041) — full scope of work + decision options (ship-then-fix vs hold-#1040). The final-cross-phase review also surfaced `AreaCalibrationService.cs:178` (`OnMapCalChanged` equality check) as part of the same root cause; it's included in #1041's scope.

## Other follow-ups (file as issues before merge)

1. **`MithrilMeters.MapCalibration.Attempts` counter does not exist** (spec §5.4 assumed it did). The new `outcome=map_asset_not_known` tag value is forward-compatible whenever the counter is wired. Recommend filing an issue: "Wire `mithril.map_calibration.attempts` counter with `outcome` tag; backfill the existing `OutcomeVocabulary` values into the tag catalog." Per Checkpoint D review.
2. **`OutcomeVocabulary` tag-value pinning test missing.** A reflection-based pin against `docs/perf-trace-schema.md`'s enumeration would catch a forgotten doc update. Per Checkpoint D review.
3. **Aggregator-scene landmark scoping** is parent-area-wide today (landmarks.json has no sub-zone field). Spec §7 explicitly defers this; flagging for the follow-up roadmap.
4. **Sidecar shared `MapTextureExtractor` keeps `Map_<X>` prepend logic** for 3 out-of-scope callers (gate-study, WPF, SynthesisProbe). Per spec §7 — research/legacy paths slated for retirement, not repair.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — all suites green (one `Mithril.GameReports.Tests` `FileSystemWatcher_Debounces` flake passed on retry; unrelated to #1021).
- [x] Phase-boundary code reviews (A/B/C/D) — all approved; findings either addressed inline or recorded above.
- [x] Strict gate verified by `AutoCalibrationEngineTests.TryCalibrate_NoCurrentMapAsset_ReturnsRejectWithMapAssetNotYetKnown` — `baseTextures.Calls.Should().BeEmpty()`, `solver.SolveCalls.Should().Be(0)`.
- [x] `assetKey` plumbing verified by `TryCalibrate_CurrentMapAssetSet_PassesLiteralAssetKeyAndSceneRefDownstream` — engine passes the literal `Map_HogansKeepBasement` form to `IBaseTextureProvider`, builds `MapSceneRef("AreaCave1", "Hogan's Basement")` for the reference provider.
- [x] `UserRefinementStore` idempotence verified by `UserRefinementStoreMigrationTests.Load_V2File_NoMutation` — file byte-for-byte unchanged on disk after load.
- [x] Sidecar `--asset` integration verified for both PascalCase forms (`Map_AreaSerbule` direct-area, `Map_HogansKeepBasement` aggregator sub-zone) via `ProcessAssetExtractorTests`.
- [ ] **Manual verification owed (post-merge):** live-fire test in Hogan's Basement triggers a `MapAssetChanged` event in Mithril's domain-event stream; autocal walkthrough in `AreaSerbule` still solves identically to pre-#1021.

## Commits (22 total)

```
2f24c2b2 fix(map-calibration): autocal persists+reads under per-scene assetKey
b4abc6f8 test(arda): MapAssetLoader replay-drain order — last Downloading Map wins
127a5c8e test(arda): extend asset-loader-noise fixture with live Downloading Map capture
370d1248 docs(telemetry): record 'map_asset_not_known' in map-calibration OutcomeVocabulary
16db9a4b feat(map-calibration): UserRefinementStore v1->v2 load-time prefix migrator
12653200 test(map-calibration): assert baseline.json v2 keys are Map_-prefixed
75b7e2be chore(map-calibration): bump baseline.json to schemaVersion 2 with Map_<X> keys
66f1a7d7 feat(map-calibration): autocal reads IMapState.CurrentMapAsset; strict gate on null
b4139e57 feat(map-calibration): format MapAssetNotYetKnown as zone-change user hint
d50f4003 feat(map-calibration): add MapAssetNotYetKnown outcome vocabulary entry
2d64f242 refactor(map-calibration): rename ProcessAssetExtractor log property {Area} to {MapAsset}
cfd466c6 refactor(asset-extractor): CLI flag --area renamed to --asset
9c8e0317 refactor(map-calibration): rename ExtractRequest.AreaKey to MapAssetName; sidecar gets --asset
d86f3d7a refactor(map-calibration): rename TryGetBaseTexture(areaKey) to mapAssetKey
9a9bb06a feat(map-calibration): IAreaReferenceProvider.ForArea takes MapSceneRef
03f2cf68 feat(map-calibration): add MapSceneRef composite scene-identity record
8c312ed9 docs(arda): add MapAssetChanged to IMapState's event cross-ref list
bfc3740d feat(arda): IMapState surfaces CurrentMapAsset + CurrentSceneFriendlyName
69676efc feat(arda): MapAssetLoader handler parses Downloading Map asset-loader line
4a8179eb feat(arda): add MapAssetChanged domain event
c708add9 feat(arda): VerbExtractor recognizes 'Downloading Map' asset-loader prefix
d013bba9 feat(arda): add Verbs.DownloadingMap synthetic verb constant
```

— drafted by Claude (Opus 4.7), posted by @arthur-conde
