### PR TITLE
feat(map-calibration): per-blob/per-template NCC observability (closes #1121)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -660,6 +660,12 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         attempt.AlignedTexture = alignedTexture;
         attempt.BaseTextureResampled = alignedTexture; // same data, distinct semantic slot per spec
 
+        // mithril#1121: collect per-blob × per-template NCC scores for the
+        // diagnostic bundle. Engine layer creates the buffer; the detector layer
+        // (via the SolveEngine's rotate180 wrapper) appends one record per
+        // (blob, template, orientation). null sink → zero producer cost; the
+        // detector skips both the LogTrace path and the per-record allocation.
+        var blobScores = new List<BlobTemplateScore>();
         var request = new DetectionRequest(
             Screenshot: crop,
             BaseTexture: alignedTexture,
@@ -671,6 +677,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             BlobOptions: BlobOpts)
         {
             RenderSizePx = RenderSizePx,
+            BlobScoreSink = blobScores.Add,
         };
 
         _logger?.LogInformation(
@@ -696,6 +703,10 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
 
         attempt.Detections = result.Detections;
         attempt.Result = result;
+        // mithril#1121: surface the per-blob × per-template observations to the
+        // bundle sink. Always assigned (even empty) so the dump distinguishes "no
+        // blobs detected" from "diagnostic wiring missing."
+        attempt.BlobTemplateScores = blobScores;
 
         if (result.Calibration is null)
         {

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
@@ -46,6 +46,16 @@ public sealed class CalibrationAttemptContext
     public IReadOnlyList<TypedDetection>? Detections { get; set; }
     public CalibrationSolveResult? Result { get; set; }
 
+    /// <summary>
+    /// Per-blob × per-template NCC observations from the deviation-blob detector
+    /// (mithril#1121). Populated by AutoCalibrationEngine when the engine wires
+    /// <see cref="DetectionRequest.BlobScoreSink"/> for the attempt. <c>null</c>
+    /// (default) when the diagnostic sink wasn't wired or when the underlying
+    /// detector doesn't emit (whole-image fallback path); empty when the wiring
+    /// fired but the deviation map produced zero blobs.
+    /// </summary>
+    public IReadOnlyList<BlobTemplateScore>? BlobTemplateScores { get; set; }
+
     // Outcome is set explicitly by the engine — either at each Fail() site, at
     // the end of the success path, or in the catch (exception → "error").
     public string Outcome { get; set; } = "unknown";

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs
@@ -63,7 +63,13 @@ public sealed record AttemptFilesJson(
     string? DetectionsImage,
     string? ProjectionOverlay,
     string? Detections,
-    string? RecoveredCalibration);
+    string? RecoveredCalibration,
+    // mithril#1121: per-blob × per-template NCC observation dump
+    // (10b-blob-template-scores.json). Default-null so pre-#1121 readers
+    // round-trip unchanged; populated when the deviation-blob detector
+    // emitted any blob scores (it always does in the production AutoCalibrationEngine
+    // path).
+    string? BlobTemplateScores = null);
 
 public sealed record MapRectJson(
     int SchemaVersion,
@@ -127,9 +133,48 @@ public sealed record SynthesisJson(
     bool Disagree,
     string? DisagreeChange);
 
+/// <summary>
+/// Per-blob × per-template NCC observation in the
+/// <c>10b-blob-template-scores.json</c> bundle dump (mithril#1121).
+/// Wire-format mirror of <see cref="Mithril.MapCalibration.BlobTemplateScore"/>;
+/// see that type's doc for field semantics (<c>Score</c> is <c>NaN</c> on the
+/// skip path; <c>aboveFloor</c> is the gate verdict; <c>rotate180</c>
+/// disambiguates the two orientation passes the engine runs).
+/// </summary>
+public sealed record BlobTemplateScoreJson(
+    int BlobIndex,
+    int BlobMinX,
+    int BlobMinY,
+    int BlobWidth,
+    int BlobHeight,
+    int BlobArea,
+    string TemplateName,
+    string TemplateLandmarkType,
+    int TemplateWidth,
+    int TemplateHeight,
+    double Score,
+    double TypeFloor,
+    bool AboveFloor,
+    bool Skipped,
+    bool Rotate180);
+
+/// <summary>
+/// Top-level shape of the <c>10b-blob-template-scores.json</c> bundle dump
+/// (mithril#1121). The list is grouped client-side by <c>blobIndex</c> /
+/// <c>rotate180</c>; the wire format is a flat array so downstream jq /
+/// pandas pipelines stay straightforward.
+/// </summary>
+public sealed record BlobTemplateScoresJson(
+    int SchemaVersion,
+    IReadOnlyList<BlobTemplateScoreJson> Scores);
+
+// mithril#1121: AllowNamedFloatingPointLiterals lets BlobTemplateScore.Score
+// round-trip its NaN sentinel (the skip-path marker) as the JSON token "NaN".
+// Existing DTOs in this context don't carry NaN values, so this is additive.
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     WriteIndented = true,
+    NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals,
     DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
 [JsonSerializable(typeof(AttemptJson))]
 [JsonSerializable(typeof(LocatorBestJson))]
@@ -137,4 +182,5 @@ public sealed record SynthesisJson(
 [JsonSerializable(typeof(DetectionsJson))]
 [JsonSerializable(typeof(RecoveredCalibrationJson))]
 [JsonSerializable(typeof(SynthesisJson))]
+[JsonSerializable(typeof(BlobTemplateScoresJson))]
 public partial class CalibrationBundleJsonContext : JsonSerializerContext;

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
@@ -238,10 +238,16 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
         catch (Exception ex) { _logger?.LogWarning(ex, "11-recovered-cal write failed"); return null; }
     }
 
-    // mithril#1121: per-blob × per-template NCC observation dump. Written only
-    // when the engine populated the context (i.e., the diagnostic sink was wired).
-    // Skipped when null or empty so a non-#1121-aware caller doesn't get an empty
-    // file written alongside their bundles.
+    // mithril#1121: per-blob × per-template NCC observation dump. Omitted in two
+    // cases:
+    //   - null: synthetic test paths only — AutoCalibrationEngine always assigns
+    //     the list (even empty) before calling the sink. Production bundles
+    //     never see null here.
+    //   - empty: legitimate runtime state when the deviation map produced zero
+    //     blobs. Matches the existing per-file convention (RecoveredCalibration
+    //     and ProjectionOverlay also omit on "no data produced") rather than
+    //     emitting an empty array.
+    // Use 07-deviation.png alongside this file's absence to distinguish the two.
     private string? TryWriteBlobTemplateScoresJson(string dir, CalibrationAttemptContext ctx)
     {
         try

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
@@ -72,7 +72,8 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
                 DetectionsImage: TryWriteDetectionsImage(subdir, context),
                 ProjectionOverlay: TryWriteProjectionOverlay(subdir, context),
                 Detections: TryWriteDetectionsJson(subdir, context),
-                RecoveredCalibration: TryWriteRecoveredCalibrationJson(subdir, context));
+                RecoveredCalibration: TryWriteRecoveredCalibrationJson(subdir, context),
+                BlobTemplateScores: TryWriteBlobTemplateScoresJson(subdir, context));
 
             WriteAttemptJson(subdir, context, files);
         }
@@ -235,6 +236,38 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
             return WriteJson(dir, "11-recovered-cal.json", dto, CalibrationBundleJsonContext.Default.RecoveredCalibrationJson);
         }
         catch (Exception ex) { _logger?.LogWarning(ex, "11-recovered-cal write failed"); return null; }
