### PR TITLE
docs+fix(map-calibration): Phase 3 live verification + 180° Warning scope (#1155)

### DIFF
--- a/docs/planning/calibration-1155-scene-class-profile/measurements/README.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/README.md
@@ -24,6 +24,12 @@ Phase 0 of the [implementation plan](../plan.md). Validates spec §6 verificatio
 |---|---|---|
 | [indoor-peak-luma-threshold.md](indoor-peak-luma-threshold.md) | Broader-corpus expansion of the §6.c spike — runs the Indoor profile (peak-luma disabled) across all 11 Hogan's + GoblinDungeon bundles in `%LOCALAPPDATA%/Mithril/diagnostics/calibration/` and reports the per-blob PeakLuma distribution. | **CONFIRMED.** Across 130 Icon-class blobs, 0 sit in the [0.55, 0.78) safety band. The 5 ≥ 0.78 are all real-icon containers; the 125 ≤ 0.55 are all floor noise. `MinPeakLuma = 0.7` ships. |
 
+## Phase 3 live verification (post-#1169)
+
+| File | Scope | Verdict |
+|---|---|---|
+| [phase-3-live-verification.md](phase-3-live-verification.md) | Fresh in-game calibration attempt against Hogan's Keep Basement on engine `3.0.0.93+98fdd54b` (post-#1169) + Eltibule drift-check (Outdoor sibling). Verifies bundle JSON carries `MinPeakLuma=0.7`, filter LogTrace fires, and the 3 final detections (Npc + 2 Portal) are semantically real vs the canonical 2-noise-Portal baseline. | **MECHANISM VERIFIED, CALIBRATION STILL REJECTED.** Phase 3 works end-to-end; detection quality lifted from 2 noise to 3 real detections. RANSAC inliers 3, gate ≥ 4 — 1 inlier short. Outdoor Eltibule byte-identical. Next load-bearing piece: Phase 2.5 morph-open to split the `IconB + IconC` merge per the audit recommendation. |
+
 ## TL;DR
 
 - §6.a + §6.e — green, spec stands.

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/phase-3-live-verification.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/phase-3-live-verification.md
@@ -2,6 +2,8 @@
 
 **Verdict: PHASE 3 MECHANISM VERIFIED. CALIBRATION STILL REJECTED.** Phase 3 fires correctly end-to-end on a fresh in-game capture, drops 93 % of floor-noise blobs at the 0° orientation, and leaves three semantically-real detections. RANSAC finds 3 inliers; the gate is ≥ 4. The remaining 1-inlier gap is the recall ceiling identified in the Phase 2 audit — `IconB + IconC` merge plus `IconA` bbox/centroid mismatch — that the plan's **Phase 2.5 (morph-open)** is scoped to address.
 
+> **Scope of this verification (review #1170-r2 finding #2).** This doc captures the LIVE in-game state at engine `3.0.0.93+98fdd54bef` — the post-#1169 squash merge, which is also the base of PR #1170. The peak-luma mechanism (Phase 3) IS field-verified by this doc. The PR #1170 log-format changes (`(rotate180={Rotate180})` template prefix on the kept/dropped/rejected-all Trace lines, the 180°-pass Trace demotion, the per-orientation tagging on the sibling Deviation/RimMask/DeviationMask/Morph/BlobClassification Trace lines) are NOT visible in the log excerpts quoted below — those quote the pre-#1170 log format. The #1170 changes are pinned by the test battery (`PeakLumaFilterTests`), not by a fresh live run. A future re-verification on engine `3.0.0.94+` (post-#1170 merge) would close that gap; for the immediate "stop false-positive 180° Warning" goal, the test-side pin is sufficient.
+
 ## Setup
 
 | | |
@@ -46,8 +48,10 @@ That's the per-orientation 0° pass. Out of 41 classified Icon-class blobs (post
 
 | Orientation | Total blobs | Icon | Noise | Fog | Structure |
 |---|---:|---:|---:|---:|---:|
-| `rotate180=false` (0°) | 250 | 41 | 203 | 2 | 4 |
-| `rotate180=true` (180°) | 126 | 40 | 66 | 0 | 20 |
+| `rotate180=False` (0°) | 250 | 41 | 203 | 2 | 4 |
+| `rotate180=True` (180°) | 126 | 40 | 66 | 0 | 20 |
+
+> Review #1170-r2 finding #14: PR #1170 emits the .NET-default `bool.ToString()` form (`True` / `False`) for the `{Rotate180}` MEL template. The table headers above were originally written in C-style lowercase; corrected so a triager copy-pasting the table value to grep the log gets a match.
 
 The 81 Icon-class total across orientations matches the per-bundle log lines (`kept 3/41` at 0° + `rejected ALL 40` at 180°).
 

--- a/docs/planning/calibration-1155-scene-class-profile/measurements/phase-3-live-verification.md
+++ b/docs/planning/calibration-1155-scene-class-profile/measurements/phase-3-live-verification.md
@@ -1,0 +1,138 @@
+# Phase 3 live verification — Hogan's Keep Basement (post-#1169)
+
+**Verdict: PHASE 3 MECHANISM VERIFIED. CALIBRATION STILL REJECTED.** Phase 3 fires correctly end-to-end on a fresh in-game capture, drops 93 % of floor-noise blobs at the 0° orientation, and leaves three semantically-real detections. RANSAC finds 3 inliers; the gate is ≥ 4. The remaining 1-inlier gap is the recall ceiling identified in the Phase 2 audit — `IconB + IconC` merge plus `IconA` bbox/centroid mismatch — that the plan's **Phase 2.5 (morph-open)** is scoped to address.
+
+## Setup
+
+| | |
+|---|---|
+| Engine version | `3.0.0.93+98fdd54bef` (post-#1169 squash merge `98fdd54b`) |
+| Test bundle | `Map_HogansKeepBasement-20260615-012510-030-rejected-solve-insufficient-inliers` |
+| Scene | Hogan's Keep Basement (`Map_HogansKeepBasement` / `AreaCave1`) |
+| Capture time | 2026-06-15 01:25:10 UTC |
+| Sibling Outdoor check | `Map_AreaEltibule` drift check 01:25:45 UTC |
+
+## Phase 3 mechanism — end-to-end verification
+
+### Bundle JSON carries `MinPeakLuma` (review #1169 finding #3)
+
+`01-attempt.json` `profile` block (verbatim):
+
+```json
+"profile": {
+  "minArea": 12,
+  "maxIconArea": 900,
+  "minSolidity": 0.3,
+  "maxAspect": 2.7,
+  "minPeak": 0.7,
+  "minPeakLuma": 0.7
+}
+```
+
+`sceneClass: "Indoor"` with `sceneClassOpaqueFraction: 0.175`. The added `minPeakLuma` field surfaces in production exactly as the post-review fix intended — a triager reading the bundle alone can now tell that Phase 3 was active for this attempt.
+
+### Filter fires on the 0° pass — drops 92.7 % of Icon-class blobs
+
+From `mithril-20260615.json` at the attempt's trace id (`2039821bdfedebfaeb39e02a8aeca7ae`):
+
+```
+{Category}=Mithril.MapCalibration.Detection
+{Message}=PeakLumaFilter: kept 3/41 Icon-class blobs (threshold 0.70, dropped 38).
+```
+
+That's the per-orientation 0° pass. Out of 41 classified Icon-class blobs (post-T1+T2 relaxed gates), 38 were dropped as floor-noise and 3 survived to the per-template-NCC typing step.
+
+`10c-blob-pipeline.json` breakdown by orientation:
+
+| Orientation | Total blobs | Icon | Noise | Fog | Structure |
+|---|---:|---:|---:|---:|---:|
+| `rotate180=false` (0°) | 250 | 41 | 203 | 2 | 4 |
+| `rotate180=true` (180°) | 126 | 40 | 66 | 0 | 20 |
+
+The 81 Icon-class total across orientations matches the per-bundle log lines (`kept 3/41` at 0° + `rejected ALL 40` at 180°).
+
+### Engine dispatches Indoor `MinPeakLuma=0.7` (review #1169 finding #7 wiring)
+
+```
+{Category}=Mithril.MapCalibration.Capture.Engine
+{Message}=Auto-calibration AreaCave1: scene class Indoor (opaqueFraction=0.1749134063720703);
+BlobOptions = BlobOptions { MinArea = 12, MaxIconArea = 900, MinSolidity = 0.3, MaxAspect = 2.7,
+MinPeak = 0.7, MinPeakLuma = 0.7 }.
+```
+
+The engine-layer dispatch trace shows the full BlobOptions including the new field. The Outdoor sibling (next section) shows `MinPeakLuma = ` (empty) for the byte-identical case.
+
+## Final detections
+
+`10-detections.json` after per-template NCC + spatial dedup:
+
+| Type | Score | Anchor (x, y) | Notes |
+|---|---:|---|---|
+| `Npc` | 0.917 | (473, 292) | High-confidence NPC pip, upper-middle |
+| `Portal` | 0.865 | (412, 737) | Portal/transition, lower |
+| `Portal` | 0.870 | (550, 751) | Portal/transition, lower |
+
+All three detections look semantically real — NPC pip at clearly-visible head-and-shoulder glyph position, two portals at the basement exits. Scores are clean (0.86 – 0.92) rather than the noise-ceiling 0.70 – 0.80 the canonical 06-13 bundle produced.
+
+`rejectReason: "only 3 inliers (need >= 4)"` — RANSAC found all 3 detections fit a consistent transform, but the engine's 4-inlier gate didn't accept.
+
+## Comparison to canonical 06-13 bundle
+
+| Metric | Canonical 06-13 (pre-#1163) | Live 06-15 (post-#1169) | Δ |
+|---|---|---|---|
+| Engine version | `3.0.0.91+304a3d9` (pre-Phase-1/2/3) | `3.0.0.93+98fdd54b` (post-Phase-3) | +2 phases |
+| Total Icon-class blobs | 18 (0°) | 41 (0°) | +23 — relaxed T1+T2 admits more |
+| Real-icon blobs admitted to Icon-class | 1 (IconF only) | 3 (IconD + IconE + IconF) | +2 (Phase 2) |
+| Floor-noise blobs admitted | 17 | 38 | +21 — but Phase 3 catches them |
+| Phase 3 filter survivors | n/a | 3 of 41 | (the 3 real-icon blobs) |
+| Final typed detections | 2 (both `Portal`, both noise) | **3 (1 `Npc` + 2 `Portal`, all real)** | +1, all real |
+| RANSAC inliers | 2 | **3** | **+1** |
+| Calibration accepts? | No (`only 2 inliers`) | No (`only 3 inliers`) | Still no — 1 short |
+
+**Detection quality is now genuinely real** rather than the floor-vs-template false-positive pattern the spec §2.1 documented for the canonical bundle. The remaining 3 → 4 gap is the recall ceiling, not a precision problem.
+
+## Outdoor regression — byte-identical confirmed
+
+The same in-game session triggered Eltibule drift checks (the engine's per-second drift cadence on a stored cal). From the log:
+
+```
+{Category}=Mithril.MapCalibration.Capture.Engine
+{Message}=Drift check Map_AreaEltibule: scene class Outdoor (cache_wired=True);
+BlobOptions = BlobOptions { MinArea = 12, MaxIconArea = 900, MinSolidity = 0.35, MaxAspect = 2.5,
+MinPeak = 0.7, MinPeakLuma =  }.
+
+{Message}=Drift check Map_AreaEltibule: OK (10 refs matched, max residual 1.36px, threshold 1.95px).
+No recalibration needed.
+```
+
+`MinPeakLuma = ` (empty / null) on Outdoor dispatch ✓. 10 references matched the stored Eltibule cal at 1.36 px residual, well under the 1.95 px threshold — the existing pre-#1169 cal is still valid. No fresh capture was triggered; the Outdoor byte-identical invariant holds in production.
+
+## One follow-up identified by the live run
+
+The post-review **100%-drop LogWarning** I added in DeviationBlobDetector fires on the 180° orientation pass in addition to the 0° pass. Excerpt from the log:
+
+```
+{@l}=Warning
+{Message}=PeakLumaFilter: rejected ALL 40 Icon-class blobs (threshold 0.70). Indoor calibration
+will fail downstream with 'no detections'; check for upstream BGRA-dim drift, an unexpectedly dim
+capture, or a misaligned crop.
+```
+
+The 180° pass legitimately produces zero survivors on non-mirrored scenes (the texture orientation doesn't match the screenshot), and the 0° pass produced 3 real detections that the engine used. So the Warning's "Indoor calibration will fail downstream" framing is structurally wrong at the per-orientation level — it should fire only when the union of both orientations produced no detections, or be tagged so triagers can filter out the expected 180° fail. Fix in the same PR as this doc.
+
+## Headline finding — what's needed to ACCEPT
+
+We are **1 inlier short** of the 4-inlier gate. Two paths:
+
+1. **Phase 2.5 morph-open** (audit-recommended). The `indoor-recall-stage-attribution.md` audit identified the `IconB + IconC` merge into a single 1242-area Structure blob as the load-bearing failure mode beyond T1+T2. The follow-up audit (`indoor-recall-merge-fix-candidates.md`) ruled out deviation-window narrowing and morph-close-radius zeroing as solutions for the merge, and named **morph-open before morph-close** as the Phase 2.5 candidate. Splitting B+C would lift RIC from 3/6 to 5/6 and clear the gate.
+
+2. **Lower the Indoor inlier gate from 4 to 3** (smaller scope, higher risk). 3 high-NCC detections (0.85+) on geometrically-consistent positions IS a valid similarity-transform fit, but the 4-inlier gate is what defends against collinear-noise edge cases producing wrong cals that then ship via `refinements.json`. Mechanically simpler but the Indoor "accept" set grows in ways that may surface in non-Hogan's scenes.
+
+Phase 2.5 fixes the cause; gate-lowering treats the symptom. Recommend Phase 2.5 next.
+
+## Files referenced
+
+- `01-attempt.json` — bundle metadata + outcome + profile
+- `10-detections.json` — final 3 typed detections
+- `10c-blob-pipeline.json` — per-orientation blob classifications (250 + 126)
+- `mithril-20260615.json` — engine + detector logs at trace id `2039821bdfedebfaeb39e02a8aeca7ae`

--- a/src/Mithril.MapCalibration.Detection/DeviationBlobCalibrationDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/DeviationBlobCalibrationDetector.cs
@@ -78,7 +78,12 @@ public sealed class DeviationBlobCalibrationDetector : ICalibrationDetector
             // filter. Null on Outdoor profile / pre-#1155 callers — DetectIconBlobs
             // short-circuits the filter when either rawBgra is null or
             // BlobOptions.MinPeakLuma is null, so legacy paths are byte-identical.
-            rawBgra: request.RawBgra);
+            rawBgra: request.RawBgra,
+            // mithril#1155 Phase 3 follow-up: forward orientation so the
+            // 100%-drop LogWarning demotes to LogTrace on the 180° pass
+            // (non-mirrored Indoor scenes legitimately drop everything there;
+            // the 0° pass is the signal-bearing branch).
+            rotate180: request.Rotate180);
 
         var byType = new Dictionary<string, List<TypedDetection>>(StringComparer.Ordinal);
 

--- a/src/Mithril.MapCalibration.Detection/DeviationBlobDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/DeviationBlobDetector.cs
@@ -52,7 +52,8 @@ public static class DeviationBlobDetector
         double meanNcc = double.NaN,
         ILogger? logger = null,
         bool[]? deviationMask = null,
-        byte[]? rawBgra = null)
+        byte[]? rawBgra = null,
+        bool rotate180 = false)
     {
         if (rim == RimMaskMode.ColourFlood)
         {
@@ -337,15 +338,32 @@ public static class DeviationBlobDetector
                 }
                 if (survivors.Count == 0 && icons.Count > 0)
                 {
-                    logger?.LogWarning(
-                        "PeakLumaFilter: rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Indoor calibration will fail downstream with 'no detections'; check for upstream BGRA-dim drift, an unexpectedly dim capture, or a misaligned crop.",
-                        icons.Count, minPeakLuma);
+                    // mithril#1155 Phase 3 follow-up — scope the Warning to the
+                    // 0° pass. The 180° pass on non-mirrored Indoor scenes (PG's
+                    // common case) legitimately drops every blob because the
+                    // rotated texture doesn't correlate with the screenshot; the
+                    // 0° pass is the signal-bearing branch where 100%-drop IS a
+                    // real "calibration will fail" signal. Per-orientation phase-3-
+                    // live-verification.md confirmed the 0° pass produces 3 valid
+                    // detections while the 180° pass legitimately rejects all 40.
+                    if (rotate180)
+                    {
+                        logger?.LogTrace(
+                            "PeakLumaFilter (rotate180=True): rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Expected on non-mirrored Indoor scenes — the 0° pass owns the failure-mode Warning.",
+                            icons.Count, minPeakLuma);
+                    }
+                    else
+                    {
+                        logger?.LogWarning(
+                            "PeakLumaFilter (rotate180=False): rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Indoor calibration will fail downstream with 'no detections'; check for upstream BGRA-dim drift, an unexpectedly dim capture, or a misaligned crop.",
+                            icons.Count, minPeakLuma);
+                    }
                 }
                 else
                 {
                     logger?.LogTrace(
-                        "PeakLumaFilter: kept {Kept}/{Total} Icon-class blobs (threshold {Threshold:0.00}, dropped {Dropped}).",
-                        survivors.Count, icons.Count, minPeakLuma, dropped);
+                        "PeakLumaFilter (rotate180={Rotate180}): kept {Kept}/{Total} Icon-class blobs (threshold {Threshold:0.00}, dropped {Dropped}).",
+                        rotate180, survivors.Count, icons.Count, minPeakLuma, dropped);
                 }
                 return survivors;
             }

--- a/src/Mithril.MapCalibration.Detection/DeviationBlobDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/DeviationBlobDetector.cs
@@ -104,9 +104,16 @@ public static class DeviationBlobDetector
                 P50: p50, P95: p95, P99: p99,
                 AboveThresholdCount: aboveThresholdCount,
                 ForegroundBuffer: ((bool[])fgInitial.Clone()).AsMemory()));
