### PR TITLE
chore(scripts): auto-detect when start.ps1 needs a clean rebuild

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,22 +1,42 @@
 [CmdletBinding()]
 param(
-    [switch]$Clean,
-    [switch]$Build
+    [switch]$Force,
+    [switch]$IgnoreDirty
 )
 
 $ErrorActionPreference = 'Stop'
 
-# -Clean implies -Build: clean+run with no build between them would leave
-# stale or missing assemblies, which is never what you want.
-if ($Clean) {
-    dotnet clean ./Mithril.slnx
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-    $Build = $true
-}
+Push-Location (Split-Path -Parent $PSScriptRoot)
+try {
+    $exe   = "src/Mithril.Shell/bin/Debug/net10.0-windows/Mithril.exe"
+    $stamp = "src/Mithril.Shell/bin/Debug/net10.0-windows/.last-build-sha"
 
-if ($Build) {
-    dotnet build ./Mithril.slnx
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-}
+    $head      = (git rev-parse HEAD).Trim()
+    $last      = if (Test-Path $stamp) { (Get-Content $stamp -Raw).Trim() } else { '' }
+    $shortHead = $head.Substring(0, 7)
+    $shortLast = if ($last) { $last.Substring(0, 7) } else { '(none)' }
 
-dotnet run ./Mithril.slnx --project ./src/Mithril.Shell/Mithril.Shell.csproj --no-build --no-restore
+    $reasons = @()
+    if ($Force)                { $reasons += 'forced (-Force)' }
+    if (-not (Test-Path $exe)) { $reasons += 'exe missing' }
+    if ($head -ne $last)       { $reasons += "new commit ($shortLast -> $shortHead)" }
+    if (-not $IgnoreDirty) {
+        $dirty = git status --porcelain
+        if ($dirty) { $reasons += 'dirty tree' }
+    }
+
+    if ($reasons.Count -gt 0) {
+        Write-Host "[start] Rebuilding: $($reasons -join ', ')" -ForegroundColor Cyan
+        dotnet clean ./Mithril.slnx
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        dotnet build ./Mithril.slnx
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        Set-Content -Path $stamp -Value $head
+    } else {
+        Write-Host "[start] Up to date ($shortHead); launching..." -ForegroundColor DarkGray
+    }
+
+    & $exe
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

- Collapses the `start -Clean` + `mithril` two-step into a single `start.ps1` that auto-detects whether a clean rebuild is needed
- New switches: `-Force` (always rebuild), `-IgnoreDirty` (don't treat uncommitted edits as a rebuild trigger)
- Replaces the old `-Clean` / `-Build` switches — the auto-detection covers their use cases

## Behavior

| Trigger | Default | `-IgnoreDirty` | `-Force` |
|---|---|---|---|
| Exe missing | rebuild | rebuild | rebuild |
| New commit since last build | rebuild | rebuild | rebuild |
| Dirty working tree | rebuild | skip → just launch | rebuild |
| Clean tree, same commit | just launch | just launch | rebuild |

Stamps the built HEAD into `src/Mithril.Shell/bin/Debug/net10.0-windows/.last-build-sha` so subsequent invocations can compare. Prints a one-line reason when it rebuilds (e.g. `[start] Rebuilding: new commit (7c4d762 -> abc1234), dirty tree`).

## Why clean instead of incremental

`CopyModuleToShell` in `Directory.Build.targets` runs `AfterTargets="Build"` on each module. If a prior build silently failed to overwrite a locked module DLL (the [stale-module-DLL trap](https://github.com/moumantai-gg/mithril/wiki) that bites when Mithril is already running), the next incremental build sees "module unchanged" and never retries the copy. Cleaning forces the copy to fire for every module, which is why `-Clean` was the existing workaround.

## Notes

- `scripts/mithril.ps1` is left in place as a "just launch, never check anything" shortcut
- The script now uses `$PSScriptRoot`-rooted paths, so it works from any cwd

## Test plan

- [ ] Fresh clone: first call rebuilds (exe missing), subsequent call on clean tree just launches
- [ ] After a `git pull` that moves HEAD: rebuilds (new commit)
- [ ] Edit a .cs file without committing: rebuilds (dirty tree)
- [ ] Same scenario with `-IgnoreDirty`: just launches (no rebuild)
- [ ] `-Force` on clean tree at current HEAD: rebuilds anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)