### PR TITLE
fix(map-calibration): gate auto-cal trigger on replay completion

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
@@ -79,6 +79,12 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
     private IDisposable? _mapAssetChangedSub;
     private readonly CancellationTokenSource _stopCts = new();
     private Task? _deferredSubscribeTask;
+    // Serialises the deferred-subscribe continuation against StopAsync/Dispose so
+    // a Stop racing with a just-completed ReplayComplete can't leak a subscription
+    // (mithril#1130 review): StopAsync awaits the deferred task AND takes this
+    // gate before disposing handles; SubscribeNow re-checks cancellation under
+    // the same gate before subscribing.
+    private readonly object _subscribeGate = new();
     private readonly object _gate = new();
     // Scenes (keyed on MapAssetKey) whose auto-attempt PERSISTED — never re-attempted (Fix C).
     private readonly HashSet<string> _persistedScenes = new(StringComparer.Ordinal);
@@ -133,10 +139,11 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
             {
                 // StopAsync fired before replay finished — leave the bus
                 // un-subscribed so the trigger stays inert.
+                _logger.LogTrace(
+                    "Auto-calibration trigger deferred subscribe cancelled before replay completed (StopAsync fired during shutdown).");
                 return;
             }
 
-            if (_stopCts.IsCancellationRequested) return;
             SubscribeNow();
         });
 
@@ -145,22 +152,43 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
 
     private void SubscribeNow()
     {
-        _areaChangedSub = _bus.Subscribe<AreaChanged>(OnAreaChanged);
-        _mapAssetChangedSub = _bus.Subscribe<MapAssetChanged>(OnMapAssetChanged);
+        // mithril#1130 review: take the gate BEFORE the cancellation re-check so
+        // a StopAsync that runs between WaitAsync returning and Subscribe firing
+        // is observed under the lock — StopAsync also takes this gate before
+        // disposing handles, so the choice is "subscribe-then-StopAsync-disposes"
+        // or "StopAsync-runs-first-and-we-skip", never "subscribe-after-Stop-returned".
+        lock (_subscribeGate)
+        {
+            if (_stopCts.IsCancellationRequested) return;
+            _areaChangedSub = _bus.Subscribe<AreaChanged>(OnAreaChanged);
+            _mapAssetChangedSub = _bus.Subscribe<MapAssetChanged>(OnMapAssetChanged);
+        }
         _logger.LogInformation(
             "Auto-calibration trigger subscribed to AreaChanged + MapAssetChanged (replay complete).");
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
         // Cancel the deferred-subscribe awaiter so a Stop before ReplayComplete
-        // leaves the bus untouched (the field stays null, dispose is a no-op).
+        // leaves the bus untouched. Then AWAIT the deferred task — this is the
+        // hosted-service contract ("StopAsync's returned task completes when the
+        // service has stopped") and the only way to deterministically synchronise
+        // with the SubscribeNow continuation. Under _subscribeGate we then dispose
+        // whatever handles SubscribeNow may have created in the gap between
+        // WaitAsync returning and Cancel firing.
         _stopCts.Cancel();
-        _areaChangedSub?.Dispose();
-        _areaChangedSub = null;
-        _mapAssetChangedSub?.Dispose();
-        _mapAssetChangedSub = null;
-        return Task.CompletedTask;
+        if (_deferredSubscribeTask is { } deferred)
+        {
+            try { await deferred.ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* awaiter ate cancel — expected */ }
+        }
+        lock (_subscribeGate)
+        {
+            _areaChangedSub?.Dispose();
+            _areaChangedSub = null;
+            _mapAssetChangedSub?.Dispose();
+            _mapAssetChangedSub = null;
+        }
     }
 
     private void OnAreaChanged(AreaChanged e)
@@ -282,8 +310,19 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
         // instance registered as both a singleton and as IHostedService.
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
         try { _stopCts.Cancel(); } catch (ObjectDisposedException) { /* StopAsync raced */ }
