### PR TITLE
feat(map-calibration): SceneClass profile + Indoor recall fix (#1163)

### DIFF
--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -304,9 +304,16 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         // mithril#1163 Phase 1: drift check picks the same scene-class profile
         // the main auto-cal path does, so the Indoor classifier gates apply
         // when re-checking an Indoor scene against its stored cal. Safe-degrade
-        // to Outdoor when the boundary cache isn't wired.
+        // to Outdoor when the boundary cache isn't wired. The two degenerate
+        // safe-degrade causes (cache unwired vs alpha unavailable) are
+        // distinguishable from the log: `cache_wired=false` vs the boundary
+        // cache emitting its own LogWarning at line 71-73 of FloorBoundaryMaskCache.
         var driftSceneClass = _boundaryMaskCache?.GetSceneClass(sceneRef.MapAssetKey) ?? SceneClass.Outdoor;
         var driftProfile = SceneCalibrationProfile.For(driftSceneClass);
+        _logger?.LogTrace(
+            "Drift check {MapAssetKey}: scene class {SceneClass} (cache_wired={CacheWired}); BlobOptions = {BlobOptions}.",
+            sceneRef.MapAssetKey, driftSceneClass, _boundaryMaskCache is not null, driftProfile.BlobOptions);
+        span?.SetTag("scene.class", driftSceneClass.ToString());
         var detectionRequest = new DetectionRequest(
             Screenshot: crop,
             BaseTexture: alignedTexture,

--- a/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
+++ b/src/Mithril.MapCalibration.Capture/AutoCalibrationEngine.cs
@@ -301,6 +301,12 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         var crop = ImageOps.Crop(gray, clamped.OriginX, clamped.OriginY, clamped.Width, clamped.Height);
         var alignedTexture = ImageOps.Resize(baseTexture, clamped.Width, clamped.Height);
         var alignedRect = new MapRect(0, 0, clamped.Width, clamped.Height, clamped.TextureWidth, clamped.TextureHeight);
+        // mithril#1163 Phase 1: drift check picks the same scene-class profile
+        // the main auto-cal path does, so the Indoor classifier gates apply
+        // when re-checking an Indoor scene against its stored cal. Safe-degrade
+        // to Outdoor when the boundary cache isn't wired.
+        var driftSceneClass = _boundaryMaskCache?.GetSceneClass(sceneRef.MapAssetKey) ?? SceneClass.Outdoor;
+        var driftProfile = SceneCalibrationProfile.For(driftSceneClass);
         var detectionRequest = new DetectionRequest(
             Screenshot: crop,
             BaseTexture: alignedTexture,
@@ -309,7 +315,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             RimMask: RimMaskMode.DeviationFlood,
             LowNcc: LowNcc,
             TypeFloor: TypeFloor,
-            BlobOptions: BlobOpts)
+            BlobOptions: driftProfile.BlobOptions)
         {
             RenderSizePx = RenderSizePx,
         };
@@ -783,6 +789,26 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
         maskSpan?.SetTag("mask.fog.available", fogAvailable);
         attempt.DeviationMaskImage = combinedMask;
 
+        // mithril#1163 Phase 1: resolve SceneClass from the same alpha buffer
+        // the boundary cache loaded above (zero extra IO) and pick the matching
+        // SceneCalibrationProfile. Skipped → safe-degrade Outdoor (byte-identical
+        // to pre-#1163). When the boundary cache is wired AND the mask block
+        // ran (DeviationMaskingEnabled=true and boundary cache available), the
+        // GetSceneClass call hits the cache populated by GetOrCompute above.
+        var sceneClass = _boundaryMaskCache?.GetSceneClass(assetKey) ?? SceneClass.Outdoor;
+        var profile = SceneCalibrationProfile.For(sceneClass);
+        attempt.SceneClass = sceneClass;
+        attempt.SceneClassOpaqueFraction = _boundaryMaskCache?.TryGetOpaqueFraction(assetKey);
+        attempt.Profile = profile;
+        maskSpan?.SetTag("scene.class", sceneClass.ToString());
+        if (attempt.SceneClassOpaqueFraction is { } frac)
+        {
+            maskSpan?.SetTag("scene.opaque_fraction", frac);
+        }
+        _logger?.LogTrace(
+            "Auto-calibration {Area}: scene class {SceneClass} (opaqueFraction={OpaqueFraction}); BlobOptions = {BlobOptions}.",
+            area, sceneClass, attempt.SceneClassOpaqueFraction, profile.BlobOptions);
+
         var request = new DetectionRequest(
             Screenshot: crop,
             BaseTexture: alignedTexture,
@@ -791,7 +817,7 @@ public sealed class AutoCalibrationEngine : IAutoCalibrationRunner
             RimMask: RimMaskMode.DeviationFlood,
             LowNcc: LowNcc,
             TypeFloor: TypeFloor,
-            BlobOptions: BlobOpts)
+            BlobOptions: profile.BlobOptions)
         {
             RenderSizePx = RenderSizePx,
             BlobScoreSink = blobScores.Add,

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
@@ -107,17 +107,20 @@ public sealed class CalibrationAttemptContext
     // SceneCalibrationProfile the engine resolved for this attempt. Populated
     // by AutoCalibrationEngine after the deviation-mask block (the same
     // alpha-coverage scan that drives the boundary mask also classifies the
-    // scene). SceneClass defaults to Outdoor so attempts that skipped the
-    // mask block (DeviationMaskingEnabled=false / boundary cache null / pre-
-    // locate reject) safe-degrade to Outdoor — byte-identical to pre-#1163.
+    // scene). All three nullable so an attempt that skipped the mask block
+    // (pre-locate reject, DeviationMaskingEnabled=false, boundary cache
+    // unwired) emits absence in the bundle rather than the misleading
+    // "Outdoor + Outdoor BlobOptions" — a reader investigating "why did this
+    // Indoor scene reject?" can distinguish "we didn't resolve a class" from
+    // "we resolved Outdoor and ran with Outdoor gates" (mithril#1168 review).
     /// <summary>
     /// mithril#1163 Phase 1: scene class for this attempt, derived from the
     /// base texture's alpha-coverage fraction (Outdoor when fraction ≥
     /// <see cref="MapCalibrationDetectorOptions.SceneClassOpaqueFractionThreshold"/>).
-    /// Defaults to <see cref="Detection.SceneClass.Outdoor"/> so unclassified
-    /// attempts get the safe-degrade profile.
+    /// Null when the scene wasn't classified (mask block skipped) — the bundle
+    /// emits absence which readers treat as "Outdoor by safe-degrade".
     /// </summary>
-    public SceneClass SceneClass { get; set; } = SceneClass.Outdoor;
+    public SceneClass? SceneClass { get; set; }
 
     /// <summary>
     /// mithril#1163 Phase 1: measured opaque-pixel fraction (alpha ≥ 128 /
@@ -131,9 +134,11 @@ public sealed class CalibrationAttemptContext
     /// mithril#1163 Phase 1: the SceneCalibrationProfile the engine resolved
     /// for this attempt — Outdoor (today's universal constants) or Indoor
     /// (relaxed classifier shape gates per the
-    /// <c>indoor-recall-merge-fix-candidates.md</c> measurement).
+    /// <c>indoor-recall-merge-fix-candidates.md</c> measurement). Null when
+    /// the scene wasn't classified (mask block skipped); the bundle emits
+    /// absence which readers treat as "Outdoor profile by safe-degrade".
     /// </summary>
-    public SceneCalibrationProfile Profile { get; set; } = SceneCalibrationProfile.Outdoor;
+    public SceneCalibrationProfile? Profile { get; set; }
 
     // Outcome is set explicitly by the engine — either at each Fail() site, at
     // the end of the success path, or in the catch (exception → "error").

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationAttemptContext.cs
@@ -103,6 +103,38 @@ public sealed class CalibrationAttemptContext
     /// </summary>
     public GrayImage? DeviationMaskImage { get; set; }
 
+    // mithril#1163 Phase 1: per-attempt scene-class classification + the
+    // SceneCalibrationProfile the engine resolved for this attempt. Populated
+    // by AutoCalibrationEngine after the deviation-mask block (the same
+    // alpha-coverage scan that drives the boundary mask also classifies the
+    // scene). SceneClass defaults to Outdoor so attempts that skipped the
+    // mask block (DeviationMaskingEnabled=false / boundary cache null / pre-
+    // locate reject) safe-degrade to Outdoor — byte-identical to pre-#1163.
+    /// <summary>
+    /// mithril#1163 Phase 1: scene class for this attempt, derived from the
+    /// base texture's alpha-coverage fraction (Outdoor when fraction ≥
+    /// <see cref="MapCalibrationDetectorOptions.SceneClassOpaqueFractionThreshold"/>).
+    /// Defaults to <see cref="Detection.SceneClass.Outdoor"/> so unclassified
+    /// attempts get the safe-degrade profile.
+    /// </summary>
+    public SceneClass SceneClass { get; set; } = SceneClass.Outdoor;
+
+    /// <summary>
+    /// mithril#1163 Phase 1: measured opaque-pixel fraction (alpha ≥ 128 /
+    /// total) for the base texture. Null when the scene wasn't classified
+    /// (mask block skipped). Diagnostic-only — drives the bundle JSON's
+    /// <c>sceneClassOpaqueFraction</c> field per spec §5.6.
+    /// </summary>
+    public double? SceneClassOpaqueFraction { get; set; }
+
+    /// <summary>
+    /// mithril#1163 Phase 1: the SceneCalibrationProfile the engine resolved
+    /// for this attempt — Outdoor (today's universal constants) or Indoor
+    /// (relaxed classifier shape gates per the
+    /// <c>indoor-recall-merge-fix-candidates.md</c> measurement).
+    /// </summary>
+    public SceneCalibrationProfile Profile { get; set; } = SceneCalibrationProfile.Outdoor;
+
     // Outcome is set explicitly by the engine — either at each Fail() site, at
     // the end of the success path, or in the catch (exception → "error").
     public string Outcome { get; set; } = "unknown";

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/CalibrationBundleJson.cs
@@ -22,6 +22,15 @@ namespace Mithril.MapCalibration.Capture.Diagnostics;
 /// <c>07a-deviation-mask.png</c> artifact path. Additive: v3 readers ignore
 /// the new key, and v4 readers treat absence as "the engine did not write
 /// a deviation mask for this attempt" (no fog/boundary mask was emitted).</para>
+///
+/// <para><b>Schema v4 additive (mithril#1163 Phase 1):</b> adds optional
+/// <see cref="SceneClass"/>, <see cref="SceneClassOpaqueFraction"/>,
+/// <see cref="Profile"/>. Additive — schema-version is NOT bumped to 5
+/// because every existing v4 reader ignores unknown keys and v5 readers
+/// would need a structural change before the bump pays off. Treat absence
+/// as "the engine ran without scene-class resolution" (mask block skipped /
+/// pre-#1163 engine), in which case the safe-degrade Outdoor profile was
+/// in effect.</para>
 /// </summary>
 public sealed record AttemptJson(
     int SchemaVersion,
@@ -40,7 +49,15 @@ public sealed record AttemptJson(
     LocatorBestJson? LocatorBest = null,
     // Per-attempt synthesis-J snapshot (#1117). Null when SynthesisRerankMode == Off
     // or when this bundle was written by a pre-#1117 engine version (schema v1/v2).
-    SynthesisJson? Synthesis = null);
+    SynthesisJson? Synthesis = null,
+    // mithril#1163 Phase 1: resolved scene class ("Outdoor" | "Indoor") + the
+    // measured opaque-pixel fraction + the BlobOptions the profile dispatched.
+    // Null when the engine ran without resolving the scene class (mask block
+    // skipped — DeviationMaskingEnabled=false, boundary cache unwired, or a
+    // pre-locate reject); readers treat absence as "Outdoor" by safe-degrade.
+    string? SceneClass = null,
+    double? SceneClassOpaqueFraction = null,
+    SceneCalibrationProfileJson? Profile = null);
 
 /// <summary>
 /// Carries the locator's raw fit rect (gate-pass-or-not), the per-algorithm
@@ -312,6 +329,21 @@ public sealed record BlobPipelineJson(
     IReadOnlyList<MorphSectionJson> Morph,
     IReadOnlyList<BlobJson> Blobs);
 
+/// <summary>
+/// mithril#1163 Phase 1: bundle wire-format for the resolved
+/// <see cref="Mithril.MapCalibration.Detection.SceneCalibrationProfile"/>.
+/// Carries the profile's BlobOptions verbatim so a triager can read the
+/// exact gates the detector ran with for this attempt (Outdoor and Indoor
+/// differ here in v1). Future phases (per spec §5.1) extend this DTO as
+/// additional fields diverge.
+/// </summary>
+public sealed record SceneCalibrationProfileJson(
+    int MinArea,
+    int MaxIconArea,
+    double MinSolidity,
+    double MaxAspect,
+    double MinPeak);
+
 // mithril#1121: AllowNamedFloatingPointLiterals lets BlobTemplateScore.Score
 // round-trip its NaN sentinel (the skip-path marker) as the JSON token "NaN".
 // Existing DTOs in this context don't carry NaN values, so this is additive.
@@ -327,5 +359,6 @@ public sealed record BlobPipelineJson(
 [JsonSerializable(typeof(RecoveredCalibrationJson))]
 [JsonSerializable(typeof(SynthesisJson))]
 [JsonSerializable(typeof(BlobTemplateScoresJson))]
-[JsonSerializable(typeof(BlobPipelineJson))]  // mithril#1123
+[JsonSerializable(typeof(BlobPipelineJson))]                        // mithril#1123
+[JsonSerializable(typeof(SceneCalibrationProfileJson))]             // mithril#1163
 public partial class CalibrationBundleJsonContext : JsonSerializerContext;

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
@@ -523,15 +523,20 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
         {
             var finalized = DateTimeOffset.UtcNow;
             // mithril#1163 Phase 1: emit the resolved scene-class fields
-            // when the engine populated them (mask block ran). Absence on
-            // older bundles / mask-disabled attempts means "Outdoor by
-            // safe-degrade" — readers treat null as that.
-            var profileJson = new SceneCalibrationProfileJson(
-                MinArea: ctx.Profile.BlobOptions.MinArea,
-                MaxIconArea: ctx.Profile.BlobOptions.MaxIconArea,
-                MinSolidity: ctx.Profile.BlobOptions.MinSolidity,
-                MaxAspect: ctx.Profile.BlobOptions.MaxAspect,
-                MinPeak: ctx.Profile.BlobOptions.MinPeak);
+            // ONLY when the engine populated them (mask block ran). Absence
+            // for pre-locate-reject / mask-disabled attempts means "Outdoor by
+            // safe-degrade" — readers treat null as that. Emitting concrete
+            // Outdoor numbers for an unresolved attempt would be the bundle
+            // actively misreporting positive evidence it never had
+            // (mithril#1168 review feedback).
+            var profileJson = ctx.Profile is { } resolved
+                ? new SceneCalibrationProfileJson(
+                    MinArea: resolved.BlobOptions.MinArea,
+                    MaxIconArea: resolved.BlobOptions.MaxIconArea,
+                    MinSolidity: resolved.BlobOptions.MinSolidity,
+                    MaxAspect: resolved.BlobOptions.MaxAspect,
+                    MinPeak: resolved.BlobOptions.MinPeak)
+                : null;
             var dto = new AttemptJson(
                 SchemaVersion: 4,
                 Area: ctx.Area,
@@ -543,7 +548,7 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
                 Files: files,
                 LocatorBest: ToLocatorBestJson(ctx),
                 Synthesis: ToSynthesisJson(ctx.Result?.Synthesis),
-                SceneClass: ctx.SceneClass.ToString(),
+                SceneClass: ctx.SceneClass?.ToString(),
                 SceneClassOpaqueFraction: ctx.SceneClassOpaqueFraction,
                 Profile: profileJson);
             WriteJson(dir, "01-attempt.json", dto, CalibrationBundleJsonContext.Default.AttemptJson);

--- a/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
+++ b/src/Mithril.MapCalibration.Capture/Diagnostics/FilesystemCalibrationAttemptBundleSink.cs
@@ -522,6 +522,16 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
         try
         {
             var finalized = DateTimeOffset.UtcNow;
+            // mithril#1163 Phase 1: emit the resolved scene-class fields
+            // when the engine populated them (mask block ran). Absence on
+            // older bundles / mask-disabled attempts means "Outdoor by
+            // safe-degrade" — readers treat null as that.
+            var profileJson = new SceneCalibrationProfileJson(
+                MinArea: ctx.Profile.BlobOptions.MinArea,
+                MaxIconArea: ctx.Profile.BlobOptions.MaxIconArea,
+                MinSolidity: ctx.Profile.BlobOptions.MinSolidity,
+                MaxAspect: ctx.Profile.BlobOptions.MaxAspect,
+                MinPeak: ctx.Profile.BlobOptions.MinPeak);
             var dto = new AttemptJson(
                 SchemaVersion: 4,
                 Area: ctx.Area,
@@ -532,7 +542,10 @@ public sealed class FilesystemCalibrationAttemptBundleSink : ICalibrationAttempt
                 EngineVersion: AssemblyVersion,
                 Files: files,
                 LocatorBest: ToLocatorBestJson(ctx),
-                Synthesis: ToSynthesisJson(ctx.Result?.Synthesis));
+                Synthesis: ToSynthesisJson(ctx.Result?.Synthesis),
+                SceneClass: ctx.SceneClass.ToString(),
+                SceneClassOpaqueFraction: ctx.SceneClassOpaqueFraction,
+                Profile: profileJson);
             WriteJson(dir, "01-attempt.json", dto, CalibrationBundleJsonContext.Default.AttemptJson);
         }
         catch (Exception ex) { _logger?.LogWarning(ex, "01-attempt.json header write failed for {Outcome}", ctx.Outcome); }

--- a/src/Mithril.MapCalibration.Detection/Internal/FloorBoundaryMaskCache.cs
+++ b/src/Mithril.MapCalibration.Detection/Internal/FloorBoundaryMaskCache.cs
@@ -41,6 +41,14 @@ internal sealed class FloorBoundaryMaskCache
     private readonly object _gate = new();
     private readonly Dictionary<string, GrayImage?> _cache = new();
 
+    // mithril#1163 spec §5.2: cache the alpha-coverage-derived SceneClass
+    // alongside the boundary mask. Same cache key (mapAssetKey); separate dict
+    // so a future GetSceneClass-only call path doesn't pay the full mask
+    // construction cost. The alpha load is the only IO side; once the boundary
+    // mask is computed for a key the alpha is gone (we don't retain it), so
+    // we compute SceneClass at the same time as the mask and stash both.
+    private readonly Dictionary<string, SceneClass> _sceneClassCache = new();
+
     public FloorBoundaryMaskCache(
         IBaseTextureProvider provider,
         MapCalibrationDetectorOptions options,
@@ -55,6 +63,9 @@ internal sealed class FloorBoundaryMaskCache
     /// Returns the dilated floor-boundary mask for <paramref name="mapAssetKey"/>,
     /// or <c>null</c> when alpha is unavailable or degenerate. Cached per key —
     /// repeat calls for the same key hit the cache (including cached nulls).
+    /// Also computes + caches the <see cref="SceneClass"/> for the same key as
+    /// a side effect (the alpha buffer is in scope; doing both in one pass
+    /// halves the provider IO when both APIs are called).
     /// </summary>
     public GrayImage? GetOrCompute(string mapAssetKey)
     {
@@ -72,25 +83,102 @@ internal sealed class FloorBoundaryMaskCache
                     "Floor-boundary mask for {MapAsset} unavailable — provider returned no alpha (safe-degrade).",
                     mapAssetKey);
                 _cache[mapAssetKey] = null;
+                // mithril#1163: alpha unavailable → can't classify → Outdoor by
+                // fail-soft default. Cache the verdict so a future call returns
+                // the same answer without re-paying the provider call.
+                _sceneClassCache[mapAssetKey] = SceneClass.Outdoor;
                 return null;
             }
+
+            // mithril#1163 spec §5.2: classify SceneClass on the same alpha
+            // buffer the boundary mask uses (zero extra IO). Stamp into the
+            // cache BEFORE the degenerate-alpha early return — an
+            // all-transparent texture (degenerate Indoor candidate) still has a
+            // well-defined SceneClass label even if its boundary mask is null.
+            var (sceneClass, opaqueFraction) = ClassifySceneClass(alpha, _options.SceneClassOpaqueFractionThreshold);
+            _sceneClassCache[mapAssetKey] = sceneClass;
+            _opaqueFractionCache[mapAssetKey] = opaqueFraction;
 
             if (IsDegenerate(alpha))
             {
                 _logger?.LogWarning(
-                    "Floor-boundary mask for {MapAsset} skipped — alpha is degenerate (all-opaque or all-transparent) (safe-degrade).",
-                    mapAssetKey);
+                    "Floor-boundary mask for {MapAsset} skipped — alpha is degenerate (all-opaque or all-transparent) (safe-degrade); scene class {SceneClass}.",
+                    mapAssetKey, sceneClass);
                 _cache[mapAssetKey] = null;
                 return null;
             }
 
             var mask = ComputeBoundaryMask(alpha, _options.BoundaryDilationPx);
             _logger?.LogInformation(
-                "Computed floor-boundary mask for {MapAsset} ({W}x{H}, dilation {DilationPx}px).",
-                mapAssetKey, mask.Width, mask.Height, _options.BoundaryDilationPx);
+                "Computed floor-boundary mask for {MapAsset} ({W}x{H}, dilation {DilationPx}px); scene class {SceneClass}.",
+                mapAssetKey, mask.Width, mask.Height, _options.BoundaryDilationPx, sceneClass);
             _cache[mapAssetKey] = mask;
             return mask;
         }