+            // Review #1170-r2 finding #4: thread the real rotate180 into the
+            // LogTrace text. The snapshot record's Rotate180 field is still
+            // hardcoded `false` here and rewritten by the engine's hook-wrap
+            // for sink consumers (MapCalibrationSolveEngine.cs:65-101) — that's
+            // the existing dual-mechanism pattern. The Trace TEXT is the
+            // triager's grep target and was the immediate fix: don't lie on
+            // the 180° pass.
             logger?.LogTrace(
-                "Deviation (rotate180=False): mean ncc={MeanNcc:0.000} above-threshold={AboveCount} of {Total} px (threshold={Threshold:0.000}, p50={P50:0.000} p95={P95:0.000} p99={P99:0.000}).",
-                meanNcc, aboveThresholdCount, n, devThr, p50, p95, p99);
+                "Deviation (rotate180={Rotate180}): mean ncc={MeanNcc:0.000} above-threshold={AboveCount} of {Total} px (threshold={Threshold:0.000}, p50={P50:0.000} p95={P95:0.000} p99={P99:0.000}).",
+                rotate180, meanNcc, aboveThresholdCount, n, devThr, p50, p95, p99);
 
             // fg is the working buffer that subsequent stages mutate; fgInitial
             // is retained by the snapshot.
@@ -158,8 +165,8 @@ public static class DeviationBlobDetector
                     FgSurvivorCount: survivorCount,
                     RimMaskBuffer: ((bool[])rimMask.Clone()).AsMemory()));
                 logger?.LogTrace(
-                    "RimMask (rotate180=False, pipeline=blob_detection): rim={Rim} of {Total} px, fg pre={Pre} post={Post}.",
-                    rimCount, n, aboveThresholdCount, survivorCount);
+                    "RimMask (rotate180={Rotate180}, pipeline=blob_detection): rim={Rim} of {Total} px, fg pre={Pre} post={Post}.",
+                    rotate180, rimCount, n, aboveThresholdCount, survivorCount);
             }
             else
             {
@@ -207,8 +214,8 @@ public static class DeviationBlobDetector
                     FgSurvivorCount: fgSurvivorCount,
                     MaskBuffer: ((bool[])deviationMask.Clone()).AsMemory()));
                 logger?.LogTrace(
-                    "DeviationMask (rotate180=False): masked={Masked} of {Total} px, fg pre={Pre} post={Post}.",
-                    maskedCount, n, fgInputCount, fgSurvivorCount);
+                    "DeviationMask (rotate180={Rotate180}): masked={Masked} of {Total} px, fg pre={Pre} post={Post}.",
+                    rotate180, maskedCount, n, fgInputCount, fgSurvivorCount);
             }
             else
             {
@@ -239,8 +246,8 @@ public static class DeviationBlobDetector
                     FgOutputCount: fgOutputCount,
                     FgAfterMorphBuffer: ((bool[])fg.Clone()).AsMemory()));
                 logger?.LogTrace(
-                    "Morph (rotate180=False): closeRadius={R} fg pre={Pre} post={Post}.",
-                    closeRadius, fgInputCount, fgOutputCount);
+                    "Morph (rotate180={Rotate180}): closeRadius={R} fg pre={Pre} post={Post}.",
+                    rotate180, closeRadius, fgInputCount, fgOutputCount);
             }
         }
 
