### PR TITLE
fix(arda): L1 classifier promotes untimestamped Downloading Map lines (#1056)

### DIFF
--- a/src/Arda/Arda.Ingest/Classification/LineClassifier.cs
+++ b/src/Arda/Arda.Ingest/Classification/LineClassifier.cs
@@ -73,6 +73,7 @@ internal sealed class LineClassifier
     /// <list type="bullet">
     ///   <item><c>Connecting to {host} port {port}</c> — server identity.</item>
     ///   <item><c>EVENT(Ok): connected, url={host}, port={port}</c> — connection confirmation.</item>
+    ///   <item><c>Downloading Map [{guid}] GUID {guid} for area {name} runtime key {guid}[{Map_*}]</c> — per-scene asset load.</item>
     /// </list>
     /// This allowlist expands as more patterns are catalogued from log samples.
     /// </summary>
@@ -82,6 +83,9 @@ internal sealed class LineClassifier
             return true;
 
         if (line.StartsWith("EVENT(Ok): connected".AsSpan(), StringComparison.Ordinal))
+            return true;
+
+        if (line.StartsWith("Downloading Map ".AsSpan(), StringComparison.Ordinal))
             return true;
 
         return false;

--- a/tests/Arda.Ingest.Tests/LineClassifierTests.cs
+++ b/tests/Arda.Ingest.Tests/LineClassifierTests.cs
@@ -54,6 +54,19 @@ public class LineClassifierTests
         result.Value.Timestamp.Should().BeNull();
     }
 
+    [Fact]
+    public void Classify_DownloadingMapSystemPattern_ReturnsClassifiedLineWithNullTimestamp()
+    {
+        var line = "Downloading Map [44d50fb35fa65dd4cbb84e3af49ca0a4] GUID 44d50fb35fa65dd4cbb84e3af49ca0a4 for area Hogan's Basement runtime key 44d50fb35fa65dd4cbb84e3af49ca0a4[Map_HogansKeepBasement]".AsSpan();
+
+        var result = _sut.Classify(line);
+
+        result.Should().NotBeNull();
+        result!.Value.Log.Should().Contain("[Map_HogansKeepBasement]");
+        result.Value.Timestamp.Should().BeNull();
+        result.Value.Raw.Should().BeNull();
+    }
+
     [Theory]
     [InlineData("LoadAssetAsync: eq-x-m2-head-0. Status=None.")]
     [InlineData("Shader warmup: 15 shaders loaded")]


### PR DESCRIPTION
## Summary

PG emits the per-scene asset-load line **without** a `[HH:MM:SS]` prefix:

```
Downloading Map [44d50fb35...] GUID 44d50fb35... for area Hogan's Basement runtime key 44d50fb35...[Map_HogansKeepBasement]
```

L1 `LineClassifier` discarded untimestamped lines unless they matched a 2-entry allowlist (`Connecting to ` / `EVENT(Ok): connected`), so the line was dropped at L1, `MapAssetLoader.Handle` never ran, `MapAssetChanged` never fired, and `SceneAssetCache` stayed at the three seeded entries. End-user symptom: `Mithril.MapCalibration.Capture.Engine` refused auto-calibration in `AreaCave1` sub-scenes with *"per-scene map asset not yet known"*.

Fix: one-line allowlist extension in `LineClassifier.IsKnownSystemPattern`. The promoted line carries `Timestamp: null`; `SceneAssetCacheRecorder.OnMapAssetChanged` already falls back to `metadata.ReadOn` for `LastObservedAt`.

## Test plan

- [x] Added failing test `Classify_DownloadingMapSystemPattern_ReturnsClassifiedLineWithNullTimestamp` in `tests/Arda.Ingest.Tests/LineClassifierTests.cs`.
- [x] Confirmed test fails on `origin/main` for the right reason (allowlist doesn't recognise the prefix, not a typo / compile error).
- [x] Applied the one-line allowlist edit in `src/Arda/Arda.Ingest/Classification/LineClassifier.cs`.
- [x] Confirmed test passes after fix.
- [x] Ran `dotnet test Mithril.slnx` — full suite green.

### Test evidence

**Before the fix** (test fails because allowlist drops the line):

```
[xUnit.net 00:00:00.30]     Arda.Ingest.Tests.LineClassifierTests.Classify_DownloadingMapSystemPattern_ReturnsClassifiedLineWithNullTimestamp [FAIL]
  Failed Arda.Ingest.Tests.LineClassifierTests.Classify_DownloadingMapSystemPattern_ReturnsClassifiedLineWithNullTimestamp [71 ms]
  Error Message:
   Expected result not to be <null>.
Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1, Duration: 71 ms - Arda.Ingest.Tests.dll (net10.0)
```

**After the fix**:

```
Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 44 ms - Arda.Ingest.Tests.dll (net10.0)
```

**Full suite** (`dotnet test Mithril.slnx`) — all projects green, e.g.:

```
Passed!  - Failed:     0, Passed:    58, Skipped:     0, Total:    58, Duration: 710 ms - Arda.Ingest.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:   154, Skipped:     0, Total:   154, Duration: 17 s  - Mithril.MapCalibration.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:  1235, Skipped:     0, Total:  1235, Duration: 22 s  - Mithril.Shared.Tests.dll (net10.0)
```

Closes #1056

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
