### PR TITLE
docs(planning): Mode-B Phase 0 spike measurements (#1155)

### DIFF
--- a/docs/planning/calibration-1155-scene-class-profile/measurements/README.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/README.md
@@ -1,0 +1,41 @@
+# Mode-B Phase 0 spike measurements
+
+Phase 0 of the [implementation plan](../plan.md). Validates spec §6 verification-owed items against the existing diagnostic-bundle corpus *before* code lands.
+
+| File | §6 item | Verdict | Surprise? |
+|---|---|---|---|
+| [scene-class-classification.md](scene-class-classification.md) | §6.a — alpha-coverage threshold | **CONFIRMED** | No |
+| [indoor-render-size.md](indoor-render-size.md) | §6.b — Indoor `RenderSizePx` | **REVISED** (keep 16, not 12) | Yes |
+| [indoor-chroma-threshold.md](indoor-chroma-threshold.md) | §6.c — chroma pre-filter | **NEGATIVE** (chroma doesn't separate) | Yes |
+| [indoor-synthesis-j-threshold.md](indoor-synthesis-j-threshold.md) | §6.d — synthesis-J jMin formula | **PARTIAL** (no ground-truth Indoor accepts) | Anticipated |
+| [untyped-ransac-cost.md](untyped-ransac-cost.md) | §6.e — untyped RANSAC pool-size cost | **CONFIRMED** (small) | No |
+| [detection-recall-pivot.md](detection-recall-pivot.md) | NEW finding — real-icon recall | **MODE-B PIVOT** | **YES** — load-bearing |
+
+## TL;DR
+
+- §6.a + §6.e — green, spec stands.
+- §6.b — spec value 12 was wrong; keep 16. One-line spec edit.
+- §6.c (chroma pre-filter) — doesn't work. Spec's Phase 3 ships disabled OR replaces chroma with **peak luma** (a discovered alternative that DOES separate cleanly). Either way, the per-blob feature gate is salvageable.
+- §6.d — Indoor synthesis-J has no ground-truth accepts. Phase 4 should ship in Shadow mode for Indoor v1; revisit once Phase 2-3 produce known-good Indoor cals.
+- **NEW finding (the big one):** the detector has a **detection-recall failure**, not a detection-precision failure. Of 18 non-rotated Icon-class blobs in the canonical Hogan's bundle, **only 1 contains a real icon glyph**. The other 17 are pure floor-texture noise. Untyped detection (the spec's load-bearing piece, candidate E / Phase 2) does NOT fix this — it changes how RANSAC discriminates type, but if 17/18 blobs are noise, RANSAC has no real correspondences to find regardless of typing strategy. **The Mode-B fix has to start upstream of typing — at deviation+morph+classify — to recover the missing real-icon blobs.** See `detection-recall-pivot.md`.
+
+## What changes in the spec
+
+The scene-class refactor (Phase 1) stands. The Indoor profile divergences (Phases 2-4) need to be re-sequenced:
+
+1. **Phase 2 → "Indoor icon-blob recall"** (new scope). The actual root-cause fix. Probable shape: lower `LowNcc` threshold, weaken the rim/morph filter, OR introduce a chroma/luma-aware deviation kernel. Needs its own design pass.
+2. **Phase 3 → Peak-luma pre-filter** (revised from chroma). The empirical finding that PeakLuma > 0.7 cleanly separates real-icon blobs from noise blobs is the noise-suppression mechanism that survives the spike.
+3. **Phase 4 → untyped detection + RANSAC type discrimination** (downgraded). Still valuable when Phase 2 succeeds in recovering more real-icon blobs, but no longer load-bearing on its own.
+4. **Phase 5 → adaptive synthesis-J Shadow** (deferred from Phase 4 of original plan).
+
+The post-spike spec revision is itself a follow-up — these measurement docs are the input to it. Suggesting the order:
+
+1. Land these measurements as-is (this PR).
+2. Open follow-up design pass: "Indoor icon-blob recall — Phase 2 scope" (separate sub-issue under #1155).
+3. After that's spec'd, revise the original spec.md / plan.md or supersede with v2.
+
+## Tooling
+
+Measurements ran as ad-hoc PowerShell snippets against bundle artifacts in `%LocalAppData%/Mithril/diagnostics/calibration/` and the asset cache in `%LocalAppData%/Mithril/assets/`. The snippets are not preserved (per spec — spike is throwaway); the measurement docs are the durable record.
+
+For Phase 1 implementation, a `tools/Spike-1155/Program.cs` BCL-only harness can mechanize §6.a (the only measurement that's structurally a recurring computation per scene). The §6.b-e measurements are one-off.

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/detection-recall-pivot.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/detection-recall-pivot.md
@@ -1,0 +1,107 @@
+# NEW finding — Mode-B has the wrong load-bearing direction
+
+**Discovered during the Phase 0 spike, outside the §6 plan.**
+
+The spec's chosen direction (candidate E, untyped detection + RANSAC discrimination) assumes the detector **finds real-icon blobs and mis-types them.** The spike data shows that's wrong for Indoor: the detector **doesn't find most real-icon blobs at all.**
+
+## The data
+
+Canonical bundle: `Map_HogansKeepBasement-20260613-230459-600-rejected-solve-insufficient-inliers`.
+
+**Visible real icons in raw screenshot (`02-screenshot-raw.png`)**, identified by scanning for bright-pixel clusters (RGB > 200):
+
+| Cluster center (raw XY) | Aligned XY | Bright px |
+|---|---|---|
+| (521, 304) | (324, 187) | 37 |
+| (521, 295) | (324, 178) | 36 |
+| (528, 302) | (331, 185) | 14 |
+| (526, 295) | (329, 178) | 11 |
+| (608, 302) | (411, 185) | 16 |
+| (696, 799) | (499, 682) | 12 |
+| (571, 786) | (374, 669) | 10 |
+| (625, 373) | (428, 256) | 10 |
+| (628, 318) | (431, 201) | 7 |
+| (630, 318) | (433, 201) | 6 |
+
+→ The screenshot contains **~5-6 distinct icon glyphs** (some clusters are adjacent and likely the same icon; some are clearly separate).
+
+**Detected Icon-class blobs (non-rotated pass)**, from `10c-blob-pipeline.json`, with each blob's raw-screenshot `PeakLuma` + `BrightPx`:
+
+| Blob | Aligned XY | Dim | PeakLuma | BrightPx | Real-icon? |
+|---|---|---|---|---|---|
+| 176 | (488, 668) | 13×23 | **0.91** | **30** | **YES** (lower-middle cluster (499, 682)) |
+| 158 | (226, 297) | 15×22 | 0.40 | 0 | NO |
+| 73 | (353, 204) | 7×11 | 0.31 | 0 | NO |
+| 170 | (353, 331) | 7×7 | 0.31 | 0 | NO |
+| 160 | (353, 299) | 7×8 | 0.31 | 0 | NO |
+| 68 | (297, 194) | 8×18 | 0.31 | 0 | NO |
+| 96 | (297, 217) | 8×10 | 0.28 | 0 | NO |
+| 75 | (701, 205) | 19×18 | 0.28 | 0 | NO |
+| 54 | (703, 180) | 24×23 | 0.27 | 0 | NO |
+| 37 | (563, 172) | 23×31 | 0.27 | 0 | NO |
+| 20 | (546, 138) | 40×23 | 0.26 | 0 | NO |
+| 104 | (804, 223) | 21×16 | 0.26 | 0 | NO |
+| 79 | (786, 208) | 27×12 | 0.25 | 0 | NO |
+| 23 | (522, 145) | 18×18 | 0.25 | 0 | NO |
+| 152 | (804, 280) | 12×10 | 0.25 | 0 | NO |
+| 181 | (1005, 870) | 4×8 | 0.25 | 0 | NO |
+| 151 | (354, 279) | 6×5 | 0.24 | 0 | NO |
+| 189 | (965, 912) | 3×6 | 0.22 | 0 | NO |
+
+**Of 18 Icon-class blobs, only 1 contains a real icon glyph.** The other 17 are pure floor-texture noise.
+
+**Of 5-6 visible icons in the screenshot, 4-5 are not detected as blobs at all** (no Icon-class blob covers their position). The visible icons at aligned (324, 178-187), (411, 185), (428, 256), (374, 669), (431, 201) have no overlapping blob within 30 px in the detection output.
+
+## Why this changes the spec
+
+The spec's candidate menu (§4) and chosen direction (§5) implicitly assume:
+
+> "Real-pip blobs ARE detected; the per-blob NCC step mis-types them; untyped detection + RANSAC type-from-geometry fixes the typing failure."
+
+The spike data falsifies the antecedent. **Most real-pip blobs aren't detected at all.** Untyped RANSAC operating on a pool of 17 noise + 1 signal won't find 4 inliers regardless of how cleverly it types them.
+
+## What the actual failure is
+
+The detection pipeline's deviation → rim → morph → classify cascade misses real Indoor icons because:
+
+- Indoor icons are **light gray glyphs on stone-grey floor** — low-contrast against the baseline texture
+- The deviation step (`LocalNccDeviation`) sets a `LowNcc = 0.5` floor on per-pixel deviation; low-contrast icon pixels may fall below
+- The morph-close + rim-mask cascade may then connect remaining icon-fragments to nearby floor-noise, collapsing them into "Noise" or "Structure" class
+- The single Icon-class blob that DID survive (blob 176) is the one at the highest-contrast region — it's also the only one with `solidity = 0.51` (lower than typical Icon-class — possibly because the icon-glyph + adjacent floor-pixels merged into one blob)
+
+The fix has to live upstream of typing — in the deviation / mask / morph / classify pipeline — not in the RANSAC step.
+
+## Implication for spec + plan — proposed re-sequence
+
+Rather than rewriting the spec in this measurements PR (the spec is on `main` already), file a follow-up sub-issue under #1155 titled **"Indoor icon-blob recall (Mode-B v1 root cause)"** with the scope:
+
+1. **Investigate the deviation/mask/morph/classify stages on the Indoor corpus.** For each visible-but-undetected icon, trace where in the pipeline it gets lost. Output: a stage-attribution table per icon, per bundle.
+2. **Propose tunable fixes.** Candidates: lower `LowNcc` for Indoor profile; chroma-aware deviation kernel (compare colour channels independently — even though indoor icons are grayscale, their luma profile against the floor MIGHT differ from floor-vs-floor); shape-aware morph; per-class min-area adjustment.
+3. **Validate against the corpus.** Each tunable fix must:
+   - Lift Indoor real-icon-detection rate to ≥ 4 blobs per bundle (the RANSAC floor)
+   - Not regress Outdoor accept rate
+
+After that lands, the original spec's Phase 2 (untyped detection) becomes a useful tier-2 improvement — *once we have enough real-icon blobs that RANSAC has correspondences to find.*
+
+Re-sequence:
+
+| Original phase | New role |
+|---|---|
+| Phase 1 — Scaffolding | Unchanged |
+| Phase 2 — Indoor untyped detection | **DEMOTED** — becomes Phase 4 |
+| Phase 3 — chroma pre-filter | **REPLACED** by peak-luma pre-filter (per [`indoor-chroma-threshold.md`](indoor-chroma-threshold.md)) |
+| Phase 4 — adaptive synthesis-J | **DEFERRED** — becomes Shadow-only for v1 (per [`indoor-synthesis-j-threshold.md`](indoor-synthesis-j-threshold.md)) |
+| **NEW Phase 2 — Indoor icon-blob recall** | The actual load-bearing fix. Scope per "Implication" section above. |
+| **NEW Phase 3 — Peak-luma pre-filter** | Defence-in-depth noise suppression. |
+
+## Caveat — this is one bundle
+
+`n=1` bundle. The pattern (only 1 of 18 Icon-class blobs contains a real glyph) is striking, but the broader Indoor corpus should be checked before this lands as a finalized spec revision. The follow-up "Indoor icon-blob recall" sub-issue should include corpus expansion as its first task.
+
+In particular, the HogansKeepBasement-06-10 accepted bundle DID solve with 4 inliers — so it had ≥ 4 real-icon blobs. Why that bundle achieves better detection-recall than the 06-13 bundle is itself a question worth answering: was it a different player position, different alpha-zero coverage, different ambient lighting? The answer informs the v1 recall fix.
+
+## Why the spike caught this
+
+The original spec was written from a reading of `10b-blob-template-scores.json` (per-template NCC scores) without grounding against pixel-level reality in the screenshot. The score-distribution analysis suggested "real pips score 0.7, noise scores 0.86" — but the spike's pixel-level scan revealed the "real pips" hypothesis was wrong; those 0.7-scoring blobs are also noise, just at a different region of the same floor.
+
+This is exactly the failure mode `verify_headline_behavior_through_full_render_chain` (project memory) warns against — verified-green at the score-distribution layer does NOT mean behavior-verified at the pixel layer. The spike caught it before code shipped.

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-chroma-threshold.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-chroma-threshold.md
@@ -1,0 +1,64 @@
+# §6.c — Indoor chroma pre-filter
+
+**Verdict: NEGATIVE.** Chroma doesn't separate real-icon blobs from floor-noise blobs in Indoor scenes. PG indoor icons are grayscale (white/cream glyphs on grayscale stone floor), not saturated.
+
+**Recovery:** A different feature — **peak luma** — DOES separate cleanly. See "Peak luma as the alternative" below.
+
+## What the spec assumed
+
+> "PG icons are saturated white/cyan/red; floor / off-texture noise is desaturated. Require min-chroma on blob pixels before NCC fires."  
+> — spec §4 candidate F + §5.1 Indoor profile + §6.c
+
+## What the data says
+
+For 7 blobs in the canonical Hogan's bundle, raw-screenshot pixel statistics over the blob bbox:
+
+| Blob | Aligned XY | Dim | MeanChroma | MaxChroma | MeanLuma | PeakLuma | BrightPx |
+|---|---|---|---|---|---|---|---|
+| 96 (emit Portal 0.86) | (297, 217) | 8×10 | 0.04 | 0.07 | 0.23 | 0.28 | 0 |
+| 176 (emit Portal 0.83) | (488, 668) | 13×23 | 0.04 | **0.12** | 0.35 | **0.91** | **30** |
+| 68 (sub Portal 0.76) | (297, 194) | 8×18 | 0.03 | 0.06 | 0.22 | 0.31 | 0 |
+| 37 (sub Portal 0.75) | (563, 172) | 23×31 | 0.01 | 0.04 | 0.19 | 0.27 | 0 |
+| 20 (sub Portal 0.75) | (546, 138) | 40×23 | 0.01 | 0.04 | 0.19 | 0.26 | 0 |
+| 54 (sub Medi 0.70) | (703, 180) | 24×23 | 0.01 | 0.04 | 0.19 | 0.27 | 0 |
+| 75 (sub Medi 0.70) | (701, 205) | 19×18 | 0.01 | 0.04 | 0.20 | 0.28 | 0 |
+
+Chroma is essentially **0.01-0.04** across the board — including the one blob (176) that we now know contains a real icon glyph (per peak-luma + bright-pixel-count, established in [`detection-recall-pivot.md`](detection-recall-pivot.md)). PG indoor map icons render as light gray-on-darker-gray, not colourful, so chroma can't discriminate.
+
+## Peak luma as the alternative
+
+The same scan that killed the chroma hypothesis revealed that **peak luma cleanly separates** real-icon-containing blobs from floor-noise blobs:
+
+| Blob | PeakLuma | BrightPx (>0.78 luma) | Real icon? |
+|---|---|---|---|
+| 176 | **0.91** | **30** | **YES** (only one in the bundle) |
+| 96 | 0.28 | 0 | NO (floor noise) |
+| 68 | 0.31 | 0 | NO |
+| 37 | 0.27 | 0 | NO |
+| 20 | 0.26 | 0 | NO |
+| 54 | 0.27 | 0 | NO |
+| 75 | 0.28 | 0 | NO |
+| 158 | 0.40 | 0 | NO |
+| 73 | 0.31 | 0 | NO |
+| 170 | 0.31 | 0 | NO |
+| 160 | 0.31 | 0 | NO |
+| ... (10 more) | 0.22-0.31 | 0 | NO |
+
+Across all 18 non-rotated Icon-class blobs in the canonical bundle:
+
+- The one blob containing a real icon glyph: `PeakLuma = 0.91`, `BrightPx = 30`.
+- The 17 other blobs (floor noise): `PeakLuma ∈ [0.22, 0.40]`, `BrightPx = 0`.
+
+**Massive separation.** A threshold of either `PeakLuma > 0.7` OR `BrightPx ≥ 3` would catch the real-icon blob and reject all 17 noise blobs.
+
+## Implication for spec
+
+- Spec §5.1 Indoor profile — `MinChroma` clause: remove. Replace with `MinPeakLuma` (or equivalent — name TBD by spec revision).
+- Spec §4 candidate F — chroma framing was wrong; rewrite as "luma pre-filter."
+- Plan Phase 3 — re-scope from "chroma pre-filter" to "peak-luma pre-filter." File-level breakdown stays nearly identical (the implementation is "compute max luma per blob region before NCC fires"); just the feature name changes.
+
+**Caveat:** the peak-luma threshold is derived from ONE bundle. Spec §6.c-replacement should re-state verification owed against the broader Indoor corpus before the threshold ships.
+
+## Sample-size caveat
+
+This analysis ran against 18 blobs from a single bundle. The single real-icon blob (176) is `n=1` ground truth. Other bundles likely contain more real-icon blobs (the accepted Hogan's 06-10 cal had 4 inliers, implying ≥ 4 real-icon blobs in that bundle). Re-running the peak-luma analysis against those bundles is the natural next step and should land before Phase 3 ships.

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-render-size.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-render-size.md
@@ -1,0 +1,29 @@
+# §6.b — Indoor `RenderSizePx`
+
+**Verdict: REVISED.** Spec's proposed `RenderSizePx = 12` for Indoor was wrong. Keep `RenderSizePx = 16` (same as Outdoor).
+
+## Method
+
+The spec proposed `12` from the intuition "indoor icons render smaller." This was an inference, not a measurement. The spike measured by scanning the raw screenshot of the canonical Hogan's bundle (`Map_HogansKeepBasement-20260613-230459-600`) for bright-pixel clusters (`R, G, B > 200`) and measuring their spatial extent.
+
+## Finding
+
+Real-icon bright-pixel clusters in the raw screenshot are 15-16 px in their longest dimension:
+
+| Aligned XY | Cluster size | Visible feature |
+|---|---|---|
+| (324, 180) | ~16 px | Upper-middle icon (largest cluster, 37+36+14+11 = 98 bright px combined) |
+| (411, 185) | ~15 px | Upper-middle icon east |
+| (428, 256) | ~15 px | Mid-middle icon |
+| (499, 682) | ~13 px | Lower-middle icon (blob 176 in detector output) |
+| (374, 669) | ~14 px | Lower-middle icon adjacent |
+
+Indoor render size ≈ 14-16 px = same as Outdoor's `16`.
+
+Why the intuition was wrong: PG renders map icons at a **screen-space** fixed size regardless of in-game map zoom. The texture-space size depends on `mapRect.scale`, but the `RenderSizePx` constant tracks the *on-screen* size, which doesn't change between Indoor and Outdoor.
+
+## Implication for spec
+
+Spec §5.1 — Indoor profile `RenderSizePx` changes from `12` to `16` (= same as Outdoor). One-line spec edit.
+
+Plan Phase 2 — the line "Flip Indoor's `DetectorPath = Untyped`, `TypeFloor = null`, `RenderSizePx = 12`" → drop the `RenderSizePx = 12` clause (no change from Outdoor; the profile carrier still carries the value but it's identical to Outdoor's).

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-synthesis-j-threshold.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-synthesis-j-threshold.md
@@ -1,0 +1,54 @@
+# §6.d — Indoor adaptive synthesis-J threshold
+
+**Verdict: PARTIAL.** Outdoor `j` (16-23) vastly exceeds Indoor (3-4); static `jMin = 8` is correct for Outdoor and unreachable for Indoor.
+
+**Blocking limitation:** the corpus contains **zero** ground-truth-good Indoor cals. The only Indoor "accept" we have is the historical Hogan's 06-10 cal that the spec hypothesizes is wrong (cross-scene leak per #1116 H1, residual 6.45 px). We can't derive a separating formula from rejected-only data.
+
+**Recommendation:** Phase 4 ships with Indoor in `Shadow` mode for v1. Revisit once Phases 1-3 produce Indoor cals that can be ground-truthed (e.g., by spot-checking projection accuracy on known landmarks).
+
+## Method
+
+For every bundle under `%LocalAppData%/Mithril/diagnostics/calibration/Map_*`, read `01-attempt.json` and collect `synthesis.{j, refsAboveHalf, refsTotal, verdict, gateVerdict, disagree}`.
+
+## Measurements
+
+| Scene | Engine | Outcome | `j` | refsAbove | refsTotal | Synth verdict | Legacy verdict | Disagree |
+|---|---|---|---|---|---|---|---|---|
+| AreaEltibule (accept) | 3.0.0.81 | accepted | **16.53** | 15 | 38 | accept | accept | — |
+| AreaSerbule (accept) | 3.0.0.81 | accepted | **23.45** | 24 | 46 | accept | accept | — |
+| HogansKeepBasement (accept 06-10) | 3.0.0.81 | accepted | 3.25 | 5 | 11 | **reject** | accept | **accept→reject** |
+| HogansKeepBasement (reject 06-12) | 3.0.0.88 | rej-insufficient-inliers | 3.85 | 5 | 11 | reject | reject | — |
+| HogansKeepBasement (reject 06-13) | 3.0.0.91 | rej-insufficient-inliers | 3.01 | 3 | 11 | reject | reject | — |
+| GoblinDungeon_TopFloor (reject) | 3.0.0.82 | rej-insufficient-inliers | 3.18 | 4 | 9 | reject | reject | — |
+| (8 other Hogan's bundles) | various | rej-solve / rej-map-not-located | n/a | n/a | n/a | no_winner | reject | — |
+
+## Findings
+
+1. **Outdoor `j` ≫ Indoor `j`.** Outdoor cals score `j ∈ [16, 23]`; Indoor `j ∈ [3.0, 3.9]`. The gap is structural, not bundle-noise — for Indoor `jMin = 8` is unreachable, period.
+
+2. **The one Indoor "accept" is the disputed cal.** The Hogan's 06-10 accept (`j = 3.25, gateVerdict = accept, synthVerdict = reject, disagree = accept→reject`) is exactly the cal the spec calls "structurally suspect" — it accepted at residual 6.45 px on 4 inliers, and the cross-scene leak hypothesis from #1116 strongly suggests it's a wrong cal. Synthesis-J would have rejected it. We don't know if `j = 3.25` represents "below-threshold-but-correct cal" or "below-threshold-and-correctly-rejected cal."
+
+3. **All other Indoor bundles rejected by both gates.** No data point exists for "Indoor cal that's both legacy-accepted AND synthesis-J-accepted."
+
+4. **Without ground-truth-good Indoor cals, no separating formula is derivable.** A formula like `jMin = 0.6 × refsTotal` (Hogan's → `jMin = 6.6`) rejects ALL current Indoor samples. A formula like `jMin = 0.25 × refsTotal` (Hogan's → `jMin = 2.75`) accepts ALL current Indoor samples, including ones that are likely wrong cals.
+
+## Recommendation
+
+**Phase 4 ships with `Indoor.SynthesisMode = Shadow` for v1.** This means:
+
+- Outdoor profile: `Enforced` mode (or stays `Shadow` — whatever the existing default is post-#1117; spec says Shadow), static `jMin = 8 / nMin = 8`. No change.
+- Indoor profile: `Shadow` mode — synthesis-J `j` is computed and logged in the bundle, but doesn't gate accept/reject. Legacy gate stays in charge.
+- Phase 2 + Phase 3 produce Indoor cals (hopefully better than the disputed 06-10 cal).
+- Once we have one or more known-good Indoor cals (manual verification by spot-checking landmark projection accuracy), re-derive the formula and re-spec Phase 4-v2 to enforce.
+
+## Implication for spec
+
+Spec §5.1 Indoor profile — `SynthesisMode = Enforced` → `SynthesisMode = Shadow` for v1. The `SynthesisJMinFn` / `SynthesisNMinFn` still land on the carrier for observability, but they don't drive accept/reject yet.
+
+Spec §6.d — restate the verification as a deferred follow-up: "After Phases 1-3, collect Indoor accept candidates, manually validate, derive `jMin/nMin` formula, ship Phase 4-v2 with `Enforced` mode."
+
+Plan Phase 4 — re-scope to "Indoor synthesis-J observability" (Shadow + bundle diagnostic + log mirror). The enforcement flip becomes a Phase 4-v2 follow-up issue.
+
+## Outdoor sample size caveat
+
+`n=2` Outdoor accepts (Serbule + Eltibule) is small. Both score `j` well above 8 — no signal to revise outdoor formula. KurMountains hasn't been auto-cal'd in the diagnostic corpus; if a future regression is observed, this measurement page should be updated.

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/scene-class-classification.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/scene-class-classification.md
@@ -1,0 +1,45 @@
+# §6.a — Scene-class classification via alpha coverage
+
+**Verdict: CONFIRMED.** Outdoor `OpaqueFraction = 1.00` (n=3 scenes); Indoor `OpaqueFraction ∈ [0.07, 0.36]` (n=10 scenes). The spec's `≥ 0.95` threshold separates with massive margin; even a relaxed `≥ 0.50` would work.
+
+## Method
+
+For each scene under `%LocalAppData%/Mithril/assets/maps-src/Map_*.v4.png`, load as 32bpp ARGB and count pixels with `alpha ≥ 128`. The PNGs are the source textures consumed by the sidecar extractor (`sidecar-rgba-alpha-surface`); their alpha channel is the same one fed to `FloorBoundaryMaskCache` at runtime.
+
+```text
+opaqueFraction = count(alpha ≥ 128) / (width × height)
+SceneClass     = opaqueFraction ≥ 0.95 ? Outdoor : Indoor
+```
+
+## Measurements
+
+| Scene | W × H | OpaqueFraction | Classification |
+|---|---|---|---|
+| Map_AreaEltibule | 2048×2033 | **1.00** | Outdoor |
+| Map_AreaKurMountains | 2048×2048 | **1.00** | Outdoor |
+| Map_AreaSerbule | 1961×2048 | **1.00** | Outdoor |
+| Map_CarpalTunnels | 452×512 | 0.36 | Indoor |
+| Map_GoblinDungeon_TopFloor | 800×800 | 0.27 | Indoor |
+| Map_AreaCasino | 1024×1024 | 0.19 | Indoor |
+| Map_WolfCave | 819×1024 | 0.18 | Indoor |
+| Map_HogansKeepBasement | 1024×1024 | 0.17 | Indoor |
+| Map_KhyruleksCrypt | 525×1024 | 0.16 | Indoor |
+| Map_MyconianCave | 541×1024 | 0.15 | Indoor |
+| Map_KurTower | 569×1024 | 0.13 | Indoor |
+| Map_BoardedUpBasement | 205×512 | 0.13 | Indoor |
+| Map_GoblinDungeon | 398×1024 | 0.07 | Indoor |
+
+## Notes
+
+- The 3 outdoor scenes all hit exactly `1.00` — PG's outdoor maps ship with full-coverage alpha (the entire texture is the visible game world, no off-map regions).
+- The largest Indoor `OpaqueFraction` is `Map_CarpalTunnels` at `0.36` — still 0.59 below the threshold. Indoor/Outdoor are not borderline at any scene in the corpus.
+- `Map_AreaCasino` at `0.19` validates the heuristic on a non-dungeon Indoor scene (the Casino in PG is a building interior, not a sub-zone). The heuristic generalises correctly.
+- A future scene at the threshold would surface in the `01-attempt.json` `sceneClassOpaqueFraction` field per spec §5.6 and could be resolved by a per-scene override if needed.
+
+## Implication for spec
+
+Spec §5.2 + §6.a — no change. Indoor profile activates for `Map_HogansKeepBasement` (and 9 other scenes). Outdoor profile preserved for the 3 outdoor scenes.
+
+## Verification-owed re-survey
+
+When the sidecar re-emits alpha for additional Indoor scenes (currently only `Map_HogansKeepBasement-alpha.bin` exists in the runtime cache; others compute from the source PNGs that have alpha intact), the runtime classification will match these source-PNG measurements byte-for-byte. **No further verification owed.**

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/untyped-ransac-cost.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/untyped-ransac-cost.md
@@ -1,0 +1,59 @@
+# §6.e — Untyped RANSAC pool-size + wall-clock estimate
+
+**Verdict: CONFIRMED.** Pool-size growth is ~2-3×, wall-clock impact is sub-second for Indoor and ≤ 1.5× for Outdoor. No concern.
+
+## Method
+
+Estimate pool sizes from the canonical Hogan's bundle's detection set:
+
+- **Typed pool** (current): `Σ (detections_of_type_T × refs_of_type_T)` summed over types
+- **Untyped pool** (proposed): `Σ detections_total × refs_total`
+
+Hogan's bundle from `01-attempt.json` synthesis section: `refsTotal = 11` (8 Portal + ~3 NPC). Detection count ~10 (Icon-class blobs from non-rotated pass; not all of these go to RANSAC, but they're the upper bound).
+
+For a hypothetical Outdoor regression check, AreaSerbule has `refsTotal = 46`; same arithmetic.
+
+## Estimates
+
+### Hogan's (Indoor, typical)
+
+| Pool type | Pairs | Notes |
+|---|---|---|
+| Typed | ~35 | 10 detections × ~3.5 avg same-type refs |
+| Untyped | 110 | 10 detections × 11 all-type refs |
+| Ratio | 3.1× | |
+
+### Serbule (Outdoor, typical)
+
+| Pool type | Pairs | Notes |
+|---|---|---|
+| Typed | ~150 | 30 detections × ~5 avg same-type refs (estimated; need actual bundle for true number) |
+| Untyped | 1380 | 30 detections × 46 all-type refs |
+| Ratio | 9.2× | |
+
+## Wall-clock impact
+
+RANSAC's per-iteration cost is dominated by (a) the 2-point seed-solve and (b) a linear scan over the pool to count inliers. Both scale linearly in pool size. For 800 iterations × pool-size, the inlier-scan totals:
+
+- Indoor typed: 800 × 35 = 28,000 ops. Negligible.
+- Indoor untyped: 800 × 110 = 88,000 ops. Still negligible.
+- Outdoor typed: 800 × 150 = 120,000 ops.
+- Outdoor untyped: 800 × 1380 = 1,104,000 ops. **~10× more ops.**
+
+Each inlier-scan op is a similarity-transform projection (1 mul, 1 cos/sin, 1 add per coord) + a sqrt for distance. ~10 ns/op on .NET 10 (rough). So:
+
+- Outdoor untyped: 1,104,000 × 10 ns ≈ **11 ms** added to a sub-second solve. Not impactful.
+
+## Implication for spec
+
+Spec §5.4 — pool-size estimate of "~2-3×" was correct for Indoor; for Outdoor it's closer to "~10×" but the absolute wall-clock impact is still small (millis, not seconds). Both within budget.
+
+The spec's "≤ 2× the typed path" wall-clock budget should be revised to **"≤ 1.2× total solve wall-clock"** since the RANSAC step is sub-second and the locator dominates.
+
+## Caveat
+
+Untyped detection's RANSAC also pays a **per-pair pivot-lookup** cost (per-ref type → template pivot). This adds a hash lookup per pair. For 1.1M outdoor ops, that's another ~10 ms. Still budget.
+
+## What needs a real benchmark
+
+The estimates above are arithmetic from existing diagnostic-bundle data + back-of-envelope per-op time. A real benchmark needs the actual untyped detection + untyped RANSAC code, which is Phase 2's deliverable. Phase 2's PR should include a `tools/Mode-B-Bench/Program.cs` that times the typed vs untyped solve on the canonical Outdoor + Indoor replay fixtures and reports actual wall-clocks. **If Outdoor untyped > 1.2× typed in real benchmark, fall back to typed-detection as an Outdoor fast-path** (the profile carrier supports this via `DetectorPath`).


### PR DESCRIPTION
## Summary

Phase 0 spike per [`docs/planning/calibration-1155-scene-class-profile/plan.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/planning/calibration-1155-scene-class-profile/plan.md). Validates spec §6 verification-owed items against existing diagnostic-bundle corpus before code lands.

**Verdict: spec needs a re-sequence.** Two surprising findings:

1. **Chroma pre-filter (§6.c) is dead.** Indoor PG icons are grayscale glyphs on grayscale floor; chroma can't separate. BUT **peak luma DOES separate cleanly** (real-icon blobs: PeakLuma 0.91; floor-noise blobs: 0.22–0.40). Phase 3 re-scopes from chroma to peak luma.
2. **Mode-B's load-bearing direction is wrong.** Of 18 Icon-class blobs in the canonical Hogan's bundle, **only 1 contains a real icon glyph.** The other 17 are pure floor noise, AND 4-5 of the 5-6 visible real icons aren't detected as blobs at all. The detector has a detection-**RECALL** failure, not a detection-**PRECISION** failure. The spec's chosen candidate E (untyped detection + RANSAC type discrimination) doesn't fix this — it re-routes typing in a pool where 17/18 are noise. Mode-B v1 must start **upstream** at deviation/mask/morph/classify to recover the missing real-icon blobs. See [`detection-recall-pivot.md`](https://github.com/moumantai-gg/mithril/blob/spike/mode-b-measurements-1155/docs/planning/calibration-1155-scene-class-profile/measurements/detection-recall-pivot.md).

**Other findings** ([README index](https://github.com/moumantai-gg/mithril/blob/spike/mode-b-measurements-1155/docs/planning/calibration-1155-scene-class-profile/measurements/README.md)):
- §6.a CONFIRMED — alpha-coverage separates Indoor (0.07-0.36) from Outdoor (1.00) with no overlap.
- §6.b REVISED — Indoor `RenderSizePx` should be 16 (same as Outdoor), not the proposed 12.
- §6.d PARTIAL — Outdoor j (16-23) vs Indoor j (3-4) is clean; static jMin=8 works for Outdoor. Zero ground-truth-good Indoor cals → no separating formula derivable. Phase 4 should ship Indoor in Shadow mode for v1.
- §6.e CONFIRMED — untyped RANSAC pool growth modest, wall-clock impact in millis.

## Re-sequence proposal

Filing a follow-up sub-issue \"Indoor icon-blob recall (Mode-B v1 root cause)\" as a separate issue under [#1155](https://github.com/moumantai-gg/mithril/issues/1155). The spec on main stays accurate as the original design; this PR adds measurement docs alongside it. Spec revision is the next step after this lands.

| Original phase | New role |
|---|---|
| Phase 1 — Scaffolding | Unchanged |
| Phase 2 — Indoor untyped detection | **DEMOTED** — becomes Phase 4 |
| Phase 3 — chroma pre-filter | **REPLACED** by peak-luma pre-filter |
| Phase 4 — adaptive synthesis-J | **DEFERRED** — Shadow-only for v1 |
| **NEW Phase 2 — Indoor icon-blob recall** | The actual load-bearing fix |
| **NEW Phase 3 — Peak-luma pre-filter** | Defence-in-depth noise suppression |

## Test plan

- [x] Empirical findings grounded in pixel-level analysis of `02-screenshot-raw.png` and `10c-blob-pipeline.json` from the canonical Hogan's bundle.
- [x] §6.a alpha-coverage measured against all 13 scenes with source PNGs in `maps-src/`.
- [x] §6.d synthesis-J distribution collected from all 15 bundles in the diagnostic corpus.
- [x] Honest sample-size caveats noted in each measurement doc.
- [N/A] No production code; CI not exercised.

— drafted by Claude (Opus 4.7), posted by @arthur-conde