+    }
+
+    /// <summary>
+    /// Returns the alpha-coverage-derived <see cref="SceneClass"/> for
+    /// <paramref name="mapAssetKey"/> (mithril#1163 spec §5.2). Cached per key
+    /// alongside the boundary mask; first call may pay the provider's alpha
+    /// load (and concurrently warms the boundary-mask cache), subsequent calls
+    /// hit the cache. Fail-soft: returns <see cref="SceneClass.Outdoor"/> when
+    /// alpha is unavailable (safe-degrade — Outdoor profile carries today's
+    /// universal constants).
+    /// </summary>
+    public SceneClass GetSceneClass(string mapAssetKey)
+    {
+        lock (_gate)
+        {
+            if (_sceneClassCache.TryGetValue(mapAssetKey, out var cached))
+            {
+                return cached;
+            }
+        }
+
+        // GetOrCompute populates _sceneClassCache as a side effect (the
+        // boundary mask + scene class share the same alpha buffer; doing both
+        // in one pass keeps the cache in sync). The boundary mask result is
+        // discarded — the caller of GetSceneClass doesn't need it.
+        _ = GetOrCompute(mapAssetKey);
+
+        lock (_gate)
+        {
+            // After GetOrCompute, _sceneClassCache MUST have the key (every
+            // code path through GetOrCompute writes it). Defensive default to
+            // Outdoor if a future refactor breaks that invariant.
+            return _sceneClassCache.TryGetValue(mapAssetKey, out var classified) ? classified : SceneClass.Outdoor;
+        }
+    }
+
+    /// <summary>
+    /// Returns the cached opaque-fraction (alpha ≥ 128 / total) for
+    /// <paramref name="mapAssetKey"/> if it has been classified, else <c>null</c>.
+    /// Diagnostic-only — the boundary mask + scene-class cache flow doesn't
+    /// retain the fraction, but the engine's bundle sink needs it for the
+    /// <c>sceneClassOpaqueFraction</c> JSON field per spec §5.6.
+    /// </summary>
+    public double? TryGetOpaqueFraction(string mapAssetKey)
+    {
+        lock (_gate)
+        {
+            return _opaqueFractionCache.TryGetValue(mapAssetKey, out var frac) ? frac : null;
+        }
+    }
+
+    private readonly Dictionary<string, double> _opaqueFractionCache = new();
+
+    private static (SceneClass SceneClass, double OpaqueFraction) ClassifySceneClass(GrayImage alpha, double opaqueThreshold)
+    {
+        var p = alpha.Pixels;
+        if (p.Length == 0) return (SceneClass.Outdoor, 1.0);
+        long opaqueCount = 0;
+        for (int i = 0; i < p.Length; i++)
+        {
+            if (p[i] >= 128) opaqueCount++;
+        }
+        double frac = opaqueCount / (double)p.Length;
+        return (frac >= opaqueThreshold ? SceneClass.Outdoor : SceneClass.Indoor, frac);
     }
 
     private static bool IsDegenerate(GrayImage alpha)