@@ -269,8 +276,8 @@ public static class DeviationBlobDetector
                     // colourmap); not serialised to 10c JSON.
                     Pixels: f.Pixels.ToArray()));
                 logger?.LogTrace(
-                    "Blob #{Ord} ({Mx},{My},{W},{H}) area={A} meanDev={MeanDev:0.000} peakDev={PeakDev:0.000} solidity={Sol:0.00} aspect={Asp:0.00} -> {Class}.",
-                    f.Ordinal, f.MinX, f.MinY, f.W, f.H, f.Area,
+                    "Blob #{Ord} (rotate180={Rotate180}) ({Mx},{My},{W},{H}) area={A} meanDev={MeanDev:0.000} peakDev={PeakDev:0.000} solidity={Sol:0.00} aspect={Asp:0.00} -> {Class}.",
+                    f.Ordinal, rotate180, f.MinX, f.MinY, f.W, f.H, f.Area,
                     f.MeanDev, f.PeakDev, f.Solidity, f.Aspect, cls);
             }
 
@@ -316,6 +323,18 @@ public static class DeviationBlobDetector
                     minPeakLuma);
                 return icons;
             }
+            if (icons.Count == 0)
+            {
+                // Review #1170-r2 finding #12: when the upstream classifier
+                // already rejected every blob, the peak-luma filter has nothing
+                // to do — but a triager scanning the log on a "no detections"
+                // attempt needs to distinguish "classifier rejected all" from
+                // "filter rejected all" per orientation. Emit a Trace so the
+                // gap doesn't silently swallow the orientation-tagged signal.
+                logger?.LogTrace(
+                    "PeakLumaFilter (rotate180={Rotate180}): skipped — 0 Icon-class candidates from upstream classifier (threshold {Threshold:0.00}).",
+                    rotate180, minPeakLuma);
+            }
             if (icons.Count > 0)
             {
                 var survivors = new List<BlobFeat>(icons.Count);
@@ -330,9 +349,12 @@ public static class DeviationBlobDetector
                     else
                     {
                         dropped++;
+                        // Review #1170-r2 finding #6: thread rotate180 into the
+                        // per-blob drop Trace so triagers can correlate by
+                        // orientation without chaining trace_id / span_id.
                         logger?.LogTrace(
-                            "Blob #{Ord} ({Mx},{My},{W},{H}) area={A}: dropped by peak-luma filter (peakLuma={PeakLuma:0.000} < threshold {Threshold:0.00}).",
-                            blob.Ordinal, blob.MinX, blob.MinY, blob.W, blob.H, blob.Area,
+                            "Blob #{Ord} (rotate180={Rotate180}) ({Mx},{My},{W},{H}) area={A}: dropped by peak-luma filter (peakLuma={PeakLuma:0.000} < threshold {Threshold:0.00}).",
+                            blob.Ordinal, rotate180, blob.MinX, blob.MinY, blob.W, blob.H, blob.Area,
                             peakLuma, minPeakLuma);
                     }
                 }
