### PR TITLE
fix(map-calibration): bundle #1053 + #1054 — SceneAssetCache silent-drop diag + schemaVersion read-back

### DIFF
--- a/src/Mithril.MapCalibration/Internal/SceneAssetCacheStore.cs
+++ b/src/Mithril.MapCalibration/Internal/SceneAssetCacheStore.cs
@@ -50,6 +50,11 @@ internal sealed class SceneAssetCacheStore
         }
     }
 
+    /// <summary>Highest <c>schemaVersion</c> this build knows how to read.
+    /// On-disk shape currently matches v1. Bump alongside any breaking
+    /// shape change to <see cref="SceneAssetCacheFile"/>.</summary>
+    private const int KnownSchemaVersion = 1;
+
     private void Load()
     {
         if (!File.Exists(_filePath)) return;
@@ -59,6 +64,31 @@ internal sealed class SceneAssetCacheStore
             using var doc = JsonDocument.Parse(stream);
 
             if (doc.RootElement.ValueKind != JsonValueKind.Object) return;
+
+            // schemaVersion read-back (mithril#1054): Persist stamps v1, but
+            // until this gate Load ignored the field. A future v>1 file read by
+            // this build would be silently half-parsed — every v2-shaped entry
+            // falls through the per-entry resilient parse as "missing fields"
+            // and the user's learned cache vanishes. Fail-closed instead: start
+            // empty so the newer build (which CAN read v>1) sees the file
+            // intact on its next run. Mirrors UserRefinementStore.Load's
+            // schemaVersion handling.
+            var schemaVersion = 1; // absent → v1 (pre-stamp shape)
+            if (doc.RootElement.TryGetProperty("schemaVersion", out var verProp) &&
+                verProp.ValueKind == JsonValueKind.Number &&
+                verProp.TryGetInt32(out var v))
+            {
+                schemaVersion = v;
+            }
+            if (schemaVersion > KnownSchemaVersion)
+            {
+                _logger?.LogWarning(
+                    "scene-asset-cache schema v{Found} at {Path} is newer than supported v{Known}; " +
+                    "starting empty this session to avoid corrupting data this build doesn't recognise.",
+                    schemaVersion, _filePath, KnownSchemaVersion);
+                return;
+            }
+
             if (!doc.RootElement.TryGetProperty("entries", out var entries) ||
                 entries.ValueKind != JsonValueKind.Array) return;
 

--- a/src/Mithril.MapCalibration/Internal/SceneAssetCacheStore.cs
+++ b/src/Mithril.MapCalibration/Internal/SceneAssetCacheStore.cs
@@ -10,6 +10,11 @@ namespace Mithril.MapCalibration.Internal;
 /// File: <c>%LocalAppData%/Mithril/MapCalibration/scene-asset-cache.json</c>.</summary>
 internal sealed class SceneAssetCacheStore
 {
+    /// <summary>Highest <c>schemaVersion</c> this build knows how to read.
+    /// On-disk shape currently matches v1. Bump alongside any breaking
+    /// shape change to <see cref="SceneAssetCacheFile"/>.</summary>
+    private const int KnownSchemaVersion = 1;
+
     private readonly string _filePath;
     private readonly ILogger? _logger;
     private readonly object _gate = new();
@@ -49,11 +54,6 @@ internal sealed class SceneAssetCacheStore
             }
         }
     }