+    }
+
+    // mithril#1121: per-blob × per-template NCC observation dump. Written only
+    // when the engine populated the context (i.e., the diagnostic sink was wired).
+    // Skipped when null or empty so a non-#1121-aware caller doesn't get an empty
+    // file written alongside their bundles.
+    private string? TryWriteBlobTemplateScoresJson(string dir, CalibrationAttemptContext ctx)
+    {
+        try
+        {
+            if (ctx.BlobTemplateScores is not { Count: > 0 } scores) return null;
+            var dtos = scores.Select(s => new BlobTemplateScoreJson(
+                BlobIndex: s.BlobIndex,
+                BlobMinX: s.BlobMinX,
+                BlobMinY: s.BlobMinY,
+                BlobWidth: s.BlobWidth,
+                BlobHeight: s.BlobHeight,
+                BlobArea: s.BlobArea,
+                TemplateName: s.TemplateName,
+                TemplateLandmarkType: s.TemplateLandmarkType,
+                TemplateWidth: s.TemplateWidth,
+                TemplateHeight: s.TemplateHeight,
+                Score: s.Score,
+                TypeFloor: s.TypeFloor,
+                AboveFloor: s.AboveFloor,
+                Skipped: s.Skipped,
+                Rotate180: s.Rotate180)).ToArray();
+            var dto = new BlobTemplateScoresJson(SchemaVersion: 1, Scores: dtos);
+            return WriteJson(dir, "10b-blob-template-scores.json", dto,
+                CalibrationBundleJsonContext.Default.BlobTemplateScoresJson);
+        }
+        catch (Exception ex) { _logger?.LogWarning(ex, "10b-blob-template-scores write failed"); return null; }
     }
 
     private void WriteAttemptJson(string dir, CalibrationAttemptContext ctx, AttemptFilesJson files)

--- a/src/Mithril.MapCalibration.Detection/DependencyInjection/DetectionServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Detection/DependencyInjection/DetectionServiceCollectionExtensions.cs
@@ -42,7 +42,9 @@ public static class DetectionServiceCollectionExtensions
                 pgVersion,
                 loggerFactory?.CreateLogger("Mithril.MapCalibration.BaseTexture"));
         });
