### PR TITLE
fix(map-calibration): wire NoTextureFrameRecord into ManualCoordinator switch (#1076)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/ManualCalibrationCoordinator.cs
+++ b/src/Mithril.MapCalibration.Capture/ManualCalibrationCoordinator.cs
@@ -134,6 +134,14 @@ public sealed class ManualCalibrationCoordinator
                 var fallback = await _runner.TryCalibrateCurrentAreaAsync(ct).ConfigureAwait(false);
                 _overlay.SetStatusMessage(CalibrationStatusFormatter.ForOutcome(fallback));
                 break;
+            case DriftCheckOutcome.NoTextureFrameRecord:
+                // The stored record exists but is overlay-frame (Legolas-wizard origin). The
+                // drift-check arithmetic only makes sense over a texture-frame record, so the
+                // engine refused at the early-return branch. Surface the actionable chip —
+                // running AutoCalibrate would land a texture-frame record that drift-check can
+                // then compare against. See #1076 §2.4 / Phase 3 Task 3.4b.
+                _overlay.SetStatusMessage(CalibrationStatusFormatter.DriftCheckNoTextureFrameRecord());
+                break;
             default:
                 _logger?.LogError(
                     "Unhandled DriftCheckOutcome variant: {Type}. Coordinator setting generic chip; this is a bug.",

--- a/tests/Mithril.MapCalibration.Capture.Tests/ManualCalibrationCoordinatorTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/ManualCalibrationCoordinatorTests.cs
@@ -110,6 +110,33 @@ public sealed class ManualCalibrationCoordinatorTests
         coordinator.IsArmed.Should().BeFalse();
     }
 
+    // ── 2b. Stored overlay-frame record → engine refuses → chip is the actionable message ─
+
+    /// <summary>
+    /// Regression for the gap noticed via live-log inspection 2026-06-05: the
+    /// engine's <see cref="DriftCheckOutcome.NoTextureFrameRecord"/> branch (Phase 3
+    /// Task 3.4b) shipped without a coordinator switch arm, so the coordinator
+    /// fell through to <c>default</c>, set "Drift check: internal error (see logs)"
+    /// as the chip, and emitted its own self-described "this is a bug" Error log.
+    /// The user-visible chip must be the actionable <c>DriftCheckNoTextureFrameRecord</c>
+    /// message — "No AutoCalibration record for this scene — press AutoCalibrate to land one."
+    /// </summary>
+    [Fact]
+    public async Task Hotkey_NoTextureFrameRecord_SurfacesActionableChip()
+    {
+        var runner = new FakeRunner { DriftReturn = new DriftCheckOutcome.NoTextureFrameRecord() };
+        var overlay = new FakeOverlayWindow();
+        var coordinator = NewCoordinator(runner, ServiceWith(Stored()), overlay: overlay);
+
+        await coordinator.HandleHotkeyAsync(CancellationToken.None);
+
+        runner.DriftCalls.Should().Be(1);
+        runner.SolveCalls.Should().Be(0);
+        overlay.StatusMessage.Should().Be(CalibrationStatusFormatter.DriftCheckNoTextureFrameRecord());
+        overlay.StatusMessage.Should().NotContain("internal error");
+        coordinator.IsArmed.Should().BeFalse();
+    }
+
     // ── 3. Stored calibration + drift detected → arm ─────────────────────────
 
     [Fact]


### PR DESCRIPTION
Hotfix for a Phase 3 follow-up gap caught via live-log inspection 2026-06-05.

## Symptom
On a scene with only an overlay-frame (Legolas-wizard) calibration record, pressing the manual-calibrate hotkey produced:

```
[Info]  MapCalibration.Capture.Engine            | Drift check Map_KhyruleksCrypt: no texture-frame calibration record — refusing to run; chip shows actionable reason.
[Error] MapCalibration.Capture.ManualCoordinator | Unhandled DriftCheckOutcome variant: NoTextureFrameRecord. Coordinator setting generic chip; this is a bug.
```

Engine refusal correct; chip wrong; Error log fires every press.

## Root cause
[#1077](https://github.com/moumantai-gg/mithril/pull/1077) Phase 3 Task 3.4b added the `NoTextureFrameRecord` variant + engine early-return + chip formatter but didn't wire the variant into `ManualCalibrationCoordinator.HandleHotkeyAsync`'s switch. Fell through to `default` → generic chip + self-described 'this is a bug' Error log.

## Fix
- One missing `case DriftCheckOutcome.NoTextureFrameRecord:` arm routing to `CalibrationStatusFormatter.DriftCheckNoTextureFrameRecord()`.
- New regression test `Hotkey_NoTextureFrameRecord_SurfacesActionableChip` asserting the variant → actionable chip wiring + no "internal error" leakage.

## Test plan
- [x] `dotnet test tests/Mithril.MapCalibration.Capture.Tests --filter ManualCalibrationCoordinatorTests` — 8 passed (was 7).
- [ ] Re-press manual-calibrate hotkey on Map_KhyruleksCrypt — chip should now read "No AutoCalibration record for this scene — press AutoCalibrate to land one" instead of "Drift check: internal error (see logs)". No Error log fires.

Refs #1076, follow-up to #1077.