@@ -346,17 +368,31 @@ public static class DeviationBlobDetector
                     // real "calibration will fail" signal. Per-orientation phase-3-
                     // live-verification.md confirmed the 0° pass produces 3 valid
                     // detections while the 180° pass legitimately rejects all 40.
+                    //
+                    // Review #1170-r2 finding #1 (altitude): the right home for
+                    // this Warning is the engine layer (which knows BOTH
+                    // orientations' results — "no detections after both passes"
+                    // is the actual user-visible failure). Documenting the
+                    // architectural debt explicitly; deferred because moving the
+                    // Warning to the engine is a larger refactor (DetectionRequest
+                    // contract change, engine-layer Warning emission, possibly a
+                    // structured detector-event sink) that's out of scope for the
+                    // immediate "stop false-positive 180° Warning" fix.
+                    //
+                    // Review #1170-r2 finding #3: unify `(rotate180={Rotate180})`
+                    // template across all three log lines so the structured
+                    // property is consistently queryable by OTLP / jq / Seq.
                     if (rotate180)
                     {
                         logger?.LogTrace(
-                            "PeakLumaFilter (rotate180=True): rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Expected on non-mirrored Indoor scenes — the 0° pass owns the failure-mode Warning.",
-                            icons.Count, minPeakLuma);
+                            "PeakLumaFilter (rotate180={Rotate180}): rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Expected on non-mirrored Indoor scenes — the 0° pass owns the failure-mode Warning.",
+                            rotate180, icons.Count, minPeakLuma);
                     }
                     else
                     {
                         logger?.LogWarning(
-                            "PeakLumaFilter (rotate180=False): rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Indoor calibration will fail downstream with 'no detections'; check for upstream BGRA-dim drift, an unexpectedly dim capture, or a misaligned crop.",
-                            icons.Count, minPeakLuma);
+                            "PeakLumaFilter (rotate180={Rotate180}): rejected ALL {Total} Icon-class blobs (threshold {Threshold:0.00}). Indoor calibration will fail downstream with 'no detections'; check for upstream BGRA-dim drift, an unexpectedly dim capture, or a misaligned crop.",
+                            rotate180, icons.Count, minPeakLuma);
                     }
                 }
                 else