--- a/src/Mithril.MapCalibration.Detection/MapCalibrationDetectorOptions.cs
+++ b/src/Mithril.MapCalibration.Detection/MapCalibrationDetectorOptions.cs
@@ -59,6 +59,7 @@ public sealed class MapCalibrationDetectorOptions : INotifyPropertyChanged, IVer
     private double _fogVarianceThreshold = 30.0;
     private byte _fogColorMin = 110;
     private byte _fogColorMax = 140;
+    private double _sceneClassOpaqueFractionThreshold = 0.95;
 
     /// <summary>
     /// Master switch for the mithril#1116 deviation-mask filter on the
@@ -136,6 +137,28 @@ public sealed class MapCalibrationDetectorOptions : INotifyPropertyChanged, IVer
     {
         get => _fogColorMax;
         set { if (_fogColorMax != value) { _fogColorMax = value; OnChanged(); } }
+    }
+
+    /// <summary>
+    /// Minimum opaque-pixel fraction (alpha ≥ 128 / total px) for a base
+    /// texture to be classified as <see cref="SceneClass.Outdoor"/>. Anything
+    /// below this is <see cref="SceneClass.Indoor"/>. Default <c>0.95</c> —
+    /// the
+    /// [`scene-class-classification.md`](../../../docs/planning/calibration-1155-scene-class-profile/measurements/scene-class-classification.md)
+    /// spike measured Outdoor opaque-fraction = 1.00 (3 scenes) versus Indoor
+    /// 0.07–0.36 (10 scenes), so the gap is wide and the threshold has
+    /// substantial margin on both sides.
+    ///
+    /// <para><b>mithril#1163 / spec §5.2.</b> Drives
+    /// <c>FloorBoundaryMaskCache.GetSceneClass</c>. Fail-soft: when alpha is
+    /// unavailable the classifier returns Outdoor (the Outdoor
+    /// <see cref="SceneCalibrationProfile"/> carries today's universal
+    /// constants, so safe-degrade is byte-identical to pre-#1163).</para>
+    /// </summary>
+    public double SceneClassOpaqueFractionThreshold
+    {
+        get => _sceneClassOpaqueFractionThreshold;
+        set { if (_sceneClassOpaqueFractionThreshold != value) { _sceneClassOpaqueFractionThreshold = value; OnChanged(); } }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/Mithril.MapCalibration.Detection/SceneCalibrationProfile.cs
+++ b/src/Mithril.MapCalibration.Detection/SceneCalibrationProfile.cs
@@ -1,0 +1,105 @@
+namespace Mithril.MapCalibration.Detection;
+
+/// <summary>
+/// Per-scene-class detection-parameter bundle (mithril#1155 spec §5.1 — the
+/// post-spike Phase-1 scaffolding for Indoor / Outdoor divergence).
+///
+/// <para>For v1, only <see cref="BlobOptions"/> diverges between profiles:
+/// the
+/// [`indoor-recall-stage-attribution.md`](../../../docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-stage-attribution.md)
+/// audit identified the classifier shape gates (<c>MaxAspect</c>,
+/// <c>MinSolidity</c>) as the load-bearing reason real-icon blobs fail
+/// classification indoors; the
+/// [`indoor-recall-merge-fix-candidates.md`](../../../docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-merge-fix-candidates.md)
+/// measurement showed that <c>LowNcc</c> / <c>RenderSizePx</c> / morph
+/// <c>closeRadius</c> / deviation kernel <c>win</c> do NOT need to diverge for
+/// the v1 recovery (the audit's T3 hypothesis was partially falsified). Future
+/// phases (per the plan's Phase 4 / Phase 5) extend this record with extra
+/// fields as those divergences land.</para>
+///
+/// <para><b>Outdoor profile</b> is today's universal constants verbatim — the
+/// gate-study sweet-spot from mithril#897 (<c>MaxAspect = 2.5</c>,
+/// <c>MinSolidity = 0.35</c>, etc.). Any scene whose alpha can't be classified
+/// gets Outdoor by fail-soft default, so the change is byte-identical to
+/// pre-#1163 behaviour for Outdoor captures.</para>
+///
+/// <para><b>Indoor profile</b> relaxes <c>MaxAspect 2.5 → 2.7</c> (recovers
+/// IconE — observed aspect 2.56 in two distinct Hogan's bundles, 0.06 above
+/// the production ceiling, structurally repeating across captures) and
+/// <c>MinSolidity 0.35 → 0.30</c> (recovers IconD — observed solidity 0.31 in
+/// the canonical 06-13 bundle). Combined recovery: +2 real-icon blobs reach
+/// Icon class on the canonical bundle (total 3/6). Falls short of the audit's
+/// "≥ 4 RANSAC floor" by one — the remaining gap is the B+C merge problem,
+/// which the
+/// [`indoor-recall-merge-fix-candidates.md`](../../../docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-merge-fix-candidates.md)
+/// measurement showed isn't reachable via (win, closeRadius) tuning. Phase 2.5
+/// (morph-open) is the candidate follow-up if v1's 3/6 isn't enough.</para>
+///
+/// <para><b>Carrier shape rationale.</b> The record is intentionally minimal
+/// (one field) to keep v1 PR review tractable. Spec §5.1 / plan §Phase 1 list
+/// additional fields (<c>RenderSizePx</c>, <c>LowNcc</c>, <c>TypeFloor</c>,
+/// <c>RansacInlierPx</c>, synthesis-J mode + formulas) — those land alongside
+/// their actual divergence in the corresponding phase, NOT speculatively here
+/// (per the project memory's "no speculative guards" pattern: fields that
+/// don't move v1 behaviour shouldn't appear in the v1 carrier).</para>
+/// </summary>
+/// <param name="SceneClass">
+/// Which scene class this profile targets. Used at the dispatcher layer
+/// (AutoCalibrationEngine resolves the SceneClass per attempt, picks the
+/// matching profile) — kept as a discriminator field so a future registry
+/// pattern (per spec §6.b — if a third class arises) doesn't need a struct
+/// shape change.
+/// </param>
+/// <param name="BlobOptions">
+/// Classifier shape thresholds passed into
+/// <see cref="DeviationBlobDetector.DetectIconBlobs"/>. Outdoor carries the
+/// gate-study sweet-spot; Indoor relaxes <c>MaxAspect</c> and
+/// <c>MinSolidity</c>.
+/// </param>
+public readonly record struct SceneCalibrationProfile(
+    SceneClass SceneClass,
+    BlobOptions BlobOptions)
+{
+    /// <summary>
+    /// Outdoor profile — today's universal constants verbatim. The
+    /// <see cref="BlobOptions"/> values match the gate-study sweet-spot quoted
+    /// in <c>AutoCalibrationEngine.cs:61-62</c>: <c>MinArea=12, MaxIconArea=900,
+    /// MinSolidity=0.35, MaxAspect=2.5, MinPeak=0.7</c>. Any scene whose alpha
+    /// can't be classified gets this profile via the fail-soft default at the
+    /// classifier seam.
+    /// </summary>
+    public static SceneCalibrationProfile Outdoor { get; } = new(
+        SceneClass: SceneClass.Outdoor,
+        BlobOptions: new BlobOptions(
+            MinArea: 12, MaxIconArea: 900,
+            MinSolidity: 0.35, MaxAspect: 2.5, MinPeak: 0.7));
+
+    /// <summary>
+    /// Indoor profile — relaxed classifier shape gates per the Phase-2
+    /// measurement. <c>MaxAspect 2.5 → 2.7</c> recovers the systematic
+    /// aspect-2.56 PG glyph that reproduces across distinct Hogan's bundles;
+    /// <c>MinSolidity 0.35 → 0.30</c> recovers the borderline IconD-style
+    /// blob. Other knobs unchanged from Outdoor — the measurement showed
+    /// <c>LowNcc</c> / kernel <c>win</c> / morph <c>closeRadius</c> divergence
+    /// doesn't move v1 recall (T3 partially falsified).
+    /// </summary>
+    public static SceneCalibrationProfile Indoor { get; } = new(
+        SceneClass: SceneClass.Indoor,
+        BlobOptions: new BlobOptions(
+            MinArea: 12, MaxIconArea: 900,
+            MinSolidity: 0.30, MaxAspect: 2.7, MinPeak: 0.7));
+
+    /// <summary>
+    /// Returns the canonical profile for <paramref name="sceneClass"/>. The
+    /// dispatch is intentionally a switch on a 2-arm enum (per the project
+    /// memory's "switch-as-registry smell" pattern, this stays a switch until a
+    /// third arm lands — at which point the registry refactor is the right
+    /// move). Outdoor is the safe-degrade default for unknown enum values.
+    /// </summary>
+    public static SceneCalibrationProfile For(SceneClass sceneClass) => sceneClass switch
+    {
+        SceneClass.Indoor => Indoor,
+        SceneClass.Outdoor => Outdoor,
+        _ => Outdoor,
+    };
+}

--- a/src/Mithril.MapCalibration.Detection/SceneCalibrationProfile.cs
+++ b/src/Mithril.MapCalibration.Detection/SceneCalibrationProfile.cs
@@ -92,9 +92,19 @@ public readonly record struct SceneCalibrationProfile(
     /// <summary>
     /// Returns the canonical profile for <paramref name="sceneClass"/>. The
     /// dispatch is intentionally a switch on a 2-arm enum (per the project
-    /// memory's "switch-as-registry smell" pattern, this stays a switch until a
-    /// third arm lands — at which point the registry refactor is the right
-    /// move). Outdoor is the safe-degrade default for unknown enum values.
+    /// memory's "switch-as-registry smell" pattern, this stays a switch until
+    /// a third arm lands — at which point the registry refactor is the right
+    /// move).
+    ///
+    /// <para>The <c>_ => Outdoor</c> arm exists because <c>warnings-as-errors</c>
+    /// (CS8524) requires the switch to handle any cast-from-int value, not
+    /// just the defined enum members. Adding a third enum value (e.g.
+    /// <c>Cave</c>) does NOT auto-extend the switch — the dispatcher author
+    /// has to explicitly add a case. Reviewers must check this method when
+    /// extending <see cref="SceneClass"/> so a new arm isn't silently routed
+    /// to Outdoor's tighter gates (the bug the mithril#1168 review flagged).
+    /// CS8524 doesn't fire here today; the manual review obligation is the
+    /// guard.</para>
     /// </summary>
     public static SceneCalibrationProfile For(SceneClass sceneClass) => sceneClass switch
     {

--- a/src/Mithril.MapCalibration.Detection/SceneClass.cs
+++ b/src/Mithril.MapCalibration.Detection/SceneClass.cs
@@ -1,0 +1,45 @@
+namespace Mithril.MapCalibration.Detection;
+
+/// <summary>
+/// Classification of a PG map scene by its base-texture alpha-coverage shape
+/// (mithril#1155 spec §5.2 — the post-spike Phase-1 scaffolding for
+/// <see cref="SceneCalibrationProfile"/> selection).
+///
+/// <para>The axis the engine has been quietly leaning on <c>null</c> for:
+/// outdoor maps render against a fully-opaque base texture
+/// (<c>opaqueFraction ≥ 0.95</c>); indoor maps have alpha=0 over the off-map
+/// regions, which produces a structurally different deviation field at the
+/// detector layer. Knobs that tune cleanly outdoors (the gate-study
+/// sweet-spot per mithril#897) admit floor-texture noise as Icon-class blobs
+/// indoors; the Indoor profile relaxes the classifier shape gates per the
+/// [`indoor-recall-merge-fix-candidates.md`](../../../docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-merge-fix-candidates.md)
+/// measurement.</para>
+///
+/// <para>Resolution source: <c>FloorBoundaryMaskCache.GetSceneClass</c>
+/// computes <c>opaqueFraction = count(alpha &gt;= 128) / (textureWidth *
+/// textureHeight)</c> from the same alpha buffer the boundary mask already
+/// loads — no extra IO. Threshold comes from
+/// <see cref="MapCalibrationDetectorOptions.SceneClassOpaqueFractionThreshold"/>
+/// (default 0.95). Fail-soft: when alpha is unavailable, <see cref="Outdoor"/>
+/// is the safe default (preserves pre-#1163 behaviour byte-identically).</para>
+/// </summary>
+public enum SceneClass
+{
+    /// <summary>
+    /// Fully-opaque base texture (alpha ≥ 128 over ≥ 95 % of the texture).
+    /// Default for any scene whose alpha can't be classified — the Outdoor
+    /// profile carries today's universal constants, so safe-degrade is
+    /// byte-identical to pre-#1163.
+    /// </summary>
+    Outdoor = 0,
+
+    /// <summary>
+    /// Substantially-transparent base texture (alpha &lt; 128 over &gt; 5 %
+    /// of the texture). Indoor scenes (Hogan's Keep Basement, GoblinDungeon,
+    /// etc.) render against alpha=0 off-map regions, so the deviation field
+    /// has structurally different connectivity than Outdoor's grass-vs-icon
+    /// signal. The Indoor profile relaxes <c>MaxAspect</c> and
+    /// <c>MinSolidity</c> per the Phase-2 measurement.
+    /// </summary>
+    Indoor = 1,
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineSceneClassTests.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/AutoCalibrationEngineSceneClassTests.cs
@@ -1,0 +1,85 @@
+using System.Threading;
+using FluentAssertions;
+using Mithril.MapCalibration.Capture.Tests.Fixtures;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Capture.Tests;
+
+/// <summary>
+/// mithril#1163 Phase 1 + Phase 2 — engine-level wiring tests for the
+/// SceneClass dispatch. Verify that the right
+/// <see cref="SceneCalibrationProfile.BlobOptions"/> reach the solver based on
+/// the base texture's alpha-coverage:
+/// <list type="bullet">
+///   <item>Outdoor alpha (≥ 95 % opaque) → Outdoor profile (today's universal constants)</item>
+///   <item>Indoor alpha (&lt; 95 % opaque) → Indoor profile (T1 + T2: MaxAspect 2.7, MinSolidity 0.30)</item>
+///   <item>Boundary cache unwired → safe-degrade Outdoor (preserves pre-#1163 byte-identically)</item>
+/// </list>
+/// Mithril#1168 review feedback: the indirect coverage via
+/// <c>IndoorRecallMergeTuningTests</c> bypasses the engine entirely; this
+/// suite pins the wiring contract at the engine layer so a future refactor
+/// that breaks the dispatch fails CI loudly.
+/// </summary>
+public sealed class AutoCalibrationEngineSceneClassTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task Outdoor_alpha_dispatches_Outdoor_BlobOptions_to_solver()
+    {
+        var harness = new EngineHarness { WireDeviationMaskDeps = true };
+        var engine = harness.Engine();
+        // BaseTextureProvider is auto-constructed by Engine() — populate alpha
+        // AFTER engine creation but BEFORE the run so the boundary cache loads
+        // it lazily on the first GetSceneClass call.
+        // Outdoor: alpha = 255 everywhere → opaque fraction 1.00 ≥ 0.95 → Outdoor.
+        harness.BaseTextureProvider.AlphaByKey[EngineHarness.DefaultMapAsset] = AlphaBuffer(64, 64, opaqueValue: true);
+
+        await engine.TryCalibrateCurrentAreaAsync(CancellationToken.None);
+
+        var blobOpts = harness.Solver.LastRequest!.BlobOptions;
+        blobOpts.Should().Be(SceneCalibrationProfile.Outdoor.BlobOptions,
+            "Outdoor-classed scene must dispatch today's universal constants — the Outdoor regression battery depends on this.");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Indoor_alpha_dispatches_Indoor_BlobOptions_to_solver()
+    {
+        var harness = new EngineHarness { WireDeviationMaskDeps = true };
+        var engine = harness.Engine();
+        // Indoor: alpha = 0 everywhere → opaque fraction 0.00 < 0.95 → Indoor.
+        // (All-transparent is a degenerate boundary mask but a well-defined SceneClass.)
+        harness.BaseTextureProvider.AlphaByKey[EngineHarness.DefaultMapAsset] = AlphaBuffer(64, 64, opaqueValue: false);
+
+        await engine.TryCalibrateCurrentAreaAsync(CancellationToken.None);
+
+        var blobOpts = harness.Solver.LastRequest!.BlobOptions;
+        blobOpts.Should().Be(SceneCalibrationProfile.Indoor.BlobOptions,
+            "Indoor-classed scene must dispatch the relaxed T1+T2 gates — the Phase 2 recall lift depends on this.");
+        blobOpts.MaxAspect.Should().Be(2.7);
+        blobOpts.MinSolidity.Should().Be(0.30);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Boundary_cache_unwired_safe_degrades_to_Outdoor_BlobOptions()
+    {
+        // Without WireDeviationMaskDeps the engine ctor leaves the boundary
+        // cache null — mirrors the pre-#1163 test graphs that never opted in.
+        // The dispatch falls through to Outdoor by safe-degrade, preserving
+        // byte-identical behaviour for those graphs.
+        var harness = new EngineHarness { WireDeviationMaskDeps = false };
+        var engine = harness.Engine();
+
+        await engine.TryCalibrateCurrentAreaAsync(CancellationToken.None);
+
+        var blobOpts = harness.Solver.LastRequest!.BlobOptions;
+        blobOpts.Should().Be(SceneCalibrationProfile.Outdoor.BlobOptions,
+            "boundary cache unwired must safe-degrade to Outdoor — pre-#1163 graphs depend on byte-identical pre-existing behaviour.");
+    }
+
+    private static GrayImage AlphaBuffer(int w, int h, bool opaqueValue)
+    {
+        var p = new byte[w * h];
+        if (opaqueValue) { for (int i = 0; i < p.Length; i++) p[i] = 255; }
+        return new GrayImage(w, h, p);
+    }
+}

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineFakes.cs
@@ -250,7 +250,17 @@ internal sealed class FakeBaseTextureProvider : IBaseTextureProvider
         return ResolveAs;
     }
 
-    public GrayImage? TryGetTextureAlpha(string mapAssetKey) => null;
+    /// <summary>
+    /// Per-key alpha buffer the provider returns for <see cref="TryGetTextureAlpha"/>.
+    /// Defaults to "no alpha available" so legacy tests keep their pre-#1163
+    /// safe-degrade-to-Outdoor behaviour. mithril#1163: tests that exercise the
+    /// scene-class classifier populate this dictionary to model "alpha-coverage
+    /// 100 %" (Outdoor) or "alpha-coverage 20 %" (Indoor).
+    /// </summary>
+    public Dictionary<string, GrayImage> AlphaByKey { get; } = new();
+
+    public GrayImage? TryGetTextureAlpha(string mapAssetKey) =>
+        AlphaByKey.TryGetValue(mapAssetKey, out var alpha) ? alpha : null;
 }
 
 /// <summary>
@@ -302,10 +312,18 @@ internal sealed class SpySolver : IMapCalibrationSolver
     /// <summary>Number of <see cref="Solve"/> calls. The mithril#1021 strict-gate
     /// test asserts this is zero when the engine refuses early.</summary>
     public int SolveCalls { get; private set; }
+    /// <summary>
+    /// The most recent <see cref="DetectionRequest"/> the engine handed to
+    /// <see cref="Solve"/>. mithril#1163: lets tests assert which
+    /// <see cref="SceneCalibrationProfile.BlobOptions"/> reached the solver
+    /// without needing the full diagnostic bundle. Null until the first call.
+    /// </summary>
+    public DetectionRequest? LastRequest { get; private set; }
     public CalibrationSolveResult Solve(DetectionRequest request, IReadOnlyList<LandmarkReference> references)
     {
         Called = true;
         SolveCalls++;
+        LastRequest = request;
         return _result;
     }
 

--- a/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineHarness.cs
+++ b/tests/Mithril.MapCalibration.Capture.Tests/Fixtures/EngineHarness.cs
@@ -2,6 +2,7 @@ using Mithril.MapCalibration;
 using Mithril.MapCalibration.Capture;
 using Mithril.MapCalibration.Capture.Diagnostics;
 using Mithril.MapCalibration.Detection;
+using Mithril.MapCalibration.Detection.Internal;
 using Mithril.Shared.Game;
 
 namespace Mithril.MapCalibration.Capture.Tests.Fixtures;
@@ -85,6 +86,28 @@ internal sealed class EngineHarness
     public IMapRegionRefiner Refiner { get; init; }
         = new FakeRefiner(new MapRect(0, 0, 64, 64, 64, 64));
 
+    /// <summary>
+    /// mithril#1163 — optional deviation-mask wiring. All three default to
+    /// null; when null the engine skips the mask block and resolves
+    /// <see cref="SceneClass.Outdoor"/> by safe-degrade. Tests that exercise
+    /// the SceneClass dispatch wire all three:
+    /// <see cref="DetectorOptions"/> with <c>DeviationMaskingEnabled=true</c>,
+    /// the cache, and the fog detector. The cache is auto-constructed in
+    /// <see cref="Engine"/> from the same <see cref="BaseTextureProvider"/>
+    /// that the engine sees — set
+    /// <see cref="FakeBaseTextureProvider.AlphaByKey"/> to populate alpha.
+    /// </summary>
+    public bool WireDeviationMaskDeps { get; init; }
+
+    /// <summary>mithril#1163 — exposed so tests can flex
+    /// <see cref="SceneClassOpaqueFractionThreshold"/>.</summary>
+    public MapCalibrationDetectorOptions? DetectorOptions { get; private set; }
+
+    /// <summary>mithril#1163 — the cache the engine resolves SceneClass through.
+    /// Auto-constructed in <see cref="Engine"/> when
+    /// <see cref="WireDeviationMaskDeps"/> is true.</summary>
+    public FloorBoundaryMaskCache? BoundaryMaskCache { get; private set; }
+
     public AutoCalibrationEngine Engine()
     {
         Solver = new SpySolver(Solve);
@@ -102,6 +125,13 @@ internal sealed class EngineHarness
                 : new MapSceneRef(CurrentArea, CurrentSceneFriendlyName, CurrentMapAsset),
         };
         var sceneCache = new FakeSceneAssetCache();
+        FogOfWarDetector? fog = null;
+        if (WireDeviationMaskDeps)
+        {
+            DetectorOptions = new MapCalibrationDetectorOptions();   // defaults: masking + fog enabled
+            BoundaryMaskCache = new FloorBoundaryMaskCache(BaseTextureProvider, DetectorOptions);
+            fog = new FogOfWarDetector(DetectorOptions);
+        }
         return new AutoCalibrationEngine(
             mapState,
             sceneCache,
@@ -118,6 +148,9 @@ internal sealed class EngineHarness
             sinkSelector: SinkSelector,
             assetExtractor: Extractor,
             gameConfig: GameConfig,
-            assetCacheDir: AssetCacheDir);
+            assetCacheDir: AssetCacheDir,
+            detectorOptions: DetectorOptions,
+            boundaryMaskCache: BoundaryMaskCache,
+            fogOfWarDetector: fog);
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/IndoorRecallMergeTuningTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/IndoorRecallMergeTuningTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Mithril.MapCalibration.Detection;
 using Mithril.MapCalibration.Tests.Fixtures;
@@ -230,5 +231,88 @@ public sealed class IndoorRecallMergeTuningTests
             Assert.Equal(152, iconF.Area);
             Assert.Equal(176, iconF.BlobOrdinal);
         }
+    }
+
+    /// <summary>
+    /// mithril#1163 Phase 2 acceptance test — the canonical 06-13 bundle run
+    /// with <see cref="SceneCalibrationProfile.Indoor"/> (T1 + T2: MaxAspect
+    /// 2.7, MinSolidity 0.30) MUST admit IconD + IconE + IconF as Icon-class
+    /// blobs (3 of 6 real icons reach Icon class). IconA isn't recovered (its
+    /// blob bbox doesn't contain its centroid in production geometry — see
+    /// indoor-recall-merge-fix-candidates.md "What 'RIC' counts"); IconB and
+    /// IconC sit in the same Structure blob (the merge problem the
+    /// measurement showed isn't reachable via classifier tuning). Phase 2 v1
+    /// acceptance is 3/6; the implementation PR's spec revision must reflect
+    /// this.
+    ///
+    /// <para>Compares against the production-parameter baseline (1/6 — only
+    /// IconF reaches Icon class with Outdoor profile gates) so a future
+    /// regression in either profile fails loudly.</para>
+    /// </summary>
+    [Fact]
+    public void Indoor_profile_admits_3_of_6_real_icons_on_canonical_bundle()
+    {
+        if (CanonicalBundleDir() is null)
+        {
+            _output.WriteLine("SKIPPED — canonical bundle absent.");
+            return;
+        }
+        var dir = CanonicalBundleDir()!;
+        var shot = WicImageLoader.LoadGray(Path.Combine(dir, "06-aligned-screenshot.png"));
+        var tex = WicImageLoader.LoadGray(Path.Combine(dir, "05-base-texture-resampled.png"));
+
+        // Load production deviation mask (same as the Measure_blob_pipeline
+        // theory does — see that test for the rationale).
+        bool[]? deviationMask = null;
+        var maskPath = Path.Combine(dir, "07a-deviation-mask.png");
+        if (File.Exists(maskPath))
+        {
+            var maskImg = WicImageLoader.LoadGray(maskPath);
+            deviationMask = new bool[maskImg.Pixels.Length];
+            for (int i = 0; i < maskImg.Pixels.Length; i++) deviationMask[i] = maskImg.Pixels[i] >= 128;
+        }
+
+        var shotF = LocalNccDeviation.ToGrayFloat(shot);
+        var texF = LocalNccDeviation.ToGrayFloat(tex);
+        var dev = LocalNccDeviation.DeviationMap(shotF, texF, shot.Width, shot.Height, win: 11, out var meanNcc, addedOnly: true);
+
+        int RunWithProfile(SceneCalibrationProfile profile)
+        {
+            var blobs = new List<BlobClassification>();
+            var hooks = new DetectionDiagnosticHooks(
+                OnDeviation: null, OnRimMask: null, OnMorph: null,
+                OnBlobClassified: blobs.Add);
+            _ = DeviationBlobDetector.DetectIconBlobs(
+                dev, shot.Width, shot.Height,
+                lowNcc: 0.5, rim: RimMaskMode.DeviationFlood, profile.BlobOptions,
+                closeRadius: 1,
+                hooks: hooks,
+                meanNcc: meanNcc,
+                logger: NullLogger.Instance,
+                deviationMask: deviationMask);
+
+            int admitted = 0;
+            foreach (var (_, x, y) in CanonicalIcons)
+            {
+                BlobClassification? container = null;
+                foreach (var b in blobs)
+                {
+                    if (x >= b.MinX && x < b.MinX + b.W && y >= b.MinY && y < b.MinY + b.H)
+                    {
+                        if (container is null || b.Area > container.Area) container = b;
+                    }
+                }
+                if (container?.BlobClass == BlobClass.Icon) admitted++;
+            }
+            return admitted;
+        }
+
+        int outdoorAdmitted = RunWithProfile(SceneCalibrationProfile.Outdoor);
+        int indoorAdmitted = RunWithProfile(SceneCalibrationProfile.Indoor);
+        _output.WriteLine($"Outdoor profile: {outdoorAdmitted}/6 real icons admitted (baseline = production parameters).");
+        _output.WriteLine($"Indoor  profile: {indoorAdmitted}/6 real icons admitted (T1+T2 — MaxAspect 2.7, MinSolidity 0.30).");
+
+        outdoorAdmitted.Should().Be(1, "production parameters (Outdoor profile) admit only IconF — the baseline pre-#1163 recall on canonical 06-13.");
+        indoorAdmitted.Should().Be(3, "Indoor profile (T1+T2) should admit IconD + IconE + IconF — the +2 lift the Phase 2 measurement proved.");
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/IndoorRecallMergeTuningTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/IndoorRecallMergeTuningTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Security.Cryptography;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Mithril.MapCalibration.Detection;
@@ -41,6 +42,16 @@ public sealed class IndoorRecallMergeTuningTests
     private const string CanonicalBundleName =
         "Map_HogansKeepBasement-20260613-230459-600-rejected-solve-insufficient-inliers";
 
+    /// <summary>
+    /// SHA-256 of the canonical bundle's <c>06-aligned-screenshot.png</c> at
+    /// the time the production-parity asserts below were measured. Asserts only
+    /// fire when this hash matches — protects other devs whose own bundles
+    /// happen to live at the same path but produce different blob counts.
+    /// mithril#1168 review feedback ("dev-local bundles are foot-guns").
+    /// </summary>
+    private const string CanonicalScreenshotSha256 =
+        "57B01CE5D4BB2DF60124B32DAB2102B2E05BE9C37ECE5BE2DBEAA87B09F9EA0B";
+
     /// <summary>Per-icon aligned-space centroids from the stage-attribution audit.</summary>
     private static readonly (string Label, int X, int Y)[] CanonicalIcons =
     [
@@ -58,6 +69,20 @@ public sealed class IndoorRecallMergeTuningTests
         if (string.IsNullOrEmpty(local)) return null;
         var dir = Path.Combine(local, "Mithril", "diagnostics", "calibration", CanonicalBundleName);
         return Directory.Exists(dir) ? dir : null;
+    }
+
+    /// <summary>
+    /// True when the on-disk <c>06-aligned-screenshot.png</c> matches the
+    /// canonical hash the production-parity asserts were measured against.
+    /// </summary>
+    private static bool BundleMatchesCanonicalHash(string bundleDir)
+    {
+        var shotPath = Path.Combine(bundleDir, "06-aligned-screenshot.png");
+        if (!File.Exists(shotPath)) return false;
+        using var stream = File.OpenRead(shotPath);
+        var bytes = SHA256.HashData(stream);
+        var hex = System.Convert.ToHexString(bytes);
+        return string.Equals(hex, CanonicalScreenshotSha256, System.StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -217,11 +242,12 @@ public sealed class IndoorRecallMergeTuningTests
         _output.WriteLine($"  Real icons reaching Icon class: {realIconAdmitted}/6");
 
         // Production-parity sanity guard at production parameters (win=11,
-        // closeRadius=1). These numbers come straight from the canonical bundle's
-        // 10c-blob-pipeline.json and 10-detections.json — any drift here means
-        // the test rig diverges from production, and the measurement table for
-        // OTHER parameter combos shouldn't be trusted.
-        if (win == 11 && closeRadius == 1)
+        // closeRadius=1). These numbers come straight from the canonical
+        // bundle's 10c-blob-pipeline.json and 10-detections.json. Hash-gated
+        // so a dev who populates the same bundle name from a different
+        // capture session doesn't get red on what should be measurement-only
+        // data (mithril#1168 review feedback).
+        if (win == 11 && closeRadius == 1 && BundleMatchesCanonicalHash(dir))
         {
             Assert.Equal(197, blobs.Count);
             Assert.Equal(18, blobs.Count(b => b.BlobClass == BlobClass.Icon));
@@ -230,6 +256,10 @@ public sealed class IndoorRecallMergeTuningTests
             Assert.Equal(BlobClass.Icon, iconF.BlobClass);
             Assert.Equal(152, iconF.Area);
             Assert.Equal(176, iconF.BlobOrdinal);
+        }
+        else if (win == 11 && closeRadius == 1)
+        {
+            _output.WriteLine("Production-parity asserts skipped — the on-disk bundle's SHA256 doesn't match the measured canonical (numbers above are still useful as a measurement record).");
         }
     }
 
@@ -312,7 +342,21 @@ public sealed class IndoorRecallMergeTuningTests
         _output.WriteLine($"Outdoor profile: {outdoorAdmitted}/6 real icons admitted (baseline = production parameters).");
         _output.WriteLine($"Indoor  profile: {indoorAdmitted}/6 real icons admitted (T1+T2 — MaxAspect 2.7, MinSolidity 0.30).");
 
-        outdoorAdmitted.Should().Be(1, "production parameters (Outdoor profile) admit only IconF — the baseline pre-#1163 recall on canonical 06-13.");
-        indoorAdmitted.Should().Be(3, "Indoor profile (T1+T2) should admit IconD + IconE + IconF — the +2 lift the Phase 2 measurement proved.");
+        // Hash-gate the load-bearing asserts so devs running their own
+        // bundles don't trip on what should be canonical-bundle-only numbers.
+        if (BundleMatchesCanonicalHash(dir))
+        {
+            outdoorAdmitted.Should().Be(1, "production parameters (Outdoor profile) admit only IconF — the baseline pre-#1163 recall on canonical 06-13.");
+            indoorAdmitted.Should().Be(3, "Indoor profile (T1+T2) should admit IconD + IconE + IconF — the +2 lift the Phase 2 measurement proved.");
+        }
+        else
+        {
+            // Soft assertion: Indoor must admit MORE than Outdoor on any
+            // Indoor bundle (the structural claim the +2 lift makes). This
+            // holds across all bundles where the audit's failure modes
+            // reproduce; the exact admit-count is canonical-bundle-specific.
+            indoorAdmitted.Should().BeGreaterThanOrEqualTo(outdoorAdmitted, "Indoor profile gates can only ADMIT — never reject — relative to Outdoor.");
+            _output.WriteLine("Skipped exact 1/3 assertion — bundle SHA mismatch with the canonical measurement (general Indoor ≥ Outdoor invariant still asserted).");
+        }
     }
 }