-        _areaChangedSub?.Dispose();
-        _mapAssetChangedSub?.Dispose();
+        // In the canonical IHostedService lifecycle StopAsync runs first and has
+        // already awaited the deferred task. This Wait is belt-and-braces for the
+        // direct-Dispose path (e.g. a test container disposing without StopAsync) —
+        // it ensures SubscribeNow can't race past the dispose and leak handlers
+        // onto the bus. The bound is short because StartAsync's continuation never
+        // does IO past the bus.Subscribe call.
+        try { _deferredSubscribeTask?.Wait(TimeSpan.FromSeconds(1)); }
+        catch { /* observed; cancellation/already-faulted are fine */ }
+        lock (_subscribeGate)
+        {
+            _areaChangedSub?.Dispose();
+            _mapAssetChangedSub?.Dispose();
+        }
         _stopCts.Dispose();
     }
 }

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Arda.Contracts;
+using Arda.Hosting;
 using Arda.World.Player;
 using Arda.World.Player.Events;
 using Microsoft.Extensions.Hosting;
@@ -49,10 +50,22 @@ namespace Mithril.MapCalibration.Capture;
 /// <para>On a non-persisted, <i>actionable</i> reject the trigger surfaces the
 /// reason on the overlay status chip (spec §10/§11) so the user learns why
 /// auto-cal isn't engaging; a persisted success clears the chip silently.</para>
