### PR TITLE
fix(map-calibration): align ReplayFixture texture dims to cropped screenshot

### DIFF
--- a/tests/Mithril.MapCalibration.Tests/Detection/ReplayFixtureTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ReplayFixtureTests.cs
@@ -125,16 +125,13 @@ public sealed class ReplayFixtureTests
         var shot = WicImageLoader.LoadGray(screenshotPath);
         var fullTex = WicImageLoader.LoadGray(texturePath);
 
-        // Mirror the production AutoCalibrationEngine alignment step
-        // (src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs:680):
-        // the screenshot is already cropped to the visible map region (a dev
-        // cropped it manually for the fixture); resample the full base texture
-        // down to the same dims so the engine's per-pixel subtraction
-        // (synthesis-J L_t builder + detector deviation map) gets aligned
-        // buffers. MapRect keeps the texture's NATIVE dims in TextureWidth/
-        // TextureHeight so the geometric solve back-projects into world space.
-        // mithril#999 made synthesis-J Shadow the default re-rank mode, which
-        // turned this previously-implicit assumption into a hard throw.
+        // The screenshot is pre-cropped to the visible map region (a dev
+        // cropped it for the fixture); resample the base texture down to the
+        // same dims so the engine's per-pixel subtraction (synthesis-J L_t
+        // builder + detector deviation map) sees aligned buffers. MapRect
+        // keeps the texture's NATIVE dims in TextureWidth/TextureHeight so
+        // the geometric solve back-projects into world space. Production
+        // AutoCalibrationEngine performs the same alignment before solve.
         var alignedTexture = ImageOps.Resize(fullTex, shot.Width, shot.Height);
         var rect = new MapRect(0, 0, shot.Width, shot.Height, fullTex.Width, fullTex.Height);
         // #931: icon templates are no longer embedded — they're loaded from the

--- a/tests/Mithril.MapCalibration.Tests/Detection/ReplayFixtureTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ReplayFixtureTests.cs
@@ -123,12 +123,20 @@ public sealed class ReplayFixtureTests
         var expected = baseline[assetKey];
 
         var shot = WicImageLoader.LoadGray(screenshotPath);
-        var tex = WicImageLoader.LoadGray(texturePath);
+        var fullTex = WicImageLoader.LoadGray(texturePath);
 
-        // The screenshot here is assumed already cropped to the map rect (1:1
-        // texture extent) for the replay; real captures crop via the production
-        // IMapRegionRefiner (FeatureMatchingRefiner) in Phase 2.
-        var rect = new MapRect(0, 0, shot.Width, shot.Height, tex.Width, tex.Height);
+        // Mirror the production AutoCalibrationEngine alignment step
+        // (src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs:680):
+        // the screenshot is already cropped to the visible map region (a dev
+        // cropped it manually for the fixture); resample the full base texture
+        // down to the same dims so the engine's per-pixel subtraction
+        // (synthesis-J L_t builder + detector deviation map) gets aligned
+        // buffers. MapRect keeps the texture's NATIVE dims in TextureWidth/
+        // TextureHeight so the geometric solve back-projects into world space.
+        // mithril#999 made synthesis-J Shadow the default re-rank mode, which
+        // turned this previously-implicit assumption into a hard throw.
+        var alignedTexture = ImageOps.Resize(fullTex, shot.Width, shot.Height);
+        var rect = new MapRect(0, 0, shot.Width, shot.Height, fullTex.Width, fullTex.Height);
         // #931: icon templates are no longer embedded — they're loaded from the
         // asset-extractor cache dir. For this fixture-gated replay the cache (a dev
         // populated it via the sidecar) lives under study/templates. Absent → Empty
@@ -144,7 +152,7 @@ public sealed class ReplayFixtureTests
         // false positives and RANSAC converges on a degenerate few-inlier fit at
         // the wrong orientation; the auto render-size sweep collapses to the
         // smallest/blurriest size that correlates with everything (mithril#916).
-        var request = new DetectionRequest(shot, tex, rect, templates, RimMaskMode.DeviationFlood,
+        var request = new DetectionRequest(shot, alignedTexture, rect, templates, RimMaskMode.DeviationFlood,
             LowNcc: 0.5, TypeFloor: 0.80,
             BlobOptions: new BlobOptions(MinArea: 12, MaxIconArea: 900, MinSolidity: 0.35, MaxAspect: 2.5, MinPeak: 0.7))
         {


### PR DESCRIPTION
## Summary

- Fixes the silent failure of `ReplayFixtureTests.Recovers_committed_baseline_for_area` (3 theories: AreaSerbule, AreaEltibule, AreaKurMountains) by mirroring the production texture-resize step at [AutoCalibrationEngine.cs:680](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs#L680).
- Regression introduced by [mithril#999](https://github.com/moumantai-gg/mithril/pull/999) (`bd01a193`, Jun 2 2026), which made `SynthesisRerankMode.Shadow` the default re-rank mode. The synthesis-J L_t builder does `screenshot[i] - baseTexture[i]` with a hard dim check at [MapCalibrationSolveEngine.cs:521](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.MapCalibration.Detection/MapCalibrationSolveEngine.cs#L521); the test passes a cropped screenshot (e.g. 881×920) alongside the full base texture (e.g. 1961×2048), so every theory threw.
- CI skips the theory (`study/` tree is gitignored), so the failure has been silent locally for ~three months of map-calibration PRs that claimed "verified-green, replay-validated."

## What the fix does

In the test, resample the full base texture down to the cropped screenshot's dims via `ImageOps.Resize` before constructing the `DetectionRequest`. The `MapRect` retains the native texture dims (`TextureWidth`/`TextureHeight`) so the engine's geometric back-projection into world space is unchanged — only the per-pixel-subtraction buffers needed alignment. This matches what the production [`AutoCalibrationEngine`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs#L679) does before calling `_solver.Solve`.

## Why test-side, not engine-side

The engine's "aligned inputs required" contract is consistent across both call sites in `Solve`: `BuildLikelihoodFieldsFromDeviation` throws explicitly, but `DeviationBlobCalibrationDetector.DeviationMap` also implicitly requires it (mismatched buffers silently produce garbage). Production already does the resize at the call site, and moving the resize into the engine would mask the contract for any other consumer that passes mismatched inputs. The test was simply missing what production already does.

## Scope this PR does NOT close

The fixture remains structurally dev-local. After this PR the dim throw is gone but the 3 theories still fail locally because [PR #932](https://github.com/moumantai-gg/mithril/pull/932) moved icon templates off-tree (sidecar-populated `study/templates/`). Even with the templates cache populated, the fixture is not contributor-runnable: the committed baselines are pinned to specific screenshot PNG bytes, and the screenshots themselves are PG art (same IP reason `#931` moved templates off-tree). Will land a follow-up that softens the CLAUDE.md / wiki "load-bearing local-replay check" language to match reality and marks the theory dev-local so xUnit discovery stops implying coverage.

## Test plan

- [x] `dotnet build tests/Mithril.MapCalibration.Tests/Mithril.MapCalibration.Tests.csproj` clean (0 warnings, 0 errors)
- [x] `dotnet test tests/Mithril.MapCalibration.Tests/Mithril.MapCalibration.Tests.csproj` — 360 pass / 3 fail; the 3 failures are the `ReplayFixtureTests` theories that now fail at `result.Calibration.Should().NotBeNull(...)` (templates-cache empty), instead of the dim `ArgumentException`. CI sees them skipped (study/ tree gitignored).
- [x] Repro confirmed pre-fix on `2caa2387` and on fix branch HEAD — same 3 theories failed pre-fix with the dim throw at line 521; post-fix the dim throw is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