-
-    /// <summary>Highest <c>schemaVersion</c> this build knows how to read.
-    /// On-disk shape currently matches v1. Bump alongside any breaking
-    /// shape change to <see cref="SceneAssetCacheFile"/>.</summary>
-    private const int KnownSchemaVersion = 1;
 
     private void Load()
     {

--- a/src/Mithril.MapCalibration/SceneAssetCache.cs
+++ b/src/Mithril.MapCalibration/SceneAssetCache.cs
@@ -30,7 +30,16 @@ public sealed class SceneAssetCache : ISceneAssetCache
     public void Record(MapSceneRef scene, DateTimeOffset observedAt)
     {
         if (string.IsNullOrEmpty(scene.ParentAreaKey) || string.IsNullOrEmpty(scene.MapAssetKey))
-            return; // an under-defined composite — don't poison the cache
+        {
+            // mithril#1053: an under-defined composite — don't poison the cache.
+            // Surface the drop at Trace so a support investigation can spot the
+            // MapAssetLoader "Downloading Map fired before Initializing area!"
+            // race (the dominant cause) without spamming Information.
+            _logger?.LogTrace(
+                "SceneAssetCache: dropped under-defined composite (parentArea='{ParentArea}', assetKey='{AssetKey}').",
+                scene.ParentAreaKey, scene.MapAssetKey);
+            return;
+        }
         _store.Record(scene.ParentAreaKey, scene.SceneFriendlyName, scene.MapAssetKey, observedAt);
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/Internal/SceneAssetCacheStoreTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Internal/SceneAssetCacheStoreTests.cs
@@ -74,6 +74,30 @@ public sealed class SceneAssetCacheStoreTests : IDisposable
     }
 
     [Fact]
+    public void Load_FutureSchemaVersion_StartsEmpty()
+    {
+        // mithril#1054: stamp-on-write was wired in #1041, but Load never
+        // recognised the field. When a future v>1 lands, a v1-aware build
+        // must refuse the whole file rather than half-parse a shape it
+        // can't validate (silent data loss on downgrade). Per-entry resilient
+        // parse would otherwise skip every v2-shaped entry as unparseable.
+        var filePath = Path.Combine(_tempDir, "scene-asset-cache.json");
+        File.WriteAllText(filePath, """
+            {
+                "schemaVersion": 99,
+                "entries": [
+                    { "parentArea": "AreaSerbule", "sceneFriendlyName": null, "mapAssetKey": "Map_AreaSerbule", "lastObservedAt": "2026-06-03T20:01:17+00:00" }
+                ]
+            }
+            """);
+
+        var store = new SceneAssetCacheStore(_tempDir, NullLogger.Instance);
+
+        // Fail-closed: the otherwise-valid v1-shaped entry is NOT loaded.
+        store.TryGet("AreaSerbule", null, out _).Should().BeFalse();
+    }
+
+    [Fact]
     public void Record_RollsBack_InMemoryState_When_Persist_Throws()
     {
         var store = new SceneAssetCacheStore(_tempDir, NullLogger.Instance);

--- a/tests/Mithril.MapCalibration.Tests/SceneAssetCacheTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/SceneAssetCacheTests.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Mithril.MapCalibration.Internal;
 using Xunit;
@@ -88,5 +90,43 @@ public sealed class SceneAssetCacheTests : IDisposable
         cache.Record(new MapSceneRef("AreaX", null, string.Empty), DateTimeOffset.UtcNow);
         // Neither should poison the cache.
         cache.TryResolve("AreaX", null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Record_UnderDefinedComposite_EmitsTraceDiagnostic()
+    {
+        // mithril#1053: the Downloading-Map-before-Initializing-area race
+        // (see MapAssetLoader) hands SceneAssetCache a composite with an
+        // empty ParentAreaKey. The drop itself is correct (don't poison the
+        // cache) but a support investigation can't tell whether THIS guard
+        // fired vs. some other path failed silently. LogTrace surfaces it
+        // in the diagnostics ring buffer without spamming Information.
+        var capture = new CapturingLogger();
+        var cache = new SceneAssetCache(new SceneAssetCacheStore(_tempDir, NullLogger.Instance), capture);
+
+        cache.Record(new MapSceneRef(string.Empty, null, "Map_X"), DateTimeOffset.UtcNow);
+
+        capture.Traces.Should().Contain(m =>
+            m.Contains("dropped under-defined composite"));
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Traces { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Trace) Traces.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/SceneAssetCacheTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/SceneAssetCacheTests.cs
@@ -114,7 +114,7 @@ public sealed class SceneAssetCacheTests : IDisposable
     {
         public List<string> Traces { get; } = new();
 
-        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
         public bool IsEnabled(LogLevel logLevel) => true;
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,


### PR DESCRIPTION
## Summary

Two non-blocker follow-ups from #1041 (PR #1048), bundled because they touch the same `Mithril.MapCalibration` surface.

- **#1053 — `SceneAssetCache.Record` silent drop is now traceable.** When a `MapAssetChanged` event arrives with an empty `ParentAreaKey` (the "`Downloading Map` fired before `Initializing area!`" race in `MapAssetLoader`), the record is silently discarded. The guard is correct — don't poison the cache — but a support investigation can't tell whether it fired vs. some other path failed silently. Now emits `LogTrace` with both key fragments so it shows up in the diagnostics ring buffer.
- **#1054 — `SceneAssetCacheStore.Load` now recognises `schemaVersion`.** `Persist` was already stamping `SchemaVersion = 1` (per memory [`json_should_be_versioned`](https://github.com/moumantai-gg/mithril/issues/208)), but `Load` ignored the field. Fail-closed clamp added: if `schemaVersion > KnownSchemaVersion` (1), log a `Warning` and start empty so a newer build can still read the file intact on its next run. Mirrors the established `UserRefinementStore.Load` shape.

On-disk shape is unchanged — `KnownSchemaVersion` stays 1; this PR only teaches `Load` to recognise unknown future `v>1`.

## Test plan

- [x] `dotnet test tests/Mithril.MapCalibration.Tests` → 154 / 154 passed (includes the two new tests).
- [x] `dotnet build Mithril.slnx` → 0 warnings, 0 errors (warnings-as-errors enforced).
- [x] `dotnet test Mithril.slnx --no-build` → all suites green except for two pre-existing parallel-execution flakes (`Mithril.GameReports.Tests`, `Arda.Ingest.Tests`) that both pass cleanly in isolation; neither touches MapCalibration.
- [x] TDD: each test was written first, watched fail, then made green:
  - `SceneAssetCacheStoreTests.Load_FutureSchemaVersion_StartsEmpty` pins the fail-closed contract against a hand-written v99 file with an otherwise-valid v1-shape entry.
  - `SceneAssetCacheTests.Record_UnderDefinedComposite_EmitsTraceDiagnostic` pins the `LogTrace` via a capturing `ILogger`.

closes #1053
closes #1054

— drafted by Claude (Opus 4.7), posted by @arthur-conde