+///
+/// <para><b>Replay gate (mithril#1117).</b> Subscription to
+/// <see cref="AreaChanged"/> + <see cref="MapAssetChanged"/> is deferred until
+/// <see cref="IReplayProgress.ReplayComplete"/> resolves. During Player.log
+/// replay the handler re-emits past scene transitions; firing a capture+solve
+/// against those would screenshot the CURRENT scene and locate it against an
+/// UNRELATED historical scene's bundled texture, contaminating the auto-cal
+/// store with rejected attempts for scenes the user never visited this session.
+/// The gate matches the documented module-activation pattern on
+/// <see cref="IReplayProgress"/>; the live tail's first scene-change event
+/// fires the right attempt.</para>
 /// </summary>
 public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
 {
     private readonly IDomainEventSubscriber _bus;
+    private readonly IReplayProgress _replayProgress;
     private readonly IAutoCalibrationRunner _runner;
     private readonly IMapCaptureRegionProvider _region;
     private readonly IGameWindowLocator _windowLocator;
@@ -64,6 +77,8 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
 
     private IDisposable? _areaChangedSub;
     private IDisposable? _mapAssetChangedSub;
+    private readonly CancellationTokenSource _stopCts = new();
+    private Task? _deferredSubscribeTask;
     private readonly object _gate = new();
     // Scenes (keyed on MapAssetKey) whose auto-attempt PERSISTED — never re-attempted (Fix C).
     private readonly HashSet<string> _persistedScenes = new(StringComparer.Ordinal);
@@ -73,6 +88,7 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
 
     public AutoCalibrationTrigger(
         IDomainEventSubscriber bus,
+        IReplayProgress replayProgress,
         IAutoCalibrationRunner runner,
         IMapCaptureRegionProvider region,
         IGameWindowLocator windowLocator,
@@ -83,6 +99,7 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
         ILogger logger)
     {
         _bus = bus;
+        _replayProgress = replayProgress;
         _runner = runner;
         _region = region;
         _windowLocator = windowLocator;
@@ -95,13 +112,50 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Fast-path: replay already complete (headless tests, second-instance
+        // takeover, or a tail-only restart). Subscribe synchronously so the
+        // first live event fires immediately without a thread-pool hop.
+        if (_replayProgress.ReplayComplete.IsCompleted)
+        {
+            SubscribeNow();
+            return Task.CompletedTask;
+        }
+
+        _logger.LogInformation(
+            "Auto-calibration trigger deferred until Player/Chat replay completes (mithril#1117 gate).");
+        _deferredSubscribeTask = Task.Run(async () =>
+        {
+            try
+            {
+                await _replayProgress.ReplayComplete.WaitAsync(_stopCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // StopAsync fired before replay finished — leave the bus
+                // un-subscribed so the trigger stays inert.
+                return;
+            }
+
+            if (_stopCts.IsCancellationRequested) return;
+            SubscribeNow();
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private void SubscribeNow()
+    {
         _areaChangedSub = _bus.Subscribe<AreaChanged>(OnAreaChanged);
         _mapAssetChangedSub = _bus.Subscribe<MapAssetChanged>(OnMapAssetChanged);
-        return Task.CompletedTask;
+        _logger.LogInformation(
+            "Auto-calibration trigger subscribed to AreaChanged + MapAssetChanged (replay complete).");
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        // Cancel the deferred-subscribe awaiter so a Stop before ReplayComplete
+        // leaves the bus untouched (the field stays null, dispose is a no-op).
+        _stopCts.Cancel();
         _areaChangedSub?.Dispose();
         _areaChangedSub = null;
         _mapAssetChangedSub?.Dispose();
@@ -221,9 +275,15 @@ public sealed class AutoCalibrationTrigger : IHostedService, IDisposable
         }
     }
 
+    private int _disposed;
     public void Dispose()
     {
+        // Idempotent: the DI container can invoke Dispose more than once for an
+        // instance registered as both a singleton and as IHostedService.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        try { _stopCts.Cancel(); } catch (ObjectDisposedException) { /* StopAsync raced */ }
         _areaChangedSub?.Dispose();
         _mapAssetChangedSub?.Dispose();
+        _stopCts.Dispose();
     }
 }

--- a/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
+++ b/src/Mithril.MapCalibration.Capture/DependencyInjection/CaptureServiceCollectionExtensions.cs
@@ -230,9 +230,13 @@ public static partial class CaptureServiceCollectionExtensions
 
         // Background auto-attempt trigger. A hosted service → ILogger is required
         // (CLAUDE.md): resolve ILoggerFactory as required and create the category
-        // logger rather than threading an optional logger.
+        // logger rather than threading an optional logger. The trigger defers its
+        // AreaChanged/MapAssetChanged subscription until IReplayProgress.ReplayComplete
+        // resolves so replayed past scene transitions don't fire capture+solve
+        // attempts against the current-screen screenshot (mithril#1117).
         services.AddSingleton<AutoCalibrationTrigger>(sp => new AutoCalibrationTrigger(
             sp.GetRequiredService<Arda.Contracts.IDomainEventSubscriber>(),
+            sp.GetRequiredService<Arda.Hosting.IReplayProgress>(),
             sp.GetRequiredService<IAutoCalibrationRunner>(),
             sp.GetRequiredService<IMapCaptureRegionProvider>(),
             sp.GetRequiredService<IGameWindowLocator>(),

--- a/src/Mithril.MapCalibration.Capture/Mithril.MapCalibration.Capture.csproj
+++ b/src/Mithril.MapCalibration.Capture/Mithril.MapCalibration.Capture.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Mithril.Overlay\Mithril.Overlay.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
     <ProjectReference Include="..\Arda\Arda.Contracts\Arda.Contracts.csproj" />
+    <ProjectReference Include="..\Arda\Arda.Hosting\Arda.Hosting.csproj" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Mithril.MapCalibration.Capture.Tests" />

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
@@ -327,6 +327,32 @@ public sealed class AutoCalibrationTriggerTests
             "MapAssetChanged subscription must be established once replay completes");
 
         await trigger.StopAsync(CancellationToken.None);
+        bus.SubscriptionCount.Should().Be(0,
+            "StopAsync must dispose every subscription handle the trigger created");
+    }
+
+    [Fact]
+    public async Task StopAsync_synchronises_deferred_subscribe_after_Complete()
+    {
+        // mithril#1130 review: closes the TOCTOU where ReplayComplete resolves
+        // and the continuation passes the cancellation check, then StopAsync
+        // runs to completion BEFORE SubscribeNow has actually called
+        // bus.Subscribe. Without the _subscribeGate + StopAsync.await of the
+        // deferred task, two handlers would land on the bus after StopAsync
+        // returned. This test exercises the Complete-then-immediate-Stop ordering
+        // and asserts the contract: after StopAsync returns, no handlers are live.
+        var bus = new FakeDomainEventSubscriber();
+        var replay = new FakeReplayProgress(completed: false);
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true,
+            bus: bus, replay: replay);
+
+        await trigger.StartAsync(CancellationToken.None);
+        replay.Complete();
+        await trigger.StopAsync(CancellationToken.None);
+
+        bus.SubscriptionCount.Should().Be(0,
+            "StopAsync must await the deferred subscribe task and dispose any handle the gap-window subscribe created");
     }
 
     [Fact]

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationTriggerTests.cs
@@ -1,4 +1,7 @@
+using System.Threading;
 using System.Threading.Tasks;
+using Arda.Abstractions.Logs;
+using Arda.World.Player.Events;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -231,9 +234,15 @@ public sealed class AutoCalibrationTriggerTests
     private static AutoCalibrationTrigger Build(
         SpyAutoCalibrationEngine engine, CaptureRect? bbox, bool focused,
         FakeCalibrationService? service = null, FakeOverlayWindow? overlay = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        FakeDomainEventSubscriber? bus = null,
+        FakeReplayProgress? replay = null)
         => new(
-            new FakeDomainEventSubscriber(),
+            bus ?? new FakeDomainEventSubscriber(),
+            // mithril#1117: default to "replay complete" so the existing
+            // OnSceneChangedAsync-direct tests aren't gated. The new replay-gate
+            // tests pass their own FakeReplayProgress(completed: false) explicitly.
+            replay ?? new FakeReplayProgress(completed: true),
             engine,
             new FakeRegionProvider(bbox),
             new FakeWindowLocator(focused ? new GameWindow(1, new CaptureRect(0, 0, 1920, 1080)) : null),
@@ -242,4 +251,128 @@ public sealed class AutoCalibrationTriggerTests
             new FakeSceneAssetCache(),
             overlay ?? new FakeOverlayWindow(),
             logger ?? NullLogger.Instance);
+
+    // -------------------------------------------------------------------------
+    // mithril#1117: replay-gate tests. The trigger must NOT subscribe to
+    // AreaChanged / MapAssetChanged while Player.log replay is in flight, because
+    // replayed past scene transitions fire capture+solve against the CURRENT
+    // screen against an UNRELATED historical scene's bundled texture and
+    // contaminate the diagnostics store with rejected attempts for scenes the
+    // user never visited this session.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task StartAsync_does_not_subscribe_while_replay_is_in_flight()
+    {
+        var bus = new FakeDomainEventSubscriber();
+        var replay = new FakeReplayProgress(completed: false);
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true,
+            bus: bus, replay: replay);
+
+        await trigger.StartAsync(CancellationToken.None);
+
+        bus.SubscriptionCount.Should().Be(0,
+            "the trigger must defer Subscribe until ReplayComplete so replayed past scene transitions don't fire capture+solve");
+
+        await trigger.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Events_published_during_replay_do_not_reach_the_handler()
+    {
+        var bus = new FakeDomainEventSubscriber();
+        var replay = new FakeReplayProgress(completed: false);
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true,
+            bus: bus, replay: replay);
+
+        await trigger.StartAsync(CancellationToken.None);
+        // Simulate Arda re-emitting a past scene transition during the replay catch-up phase.
+        var replayMeta = new LogLineMetadata(
+            Timestamp: new DateTimeOffset(2026, 6, 10, 10, 18, 36, TimeSpan.Zero),
+            ReadOn: new DateTimeOffset(2026, 6, 10, 10, 18, 36, TimeSpan.Zero),
+            IsReplay: true);
+        bus.Publish(new AreaChanged(PreviousArea: null, CurrentArea: Area, replayMeta));
+        bus.Publish(new MapAssetChanged(
+            PreviousScene: null,
+            CurrentScene: new MapSceneRef(Area, null, AssetKey),
+            replayMeta));
+
+        engine.Calls.Should().Be(0,
+            "replay-time events must not reach the handler — the locator would screenshot the current scene against an unrelated historical scene's texture");
+
+        await trigger.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Subscribes_after_replay_completes()
+    {
+        var bus = new FakeDomainEventSubscriber();
+        var replay = new FakeReplayProgress(completed: false);
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true,
+            bus: bus, replay: replay);
+
+        await trigger.StartAsync(CancellationToken.None);
+        bus.SubscriptionCount.Should().Be(0);
+
+        replay.Complete();
+        // The deferred Subscribe runs on the thread pool; wait until it lands.
+        await WaitForAsync(() => bus.SubscriptionCount > 0);
+
+        bus.HasSubscriber<AreaChanged>().Should().BeTrue(
+            "AreaChanged subscription must be established once replay completes");
+        bus.HasSubscriber<MapAssetChanged>().Should().BeTrue(
+            "MapAssetChanged subscription must be established once replay completes");
+
+        await trigger.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_subscribes_synchronously_when_replay_already_complete()
+    {
+        // Headless tests, second-instance takeover, or a tail-only restart all
+        // hit StartAsync with ReplayComplete already resolved. The trigger should
+        // subscribe synchronously in that case — no thread-pool hop, no race.
+        var bus = new FakeDomainEventSubscriber();
+        var replay = new FakeReplayProgress(completed: true);
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true,
+            bus: bus, replay: replay);
+
+        await trigger.StartAsync(CancellationToken.None);
+
+        bus.HasSubscriber<AreaChanged>().Should().BeTrue();
+        bus.HasSubscriber<MapAssetChanged>().Should().BeTrue();
+
+        await trigger.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_before_replay_completes_leaves_the_bus_un_subscribed()
+    {
+        var bus = new FakeDomainEventSubscriber();
+        var replay = new FakeReplayProgress(completed: false);
+        var engine = new SpyAutoCalibrationEngine();
+        var trigger = Build(engine, bbox: new CaptureRect(0, 0, 64, 64), focused: true,
+            bus: bus, replay: replay);
+
+        await trigger.StartAsync(CancellationToken.None);
+        await trigger.StopAsync(CancellationToken.None);
+        replay.Complete();
+
+        // Give the deferred-subscribe task a moment to observe the cancellation.
+        await Task.Delay(50);
+        bus.SubscriptionCount.Should().Be(0,
+            "a Stop before ReplayComplete must cancel the deferred Subscribe — the trigger stays inert");
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            await Task.Delay(10);
+        condition().Should().BeTrue("the awaited condition should have flipped within {0}ms", timeoutMs);
+    }
 }

--- a/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/CaptureDependencyInjectionTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Reflection;
 using Arda.Contracts;
+using Arda.Hosting;
 using Arda.World.Player;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -135,6 +136,10 @@ public sealed class CaptureDependencyInjectionTests
         services.AddSingleton(new GameConfig { CalibrationGoodResidualPx = 9.0, GameRoot = "" });
         services.AddSingleton<IOverlayWindow>(new FakeOverlayWindow());
         services.AddSingleton<IDomainEventSubscriber>(new FakeDomainEventSubscriber());
+        // mithril#1117: AutoCalibrationTrigger now gates its event subscription on
+        // IReplayProgress.ReplayComplete. Register the "replay complete" fake so the
+        // DI graph resolves; the trigger subscribes synchronously in StartAsync.
+        services.AddSingleton<IReplayProgress>(new FakeReplayProgress(completed: true));
         services.AddSingleton<IAreaState>(new FakeAreaState("AreaSerbule"));
         // #1021: the engine now resolves IMapState (per-scene asset + sub-zone)
         // instead of IAreaState. AutoCalibrationTrigger still consumes IAreaState

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Arda.Contracts;
+using Arda.Hosting;
 using Arda.World.Player;
 using Arda.World.Player.Events;
 using Mithril.MapCalibration;
@@ -23,13 +24,107 @@ internal sealed class FakeOverlayWindow : IOverlayWindow
     private sealed class Noop : IDisposable { public void Dispose() { } }
 }
 
-/// <summary>No-op event bus: the trigger's hosted-service Subscribe wiring is
-/// exercised by the DI-resolution test; the gating logic is tested directly via
-/// the extracted OnSceneChangedAsync seam.</summary>
+/// <summary>
+/// Recording event bus: tracks every <see cref="Subscribe{T}"/> call so tests
+/// can assert subscription state (e.g. the mithril#1117 replay-gate tests that
+/// verify <c>StartAsync</c> does NOT subscribe before <c>ReplayComplete</c>),
+/// and lets tests publish events through any handler that has subscribed.
+/// </summary>
 internal sealed class FakeDomainEventSubscriber : IDomainEventSubscriber
 {
-    public IDisposable Subscribe<T>(Action<T> handler) where T : struct => new Noop();
-    private sealed class Noop : IDisposable { public void Dispose() { } }
+    private readonly Dictionary<Type, List<object>> _handlers = new();
+    private readonly object _gate = new();
+
+    /// <summary>Total number of live subscriptions across all event types.</summary>
+    public int SubscriptionCount
+    {
+        get { lock (_gate) return _handlers.Values.Sum(h => h.Count); }
+    }
+
+    /// <summary>True iff at least one handler is currently subscribed to <typeparamref name="T"/>.</summary>
+    public bool HasSubscriber<T>() where T : struct
+    {
+        lock (_gate) return _handlers.TryGetValue(typeof(T), out var hs) && hs.Count > 0;
+    }
+
+    public IDisposable Subscribe<T>(Action<T> handler) where T : struct
+    {
+        lock (_gate)
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list))
+                _handlers[typeof(T)] = list = new List<object>();
+            list.Add(handler);
+        }
+        return new Subscription(this, typeof(T), handler);
+    }
+
+    /// <summary>Dispatch <paramref name="evt"/> to every currently-subscribed handler for type <typeparamref name="T"/>.</summary>
+    public void Publish<T>(T evt) where T : struct
+    {
+        List<object> snapshot;
+        lock (_gate)
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list)) return;
+            snapshot = new List<object>(list);
+        }
+        foreach (var h in snapshot)
+            ((Action<T>)h)(evt);
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly FakeDomainEventSubscriber _owner;
+        private readonly Type _type;
+        private readonly object _handler;
+        public Subscription(FakeDomainEventSubscriber owner, Type type, object handler)
+            => (_owner, _type, _handler) = (owner, type, handler);
+        public void Dispose()
+        {
+            lock (_owner._gate)
+            {
+                if (_owner._handlers.TryGetValue(_type, out var list))
+                    list.Remove(_handler);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Controllable <see cref="IReplayProgress"/> for the mithril#1117 trigger
+/// gate tests. Defaults to "replay already complete" so the bulk of the
+/// existing trigger tests — which exercise <see cref="AutoCalibrationTrigger.OnSceneChangedAsync"/>
+/// directly and don't care about the subscription path — keep their old shape.
+/// </summary>
+internal sealed class FakeReplayProgress : IReplayProgress
+{
+    private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <param name="completed">When <c>true</c> (default) <see cref="ReplayComplete"/> is already resolved.</param>
+    public FakeReplayProgress(bool completed = true)
+    {
+        if (completed)
+        {
+            _tcs.SetResult();
+            PlayerProgress = 1.0;
+            ChatProgress = 1.0;
+        }
+    }
+
+    public double PlayerProgress { get; private set; }
+    public double ChatProgress { get; private set; }
+    public Task ReplayComplete => _tcs.Task;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Resolve <see cref="ReplayComplete"/> if it hasn't been already.</summary>
+    public void Complete()
+    {
+        PlayerProgress = 1.0;
+        ChatProgress = 1.0;
+        _tcs.TrySetResult();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PlayerProgress)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ChatProgress)));
+    }
 }
 
 internal sealed class FakeAreaState : IAreaState


