### PR TITLE
mithril#1114 — Guard ForegroundFocusGate against WPF teardown

### DIFF
--- a/src/Legolas.Module/Services/ForegroundFocusGate.cs
+++ b/src/Legolas.Module/Services/ForegroundFocusGate.cs
@@ -37,6 +37,17 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
     private Task? _activationTask;
     private bool _isInApp = true;
 
+    // mithril#1114 — Probe for "WPF Application is tearing down" so OnWinEvent
+    // can bail before cascading into lazy OverlayWindow construction. Default
+    // reads Dispatcher.HasShutdownStarted; tests inject a constant since the
+    // static Dispatcher state can't be faked.
+    private Func<bool> _shutdownProbe = DefaultShutdownProbe;
+    private static bool DefaultShutdownProbe() =>
+        Application.Current?.Dispatcher.HasShutdownStarted ?? false;
+
+    // mithril#1114 — Cached so UninstallHook can detach symmetrically.
+    private ExitEventHandler? _applicationExitHandler;
+
     public ForegroundFocusGate(ModuleGates gates, GameConfig gameConfig)
     {
         _gates = gates;
@@ -110,6 +121,18 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
         // a corrected name take effect.
         _gameConfig.PropertyChanged += OnSettingsPropertyChanged;
 
+        // mithril#1114 — Tear the hook down inside the WPF teardown sequence
+        // rather than waiting for IHostedService.StopAsync, which Program.cs
+        // only runs in its finally block AFTER app.Run() returns. By then WPF
+        // has already finished shutting down and any foreground event
+        // delivered during teardown has already cascaded through OverlayController
+        // into Application.LoadComponent (which throws once IsShuttingDown).
+        if (Application.Current is { } app)
+        {
+            _applicationExitHandler = (_, _) => UninstallHook();
+            app.Exit += _applicationExitHandler;
+        }
+
         // Hook delivery is event-driven, so seed the gate from the current
         // foreground window — otherwise IsInApp stays at its default until the
         // next focus change.
@@ -119,6 +142,11 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
     private void UninstallHook()
     {
         if (_hookHandle == IntPtr.Zero) return;
+        if (_applicationExitHandler is not null && Application.Current is { } app)
+        {
+            app.Exit -= _applicationExitHandler;
+        }
+        _applicationExitHandler = null;
         _gameConfig.PropertyChanged -= OnSettingsPropertyChanged;
         User32Focus.UnhookWinEvent(_hookHandle);
         _hookHandle = IntPtr.Zero;
@@ -141,14 +169,40 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
         uint dwmsEventTime)
     {
         if (eventType != User32Focus.EVENT_SYSTEM_FOREGROUND) return;
+        // mithril#1114 — Race backstop for any foreground event already in the
+        // dispatcher queue when Application.Exit fires (Exit runs AFTER
+        // IsShuttingDown is set). Without this, OverlayController.SyncMap
+        // would lazily construct an OverlayWindow whose InitializeComponent
+        // calls Application.LoadComponent and throws.
+        if (_shutdownProbe()) return;
         EvaluateForeground(hwnd);
     }
 
     private void EvaluateForeground(IntPtr hwnd)
     {
+        EvaluateForegroundCallsForTest++;
         if (hwnd == IntPtr.Zero) return;
         IsInApp = IsForegroundInApp(hwnd);
     }
+
+    // ---- mithril#1114 test seams (not part of the production surface) ----
+
+    /// <summary>Test seam — count of EvaluateForeground entries. Lets the
+    /// shutdown-guard test assert that OnWinEvent's early-return BEFORE
+    /// EvaluateForeground is what stops the cascade (vs. the existing
+    /// hwnd==IntPtr.Zero early-return inside EvaluateForeground).</summary>
+    internal int EvaluateForegroundCallsForTest { get; private set; }
+
+    /// <summary>Test seam — override the "Application is shutting down" probe.
+    /// Production reads <see cref="System.Windows.Threading.Dispatcher.HasShutdownStarted"/>,
+    /// which is sealed on the static dispatcher and can't be faked.</summary>
+    internal void SetShutdownProbeForTest(Func<bool> probe) =>
+        _shutdownProbe = probe ?? throw new ArgumentNullException(nameof(probe));
+
+    /// <summary>Test seam — drive <see cref="OnWinEvent"/> directly with the
+    /// foreground-changed event type, bypassing the Win32 hook dispatch.</summary>
+    internal void TestSimulateForegroundChanged(IntPtr hwnd) =>
+        OnWinEvent(IntPtr.Zero, User32Focus.EVENT_SYSTEM_FOREGROUND, hwnd, 0, 0, 0, 0);
 
     private bool IsForegroundInApp(IntPtr hwnd)
     {

--- a/tests/Legolas.Tests/Services/ForegroundFocusGateTests.cs
+++ b/tests/Legolas.Tests/Services/ForegroundFocusGateTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Legolas.Services;
+using Mithril.Shared.Game;
+using Mithril.Shared.Modules;
+
+namespace Legolas.Tests.Services;
+
+/// <summary>
+/// mithril#1114 — Regression coverage for the shutdown-time crash where a
+/// Win32 foreground-changed event delivered during WPF Application teardown
+/// cascaded through <see cref="ForegroundFocusGate.IsInApp"/> ->
+/// <c>OverlayController.SyncMap</c> -> lazy <c>OverlayWindow</c> construction
+/// -> <c>Application.LoadComponent</c>, which throws once
+/// <c>Application.IsShuttingDown</c> is true.
+///
+/// <para>The guard lives at the source (OnWinEvent) so any future
+/// PropertyChanged consumer is protected. These tests drive
+/// <see cref="ForegroundFocusGate.TestSimulateForegroundChanged"/> with the
+/// shutdown probe set to true/false and assert that
+/// <c>EvaluateForeground</c> runs only when the probe says we're alive.</para>
+/// </summary>
+public sealed class ForegroundFocusGateTests
+{
+    [Fact]
+    public void OnWinEvent_skips_EvaluateForeground_when_shutdown_probe_true()
+    {
+        var gate = MakeGate();
+        gate.SetShutdownProbeForTest(() => true);
+
+        gate.TestSimulateForegroundChanged(new IntPtr(0xABCD));
+
+        gate.EvaluateForegroundCallsForTest.Should().Be(0,
+            "OnWinEvent must return BEFORE EvaluateForeground while Dispatcher.HasShutdownStarted is true — "
+            + "otherwise IsInApp can flip during WPF teardown and cascade into Application.LoadComponent (mithril#1114).");
+    }
+
+    [Fact]
+    public void OnWinEvent_runs_EvaluateForeground_when_shutdown_probe_false()
+    {
+        var gate = MakeGate();
+        gate.SetShutdownProbeForTest(() => false);
+
+        gate.TestSimulateForegroundChanged(new IntPtr(0xABCD));
+
+        gate.EvaluateForegroundCallsForTest.Should().Be(1,
+            "the steady-state path must remain unchanged — OnWinEvent should still call EvaluateForeground "
+            + "for every foreground-changed event delivered while WPF is alive.");
+    }
+
+    [Fact]
+    public void Shutdown_probe_is_consulted_on_every_event_not_just_the_first()
+    {
+        var gate = MakeGate();
+        var shuttingDown = false;
+        gate.SetShutdownProbeForTest(() => shuttingDown);
+
+        // Three events delivered while alive — all three run EvaluateForeground.
+        gate.TestSimulateForegroundChanged(new IntPtr(1));
+        gate.TestSimulateForegroundChanged(new IntPtr(2));
+        gate.TestSimulateForegroundChanged(new IntPtr(3));
+        gate.EvaluateForegroundCallsForTest.Should().Be(3);
+
+        // WPF starts shutting down; subsequent events are dropped at the gate.
+        shuttingDown = true;
+        gate.TestSimulateForegroundChanged(new IntPtr(4));
+        gate.TestSimulateForegroundChanged(new IntPtr(5));
+        gate.EvaluateForegroundCallsForTest.Should().Be(3,
+            "once the shutdown probe flips to true, no further events should reach EvaluateForeground.");
+    }
+
+    private static ForegroundFocusGate MakeGate()
+    {
+        var gates = new ModuleGates();
+        var gameConfig = new GameConfig { GameProcessName = "ProjectGorgon" };
+        return new ForegroundFocusGate(gates, gameConfig);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1114 — `mithril-crash.log` gains two `InvalidOperationException: The Application object is being shut down` entries on every clean exit.

A Win32 `EVENT_SYSTEM_FOREGROUND` event delivered during WPF teardown cascades through `ForegroundFocusGate.OnWinEvent` → `IsInApp` setter → `OverlayController.OnFocusGatePropertyChanged` → `SyncMap` → lazy `OverlayWindow` construction → `Application.LoadComponent`, which throws once `IsShuttingDown` is true. Pre-existing — latent since the focus gate landed in #133. Pollutes `mithril-crash.log`, masking real crashes.

## What changed

`ForegroundFocusGate` only — fix at the source so any current or future `PropertyChanged` consumer is protected:

1. **Subscribe `UninstallHook` to `Application.Exit`** — the hook tears down inside the WPF teardown sequence rather than waiting for `host.StopAsync`, which `Program.cs:405` only runs in `finally` after `app.Run()` returns (by which point WPF is already shut down).
2. **`Dispatcher.HasShutdownStarted` guard at the top of `OnWinEvent`** — race backstop for any foreground event already queued before `Exit` fires (`Exit` raises *after* `IsShuttingDown` is set, so a queued event could still race past `UninstallHook`).
3. **Test seams** (`SetShutdownProbeForTest`, `TestSimulateForegroundChanged`, `EvaluateForegroundCallsForTest`) — `Dispatcher.HasShutdownStarted` is sealed on the static dispatcher, so the production probe is wrapped in a swappable `Func<bool>` for tests.

3 new tests in `tests/Legolas.Tests/Services/ForegroundFocusGateTests.cs`:
- probe=true → `EvaluateForeground` is skipped (regression coverage)
- probe=false → `EvaluateForeground` runs (steady-state preserved)
- probe is consulted per event, not cached (3 events alive → all evaluate; then flip probe → 2 more events dropped at gate)

## Stack on top of #1107

This PR is branched off `claude/eager-blackburn-434b57` so it sits on top of #1107 — the bug is unrelated to that work but I'm stacking to keep `main` history linear while #1107 is in flight. If #1107 retargets or rebases, this branch needs a rebase too. If you'd prefer it stand alone against `main`, retarget the PR (no code change needed).

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings / 0 errors (warnings-as-errors).
- [x] `dotnet test Mithril.slnx` — all suites green. Legolas.Tests 516/516 (513 baseline + 3 new); Mithril.Overlay.Tests 55/55; Mithril.Shell.Tests 97/97; all others green.
- [ ] **Manual verification owed** — launch Mithril, click the Legolas tab to activate the focus gate, close Mithril, confirm `%LocalAppData%/Mithril/Shell/logs/mithril-crash.log` does not grow. The unit tests cover the guard logic but the end-to-end shutdown cascade requires a live shell session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