--- a/src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs
@@ -91,18 +91,38 @@ public sealed record DetectionRequest(
 
     /// <summary>
     /// Orientation flag (mithril#1155 Phase 3 follow-up): <c>true</c> means the
-    /// solver is running the rotated-180° base-texture pass. The detector uses
-    /// this to scope the per-orientation 100%-drop LogWarning emitted by the
-    /// peak-luma filter — non-mirrored Indoor scenes legitimately produce zero
-    /// surviving blobs on the 180° pass (the texture orientation doesn't match
-    /// the screenshot), so the "calibration will fail downstream" framing is
-    /// structurally wrong at the per-orientation level. The 0° pass is the
-    /// signal-bearing branch; the 180° pass demotes 100%-drop to LogTrace.
+    /// solver is running the rotated-180° base-texture pass. Used by the peak-
+    /// luma filter to scope the per-orientation 100%-drop LogWarning — non-
+    /// mirrored Indoor scenes legitimately produce zero surviving blobs on the
+    /// 180° pass (the texture orientation doesn't match the screenshot), so
+    /// the "calibration will fail downstream" framing is structurally wrong at
+    /// the per-orientation level. The 0° pass is the signal-bearing branch on
+    /// the current PG asset set; the 180° pass demotes 100%-drop to LogTrace.
     ///
-    /// <para><see cref="MapCalibrationSolveEngine"/> sets this per pass via
-    /// <c>request with { Rotate180 = rotate180 }</c>. Pre-#1155 callers and the
-    /// non-orientation-aware paths default to <c>false</c>, preserving the
-    /// existing Warning behaviour on the only orientation they invoke.</para>
+    /// <para><see cref="MapCalibrationSolveEngine.Solve"/> OWNS this field —
+    /// the orientation loop sets <c>request with { Rotate180 = rotate180 }</c>
+    /// per pass, so a caller-supplied value is silently overwritten on every
+    /// iteration. <see cref="MapCalibrationSolveEngine.DetectOnly"/> HONORS the
+    /// caller-supplied value as-is (single pass, no overwrite); drift checks
+    /// inherit the default <c>false</c> which matches the single-orientation
+    /// detector behaviour. If you set <c>Rotate180 = true</c> on a request
+    /// passed to <c>DetectOnly</c>, the detector takes you at your word — it
+    /// does NOT rotate the texture on your behalf. (Review #1170-r2 finding #7.)</para>
+    ///
+    /// <para><b>Architectural debt acknowledged.</b> The severity-decision-by-
+    /// orientation logic is at the wrong altitude — the engine knows BOTH
+    /// orientations' results and should own the Warning emission; threading
+    /// orientation through the public detector contract leaks engine-loop
+    /// state. The current shape preserves orientation tagging in detector-
+    /// level Trace lines (which has real triage value) while accepting that
+    /// the Warning-vs-Trace severity decision should migrate engine-side
+    /// when Phase 4 / a future refactor consolidates the per-orientation
+    /// diagnostic surface. (Review #1170-r2 finding #1 — deferred.) The
+    /// "non-mirrored Indoor" assumption embedded in the 0°-as-signal-bearing
+    /// branch is also empirical to today's PG asset set, not a structural
+    /// invariant — a mirrored Indoor scene would flip which orientation
+    /// should fire the Warning. (Review #1170-r2 finding #5 — deferred until
+    /// PG ships such an asset.)</para>
     /// </summary>
     public bool Rotate180 { get; init; }
 }

