### PR TITLE
fix(map-calibration): add missing using to SynthesisProbe (pre-existing CS0246)

### DIFF
--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E1_TruthScore.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E1_TruthScore.cs
@@ -1,3 +1,4 @@
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E2_TranslationSweep.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E2_TranslationSweep.cs
@@ -1,3 +1,4 @@
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E3_ScaleSweep.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E3_ScaleSweep.cs
@@ -1,3 +1,4 @@
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E4_RansacSeedScore.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E4_RansacSeedScore.cs
@@ -1,3 +1,4 @@
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/Experiments/E5_ColdGrid.cs
@@ -1,3 +1,4 @@
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe.Experiments;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/RansacSeedsCsv.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/RansacSeedsCsv.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;

--- a/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeWriter.cs
+++ b/tools/MapCalibrationFromScreenshot/SynthesisProbe/SynthesisProbeWriter.cs
@@ -2,6 +2,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Mithril.MapCalibration;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.Tools.MapCalibrationFromScreenshot.SynthesisProbe;


### PR DESCRIPTION
## Summary

- `CandidateTransform` and `LandmarkReference` live in `Mithril.MapCalibration` but seven files under `tools/MapCalibrationFromScreenshot/SynthesisProbe/` only imported `Mithril.MapCalibration.Detection`.
- The tool csproj built dirty (13 CS0246 errors) on a fresh checkout.
- Pure `using` directive addition — no logic change.

Discovered while running #1061 spike work; surfacing as its own PR because it stands on its own merits independent of the spike.

## Test plan

- [x] `dotnet build tools/MapCalibrationFromScreenshot/MapCalibrationFromScreenshot.csproj -c Debug` succeeds on a fresh checkout

---

— drafted by Claude (Opus 4.7), posted by @arthur-conde