--- a/tests/Mithril.MapCalibration.Tests/Detection/SceneCalibrationProfileTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/SceneCalibrationProfileTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+/// <summary>
+/// mithril#1163 Phase 1 — pins the <see cref="SceneCalibrationProfile"/>
+/// Outdoor / Indoor values against regressions. Outdoor MUST stay identical to
+/// today's universal constants quoted in <c>AutoCalibrationEngine.cs:61-62</c>
+/// so the Outdoor replay-fixture battery (Serbule / Eltibule / Kur) keeps
+/// solving byte-identically. Indoor MUST stay at T1+T2 (<c>MaxAspect 2.7,
+/// MinSolidity 0.30</c>) so the Phase-2 measurement's 3/6 RIC recovery on the
+/// canonical Hogan's 06-13 bundle remains the design contract.
+/// </summary>
+public sealed class SceneCalibrationProfileTests
+{
+    [Fact]
+    public void Outdoor_profile_matches_today_universal_constants()
+    {
+        // Pinned to AutoCalibrationEngine.cs:61-62 — the gate-study sweet-spot
+        // from mithril#897. If any of these change without the Outdoor replay
+        // battery being re-verified, this assertion fails loudly.
+        SceneCalibrationProfile.Outdoor.SceneClass.Should().Be(SceneClass.Outdoor);
+        SceneCalibrationProfile.Outdoor.BlobOptions.MinArea.Should().Be(12);
+        SceneCalibrationProfile.Outdoor.BlobOptions.MaxIconArea.Should().Be(900);
+        SceneCalibrationProfile.Outdoor.BlobOptions.MinSolidity.Should().Be(0.35);
+        SceneCalibrationProfile.Outdoor.BlobOptions.MaxAspect.Should().Be(2.5);
+        SceneCalibrationProfile.Outdoor.BlobOptions.MinPeak.Should().Be(0.7);
+    }
+
+    [Fact]
+    public void Indoor_profile_relaxes_aspect_and_solidity_per_T1_T2()
+    {
+        // T1 (MaxAspect 2.5 → 2.7) recovers IconE (aspect 2.56, reproduces
+        // across distinct Hogan's bundles per the audit).
+        // T2 (MinSolidity 0.35 → 0.30) recovers IconD (solidity 0.31 on
+        // canonical 06-13).
+        // Other knobs identical to Outdoor — measurement showed (win,
+        // closeRadius, LowNcc) divergence doesn't move v1 recall.
+        SceneCalibrationProfile.Indoor.SceneClass.Should().Be(SceneClass.Indoor);
+        SceneCalibrationProfile.Indoor.BlobOptions.MinArea.Should().Be(12);
+        SceneCalibrationProfile.Indoor.BlobOptions.MaxIconArea.Should().Be(900);
+        SceneCalibrationProfile.Indoor.BlobOptions.MinSolidity.Should().Be(0.30);
+        SceneCalibrationProfile.Indoor.BlobOptions.MaxAspect.Should().Be(2.7);
+        SceneCalibrationProfile.Indoor.BlobOptions.MinPeak.Should().Be(0.7);
+    }
+
+    [Theory]
+    [InlineData(SceneClass.Outdoor)]
+    [InlineData(SceneClass.Indoor)]
+    public void For_returns_the_matching_profile(SceneClass sceneClass)
+    {
+        var profile = SceneCalibrationProfile.For(sceneClass);
+        profile.SceneClass.Should().Be(sceneClass);
+    }
+
+    [Fact]
+    public void For_unknown_enum_value_safe_degrades_to_Outdoor()
+    {
+        // A future-proofing assertion against a fourth enum value getting
+        // added without updating the switch — better to ship Outdoor (the
+        // safe-degrade default) than throw on a release-mode runtime path.
+        var profile = SceneCalibrationProfile.For((SceneClass)42);
+        profile.Should().Be(SceneCalibrationProfile.Outdoor);
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/Detection/SceneCalibrationProfileTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/SceneCalibrationProfileTests.cs
@@ -56,11 +56,16 @@ public sealed class SceneCalibrationProfileTests
     }
 
     [Fact]
-    public void For_unknown_enum_value_safe_degrades_to_Outdoor()
+    public void For_unknown_cast_value_falls_to_Outdoor_per_CS8524_arm()
     {
-        // A future-proofing assertion against a fourth enum value getting
-        // added without updating the switch — better to ship Outdoor (the
-        // safe-degrade default) than throw on a release-mode runtime path.
+        // The `_ => Outdoor` arm in SceneCalibrationProfile.For exists because
+        // warnings-as-errors makes CS8524 break the build without it (every
+        // 2-arm enum dispatch needs an arm for the cast-from-int case). This
+        // test pins the documented behaviour so a future refactor doesn't
+        // accidentally change it to a throw — which would propagate into the
+        // engine's catch and surface as an Error chip with no actionable text
+        // (worse than safe-degrade). See mithril#1168 review for the full
+        // argument.
         var profile = SceneCalibrationProfile.For((SceneClass)42);
         profile.Should().Be(SceneCalibrationProfile.Outdoor);
     }

--- a/tests/Mithril.MapCalibration.Tests/Detection/SceneClassClassifierTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/SceneClassClassifierTests.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Mithril.MapCalibration.Detection.Internal;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+/// <summary>
+/// mithril#1163 Phase 1 — covers the
+/// <see cref="FloorBoundaryMaskCache.GetSceneClass"/> /
+/// <see cref="FloorBoundaryMaskCache.TryGetOpaqueFraction"/> API. The
+/// classification rule (Outdoor when alpha-coverage ≥
+/// <see cref="MapCalibrationDetectorOptions.SceneClassOpaqueFractionThreshold"/>,
+/// Indoor otherwise) lives in the cache so the boundary mask + scene-class
+/// label share the alpha load.
+/// </summary>
+public sealed class SceneClassClassifierTests
+{
+    [Fact]
+    public void All_opaque_alpha_classifies_as_Outdoor()
+    {
+        // Outdoor maps (Serbule / Eltibule / Kur per the spike measurement) ship
+        // alpha = 255 over the entire texture — opaque fraction 1.00, well above
+        // the 0.95 threshold.
+        var provider = new FakeAlphaProvider();
+        provider.SetAlpha("Map_Outdoor", MakeUniformAlpha(64, 64, value: 255));
+        var cache = new FloorBoundaryMaskCache(provider, new MapCalibrationDetectorOptions());
+
+        cache.GetSceneClass("Map_Outdoor").Should().Be(SceneClass.Outdoor);
+        cache.TryGetOpaqueFraction("Map_Outdoor").Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Mostly_transparent_alpha_classifies_as_Indoor()
+    {
+        // Indoor maps (Hogan's etc per the spike) ship alpha = 0 over the
+        // off-map regions — opaque fraction 0.07-0.36 per the measurement,
+        // well below the 0.95 threshold.
+        var provider = new FakeAlphaProvider();
+        provider.SetAlpha("Map_Indoor", MakeAlphaWithOpaqueFraction(width: 100, height: 100, opaqueFraction: 0.20));
+        var cache = new FloorBoundaryMaskCache(provider, new MapCalibrationDetectorOptions());
+
+        cache.GetSceneClass("Map_Indoor").Should().Be(SceneClass.Indoor);
+        cache.TryGetOpaqueFraction("Map_Indoor").Should().BeApproximately(0.20, 0.001);
+    }
+
+    [Fact]
+    public void Threshold_boundary_falls_on_Outdoor_side()
+    {
+        // The default threshold is 0.95 inclusive — a texture at exactly 0.95
+        // opaque fraction classifies as Outdoor. The wide gap between Outdoor
+        // (1.00) and Indoor (≤0.36) measured in the corpus gives this room.
+        var provider = new FakeAlphaProvider();
+        provider.SetAlpha("Map_Boundary", MakeAlphaWithOpaqueFraction(width: 100, height: 100, opaqueFraction: 0.95));
+        var cache = new FloorBoundaryMaskCache(provider, new MapCalibrationDetectorOptions());
+
+        cache.GetSceneClass("Map_Boundary").Should().Be(SceneClass.Outdoor);
+    }
+
+    [Fact]
+    public void Configurable_threshold_moves_the_boundary()
+    {
+        // Settings UI can tune the threshold; verify the cache honours it.
+        var provider = new FakeAlphaProvider();
+        provider.SetAlpha("Map_50pct", MakeAlphaWithOpaqueFraction(width: 100, height: 100, opaqueFraction: 0.50));
+        var options = new MapCalibrationDetectorOptions { SceneClassOpaqueFractionThreshold = 0.40 };
+        var cache = new FloorBoundaryMaskCache(provider, options);
+
+        // 0.50 ≥ 0.40 → Outdoor under the tightened-down threshold.
+        cache.GetSceneClass("Map_50pct").Should().Be(SceneClass.Outdoor);
+    }
+
+    [Fact]
+    public void Missing_alpha_safe_degrades_to_Outdoor()
+    {
+        // Per spec §5.2 — when the provider can't furnish alpha (degraded
+        // capture, asset cache miss, etc.) the safe-degrade path is Outdoor.
+        // The Outdoor profile carries today's universal constants, so this
+        // preserves pre-#1163 behaviour byte-identically.
+        var provider = new FakeAlphaProvider();   // no SetAlpha — returns null
+        var cache = new FloorBoundaryMaskCache(provider, new MapCalibrationDetectorOptions());
+
+        cache.GetSceneClass("Map_Absent").Should().Be(SceneClass.Outdoor);
+        // Opaque fraction stays null when we couldn't measure.
+        cache.TryGetOpaqueFraction("Map_Absent").Should().BeNull();
+    }
+
+    [Fact]
+    public void Result_is_cached_across_calls()
+    {
+        // Hot-path invariant: calling GetSceneClass twice + GetOrCompute twice
+        // should hit the provider once. Same caching shape as the existing
+        // boundary-mask path.
+        var provider = new FakeAlphaProvider();
+        provider.SetAlpha("Map_Cached", MakeAlphaWithOpaqueFraction(width: 32, height: 32, opaqueFraction: 0.50));
+        var cache = new FloorBoundaryMaskCache(provider, new MapCalibrationDetectorOptions());
+
+        cache.GetSceneClass("Map_Cached").Should().Be(SceneClass.Indoor);
+        cache.GetSceneClass("Map_Cached").Should().Be(SceneClass.Indoor);
+        _ = cache.GetOrCompute("Map_Cached");
+        _ = cache.GetOrCompute("Map_Cached");
+
+        provider.AlphaCallCount("Map_Cached").Should().Be(1, "alpha should be loaded once for both APIs");
+    }
+
+    [Fact]
+    public void All_transparent_alpha_classifies_as_Indoor()
+    {
+        // Pathological: alpha = 0 everywhere is a degenerate boundary mask
+        // input — but it still has a well-defined SceneClass (Indoor — opaque
+        // fraction 0.00).
+        var provider = new FakeAlphaProvider();
+        provider.SetAlpha("Map_AllTransparent", MakeUniformAlpha(64, 64, value: 0));
+        var cache = new FloorBoundaryMaskCache(provider, new MapCalibrationDetectorOptions());
+
+        cache.GetSceneClass("Map_AllTransparent").Should().Be(SceneClass.Indoor);
+        cache.TryGetOpaqueFraction("Map_AllTransparent").Should().Be(0.0);
+        // Boundary mask path returns null on degenerate alpha (no boundary to
+        // dilate) — the scene-class label is independent of that.
+        cache.GetOrCompute("Map_AllTransparent").Should().BeNull();
+    }
+
+    private static GrayImage MakeUniformAlpha(int w, int h, byte value)
+    {
+        var p = new byte[w * h];
+        for (int i = 0; i < p.Length; i++) p[i] = value;
+        return new GrayImage(w, h, p);
+    }
+
+    private static GrayImage MakeAlphaWithOpaqueFraction(int width, int height, double opaqueFraction)
+    {
+        var p = new byte[width * height];
+        int opaqueCount = (int)(width * height * opaqueFraction);
+        for (int i = 0; i < opaqueCount; i++) p[i] = 255;
+        return new GrayImage(width, height, p);
+    }
+
+    private sealed class FakeAlphaProvider : IBaseTextureProvider
+    {
+        private readonly Dictionary<string, GrayImage> _alpha = new();
+        private readonly Dictionary<string, int> _alphaCalls = new();
+
+        public void SetAlpha(string key, GrayImage image) => _alpha[key] = image;
+
+        public int AlphaCallCount(string key) =>
+            _alphaCalls.TryGetValue(key, out var n) ? n : 0;
+
+        public GrayImage? TryGetBaseTexture(string mapAssetKey) => null;
+
+        public GrayImage? TryGetTextureAlpha(string mapAssetKey)
+        {
+            _alphaCalls[mapAssetKey] = (_alphaCalls.TryGetValue(mapAssetKey, out var n) ? n : 0) + 1;
+            return _alpha.TryGetValue(mapAssetKey, out var image) ? image : null;
+        }
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/MapCalibrationDetectorOptionsTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/MapCalibrationDetectorOptionsTests.cs
@@ -16,6 +16,12 @@ public class MapCalibrationDetectorOptionsTests
         opts.FogVarianceThreshold.Should().Be(30.0);
         opts.FogColorMin.Should().Be((byte)110);
         opts.FogColorMax.Should().Be((byte)140);
+        // mithril#1163 Phase 1 — pinned alongside the spec §D defaults because
+        // SceneClassOpaqueFractionThreshold is load-bearing: it drives
+        // FloorBoundaryMaskCache.ClassifySceneClass and the JSON-persisted
+        // SceneCalibrationProfile dispatch. A drop to 0.90 here would silently
+        // re-classify some Outdoor scenes as Indoor.
+        opts.SceneClassOpaqueFractionThreshold.Should().Be(0.95);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Phase 1 (scaffolding) + Phase 2 (Indoor recall) of the `calibration-1155-scene-class-profile` slug. Closes the load-bearing Indoor-recall work for [#1163](https://github.com/moumantai-gg/mithril/issues/1163); the scene-class axis the engine has been quietly leaning on `null` for now exists end-to-end.

Companion docs already on main: [`indoor-recall-stage-attribution.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-stage-attribution.md) (#1165) + [`indoor-recall-merge-fix-candidates.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-merge-fix-candidates.md) (#1167).

## What lands

**Phase 1 — `SceneClass` + `SceneCalibrationProfile`:**
- `SceneClass { Outdoor, Indoor }` enum
- `SceneCalibrationProfile` record. For v1 only `BlobOptions` diverges — audit + measurement showed `LowNcc` / kernel `win` / morph `closeRadius` don't move v1 recall.
- `FloorBoundaryMaskCache.GetSceneClass(mapAssetKey)` + `TryGetOpaqueFraction(mapAssetKey)` — alpha-coverage classifier on the same buffer the boundary mask loads (zero extra IO). Fail-soft to Outdoor when alpha is unavailable — preserves pre-#1163 behaviour byte-identically.
- `MapCalibrationDetectorOptions.SceneClassOpaqueFractionThreshold` (default 0.95, `INotifyPropertyChanged` on the existing options surface).

**Phase 2 — Indoor profile divergence:**
- `Outdoor` profile = today's gate-study sweet-spot verbatim (`MinArea=12, MaxIconArea=900, MinSolidity=0.35, MaxAspect=2.5, MinPeak=0.7`).
- `Indoor` profile = T1 (`MaxAspect 2.5 → 2.7`) + T2 (`MinSolidity 0.35 → 0.30`). Recovers IconD (sol 0.31) and IconE (asp 2.56) which the production gates rejected by margin 0.04 / 0.06 respectively.
- `AutoCalibrationEngine` resolves SceneClass per attempt, picks the matching profile, uses `profile.BlobOptions` in `DetectionRequest`. Same wiring on the drift-check path so re-checking an Indoor scene against its stored cal uses the relaxed gates too.

**Diagnostic bundle (additive schema-v4 extension):**
- `01-attempt.json` gains `sceneClass`, `sceneClassOpaqueFraction`, `profile.{minArea,maxIconArea,minSolidity,maxAspect,minPeak}`. Pre-#1163 readers ignore the new keys; pre-#1163 bundles read as "Outdoor by safe-degrade" on new readers.

## Verification

**New tests (12 added) — all pass:**
- `SceneClassClassifierTests` (7 cases — synthetic alpha buffers)
- `SceneCalibrationProfileTests` (5 cases — Outdoor and Indoor values pinned against regressions)

**Extended test — passes:**
- `IndoorRecallMergeTuningTests.Indoor_profile_admits_3_of_6_real_icons_on_canonical_bundle`. Asserts the Phase 2 measurement's findings end-to-end: Outdoor profile admits 1/6 (only IconF — the baseline); Indoor profile admits 3/6 (IconD + IconE + IconF — the +2 lift T1+T2 deliver).

**Existing test suites — pass green:**
- Mithril.MapCalibration.Tests — **383/383**
- Mithril.MapCalibration.Capture.Tests — **255/255**

ReplayFixtureTests covers the Outdoor regression battery (Serbule, Eltibule, Kur). Outdoor profile = today's constants verbatim → byte-identical solves.

## Phase 2 v1 acceptance — 3/6, not ≥ 4

The audit's "≥ 4 RANSAC floor" criterion is unreachable with classifier-gate tuning alone. The remaining gap is the B+C merge problem ([`indoor-recall-merge-fix-candidates.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/planning/calibration-1155-scene-class-profile/measurements/indoor-recall-merge-fix-candidates.md) — no `(win, closeRadius)` combo splits the merge; needs morph-open or a luma-aware deviation kernel). Phase 2.5 if v1's 3/6 isn't enough downstream — file a sibling sub-issue then.

Closes [#1163](https://github.com/moumantai-gg/mithril/issues/1163) at v1.

## Test plan

- [x] Build clean (`dotnet build Mithril.slnx`, 0 warnings, 0 errors)
- [x] 22 new + extended Phase 2 tests pass
- [x] Full Mithril.MapCalibration.Tests passes (383/383)
- [x] Full Mithril.MapCalibration.Capture.Tests passes (255/255)
- [x] ReplayFixtureTests (Outdoor regression battery) covered in the above

— drafted by Claude (Opus 4.7), posted by @arthur-conde