--- a/src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs
+++ b/src/Mithril.MapCalibration.Detection/ICalibrationDetector.cs
@@ -88,6 +88,23 @@ public sealed record DetectionRequest(
     /// short-circuits to byte-identical pre-#1155 behaviour.
     /// </summary>
     public byte[]? RawBgra { get; init; }
+
+    /// <summary>
+    /// Orientation flag (mithril#1155 Phase 3 follow-up): <c>true</c> means the
+    /// solver is running the rotated-180° base-texture pass. The detector uses
+    /// this to scope the per-orientation 100%-drop LogWarning emitted by the
+    /// peak-luma filter — non-mirrored Indoor scenes legitimately produce zero
+    /// surviving blobs on the 180° pass (the texture orientation doesn't match
+    /// the screenshot), so the "calibration will fail downstream" framing is
+    /// structurally wrong at the per-orientation level. The 0° pass is the
+    /// signal-bearing branch; the 180° pass demotes 100%-drop to LogTrace.
+    ///
+    /// <para><see cref="MapCalibrationSolveEngine"/> sets this per pass via
+    /// <c>request with { Rotate180 = rotate180 }</c>. Pre-#1155 callers and the
+    /// non-orientation-aware paths default to <c>false</c>, preserving the
+    /// existing Warning behaviour on the only orientation they invoke.</para>
+    /// </summary>
+    public bool Rotate180 { get; init; }
 }
 
 /// <summary>

--- a/src/Mithril.MapCalibration.Detection/MapCalibrationSolveEngine.cs
+++ b/src/Mithril.MapCalibration.Detection/MapCalibrationSolveEngine.cs
@@ -105,6 +105,14 @@ public sealed class MapCalibrationSolveEngine
                 BaseTexture = texture,
                 BlobScoreSink = wrappedSink,
                 Diagnostics = wrappedHooks,
+                // mithril#1155 Phase 3 follow-up: scope the per-orientation
+                // 100%-drop LogWarning inside DeviationBlobDetector. The
+                // detector itself has no orientation knowledge; the solver
+                // owns it. Without this, the 180° pass on non-mirrored Indoor
+                // scenes (e.g. Hogan's basement) fires a structurally-wrong
+                // "Indoor calibration will fail downstream" Warning even when
+                // the 0° pass produced valid detections.
+                Rotate180 = rotate180,
             };
 
             var detections = _detector.Detect(req);