### PR DESCRIPTION
## Symptom

When Mithril starts, Arda's Player.log handler re-emits past scene transitions through `AreaChanged` / `MapAssetChanged` during the replay catch-up phase. `AutoCalibrationTrigger` subscribed at hosted-service start with no gating, so those replayed events fired capture+solve attempts. The screenshot at capture time is whatever's on screen NOW (usually unrelated to the historical scene), so the locator ran the wrong screenshot against the wrong scene's bundled texture. Result: bundles got written for scenes the user never visited in the current session.

Example bundles in `%LocalAppData%/Mithril/diagnostics/calibration/` (2026-06-10 capture session):
- `Map_GoblinDungeon-20260610-101837-104-rejected-solve` — scale=0.14, NCC=0.279, region 56×143. Fired during what was meant to be an Eltibule capture.
- `Map_GoblinDungeon_TopFloor-20260610-101836-789-rejected-solve` — scale=0.12, NCC=0.228, region 96×96.

The two Goblin* timestamps are 0.3 seconds apart, ~34 seconds before the actual Eltibule trigger — a burst signature consistent with replay catching up past transitions.

## Root cause

[`AutoCalibrationTrigger.StartAsync`](src/Mithril.MapCalibration.Capture/AutoCalibrationTrigger.cs#L96) subscribed to `IDomainEventSubscriber.Subscribe<AreaChanged>` and `<MapAssetChanged>` at hosted-service start with no gating on whether incoming events are live or replayed. [`IAreaState.cs:5-7`](src/Arda/Arda.Contracts/State/Player/IAreaState.cs#L5) explicitly warned about this pattern.

## Fix

Approach (1) of the two options in the brief — **defer subscription**. Inject `IReplayProgress`; in `StartAsync`, schedule the `Subscribe<AreaChanged>` + `Subscribe<MapAssetChanged>` to fire only after `await replayProgress.ReplayComplete` resolves. A `Stop` before `ReplayComplete` cancels the deferred subscribe via a `CancellationTokenSource` so the bus stays untouched. `Dispose` is idempotent so the DI container's singleton+IHostedService double-dispose path doesn't throw.

Fast-path: when `ReplayComplete.IsCompleted` at StartAsync time (headless tests, second-instance takeover, tail-only restart), subscribe synchronously — no thread-pool hop.

## Tests

- `StartAsync_does_not_subscribe_while_replay_is_in_flight` — the bus has zero subscriptions after StartAsync when replay is mid-flight.
- `Events_published_during_replay_do_not_reach_the_handler` — replay-time `AreaChanged` + `MapAssetChanged` don't reach the engine.
- `Subscribes_after_replay_completes` — flipping `ReplayComplete` lights up both subscriptions.
- `StartAsync_subscribes_synchronously_when_replay_already_complete` — fast-path covered.
- `StopAsync_before_replay_completes_leaves_the_bus_un_subscribed` — Stop cancels the deferred subscribe.

All 18 pre-existing `AutoCalibrationTriggerTests` continue to pass (the Build helper defaults `replay: completed=true` so the existing `OnSceneChangedAsync`-direct tests aren't gated).

## Out of scope

- Per-event `IsReplay` flag on the event records — overkill for this consumer.
- ChatLog gating — chat is live-only by design.
- Cleanup of contaminated diagnostic bundles users may already have on disk — workflow concern, users move them aside.

## Test plan

- [x] `dotnet test tests/Mithril.MapCalibration.Capture.Tests/...` — 249/249 pass
- [x] `dotnet build src/Mithril.MapCalibration.Capture/...` — green
- [ ] live verify: start Mithril against a Player.log with past scene transitions; confirm no `…-rejected-solve` bundles fire during the replay window

— drafted by Claude (Opus 4.7), posted by @arthur-conde