-        services.AddSingleton<ICalibrationDetector, DeviationBlobCalibrationDetector>();
+        services.AddSingleton<ICalibrationDetector>(sp =>
+            new DeviationBlobCalibrationDetector(
+                sp.GetService<ILoggerFactory>()?.CreateLogger("Mithril.MapCalibration.Detection")));
         services.AddSingleton<ICalibrationConfidenceGate, CalibrationConfidenceGate>();
         services.TryAddSingleton<MapCalibrationSolverOptions>();
         services.AddSingleton(sp => new MapCalibrationSolveEngine(

--- a/src/Mithril.MapCalibration.Detection/DeviationBlobCalibrationDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/DeviationBlobCalibrationDetector.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace Mithril.MapCalibration.Detection;
 
@@ -21,9 +20,27 @@ namespace Mithril.MapCalibration.Detection;
 ///         per-blob TypeFloor" pairing — deviation-rim alone is not enough).</item>
 /// </list>
 /// BCL-only.
+///
+/// <para><b>Diagnostic observability (mithril#1121).</b> When the request carries
+/// a <see cref="DetectionRequest.BlobScoreSink"/>, every (blob, template) pair
+/// considered emits a <see cref="BlobTemplateScore"/> — both the skip path
+/// (template too large for the padded crop) and the scored path (absolute best
+/// NCC peak in the crop, irrespective of <see cref="DetectionRequest.TypeFloor"/>).
+/// The same data is mirrored to <see cref="LogLevel.Trace"/> via the optional
+/// logger. Used to pick between three different NPC-pip-recall fixes (threshold
+/// vs template-quality vs pipeline-bug) instead of inferring from end-state.
+/// Producer cost is zero when the sink is null and no Trace listener is
+/// attached.</para>
 /// </summary>
 public sealed class DeviationBlobCalibrationDetector : ICalibrationDetector
 {
+    private readonly ILogger? _logger;
+
+    public DeviationBlobCalibrationDetector(ILogger? logger = null)
+    {
+        _logger = logger;
+    }
+
     public IReadOnlyDictionary<string, IReadOnlyList<TypedDetection>> Detect(DetectionRequest request)
     {
         int w = request.Screenshot.Width;
@@ -51,6 +68,13 @@ public sealed class DeviationBlobCalibrationDetector : ICalibrationDetector
         // already small (the synthetic-fixture path).
         var templates = IconRenderScaler.RenderSized(request.Screenshot, request.Templates.Templates, request.TypeFloor, request.RenderSizePx);
 
+        // mithril#1121: diagnostic sink fires when wired. We use the unfiltered
+        // best NCC peak (minScore = -1) for the diagnostic so a 0.78-just-below-floor
+        // blob is distinguishable from a 0.30-way-below-floor blob — see
+        // BlobTemplateScore. The detection-decision NCC stays gated by TypeFloor.
+        var sink = request.BlobScoreSink;
+        int blobIndex = 0;
+
         foreach (var blob in blobs)
         {
             // Search region: blob bbox padded so a template centred near a blob
@@ -67,16 +91,35 @@ public sealed class DeviationBlobCalibrationDetector : ICalibrationDetector
             double bestScore = double.NegativeInfinity;
             foreach (var t in templates)
             {
-                if (t.Gray.Width > cw || t.Gray.Height > ch) continue;
-                var hit = NccTemplateMatch.FindBest(crop, t.Gray, t.Alpha, request.TypeFloor);
-                if (hit is null) continue;
-                if (hit.Value.Score > bestScore)
+                if (t.Gray.Width > cw || t.Gray.Height > ch)
                 {
-                    bestScore = hit.Value.Score;
-                    bestDet = hit.Value;
+                    EmitDiagnostic(sink, blob, blobIndex, t,
+                        score: double.NaN, typeFloor: request.TypeFloor,
+                        aboveFloor: false, skipped: true);
+                    continue;
+                }
+                // mithril#1121: probe the unfiltered best NCC peak so the diagnostic
+                // surfaces the actual score, not just "below floor → null." The
+                // detection decision still uses TypeFloor via the explicit compare
+                // on line below.
+                var diagHit = NccTemplateMatch.FindBest(crop, t.Gray, t.Alpha, minScore: -1.0);
+                var hitScore = diagHit?.Score ?? double.NaN;
+                var clearedFloor = diagHit is not null && hitScore >= request.TypeFloor;
+
+                EmitDiagnostic(sink, blob, blobIndex, t,
+                    score: hitScore, typeFloor: request.TypeFloor,
+                    aboveFloor: clearedFloor, skipped: false);
+
+                if (!clearedFloor) continue;
+                if (hitScore > bestScore)
+                {
+                    bestScore = hitScore;
+                    bestDet = diagHit!.Value;
                     bestIcon = t;
                 }
             }
+
+            blobIndex++;
             if (bestIcon is null) continue;
 
             var (cx, cy) = bestDet.Centre(bestIcon.Gray.Width, bestIcon.Gray.Height);
@@ -94,5 +137,49 @@ public sealed class DeviationBlobCalibrationDetector : ICalibrationDetector
         var result = new Dictionary<string, IReadOnlyList<TypedDetection>>(byType.Count, StringComparer.Ordinal);
         foreach (var kv in byType) result[kv.Key] = kv.Value;
         return result;
+    }
+
+    // mithril#1121: emit the per-(blob, template) observation to the sink + Trace
+    // log. Rotate180 is left default-false; the SolveEngine's two-orientation
+    // wrapper rewrites it via `with { Rotate180 = ... }` before appending — the
+    // detector itself has no knowledge of which orientation pass it's running in.
+    private void EmitDiagnostic(
+        Action<BlobTemplateScore>? sink,
+        BlobFeat blob, int blobIndex, IconTemplate template,
+        double score, double typeFloor, bool aboveFloor, bool skipped)
+    {
+        if (skipped)
+        {
+            _logger?.LogTrace(
+                "Blob #{Idx} ({Mx},{My},{W},{H}) area={A}: skipped template {T} ({Tt}) — too large ({Tw}x{Th}).",
+                blobIndex, blob.MinX, blob.MinY, blob.W, blob.H, blob.Area,
+                template.Name, template.LandmarkType, template.Gray.Width, template.Gray.Height);
+        }
+        else
+        {
+            _logger?.LogTrace(
+                "Blob #{Idx} ({Mx},{My},{W},{H}) area={A}: template {T} ({Tt}) score={S:0.000} floor={F:0.00} {Outcome}.",
+                blobIndex, blob.MinX, blob.MinY, blob.W, blob.H, blob.Area,
+                template.Name, template.LandmarkType, score, typeFloor,
+                aboveFloor ? "above" : "below");
+        }
+
+        if (sink is null) return;
+        sink(new BlobTemplateScore(
+            BlobIndex: blobIndex,
+            BlobMinX: blob.MinX,
+            BlobMinY: blob.MinY,
+            BlobWidth: blob.W,
+            BlobHeight: blob.H,
+            BlobArea: blob.Area,
+            TemplateName: template.Name,
+            TemplateLandmarkType: template.LandmarkType,
+            TemplateWidth: template.Gray.Width,
+            TemplateHeight: template.Gray.Height,
+            Score: score,
+            TypeFloor: typeFloor,
+            AboveFloor: aboveFloor,
+            Skipped: skipped,
+            Rotate180: false));
     }
 }

--- a/src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mithril.MapCalibration.Detection;
 
 namespace Mithril.MapCalibration;
@@ -41,4 +40,49 @@ public sealed record DetectionRequest(
     /// mithril#916). Ignored when templates are already small (synthetic fixtures).
     /// </summary>
     public int? RenderSizePx { get; init; } = 16;
+
+    /// <summary>
+    /// Optional diagnostic sink for per-blob × per-template NCC scores (mithril#1121).
+    /// When non-null, the deviation-blob detector emits one
+    /// <see cref="BlobTemplateScore"/> for every (blob, template) pair it considers
+    /// — including the skip path (template too large for the padded crop) — using
+    /// the absolute best NCC peak in the crop irrespective of <see cref="TypeFloor"/>.
+    /// Used by the calibration attempt-bundle sink to write <c>10b-blob-template-scores.json</c>
+    /// for offline triage of NPC pip recall failures (#1116). Null in tests +
+    /// production paths that don't need the diagnostic; producer cost is zero
+    /// when null.
+    /// </summary>
+    public Action<BlobTemplateScore>? BlobScoreSink { get; init; }
 }
+
+/// <summary>
+/// Per-blob × per-template NCC observation (mithril#1121). Produced by the
+/// deviation-blob detector when <see cref="DetectionRequest.BlobScoreSink"/> is
+/// wired. Records the absolute best NCC peak the template achieves anywhere in
+/// the blob's padded crop, regardless of whether it cleared the type floor — so
+/// downstream triage can distinguish "scored 0.78 (one fix)" from "scored 0.30
+/// (different fix)" instead of seeing both as "below floor → silent drop."
+/// </summary>
+/// <remarks>
+/// <para><see cref="Score"/> is <see cref="double.NaN"/> when the template was
+/// skipped (its dimensions exceeded the padded crop). <see cref="AboveFloor"/>
+/// is the gate verdict — <c>true</c> iff the template participated in the
+/// "best-icon-wins" competition for this blob. <see cref="Rotate180"/>
+/// disambiguates the two passes the engine runs (0° and 180° base texture).</para>
+/// </remarks>
+public sealed record BlobTemplateScore(
+    int BlobIndex,
+    int BlobMinX,
+    int BlobMinY,
+    int BlobWidth,
+    int BlobHeight,
+    int BlobArea,
+    string TemplateName,
+    string TemplateLandmarkType,
+    int TemplateWidth,
+    int TemplateHeight,
+    double Score,
+    double TypeFloor,
+    bool AboveFloor,
+    bool Skipped,
+    bool Rotate180);

--- a/src/Mithril.MapCalibration.Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration.Detection/MapCalibrationSolveEngine.cs
@@ -51,7 +51,16 @@ public sealed class MapCalibrationSolveEngine
         foreach (var rotate180 in new[] { false, true })
         {
             var texture = rotate180 ? ImageOps.Rotate180(request.BaseTexture) : request.BaseTexture;
-            var req = request with { BaseTexture = texture };
+            // mithril#1121: wrap the caller's blob-score sink so the orientation
+            // flag is set per pass. The detector emits with Rotate180=false
+            // (it has no knowledge of which orientation pass it's in); the
+            // wrapper rewrites that field before forwarding to the original sink.
+            var orientationFlag = rotate180;
+            var callerSink = request.BlobScoreSink;
+            var wrappedSink = callerSink is null
+                ? null
+                : (Action<BlobTemplateScore>)(score => callerSink(score with { Rotate180 = orientationFlag }));
+            var req = request with { BaseTexture = texture, BlobScoreSink = wrappedSink };
 
             var detections = _detector.Detect(req);
             LogDetectSummary(rotate180, detections, references);

--- a/tests/Mithril.MapCalibration.Capture.Tests/Diagnostics/CalibrationAttemptBundleSinkTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Diagnostics/CalibrationAttemptBundleSinkTests.cs
@@ -164,6 +164,108 @@ public sealed class CalibrationAttemptBundleSinkTests : IDisposable
     }
 
     /// <summary>
+    /// mithril#1121: per-blob × per-template NCC observation dump. When the
+    /// AutoCalibrationEngine wires the diagnostic sink, the resulting context
+    /// carries a populated list and the bundle writer emits
+    /// <c>10b-blob-template-scores.json</c> alongside the existing files.
+    /// </summary>
+    [Fact]
+    public void Writes_blobTemplateScores_when_context_populated()
+    {
+        var ctx = PopulatedAccepted();
+        ctx.BlobTemplateScores = new[]
+        {
+            new BlobTemplateScore(
+                BlobIndex: 0, BlobMinX: 239, BlobMinY: 106, BlobWidth: 16, BlobHeight: 17,
+                BlobArea: 230,
+                TemplateName: "landmark_npc", TemplateLandmarkType: "Npc",
+                TemplateWidth: 15, TemplateHeight: 16,
+                Score: 0.78, TypeFloor: 0.80, AboveFloor: false, Skipped: false,
+                Rotate180: false),
+            new BlobTemplateScore(
+                BlobIndex: 0, BlobMinX: 239, BlobMinY: 106, BlobWidth: 16, BlobHeight: 17,
+                BlobArea: 230,
+                TemplateName: "landmark_portal", TemplateLandmarkType: "Portal",
+                TemplateWidth: 16, TemplateHeight: 16,
+                Score: 0.65, TypeFloor: 0.80, AboveFloor: false, Skipped: false,
+                Rotate180: false),
+            new BlobTemplateScore(
+                BlobIndex: 1, BlobMinX: 249, BlobMinY: 149, BlobWidth: 16, BlobHeight: 17,
+                BlobArea: 220,
+                TemplateName: "landmark_telepad", TemplateLandmarkType: "TeleportationPlatform",
+                TemplateWidth: 0, TemplateHeight: 0,
+                Score: double.NaN, TypeFloor: 0.80, AboveFloor: false, Skipped: true,
+                Rotate180: true),
+        };
+
+        NewSink().Write(ctx);
+
+        var dir = Directory.GetDirectories(_root).Single();
+        var files = Directory.GetFiles(dir).Select(Path.GetFileName).ToArray();
+        files.Should().Contain("10b-blob-template-scores.json");
+
+        var path = Path.Combine(dir, "10b-blob-template-scores.json");
+        using var fs = File.OpenRead(path);
+        var dto = JsonSerializer.Deserialize(fs, CalibrationBundleJsonContext.Default.BlobTemplateScoresJson);
+        dto.Should().NotBeNull();
+        dto!.SchemaVersion.Should().Be(1);
+        dto.Scores.Should().HaveCount(3);
+
+        // First record round-trips faithfully.
+        dto.Scores[0].BlobIndex.Should().Be(0);
+        dto.Scores[0].TemplateName.Should().Be("landmark_npc");
+        dto.Scores[0].TemplateLandmarkType.Should().Be("Npc");
+        dto.Scores[0].Score.Should().BeApproximately(0.78, 1e-9);
+        dto.Scores[0].TypeFloor.Should().BeApproximately(0.80, 1e-9);
+        dto.Scores[0].AboveFloor.Should().BeFalse();
+        dto.Scores[0].Skipped.Should().BeFalse();
+
+        // Skip path round-trips with NaN score.
+        dto.Scores[2].Skipped.Should().BeTrue();
+        dto.Scores[2].Score.Should().Match(d => double.IsNaN(d));
+        dto.Scores[2].Rotate180.Should().BeTrue();
+
+        // 01-attempt.json carries the new file slot.
+        var attemptPath = Path.Combine(dir, "01-attempt.json");
+        using var attemptFs = File.OpenRead(attemptPath);
+        var attempt = JsonSerializer.Deserialize(attemptFs, CalibrationBundleJsonContext.Default.AttemptJson);
+        attempt!.Files.BlobTemplateScores.Should().Be("10b-blob-template-scores.json");
+    }
+
+    /// <summary>
+    /// mithril#1121: when the context's blob-score list is null OR empty, the
+    /// sink omits the dump file. Distinguishes "diagnostic wiring not active"
+    /// from "diagnostic ran but found nothing" — both produce no file (the
+    /// detector emits zero records only on the empty-deviation-map path, which
+    /// is observable elsewhere via 07-deviation.png).
+    /// </summary>
+    [Fact]
+    public void Omits_blobTemplateScores_when_context_null_or_empty()
+    {
+        var nullCtx = PopulatedAccepted();
+        nullCtx.BlobTemplateScores = null;
+        NewSink().Write(nullCtx);
+        var nullDir = Directory.GetDirectories(_root).Single();
+        Directory.GetFiles(nullDir).Select(Path.GetFileName)
+            .Should().NotContain("10b-blob-template-scores.json");
+
+        // Re-run with empty list.
+        Directory.Delete(nullDir, recursive: true);
+        var emptyCtx = PopulatedAccepted();
+        emptyCtx.BlobTemplateScores = Array.Empty<BlobTemplateScore>();
+        NewSink().Write(emptyCtx);
+        var emptyDir = Directory.GetDirectories(_root).Single();
+        Directory.GetFiles(emptyDir).Select(Path.GetFileName)
+            .Should().NotContain("10b-blob-template-scores.json");
+
+        // The 01-attempt.json's Files.BlobTemplateScores field is null in both cases.
+        var attemptPath = Path.Combine(emptyDir, "01-attempt.json");
+        using var attemptFs = File.OpenRead(attemptPath);
+        var attempt = JsonSerializer.Deserialize(attemptFs, CalibrationBundleJsonContext.Default.AttemptJson);
+        attempt!.Files.BlobTemplateScores.Should().BeNull();
+    }
+
+    /// <summary>
     /// Observability: on a <c>rejected-map-not-located</c> outcome the bundle's
     /// <c>01-attempt.json</c> must carry the coarse locator's best origin+size (under
     /// <c>LocatorBest</c>), so triaging close-miss vs catastrophic-mismatch via the

--- a/tests/Mithril.MapCalibration.Tests/Detection/DeviationBlobCalibrationDetectorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/DeviationBlobCalibrationDetectorTests.cs
@@ -70,4 +70,97 @@ public sealed class DeviationBlobCalibrationDetectorTests
 
         byType.Values.Sum(v => v.Count).Should().Be(0);
     }
+
+    // mithril#1121: the diagnostic sink fires for every (blob, template) pair the
+    // detector considers — both the gated decision path (above-floor / below-floor)
+    // and the skip path (template too large for the padded crop). Used by the
+    // calibration bundle to distinguish "blob NCC was 0.78 just below floor"
+    // (threshold problem) from "blob NCC was 0.30" (template-vs-rendering problem).
+    [Fact]
+    public void Diagnostic_sink_fires_per_blob_per_template_when_wired()
+    {
+        var (shot, tex) = BuildPair();
+        var detector = new DeviationBlobCalibrationDetector();
+        var collected = new List<BlobTemplateScore>();
+        var request = Request(shot, tex) with { BlobScoreSink = collected.Add };
+
+        detector.Detect(request);
+
+        collected.Should().NotBeEmpty("at least one synthetic icon should produce a blob");
+
+        // Every record must reference one of the 4 placed templates.
+        collected.Select(s => s.TemplateName).Distinct()
+            .Should().BeSubsetOf(["landmark_portal", "landmark_telepad", "landmark_medipillar", "landmark_npc"]);
+
+        // For each distinct blob index, we expect a record per template the detector
+        // considered (skips + scored). This is the per-blob fan-out the bundle dump
+        // reflects.
+        var byBlob = collected.GroupBy(s => s.BlobIndex).ToList();
+        byBlob.Should().NotBeEmpty();
+        foreach (var grp in byBlob)
+        {
+            grp.Select(s => s.TemplateName).Distinct().Count()
+                .Should().BeGreaterThanOrEqualTo(1,
+                    "each blob considers at least one template (skipped or scored)");
+        }
+
+        // Scored records carry a finite score in [-1, 1]; skipped records carry NaN.
+        // Whether any skip records exist depends on the test fixture (small synthetic
+        // templates don't trigger the "template > crop" skip path), so the skip-side
+        // assertion is conditional — when skips DO occur their score must be NaN.
+        collected.Where(s => !s.Skipped).Select(s => s.Score)
+            .Should().OnlyContain(v => !double.IsNaN(v) && v >= -1.0 && v <= 1.0001);
+        foreach (var skipped in collected.Where(s => s.Skipped))
+        {
+            double.IsNaN(skipped.Score).Should().BeTrue(
+                "skip-path records must carry the NaN sentinel");
+        }
+
+        // AboveFloor is the gate verdict: score >= TypeFloor on non-skipped records.
+        collected.Where(s => !s.Skipped).Should().AllSatisfy(s =>
+            s.AboveFloor.Should().Be(s.Score >= s.TypeFloor));
+
+        // Rotate180 is left default-false at the detector layer — the SolveEngine
+        // wrapper rewrites it per orientation pass. The detector by itself emits
+        // rotate180=false.
+        collected.Should().AllSatisfy(s => s.Rotate180.Should().BeFalse(
+            "the detector doesn't know about orientation passes; that's the SolveEngine wrapper's job"));
+    }
+
+    // mithril#1121: backward-compat — without a sink, output is byte-identical to
+    // the pre-#1121 detector. Any change to the detection-decision logic would
+    // surface as a behavioural delta here.
+    [Fact]
+    public void Detector_output_is_identical_with_and_without_sink()
+    {
+        var (shot, tex) = BuildPair();
+        var detector = new DeviationBlobCalibrationDetector();
+        var baseRequest = Request(shot, tex);
+
+        var withoutSink = detector.Detect(baseRequest);
+        var collected = new List<BlobTemplateScore>();
+        var withSink = detector.Detect(baseRequest with { BlobScoreSink = collected.Add });
+
+        withSink.Keys.Should().BeEquivalentTo(withoutSink.Keys);
+        foreach (var key in withoutSink.Keys)
+        {
+            withSink[key].Should().BeEquivalentTo(withoutSink[key],
+                "wiring the sink must not change the gated detection decision");
+        }
+    }
+
+    // mithril#1121: when the sink is null, the detector skips all per-blob/per-template
+    // diagnostic work (zero producer cost). This is a contract guarantee, not just
+    // an observation — null-sink path doesn't allocate the BlobTemplateScore record.
+    [Fact]
+    public void Null_sink_path_does_not_throw()
+    {
+        var (shot, tex) = BuildPair();
+        var detector = new DeviationBlobCalibrationDetector();
+        var req = Request(shot, tex);
+        req.BlobScoreSink.Should().BeNull();
+
+        var act = () => detector.Detect(req);
+        act.Should().NotThrow();
+    }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/DeviationBlobCalibrationDetectorTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/DeviationBlobCalibrationDetectorTests.cs
@@ -163,4 +163,57 @@ public sealed class DeviationBlobCalibrationDetectorTests
         var act = () => detector.Detect(req);
         act.Should().NotThrow();
     }
+
+    // mithril#1121: the skip path fires when a template's dimensions exceed the
+    // blob's padded crop (rare in production at RenderSizePx=16 + outdoor maps,
+    // but real on degenerate inputs). The default-sized fixture never trips this
+    // branch, so the per-blob test asserts conditional NaN; this test exercises
+    // it directly so the skip-side semantic stays under coverage.
+    [Fact]
+    public void Diagnostic_sink_records_skip_path_when_template_exceeds_padded_crop()
+    {
+        // 24x24 image with a small painted square at the centre — the deviation
+        // map produces one blob. The default templates' max dimension is 40 px
+        // (medipillar) and the image is only 24 px, so every template's height
+        // dimension exceeds the padded crop and all four hit the skip branch.
+        // RenderSizePx left null so IconRenderScaler doesn't downscale (templates
+        // are already below ScaleSearchThresholdPx = 64).
+        const int W = 24, H = 24;
+        var texPixels = new byte[W * H];
+        var shotPixels = new byte[W * H];
+        for (int y = 10; y < 14; y++)
+            for (int x = 10; x < 14; x++)
+                shotPixels[y * W + x] = 255;
+
+        var shot = new GrayImage(W, H, shotPixels);
+        var tex = new GrayImage(W, H, texPixels);
+
+        var templates = SyntheticMap.BuildTemplates(SyntheticMap.DefaultIcons);
+        var rect = new MapRect(0, 0, W, H, W, H);
+        var opts = new BlobOptions(MinArea: 4, MaxIconArea: 1500, MinSolidity: 0.10, MaxAspect: 4.0, MinPeak: 0.3);
+        var request = new DetectionRequest(shot, tex, rect, templates, RimMaskMode.None,
+            LowNcc: 0.3, TypeFloor: 0.45, BlobOptions: opts)
+        {
+            RenderSizePx = null,
+        };
+
+        var collected = new List<BlobTemplateScore>();
+        request = request with { BlobScoreSink = collected.Add };
+
+        new DeviationBlobCalibrationDetector().Detect(request);
+
+        var skipped = collected.Where(s => s.Skipped).ToArray();
+        skipped.Should().NotBeEmpty(
+            "templates whose max dim (40 px) exceeds the 24x24 image must skip the per-template NCC");
+
+        // Skipped records preserve the original template dims (so triage can see
+        // WHICH dim exceeded the crop) and carry the NaN sentinel.
+        skipped.Should().AllSatisfy(s =>
+        {
+            double.IsNaN(s.Score).Should().BeTrue();
+            s.AboveFloor.Should().BeFalse();
+            s.TemplateWidth.Should().BeGreaterThan(0);
+            s.TemplateHeight.Should().BeGreaterThan(0);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Adds per-blob × per-template NCC observability to the calibration detector so the [Hogan's Basement NPC-recall failure (#1116)](https://github.com/moumantai-gg/mithril/issues/1116) can be triaged from bundle data instead of inferred from end-state.

The deviation-blob detector was silently dropping blobs whose NCC against every template fell below `TypeFloor = 0.80`. With three candidate fixes (threshold, template-vs-rendering, pipeline bug) producing very different evidence, the existing diagnostic surface couldn't tell them apart. Closes [#1121](https://github.com/moumantai-gg/mithril/issues/1121).

What lands:

- `BlobTemplateScore` record + optional `Action<BlobTemplateScore> BlobScoreSink` on `DetectionRequest` ([src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs](src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs)). Null sink → zero producer cost.
- `DeviationBlobCalibrationDetector` emits one record per (blob, template) considered — skip path + scored path. The scored path probes the **unfiltered** best NCC peak (`minScore: -1.0`), so 0.78 (close-to-floor) and 0.30 (way below) are distinguishable. The gated detection decision is unchanged — locked in by a backward-compat test.
- `MapCalibrationSolveEngine` wraps the sink to inject `Rotate180` per orientation pass. The detector itself has no orientation awareness.
- `AutoCalibrationEngine` wires the sink and snapshots into `CalibrationAttemptContext.BlobTemplateScores`.
- `FilesystemCalibrationAttemptBundleSink` writes `10b-blob-template-scores.json` (schema v1) using a new `BlobTemplateScoresJson` DTO. `AttemptFilesJson` gains a default-null `BlobTemplateScores` field. `NumberHandling = AllowNamedFloatingPointLiterals` on the bundle JSON context lets the NaN skip-path sentinel round-trip as the JSON `"NaN"` token.
- `LogTrace` mirrors the same data per pair (category `Mithril.MapCalibration.Detection`) for the Palantir live-log path.
- ILogger registered for the detector in DI ([src/Mithril.MapCalibration.Detection/DependencyInjection/DetectionServiceCollectionExtensions.cs](src/Mithril.MapCalibration.Detection/DependencyInjection/DetectionServiceCollectionExtensions.cs)).

What this does NOT do: fix the NPC recall problem. That's a follow-up once the diagnostic produces real Hogan's + Eltibule data — see #1116 for the three candidate fixes the data will pick between.

## Test plan

- [x] `dotnet build Mithril.slnx` — green, 0 warnings.
- [x] `dotnet test Mithril.slnx` — 3905/3905 passing, including:
  - `DeviationBlobCalibrationDetectorTests` (5 tests, 3 new): sink fires per blob × per template, scored/skipped/AboveFloor invariants, rotate180 detector-side default-false, output byte-identical with and without sink, null-sink path doesn't throw.
  - `CalibrationAttemptBundleSinkTests` (17 tests, 2 new): `10b-blob-template-scores.json` written when context populated (round-trips NaN, skip flag, rotate180), omitted when null OR empty, `AttemptFilesJson.BlobTemplateScores` field surfaces correctly in `01-attempt.json`.
- [ ] Run one auto-calibration attempt on `Map_HogansKeepBasement` locally and confirm the bundle subdirectory contains the new `10b-blob-template-scores.json` with the 3 visible NPC pips' scores. Logs to `%LocalAppData%/Mithril/logs/mithril-*.json` at LogTrace level for the same data.
- [ ] Compare a Hogan's bundle vs an Eltibule bundle to triage between the three candidate NPC-recall fixes (per [#1116](https://github.com/moumantai-gg/mithril/issues/1116)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