--- a/tests/Mithril.MapCalibration.Tests/Detection/PeakLumaFilterTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/PeakLumaFilterTests.cs
@@ -252,6 +252,46 @@ public sealed class PeakLumaFilterTests
             "the 100%-drop case is a safe-degrade signal — must LogWarning so the silent-zero-icon failure mode is visible at production log levels.");
     }
 
+    [Fact]
+    public void DetectIconBlobs_demotes_100_percent_drop_Warning_to_Trace_when_rotate180_true()
+    {
+        // Phase 3 follow-up — the 180° base-texture pass on non-mirrored Indoor
+        // scenes (PG's common case) legitimately drops every blob because the
+        // rotated texture doesn't correlate with the screenshot. The 0° pass
+        // owns the signal-bearing failure-mode Warning; the 180° pass demotes
+        // to LogTrace to avoid Warning-noise on the live diagnostics surface.
+        // See phase-3-live-verification.md for the in-game evidence.
+        int w = 20, h = 20;
+        var dev = SyntheticDevWithOneBrightBlob(w, h);
+        var bgraDark = new byte[w * h * 4];  // all-dark → 100% drop expected.
+
+        var opts = new BlobOptions(MinArea: 4, MaxIconArea: 1000, MinSolidity: 0.0, MaxAspect: 100, MinPeak: 0.0)
+        {
+            MinPeakLuma = 0.7,
+        };
+
+        // Sanity-pin the 0° pass — it MUST still LogWarning (sibling test pins
+        // the same case at default rotate180=false, but capturing here side-by-
+        // side keeps the asymmetry explicit and resistant to a future refactor
+        // that accidentally flips the default).
+        var logger0 = new RecordingLogger();
+        _ = DeviationBlobDetector.DetectIconBlobs(
+            dev, w, h, lowNcc: 0.5, rim: RimMaskMode.None, opts, closeRadius: 0,
+            logger: logger0, rawBgra: bgraDark, rotate180: false);
+        logger0.WarningCount.Should().BeGreaterThan(0,
+            "0° pass at 100% drop must still LogWarning — that's the signal-bearing branch.");
+
+        // 180° pass — same inputs, must NOT increment WarningCount.
+        var logger180 = new RecordingLogger();
+        var icons180 = DeviationBlobDetector.DetectIconBlobs(
+            dev, w, h, lowNcc: 0.5, rim: RimMaskMode.None, opts, closeRadius: 0,
+            logger: logger180, rawBgra: bgraDark, rotate180: true);
+
+        icons180.Should().BeEmpty("180° pass still drops every blob — only the log severity changed.");
+        logger180.WarningCount.Should().Be(0,
+            "180° pass at 100% drop is expected on non-mirrored Indoor scenes; the Warning belongs to the 0° pass, not this one. Demoted to LogTrace.");
+    }
+
     /// <summary>Synthesises a deviation map with one bright (high-dev) blob at (5..9, 5..9).</summary>
     private static float[] SyntheticDevWithOneBrightBlob(int w, int h)
     {

--- a/tests/Mithril.MapCalibration.Tests/Detection/PeakLumaFilterTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/PeakLumaFilterTests.cs
@@ -290,6 +290,13 @@ public sealed class PeakLumaFilterTests
         icons180.Should().BeEmpty("180° pass still drops every blob — only the log severity changed.");
         logger180.WarningCount.Should().Be(0,
             "180° pass at 100% drop is expected on non-mirrored Indoor scenes; the Warning belongs to the 0° pass, not this one. Demoted to LogTrace.");
+        // Review #1170-r2 finding #10: don't just assert the Warning is absent —
+        // verify the Trace replacement actually fired. A future refactor that
+        // accidentally drops both branches passes the WarningCount==0 assertion
+        // silently and loses ALL observability on the 180° pass; the TraceCount
+        // assertion closes that seam.
+        logger180.TraceCount.Should().BeGreaterThan(0,
+            "180° demotion must REPLACE the Warning with a Trace, not silently drop both — the per-orientation observability claim depends on the Trace actually firing.");
     }
 
     /// <summary>Synthesises a deviation map with one bright (high-dev) blob at (5..9, 5..9).</summary>
@@ -315,10 +322,16 @@ public sealed class PeakLumaFilterTests
         return bgra;
     }
 
