### PR TITLE
fix(map-calibration): ReplayFixtureTests use Map_<X> keys post-#1041 baseline migration

### DIFF
--- a/tests/Mithril.MapCalibration.Tests/Detection/ReplayFixtureTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ReplayFixtureTests.cs
@@ -114,8 +114,13 @@ public sealed class ReplayFixtureTests
         }
 
         var baseline = Mithril.MapCalibration.Internal.BundledBaselineLoader.Load(logger: null);
-        baseline.Should().ContainKey(area, "the area must have a committed baseline to compare against");
-        var expected = baseline[area];
+        // PR #1048 (closes #1041) migrated baseline keys from bare area names to
+        // per-scene Map_<X> keys. Screenshot/refs file paths still key off the bare
+        // area name (study/screenshots/<area>.png, study/refs/<area>.json), so the
+        // Map_ prefix is local to the baseline lookup.
+        var assetKey = "Map_" + area;
+        baseline.Should().ContainKey(assetKey, "the area must have a committed baseline to compare against");
+        var expected = baseline[assetKey];
 
         var shot = WicImageLoader.LoadGray(screenshotPath);
         var tex = WicImageLoader.LoadGray(texturePath);


### PR DESCRIPTION
Closes #1067.

## Summary

PR [#1048](https://github.com/moumantai-gg/mithril/pull/1048) (closes [#1041](https://github.com/moumantai-gg/mithril/issues/1041)) migrated the map-calibration baseline JSON's dictionary keys from bare area names (`AreaSerbule`) to per-scene asset keys (`Map_AreaSerbule`). `ReplayFixtureTests.Recovers_committed_baseline_for_area` still keyed its baseline lookup by the bare area name, so when local `study/screenshots/Area*.png` assets were present the theory failed with:

```
Expected baseline {["Map_AreaSerbule"] = …, ["Map_AreaEltibule"] = …, ["Map_AreaKurMountains"] = …}
  to contain key "AreaSerbule" because the area must have a committed baseline to compare against.
```

CI was unaffected: the test is presence-gated on the gitignored `study/` tree and yields a sentinel-null skip row when assets are absent.

## Change

Prefix `Map_` at the baseline lookup only. Screenshot and refs file paths still key off the bare area name (`study/screenshots/<area>.png`, `study/refs/<area>.json`), matching on-disk naming. The `Areas` array is unchanged.

## Test plan

- [x] `dotnet build tests/Mithril.MapCalibration.Tests/Mithril.MapCalibration.Tests.csproj` — green
- [x] Full project suite: `dotnet test tests/Mithril.MapCalibration.Tests --no-build` → **161 passed, 0 failed**
- [x] Skip path (no `study/` assets): `dotnet test … --filter "FullyQualifiedName~Recovers_committed_baseline_for_area" --no-build` → 1 sentinel-null row passes
- [x] Asset-present path (junctioned `study/` from parent checkout): the `Expected baseline … to contain key "AreaSerbule"` failure is **gone**. The new failure mode hit on this machine is `screenshot and base texture must have matching dimensions` — unrelated to the key migration, caused by my local screenshots not being pre-cropped to texture extent (the fixture comment at line 123 documents the crop expectation). The reporter's machine has correctly-prepared assets.

— drafted by Claude (Opus 4.7), posted by @arthur-conde