### PR TITLE
fix(map-calibration): picker reads AreaCalibration.Frame, stamp Frame at save sites (#1078)

### DIFF
--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -236,9 +236,16 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
         // Stamp the zoom the user solved at (solver is zoom-agnostic — it just
         // fits the clicked pixels). > 0 guard so a bad value can't poison the
         // later currentZoom/CalibrationZoom division.
+        //
+        // mithril#1078: explicit Frame=Overlay. The wizard fits (WorldCoord, OverlayPixel)
+        // pairs the user clicks on the overlay window; the resulting OriginX/Scale/etc.
+        // are in overlay-pixel units. Without this stamp, AreaCalibration.Frame would
+        // take its default of Texture and the picker would mis-frame this record. The
+        // defensive Source stamp in UserRefinementStore.Save preserves Frame verbatim.
         var calibration = solved with
         {
             CalibrationZoom = calibrationZoom > 1e-6 ? calibrationZoom : 1.0,
+            Frame = CalibrationFrame.Overlay,
         };
 
         // mithril#1041: single write path — every solved calibration (manual

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -704,9 +704,17 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
 
         // Gate-accept: persist through the user store stamped AutoCapture, which
         // inherits user-store precedence by construction (Task 20).
+        //
+        // mithril#1078: explicit Frame=Texture. The auto-capture RANSAC solves over
+        // the aligned base texture (`alignedTexture` + `alignedRect = (0,0,…)`); the
+        // resulting OriginX/Scale/etc. are in texture-pixel units. AreaCalibration.Frame
+        // defaults to Texture so this stamp is documentation today, but making it
+        // explicit defends against the default flipping in a future cleanup and
+        // keeps the save sites symmetric with Legolas-wizard's Frame=Overlay stamp.
         var stamped = result.Calibration with
         {
             Source = CalibrationSource.AutoCapture,
+            Frame = CalibrationFrame.Texture,
         };
 
         attempt.Outcome = OutcomeVocabulary.Accepted;

--- a/src/Mithril.MapCalibration/Internal/MapCalibrationService.cs
+++ b/src/Mithril.MapCalibration/Internal/MapCalibrationService.cs
@@ -122,26 +122,29 @@ internal sealed class MapCalibrationService : IMapCalibrationService
     /// </summary>
     private WorldToTextureCalibration? PickTexture(MapSceneRef scene)
     {
-        var legacy = PickByFrame(scene, CalibrationFrameKind.Texture);
+        var legacy = PickByFrame(scene, CalibrationFrame.Texture);
         return legacy is null ? null : ToTextureCalibration(legacy);
     }
 
     /// <summary>#1076 picker for the overlay-frame slice; see <see cref="PickTexture"/>.</summary>
     private WorldToOverlayCalibration? PickOverlay(MapSceneRef scene)
     {
-        var legacy = PickByFrame(scene, CalibrationFrameKind.Overlay);
+        var legacy = PickByFrame(scene, CalibrationFrame.Overlay);
         return legacy is null ? null : ToOverlayCalibration(legacy);
     }
 
-    private AreaCalibration? PickByFrame(MapSceneRef scene, CalibrationFrameKind frame)
+    private AreaCalibration? PickByFrame(MapSceneRef scene, CalibrationFrame frame)
     {
         if (string.IsNullOrWhiteSpace(scene.MapAssetKey)) return null;
 
+        // mithril#1078: read AreaCalibration.Frame directly (single source of truth).
+        // The Schema-1 → Schema-2 inference has already been done by UserRefinementStore
+        // and BundledBaselineLoader at load time; the picker must not re-infer from
+        // Source. Stamping Source AND Frame at save sites (AutoCalibrationEngine and
+        // AreaCalibrationService) keeps disk records self-describing.
         var candidates = new List<AreaCalibration>(capacity: 2);
-        if (_userStore.TryGet(scene.MapAssetKey, out var user)
-            && InferFrameFromSource(user.Source) == frame) candidates.Add(user);
-        if (_baseline.TryGetValue(scene.MapAssetKey, out var baseline)
-            && InferFrameFromSource(baseline.Source) == frame) candidates.Add(baseline);
+        if (_userStore.TryGet(scene.MapAssetKey, out var user) && user.Frame == frame) candidates.Add(user);
+        if (_baseline.TryGetValue(scene.MapAssetKey, out var baseline) && baseline.Frame == frame) candidates.Add(baseline);
 
         if (candidates.Count == 0) return null;
 
@@ -185,10 +188,15 @@ internal sealed class MapCalibrationService : IMapCalibrationService
 
     /// <summary>
     /// #1076 typed-frame view: every candidate AreaCalibration for the scene
-    /// that infers to TEXTURE frame (see <see cref="InferFrameFromSource"/>),
-    /// wrapped as <see cref="WorldToTextureCalibration"/>. Underlying storage
-    /// is unchanged — this is a derived projection of <see cref="GetAllSources"/>
+    /// whose <see cref="AreaCalibration.Frame"/> is <see cref="CalibrationFrame.Texture"/>,
+    /// wrapped as <see cref="WorldToTextureCalibration"/>. Underlying storage is
+    /// unchanged — this is a derived projection of <see cref="GetAllSources"/>
     /// for the texture-frame consumers (drift check, AutoCal).
+    ///
+    /// <para>mithril#1078: reads <c>cal.Frame</c> directly. The Schema-1 → Schema-2
+    /// inference is owned by <see cref="UserRefinementStore"/> and
+    /// <see cref="BundledBaselineLoader"/> at load time; this method is a pure
+    /// filter, no re-inference.</para>
     /// </summary>
     internal IReadOnlyList<WorldToTextureCalibration> GetTextureRecords(MapSceneRef scene)
     {
@@ -197,7 +205,7 @@ internal sealed class MapCalibrationService : IMapCalibrationService
         var result = new List<WorldToTextureCalibration>(all.Count);
         foreach (var cal in all)
         {
-            if (InferFrameFromSource(cal.Source) == CalibrationFrameKind.Texture)
+            if (cal.Frame == CalibrationFrame.Texture)
                 result.Add(ToTextureCalibration(cal));
         }
         return result;
@@ -205,8 +213,12 @@ internal sealed class MapCalibrationService : IMapCalibrationService
 
     /// <summary>
     /// #1076 typed-frame view: every candidate AreaCalibration for the scene
-    /// that infers to OVERLAY frame, wrapped as <see cref="WorldToOverlayCalibration"/>.
-    /// Used by Legolas overlay rendering.
+    /// whose <see cref="AreaCalibration.Frame"/> is <see cref="CalibrationFrame.Overlay"/>,
+    /// wrapped as <see cref="WorldToOverlayCalibration"/>. Used by Legolas overlay
+    /// rendering.
+    ///
+    /// <para>mithril#1078: reads <c>cal.Frame</c> directly; see
+    /// <see cref="GetTextureRecords"/>.</para>
     /// </summary>
     internal IReadOnlyList<WorldToOverlayCalibration> GetOverlayRecords(MapSceneRef scene)
     {
@@ -215,27 +227,11 @@ internal sealed class MapCalibrationService : IMapCalibrationService
         var result = new List<WorldToOverlayCalibration>(all.Count);
         foreach (var cal in all)
         {
-            if (InferFrameFromSource(cal.Source) == CalibrationFrameKind.Overlay)
+            if (cal.Frame == CalibrationFrame.Overlay)
                 result.Add(ToOverlayCalibration(cal));
         }
         return result;
     }
-
-    /// <summary>
-    /// #1076 source→frame inference. Spec §7.2 (revised after P.1/P.1b):
-    /// AutoCapture + BundledBaseline + CommunitySync → Texture frame;
-    /// UserRefinement → Overlay (the in-the-wild Schema-1 default since AutoCal
-    /// has never shipped to users — every persisted UserRefinement record is
-    /// Legolas-wizard-produced overlay-frame).
-    /// </summary>
-    private static CalibrationFrameKind InferFrameFromSource(CalibrationSource source) => source switch
-    {
-        CalibrationSource.AutoCapture     => CalibrationFrameKind.Texture,
-        CalibrationSource.BundledBaseline => CalibrationFrameKind.Texture,
-        CalibrationSource.CommunitySync   => CalibrationFrameKind.Texture,
-        CalibrationSource.UserRefinement  => CalibrationFrameKind.Overlay,
-        _ => CalibrationFrameKind.Overlay, // unknown → safest default; spec §13 P.1b
-    };
 
     private static WorldToTextureCalibration ToTextureCalibration(AreaCalibration legacy) =>
         new(legacy.OriginX, legacy.OriginY, legacy.Scale, legacy.RotationRadians,
@@ -244,8 +240,6 @@ internal sealed class MapCalibrationService : IMapCalibrationService
     private static WorldToOverlayCalibration ToOverlayCalibration(AreaCalibration legacy) =>
         new(legacy.OriginX, legacy.OriginY, legacy.Scale, legacy.RotationRadians,
             legacy.MirrorNorth, legacy.CalibrationZoom);
-
-    private enum CalibrationFrameKind { Texture, Overlay }
 
     public void SaveUserRefinement(MapSceneRef scene, AreaCalibration calibration)
     {

--- a/tests/Mithril.MapCalibration.Tests/MapCalibrationServiceTypedFrameTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/MapCalibrationServiceTypedFrameTests.cs
@@ -6,21 +6,38 @@ using Xunit;
 namespace Mithril.MapCalibration.Tests;
 
 /// <summary>
-/// #1076 Task 2.3 — assert that <see cref="MapCalibrationService"/>'s typed
-/// frame views route each stored <see cref="AreaCalibration"/> into the right
-/// frame list based on its <see cref="AreaCalibration.Source"/>. The frame
-/// inference rule (spec §7.2): AutoCapture / BundledBaseline / CommunitySync
-/// → texture; UserRefinement → overlay (Schema-1 default since AutoCal had
-/// never shipped at the cutover).
+/// #1076 Task 2.3 + mithril#1078 — assert that <see cref="MapCalibrationService"/>'s
+/// typed frame views route each stored <see cref="AreaCalibration"/> into the right
+/// frame list based on its <see cref="AreaCalibration.Frame"/> field.
+///
+/// <para>Pre-#1078 the picker re-inferred frame from <see cref="AreaCalibration.Source"/>;
+/// post-#1078 the loaders own the inference (Schema-1 → Schema-2 at load time) and the
+/// picker just reads <c>cal.Frame</c>. The <see cref="Cal"/> helper mirrors the
+/// loader's Source-based default so the existing tests keep working;
+/// <see cref="FrameDisagreesWithSource_PickerHonorsFrame"/> asserts the picker
+/// honors Frame even when it disagrees with the Source-inferred default.</para>
 /// </summary>
 public sealed class MapCalibrationServiceTypedFrameTests
 {
     private const string Key = "Map_AreaTest";
     private static readonly MapSceneRef Scene = new("AreaTest", null, Key);
 
-    private static AreaCalibration Cal(CalibrationSource source) =>
+    private static AreaCalibration Cal(CalibrationSource source, CalibrationFrame? frame = null) =>
         new(Scale: 1.0, RotationRadians: 0, OriginX: 100, OriginY: 200,
-            ReferenceCount: 6, ResidualPixels: 0.5) { Source = source };
+            ReferenceCount: 6, ResidualPixels: 0.5)
+        {
+            Source = source,
+            // Mirror what the loaders do at Schema-1 → Schema-2 inference time
+            // (spec §7.2). Lets callers override for the disagreement case.
+            Frame = frame ?? source switch
+            {
+                CalibrationSource.AutoCapture     => CalibrationFrame.Texture,
+                CalibrationSource.BundledBaseline => CalibrationFrame.Texture,
+                CalibrationSource.UserRefinement  => CalibrationFrame.Overlay,
+                CalibrationSource.CommunitySync   => CalibrationFrame.Overlay,
+                _                                 => CalibrationFrame.Overlay,
+            },
+        };
 
     private static MapCalibrationService NewSvc(
         IReadOnlyDictionary<string, AreaCalibration>? baseline = null,
@@ -77,6 +94,39 @@ public sealed class MapCalibrationServiceTypedFrameTests
         var svc = NewSvc();
         svc.GetTextureRecords(Scene).Should().BeEmpty();
         svc.GetOverlayRecords(Scene).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// mithril#1078 regression: the picker honors <see cref="AreaCalibration.Frame"/>
+    /// even when it disagrees with the Source-inferred default. Pre-#1078 the picker
+    /// re-inferred from Source; a Schema-2 record whose stored Frame disagreed with
+    /// its Source silently followed Source. After #1078 the loaders own the
+    /// inference and the picker is a pure Frame reader — a pathological record
+    /// (e.g. AutoCapture + Frame=Overlay, hand-edited or future writer that
+    /// decouples them) routes to the Frame-tagged list, not the Source-inferred one.
+    /// </summary>
+    [Theory]
+    [InlineData(CalibrationSource.UserRefinement, CalibrationFrame.Texture)]
+    [InlineData(CalibrationSource.AutoCapture, CalibrationFrame.Overlay)]
+    [InlineData(CalibrationSource.BundledBaseline, CalibrationFrame.Overlay)]
+    public void FrameDisagreesWithSource_PickerHonorsFrame(
+        CalibrationSource source, CalibrationFrame frame)
+    {
+        var svc = NewSvc(
+            userRefs: new Dictionary<string, AreaCalibration> { [Key] = Cal(source, frame) });
+
+        if (frame == CalibrationFrame.Texture)
+        {
+            svc.GetTextureRecords(Scene).Should().HaveCount(1,
+                "picker reads cal.Frame, not InferFromSource(cal.Source)");
+            svc.GetOverlayRecords(Scene).Should().BeEmpty();
+        }
+        else
+        {
+            svc.GetOverlayRecords(Scene).Should().HaveCount(1,
+                "picker reads cal.Frame, not InferFromSource(cal.Source)");
+            svc.GetTextureRecords(Scene).Should().BeEmpty();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1078.

## Root cause (deeper than the reviewer's nit)

Reviewer flagged `MapCalibrationService.PickByFrame` re-inferring from `cal.Source` while `UserRefinementStore.Load` already set `cal.Frame`. Investigation found a second gap: **save paths don't stamp `Frame`**. `AreaCalibration.Frame` defaults to `Texture`; the Legolas wizard's solver output flows through `SaveUserRefinement` carrying `Frame=Texture` (default) while the same record gets `Source=UserRefinement` from the defensive stamp. Schema-2 writes would land with mismatched metadata; only Schema-1 records (no `frame` field → inference fires) were safe.

## Fix

- Picker reads `cal.Frame` directly (single source of truth). `GetTextureRecords` / `GetOverlayRecords` too.
- Deleted the private `InferFrameFromSource` helper + the redundant private `CalibrationFrameKind` enum.
- `AreaCalibrationService.CalibrateCurrentArea` stamps `Frame = Overlay` on wizard saves.
- `AutoCalibrationEngine.RunAttemptCoreAsync` stamps `Frame = Texture` on auto-capture saves (matches existing default; explicit for symmetry + defense).
- New `FrameDisagreesWithSource_PickerHonorsFrame` Theory (3 rows) asserts the picker honors `Frame` over Source-inferred default — the regression marker.

## Test plan
- [x] `dotnet build Mithril.slnx` — 0/0
- [x] `dotnet test tests/Mithril.MapCalibration.Tests` — 234 pass (+3 new), 3 pre-existing ReplayFixtureTests failures persist
- [x] `dotnet test tests/Mithril.MapCalibration.Capture.Tests` — 231 pass
- [x] `dotnet test tests/Legolas.Tests` — 517 pass

Refs #1077.