-    /// <summary>Captures LogWarning count across the DetectIconBlobs path so the guards are testable.</summary>
+    /// <summary>
+    /// Captures per-level counts across the DetectIconBlobs path so the guards
+    /// are testable. Review #1170-r2 finding #10: WarningCount alone can't tell
+    /// a refactor that drops BOTH the Warning AND its replacement Trace from a
+    /// successful demotion — TraceCount closes that seam.
+    /// </summary>
     private sealed class RecordingLogger : Microsoft.Extensions.Logging.ILogger
     {
         public int WarningCount { get; private set; }
+        public int TraceCount { get; private set; }
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -332,6 +345,7 @@ public sealed class PeakLumaFilterTests
             Func<TState, Exception?, string> formatter)
         {
             if (logLevel == Microsoft.Extensions.Logging.LogLevel.Warning) WarningCount++;
+            else if (logLevel == Microsoft.Extensions.Logging.LogLevel.Trace) TraceCount++;
         }
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups from the live in-game verification of [mithril#1169](https://github.com/moumantai-gg/mithril/pull/1169):

**(a)** New `measurements/phase-3-live-verification.md` capturing a fresh in-game Hogan's Keep Basement calibration on engine `3.0.0.93+98fdd54b` (post-#1169). The Phase 3 mechanism is verified end-to-end against a live capture: bundle JSON carries `MinPeakLuma=0.7`, filter LogTrace fires with `kept 3/41 Icon-class blobs`, and the 3 final detections are **semantically real** (`Npc` 0.917 + 2× `Portal` 0.87) vs the canonical 06-13 bundle's 2 noise blobs typed as Portal. RANSAC inliers lifted from 2 → 3, but the gate is ≥ 4; calibration still rejects. The remaining gap is **Phase 2.5 morph-open territory** (the audit's named candidate for the IconB + IconC merge), not a Phase 3 regression. Outdoor sibling: Eltibule drift check passes (10 refs at 1.36 px residual ≤ 1.95 px threshold) — existing pre-#1169 cal still valid; Outdoor byte-identical invariant holds in production.

**(b)** Live verification surfaced that the new `rejected ALL N Icon-class blobs` LogWarning fires on **both orientation passes**, but the 180° pass on non-mirrored Indoor scenes (PG's common case) legitimately drops every blob because the rotated texture doesn't correlate with the screenshot. The 0° pass produced 3 valid detections; the 180° pass's "calibration will fail downstream" framing is structurally wrong at the per-orientation level. Fix scopes the Warning to the signal-bearing 0° pass; 180° pass demotes to LogTrace with an explicit `(rotate180=True)` tag.

References:
- Umbrella: [mithril#1155](https://github.com/moumantai-gg/mithril/issues/1155)
- Predecessor: [mithril#1169](https://github.com/moumantai-gg/mithril/pull/1169) (Phase 3 ship + 9-angle review)
- Spec: [`docs/planning/calibration-1155-scene-class-profile/spec.md`](docs/planning/calibration-1155-scene-class-profile/spec.md)
- Plan: [`docs/planning/calibration-1155-scene-class-profile/plan.md`](docs/planning/calibration-1155-scene-class-profile/plan.md)
- New: [`docs/planning/calibration-1155-scene-class-profile/measurements/phase-3-live-verification.md`](docs/planning/calibration-1155-scene-class-profile/measurements/phase-3-live-verification.md)

## What changed

### Source

- **`DetectionRequest` extended** with init-only `bool Rotate180` (default `false`). Pre-orientation-aware callers behave exactly as before.
- **`MapCalibrationSolveEngine.Solve`** sets `Rotate180 = rotate180` per orientation via `request with { … }` inside the existing orientation loop — mirrors the per-pass diagnostic-hook orientation rewrite pattern that already lives there.
- **`DeviationBlobCalibrationDetector.Detect`** forwards `request.Rotate180` to `DetectIconBlobs`.
- **`DeviationBlobDetector.DetectIconBlobs`** accepts `bool rotate180 = false`. When the 100%-drop case fires with `rotate180 = true`, it demotes from `LogWarning` to `LogTrace` and reframes the message as expected-on-non-mirrored-Indoor. The "kept X/Y" LogTrace also gains the `(rotate180={Rotate180})` tag for symmetric observability across both orientations.

### Tests

- **New `DetectIconBlobs_demotes_100_percent_drop_Warning_to_Trace_when_rotate180_true`** in `PeakLumaFilterTests` — pins both halves of the asymmetry side by side:
  - 0° pass at 100% drop MUST `LogWarning` (signal-bearing branch).
  - 180° pass at 100% drop MUST NOT `LogWarning` (demoted to Trace).

### Docs

- **New `measurements/phase-3-live-verification.md`** — the durable record of the live verification. Captures bundle JSON, per-orientation blob distribution from `10c-blob-pipeline.json`, the 3 typed detections from `10-detections.json`, the engine + detector log lines, and the comparison vs canonical 06-13.
- **`measurements/README.md`** index updated with a row pointing at the new doc.

## Verification

- `Mithril.MapCalibration.Tests`: **395/395 pass** (394 + 1 new test).
- `Mithril.MapCalibration.Capture.Tests`: **260/260 pass** (unchanged — no Capture-layer changes in this PR).
- Full `Mithril.slnx` build clean (0 warnings, 0 errors).
- The new test verifies that the live false-positive flagged in `phase-3-live-verification.md` will not reappear after this fix lands.

## Headline-goal status update

For visibility — the Phase 3 + 9-angle-review work shipped via #1169 lifted Hogan's basement from 2 inliers (both noise) to **3 inliers (all real detections)**, but the 4-inlier solver gate still rejects. The next load-bearing piece for the headline goal of "Indoor calibration accepting" is **Phase 2.5 morph-open** — the audit-named fix for the IconB + IconC merge that ceilings the recall at 3/6 RIC. Tracked separately under the same #1155 umbrella; not in scope for this PR.

## Test plan

- [x] New 180° demotion test passes
- [x] Existing 100%-drop Warning test still passes (0° default branch)
- [x] Full `Mithril.MapCalibration.Tests` battery (395/395)
- [x] Full `Mithril.MapCalibration.Capture.Tests` battery (260/260)
- [x] Full `Mithril.slnx` build clean
- [x] Live verification doc cites concrete bundle + log evidence

— drafted by Claude (Opus 4.7), posted by @arthur-conde
