### PR TITLE
fix(map-calibration): bump locator ScaleMax 1.20 → 2.00 (#1153)

### DIFF
--- a/docs/planning/calibration-1155-scene-class-profile/spec.md
+++ b/docs/planning/calibration-1155-scene-class-profile/spec.md
@@ -267,7 +267,7 @@ Out of scope (file separately, link from #1155 / #1116):
 - **#1155-sibling: Alpha-zero interior mask gap.** `BuildDeviationMask` extends to gate `alpha < ε` regardless of boundary proximity. Small fix; landing path independent of this work. (Confirmed by Phase 0 spike — to be filed as #1148 follow-up.)
 - **#1155-sibling: Better / multi-scale templates** (candidate D). Root-cause fix for indoor type-discrimination failure; high engineering cost; needs a richer fixture corpus. Mode-B v1 sidesteps it via the Phase 2 recall fix + peak-luma pre-filter; future Mode-B v2 could revisit if the carrier still shows typing errors after Phase 4.
 - **#1116 close-out remaining work:** cross-scene landmark leak via `AreaCave1` aggregator (#1116's H1 hypothesis) — once Phase 5 ships Indoor synthesis-J in Enforcement mode (post-Phase 2 / 3), geometric self-consistency addresses it without needing landmarks.json structural changes.
-- **#1153 ScaleMax adaptive ladder** — separate trivial follow-up, not blocked by this.
+- **#1153 ScaleMax ceiling bump** — landed as a static `ScaleMax = 1.20 → 2.00` default-bump + v2→v3 schema migration in [PR #1181](https://github.com/moumantai-gg/mithril/pull/1181), not the adaptive-ladder shape originally sketched here. The adaptive-ladder follow-up (detect L1 winner at ladder edge, extend the search range one direction) and a downstream `ClampToFrame`/`ImageOps.Resize` correctness gap at scale > 1.0 are deferred — see #1181's body for the issue links.
 - **#1151 wiki close-out** — post-Mode-B.
 
 ## 8. Open questions answered in [`plan.md`](plan.md)

--- a/docs/planning/map-calibration-sparse-locate-fallback-1061/spec.md
+++ b/docs/planning/map-calibration-sparse-locate-fallback-1061/spec.md
@@ -23,7 +23,7 @@ For outdoor maps with rich texture (Eltibule: 696 Lowe survivors, 645 RANSAC inl
 4. **Parabolic peak refinement** on the L0 ladder's scale axis: `refinedScale = winner + step * 0.5 * (y_{i-1} - y_{i+1}) / (y_{i-1} - 2*y_i + y_{i+1})`, gated on concave-down curvature. Re-match at refinedScale to recover the refined response map.
 5. **Sub-pixel translation refinement** via 2D parabolic on the response map's 3×3 neighborhood around the integer peak (independent X/Y curves, clamped to ±1 px). Translate `(tx, ty)` back to original capture coords by subtracting the pad.
 
-Ladder parameters: `ScaleMin = 0.20`, `ScaleMax = 1.20`, `ScaleStep = 0.02`. Round 4 confirmed PG is empirically isotropic similarity — no anisotropic (`sx, sy`) search.
+Ladder parameters: `ScaleMin = 0.20`, `ScaleMax = 2.00` (bumped from 1.20 by [mithril#1153](https://github.com/moumantai-gg/mithril/pull/1181) after the original ceiling was found to truncate at in-game zooms above 1.20×), `ScaleStep = 0.02`. Round 4 confirmed PG is empirically isotropic similarity — no anisotropic (`sx, sy`) search.
 
 ## 3. Dispatch
 
@@ -122,7 +122,7 @@ All `MapCalibrationLocateOptions` properties — both pre-existing ORB knobs and
 | `FallbackNccFloor` | 0.20 | Sobel (new in this spec) |
 | `FallbackPadPx` | 100 | Sobel (new in this spec) |
 | `ScaleMin` | 0.20 | Sobel ladder bounds (promoted from `const`) |
-| `ScaleMax` | 1.20 | Sobel ladder bounds (promoted from `const`) |
+| `ScaleMax` | 2.00 | Sobel ladder bounds (promoted from `const`; bumped 1.20 → 2.00 by [mithril#1153](https://github.com/moumantai-gg/mithril/pull/1181)) |
 | `ScaleStep` | 0.02 | Sobel ladder bounds (promoted from `const`) |
 | `MinScaledDim` | 20 | Sobel min template dim — full res (promoted from `const`) |
 | `MinScaledDimHalf` | 10 | Sobel min template dim — half-res (promoted from `const`) |

--- a/src/Mithril.MapCalibration.Detection/MapCalibrationLocateOptions.cs
+++ b/src/Mithril.MapCalibration.Detection/MapCalibrationLocateOptions.cs
@@ -22,13 +22,13 @@ namespace Mithril.MapCalibration.Detection;
 /// </summary>
 public sealed class MapCalibrationLocateOptions : INotifyPropertyChanged, IVersionedState<MapCalibrationLocateOptions>
 {
-    public const int Version = 2;
+    public const int Version = 3;
     public static int CurrentVersion => Version;
 
     /// <summary>
     /// Persisted schema version. Defaults to <c>1</c> so a v1 JSON file (no
     /// pre-existing schema field) deserialises as v1; fresh in-memory instances
-    /// also start at <c>1</c> — <see cref="Migrate"/> is a no-op for v1→v2 (additive).
+    /// also start at <c>1</c> — <see cref="Migrate"/> back-fills any deltas.
     ///
     /// <para>Future deltas document themselves in this comment block, mirroring
     /// the <c>LegolasSettings</c> convention. The first time a property is
@@ -39,19 +39,50 @@ public sealed class MapCalibrationLocateOptions : INotifyPropertyChanged, IVersi
     /// knobs gating the blur-aware Sobel template at the fallback's
     /// full-resolution stage. Loading a v1 file leaves the new properties at
     /// their constructor defaults (the measured σ-curve).</para>
+    ///
+    /// <para><b>v2 → v3 (mithril#1153):</b> the default <see cref="ScaleMax"/>
+    /// changed from 1.20 to 2.00 after two Hogan's Keep Basement bundles four
+    /// days apart showed the locator's coarse ladder truncating at the in-game
+    /// map's true ~1.5× zoom. A constructor-default-only bump would leave
+    /// every existing install stuck at 1.20 on disk (the prior default), so
+    /// this Migrate body lifts the persisted value from 1.20 → 2.00 ONLY when
+    /// it equals the old default — an explicit user override (e.g. a value
+    /// the user set themselves) is preserved as-is.</para>
     /// </summary>
     public int SchemaVersion { get; set; } = 1;
 
     /// <summary>
-    /// Identity passthrough for v1 → v2 (mithril#1070, additive — new
-    /// RendererBlur* properties initialise from constructor defaults). Caller
-    /// (the versioned-settings loader) writes the bumped
-    /// <see cref="SchemaVersion"/> back after this returns, so Migrate doesn't
-    /// need to stamp it.
+    /// v2 → v3 (mithril#1153): lift the persisted <see cref="ScaleMax"/> from
+    /// the prior default 1.20 to the new default 2.00 when it has not been
+    /// explicitly customised. v1 → v2 (mithril#1070) was additive (new
+    /// RendererBlur* properties initialise from constructor defaults) so the
+    /// v1→v2 path also runs through this v2→v3 branch via the cumulative
+    /// migration shape — a v1 JSON that lacked any scaleMax field would have
+    /// deserialised to the (then-current) 1.20 default, so the same equality
+    /// gate lifts it to 2.00 on this migration.
+    ///
+    /// <para>Caller (the versioned-settings loader at
+    /// <c>AddMithrilVersionedSettings</c>) writes the bumped
+    /// <see cref="SchemaVersion"/> back after this returns, then persists, so
+    /// Migrate does not need to stamp the version itself.</para>
     /// </summary>
     public static MapCalibrationLocateOptions Migrate(MapCalibrationLocateOptions loaded)
     {
         if (loaded.SchemaVersion >= Version) return loaded;
+
+        // v2 → v3: bump the persisted ScaleMax default from 1.20 → 2.00 for
+        // users still carrying the pre-mithril#1153 value on disk. The check
+        // is exact-equal because STJ serialises the constructor default 1.20
+        // as the JSON literal "1.2", which parses back to the same IEEE-754
+        // double — so a user who never touched the setting has
+        // loaded.ScaleMax == 1.20 bit-for-bit. Anyone who explicitly set a
+        // different value (e.g. 1.5 to work around the prior failure mode)
+        // keeps their override.
+        if (loaded._scaleMax == 1.20)
+        {
+            loaded._scaleMax = 2.00;
+        }
+
         return loaded;
     }
 
@@ -70,8 +101,10 @@ public sealed class MapCalibrationLocateOptions : INotifyPropertyChanged, IVersi
     // the locator picking ladder-bottom (scale 0.14 / 0.18) with fallbackNcc
     // just above the 0.20 gate floor because the true scale (~1.5×) sat
     // OUTSIDE the [ScaleMin, ScaleMax] search range. 2.00 covers the measured
-    // 1.495 and headroom for higher in-game map zooms; ~67% more scale-ladder
-    // steps per coarse stage is user-imperceptible at typical attempt rates.
+    // 1.495 and headroom for higher in-game map zooms; ~78% more scale-ladder
+    // steps per coarse stage (51 → 91 rungs at step 0.02) is
+    // user-imperceptible at typical attempt rates. v2→v3 schema migration
+    // in Migrate above lifts the persisted value for existing installs.
     private double _scaleMax = 2.00;
     private double _scaleStep = 0.02;
     private int _minScaledDim = 20;

--- a/src/Mithril.MapCalibration.Detection/MapCalibrationLocateOptions.cs
+++ b/src/Mithril.MapCalibration.Detection/MapCalibrationLocateOptions.cs
@@ -64,7 +64,15 @@ public sealed class MapCalibrationLocateOptions : INotifyPropertyChanged, IVersi
     private double _fallbackNccFloor = 0.20;
     private int _fallbackPadPx = 100;
     private double _scaleMin = 0.20;
-    private double _scaleMax = 1.20;
+    // mithril#1153: bumped 1.20 → 2.00. Two corroborating
+    // Map_HogansKeepBasement bundles four days apart (engine 3.0.0.88 on
+    // 20260612-233006-375 and engine 3.0.0.96 on 20260616-103608-261) showed
+    // the locator picking ladder-bottom (scale 0.14 / 0.18) with fallbackNcc
+    // just above the 0.20 gate floor because the true scale (~1.5×) sat
+    // OUTSIDE the [ScaleMin, ScaleMax] search range. 2.00 covers the measured
+    // 1.495 and headroom for higher in-game map zooms; ~67% more scale-ladder
+    // steps per coarse stage is user-imperceptible at typical attempt rates.
+    private double _scaleMax = 2.00;
     private double _scaleStep = 0.02;
     private int _minScaledDim = 20;
     private int _minScaledDimHalf = 10;
@@ -160,7 +168,14 @@ public sealed class MapCalibrationLocateOptions : INotifyPropertyChanged, IVersi
         set { if (_scaleMin != value) { _scaleMin = value; OnChanged(); } }
     }
 
-    /// <summary>Upper bound of the fallback's scale ladder. Default 1.20 (mithril#1061).</summary>
+    /// <summary>
+    /// Upper bound of the fallback's scale ladder. Default 2.00 (mithril#1153,
+    /// bumped from 1.20). The original 1.20 ceiling truncated the search range
+    /// when the in-game map view rendered the texture above 1.20× native — two
+    /// Hogan's Keep Basement bundles (06-12 + 06-16) had true scale ~1.50, and
+    /// the locator silently picked ladder-bottom degenerate regions instead.
+    /// Originally introduced at mithril#1061.
+    /// </summary>
     public double ScaleMax
     {
         get => _scaleMax;

--- a/tests/Mithril.MapCalibration.Tests/Detection/ScaleMaxBumpVerificationTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ScaleMaxBumpVerificationTests.cs
@@ -56,16 +56,24 @@ public sealed class ScaleMaxBumpVerificationTests
             "B3D2009C1E6C1FF7A45A936BD9C9A46D18A51F7E283A99350B2672F36B34597C",
     };
 
+    /// <summary>
+    /// (bundleName, engineVersion, priorScale, priorNcc, newExpectedScale,
+    /// newExpectedNcc). The "prior" pair is the auto-cal bundle's own recovered
+    /// locator state (history — what the user saw). The "new expected" pair is
+    /// the value measured by replaying the refiner at ScaleMax=2.00 at PR time;
+    /// asserts use it with ±0.02 (one ladder step) on scale and ±0.10 on NCC.
+    /// </summary>
     public static IEnumerable<object[]> Bundles() =>
     [
-        ["Map_HogansKeepBasement-20260612-233006-375-rejected-solve", "3.0.0.88", 0.14, 0.32],
-        ["Map_HogansKeepBasement-20260616-103608-261-rejected-solve", "3.0.0.96", 0.18, 0.27],
+        ["Map_HogansKeepBasement-20260612-233006-375-rejected-solve", "3.0.0.88", 0.14, 0.32, 1.460, 0.278],
+        ["Map_HogansKeepBasement-20260616-103608-261-rejected-solve", "3.0.0.96", 0.18, 0.27, 1.427, 0.611],
     ];
 
     [Theory]
     [MemberData(nameof(Bundles))]
     public void ScaleMax_2_00_recovers_true_scale(
-        string bundleName, string engineVersion, double priorScale, double priorNcc)
+        string bundleName, string engineVersion, double priorScale, double priorNcc,
+        double newExpectedScale, double newExpectedNcc)
     {
         var bundleDir = BundleDir(bundleName);
         if (bundleDir is null)
@@ -141,19 +149,49 @@ public sealed class ScaleMaxBumpVerificationTests
             return;
         }
 
+        // === Prior-default (1.20) assertions — pin the documented ladder-bottom
+        // failure mode so a future refactor that lets 1.20 also recover (e.g.
+        // an adaptive coarse stage) fails loudly here. Without these the
+        // measurement is a noisy log line, not a regression signal.
+        priorResult.Metrics.Should().NotBeNull(
+            "ScaleMax=1.20 should still produce a (degenerate) fit — the locator finds SOMETHING at the ladder bottom");
+        priorResult.Metrics!.Scale.Should().BeLessThan(0.30,
+            "ScaleMax=1.20 truncates the true ~1.5× scale; the locator picks ladder-bottom (measured 0.14 / 0.18 on these bundles). " +
+            "If a future PR makes 1.20 also recover the true scale, update this assertion AND drop the bump in MapCalibrationLocateOptions.");
+        priorResult.RawFitRect.Should().NotBeNull();
+        priorResult.RawFitRect!.Width.Should().BeLessThan(300,
+            "ladder-bottom fits are tiny degenerate patches (measured 143×143 and 184×184 on these bundles)");
+
+        // === New-default (2.00) assertions — non-null fit, recovered scale
+        // matches the measured value within one ladder step, NCC within a
+        // wide tolerance of the measured value, recovered rect intersects
+        // the capture.
         newMetrics.Should().NotBeNull(
             "ScaleMax=2.00 must produce a non-null fit on the canonical Hogan's Basement bundles");
         newRect.Should().NotBeNull(
             "ScaleMax=2.00 must produce a non-null RawFitRect on the canonical Hogan's Basement bundles");
 
-        // Acceptance per #1153: at the widened ceiling, the recovered scale
-        // must land in [1.4, 1.6] (the user's manual measurement of the true
-        // map-render scale was ~1.495) with NCC clear of the 0.20 gate floor.
-        newMetrics!.Scale.Should().BeInRange(1.4, 1.6,
-            "the true map-render scale was manually measured at ~1.495; ScaleMax=2.00 lets the locator find it");
+        // Scale within ±0.02 of measured value (one ladder step at ScaleStep=0.02).
+        newMetrics!.Scale.Should().BeInRange(newExpectedScale - 0.02, newExpectedScale + 0.02,
+            $"the measured-at-PR-time recovered scale was {newExpectedScale:0.000} (true map-render scale ~1.495); " +
+            "drift beyond one ladder step is a refiner regression");
         newMetrics.Confidence.Should().NotBeNull();
+
+        // NCC within ±0.10 of measured value. Wider tolerance than the gate
+        // floor (0.20) because legitimate downstream tuning (blur σ-curve,
+        // FallbackPadPx, OpenCV impl) can nudge NCC by a few hundredths
+        // without #1153 regressing. The 06-12 bundle's measured NCC is 0.278
+        // — only 0.078 above the gate floor — so the previous flat 'NCC > 0.20'
+        // assertion was brittle to any drop in that 0.08 margin.
+        newMetrics.Confidence!.Value.Should().BeInRange(newExpectedNcc - 0.10, newExpectedNcc + 0.10,
+            $"the measured-at-PR-time recovered NCC was {newExpectedNcc:0.000}; drift beyond ±0.10 is a refiner regression. " +
+            "A drop below the FallbackNccFloor (0.20) trips the gate independently and shows as AcceptedRect == null.");
+
+        // Above-floor floor: a final independent sanity check that the gate
+        // accepts. This is the bedrock — even if the per-bundle NCC drifts,
+        // the production gate must still be cleared, or the fix is no-op.
         newMetrics.Confidence!.Value.Should().BeGreaterThan(0.20,
-            "a real recovery clears the FallbackNccFloor (0.20). Measured: 0.611 on 06-16, 0.278 on the harder 06-12 bundle — both above floor.");
+            "the FallbackNccFloor (0.20) is the production gate; below this the rect is rejected and the fix is no-op");
 
         // The recovered rect must intersect the capture. At scale > 1.0 the
         // texture is LARGER than the screenshot, so the natural rect can have
@@ -183,7 +221,18 @@ public sealed class ScaleMaxBumpVerificationTests
 
     private static bool BundleMatchesCanonicalHash(string shotPath, string bundleName)
     {
-        if (!CanonicalScreenshotSha256.TryGetValue(bundleName, out var expected)) return false;
+        // FAIL LOUDLY on a Bundles()-vs-CanonicalScreenshotSha256 dataset
+        // inconsistency — without this, a future Theory row added without a
+        // matching SHA entry would silently SKIP all assertions for that row
+        // (TryGetValue=false is indistinguishable from hash divergence further
+        // down). Real on-disk hash divergence still degrades to false → the
+        // test prints the measurement and returns clean.
+        if (!CanonicalScreenshotSha256.TryGetValue(bundleName, out var expected))
+        {
+            Assert.Fail($"bundle '{bundleName}' is in Bundles() but missing from CanonicalScreenshotSha256 — " +
+                "add its 03-screenshot-gray.png SHA-256 to the dictionary, or remove the row from Bundles().");
+            return false; // unreachable; here for the compiler
+        }
         using var stream = File.OpenRead(shotPath);
         var bytes = SHA256.HashData(stream);
         var hex = Convert.ToHexString(bytes);

--- a/tests/Mithril.MapCalibration.Tests/Detection/ScaleMaxBumpVerificationTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/Detection/ScaleMaxBumpVerificationTests.cs
@@ -1,0 +1,220 @@
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mithril.MapCalibration.Detection;
+using Mithril.MapCalibration.Tests.Fixtures;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mithril.MapCalibration.Tests.Detection;
+
+/// <summary>
+/// mithril#1153 verification — replays the
+/// <see cref="SobelPaddedPyramidRefiner"/> at the prior <c>ScaleMax = 1.20</c>
+/// (pre-#1153) and the new <c>ScaleMax = 2.00</c> default against the two
+/// corroborating Hogan's Keep Basement bundles (engine 3.0.0.88 from
+/// 2026-06-12 and 3.0.0.96 from 2026-06-16). The 1.20 row reproduces the
+/// ladder-bottom failure documented in the issue; the 2.00 row demonstrates
+/// the recovered fit lands at the true ~1.50× scale with confidence well
+/// above the 0.20 gate floor.
+///
+/// <para>Skippable per the dev-local-bundle convention (PG art + 2-decimal
+/// zoom-slider give-rule out contributor reproducibility — see
+/// <c>map_calibration_replay_fixtures_dev_local</c> in memory). Bundles live
+/// under <c>%LOCALAPPDATA%/Mithril/diagnostics/calibration/</c>; the base
+/// texture cache lives at <c>%LOCALAPPDATA%/Mithril/assets/</c>. Both must
+/// be present for assertions to fire; otherwise the test prints SKIPPED
+/// and returns clean.</para>
+///
+/// <para>SHA-256 of each bundle's <c>03-screenshot-gray.png</c> at the time
+/// the assertions below were authored protects other devs whose own bundles
+/// happen to live at the same path but contain a different capture
+/// (mithril#1168 review: "dev-local bundles are foot-guns").</para>
+/// </summary>
+public sealed class ScaleMaxBumpVerificationTests
+{
+    private readonly ITestOutputHelper _output;
+    public ScaleMaxBumpVerificationTests(ITestOutputHelper output) => _output = output;
+
+    private const string MapAssetKey = "Map_HogansKeepBasement";
+
+    /// <summary>
+    /// SHA-256 of each bundle's <c>03-screenshot-gray.png</c> at the time the
+    /// assertions in <see cref="ScaleMax_2_00_recovers_true_scale"/> were
+    /// measured. When the on-disk hash differs, the test skips asserting and
+    /// only prints the measurement so divergent dev-local bundles surface as
+    /// data, not as red.
+    /// </summary>
+    private static readonly Dictionary<string, string> CanonicalScreenshotSha256 = new()
+    {
+        ["Map_HogansKeepBasement-20260612-233006-375-rejected-solve"] =
+            "EB68F2E9F9F31FAB61ED25BDA297A441EC2DB0A4844B3C5EE6F12CAD2643C69E",
+        ["Map_HogansKeepBasement-20260616-103608-261-rejected-solve"] =
+            "B3D2009C1E6C1FF7A45A936BD9C9A46D18A51F7E283A99350B2672F36B34597C",
+    };
+
+    public static IEnumerable<object[]> Bundles() =>
+    [
+        ["Map_HogansKeepBasement-20260612-233006-375-rejected-solve", "3.0.0.88", 0.14, 0.32],
+        ["Map_HogansKeepBasement-20260616-103608-261-rejected-solve", "3.0.0.96", 0.18, 0.27],
+    ];
+
+    [Theory]
+    [MemberData(nameof(Bundles))]
+    public void ScaleMax_2_00_recovers_true_scale(
+        string bundleName, string engineVersion, double priorScale, double priorNcc)
+    {
+        var bundleDir = BundleDir(bundleName);
+        if (bundleDir is null)
+        {
+            _output.WriteLine($"SKIPPED [{bundleName}] — bundle absent in %LOCALAPPDATA%/Mithril/diagnostics/calibration/.");
+            return;
+        }
+
+        var screenshotPath = Path.Combine(bundleDir, "03-screenshot-gray.png");
+        if (!File.Exists(screenshotPath))
+        {
+            _output.WriteLine($"SKIPPED [{bundleName}] — bundle missing 03-screenshot-gray.png.");
+            return;
+        }
+
+        var baseTexture = TryLoadBaseTexture(MapAssetKey);
+        if (baseTexture is null)
+        {
+            _output.WriteLine($"SKIPPED [{bundleName}] — base texture for {MapAssetKey} absent in %LOCALAPPDATA%/Mithril/assets/.");
+            return;
+        }
+
+        var screenshot = WicImageLoader.LoadGray(screenshotPath);
+        bool sameAsCanonical = BundleMatchesCanonicalHash(screenshotPath, bundleName);
+
+        _output.WriteLine($"=== {bundleName} (engine {engineVersion}) ===");
+        _output.WriteLine($"  screenshot {screenshot.Width}x{screenshot.Height}; baseTex {baseTexture.Width}x{baseTexture.Height}");
+        _output.WriteLine($"  prior auto-cal bundle: scale={priorScale:0.00}, fallbackNcc={priorNcc:0.000} (rejected-solve)");
+        _output.WriteLine($"  canonical-hash match: {sameAsCanonical}");
+
+        // Row 1: prior default (1.20) — must reproduce the ladder-bottom degenerate fit.
+        var priorRefiner = new SobelPaddedPyramidRefiner(
+            new MapCalibrationLocateOptions { ScaleMax = 1.20 },
+            NullLogger<SobelPaddedPyramidRefiner>.Instance);
+        var priorResult = priorRefiner.Refine(screenshot, baseTexture);
+
+        _output.WriteLine($"  [ScaleMax=1.20] scale={priorResult.Metrics?.Scale:0.000}, "
+            + $"ncc={priorResult.Metrics?.Confidence:0.000}, "
+            + $"origin=({priorResult.RawFitRect?.OriginX},{priorResult.RawFitRect?.OriginY}), "
+            + $"size={priorResult.RawFitRect?.Width}x{priorResult.RawFitRect?.Height}, "
+            + $"accepted={priorResult.AcceptedRect is not null}");
+
+        // Row 2: new default (2.00) — must recover the true ~1.50× scale.
+        var newRefiner = new SobelPaddedPyramidRefiner(
+            new MapCalibrationLocateOptions { ScaleMax = 2.00 },
+            NullLogger<SobelPaddedPyramidRefiner>.Instance);
+        var newResult = newRefiner.Refine(screenshot, baseTexture);
+
+        var newRect = newResult.RawFitRect;
+        var newMetrics = newResult.Metrics;
+        _output.WriteLine($"  [ScaleMax=2.00] scale={newMetrics?.Scale:0.000}, "
+            + $"ncc={newMetrics?.Confidence:0.000}, "
+            + $"origin=({newRect?.OriginX},{newRect?.OriginY}), "
+            + $"size={newRect?.Width}x{newRect?.Height}, "
+            + $"accepted={newResult.AcceptedRect is not null}");
+        if (newRect is not null)
+        {
+            // Real-zoom captures have scale > 1.0 — the texture at 1.46× is
+            // LARGER than the 1313-px-tall capture, so the natural recovered
+            // origin is negative on the truncated axis (the visible map view
+            // shows the texture's interior, not its top-left). The meaningful
+            // bounds check is that the rect INTERSECTS the capture — i.e. the
+            // locator hasn't drifted entirely off-screen.
+            bool intersectsCapture =
+                newRect.OriginX + newRect.Width > 0 && newRect.OriginX < screenshot.Width &&
+                newRect.OriginY + newRect.Height > 0 && newRect.OriginY < screenshot.Height;
+            _output.WriteLine($"  [ScaleMax=2.00] rect intersects capture: {intersectsCapture}");
+        }
+
+        if (!sameAsCanonical)
+        {
+            _output.WriteLine($"  SKIPPED asserts — bundle's screenshot hash diverges from the canonical at the time these assertions were authored. The measurement above is the durable record.");
+            return;
+        }
+
+        newMetrics.Should().NotBeNull(
+            "ScaleMax=2.00 must produce a non-null fit on the canonical Hogan's Basement bundles");
+        newRect.Should().NotBeNull(
+            "ScaleMax=2.00 must produce a non-null RawFitRect on the canonical Hogan's Basement bundles");
+
+        // Acceptance per #1153: at the widened ceiling, the recovered scale
+        // must land in [1.4, 1.6] (the user's manual measurement of the true
+        // map-render scale was ~1.495) with NCC clear of the 0.20 gate floor.
+        newMetrics!.Scale.Should().BeInRange(1.4, 1.6,
+            "the true map-render scale was manually measured at ~1.495; ScaleMax=2.00 lets the locator find it");
+        newMetrics.Confidence.Should().NotBeNull();
+        newMetrics.Confidence!.Value.Should().BeGreaterThan(0.20,
+            "a real recovery clears the FallbackNccFloor (0.20). Measured: 0.611 on 06-16, 0.278 on the harder 06-12 bundle — both above floor.");
+
+        // The recovered rect must intersect the capture. At scale > 1.0 the
+        // texture is LARGER than the screenshot, so the natural rect can have
+        // negative origin on the truncated axis (the visible map shows the
+        // texture's interior). The pre-#1153 ladder-bottom pick had origin
+        // (1048, 891) at size 143×143 — a tiny degenerate patch in the bottom
+        // corner of the screenshot, far from any sensible map view.
+        newRect!.Width.Should().BeGreaterThan(0);
+        newRect.Height.Should().BeGreaterThan(0);
+        (newRect.OriginX + newRect.Width).Should().BeGreaterThan(0,
+            "the recovered rect must intersect the capture horizontally");
+        newRect.OriginX.Should().BeLessThan(screenshot.Width,
+            "the recovered rect must intersect the capture horizontally");
+        (newRect.OriginY + newRect.Height).Should().BeGreaterThan(0,
+            "the recovered rect must intersect the capture vertically");
+        newRect.OriginY.Should().BeLessThan(screenshot.Height,
+            "the recovered rect must intersect the capture vertically");
+    }
+
+    private static string? BundleDir(string bundleName)
+    {
+        var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrEmpty(local)) return null;
+        var dir = Path.Combine(local, "Mithril", "diagnostics", "calibration", bundleName);
+        return Directory.Exists(dir) ? dir : null;
+    }
+
+    private static bool BundleMatchesCanonicalHash(string shotPath, string bundleName)
+    {
+        if (!CanonicalScreenshotSha256.TryGetValue(bundleName, out var expected)) return false;
+        using var stream = File.OpenRead(shotPath);
+        var bytes = SHA256.HashData(stream);
+        var hex = Convert.ToHexString(bytes);
+        return string.Equals(hex, expected, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Loads the per-area base texture from <c>%LocalAppData%/Mithril/assets/</c>.
+    /// Same manifest+blob shape as <c>CachedBaseTextureProvider</c>; reproduced
+    /// here because that type is internal to Detection (matches the loader in
+    /// <see cref="LiveMapViewProbeRealScreenshotBenchmark"/>).
+    /// </summary>
+    private static GrayImage? TryLoadBaseTexture(string mapAssetKey)
+    {
+        var cacheDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mithril", "assets");
+        var manifestPath = Path.Combine(cacheDir, $"map-texture-{mapAssetKey}.json");
+        var blobPath = Path.Combine(cacheDir, $"map-texture-{mapAssetKey}.bin");
+        if (!File.Exists(manifestPath) || !File.Exists(blobPath)) return null;
+
+        using var manifestStream = File.OpenRead(manifestPath);
+        using var doc = JsonDocument.Parse(manifestStream);
+        int w = doc.RootElement.GetProperty("width").GetInt32();
+        int h = doc.RootElement.GetProperty("height").GetInt32();
+
+        using var fileStream = File.OpenRead(blobPath);
+        using var deflate = new DeflateStream(fileStream, CompressionMode.Decompress);
+        using var ms = new MemoryStream();
+        deflate.CopyTo(ms);
+        var pixels = ms.ToArray();
+        if (pixels.Length != w * h) return null;
+
+        return new GrayImage(w, h, pixels);
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/MapCalibrationLocateOptionsDefaultsTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/MapCalibrationLocateOptionsDefaultsTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests;
+
+/// <summary>
+/// Pins the load-bearing constructor defaults on
+/// <see cref="MapCalibrationLocateOptions"/> so silent drift surfaces here
+/// rather than in field-collected diagnostic bundles. Mirrors the pin-test
+/// pattern from <c>SceneCalibrationProfileTests</c> (mithril#1173).
+///
+/// <para>The scale-ladder bounds are the headline contract: ScaleMin / ScaleMax
+/// define the search window for <see cref="SobelPaddedPyramidRefiner"/>. A
+/// regression that narrowed the window again would silently reintroduce the
+/// mithril#1153 failure mode (locator picks ladder-edge degenerate regions and
+/// downstream pipeline starves).</para>
+/// </summary>
+public sealed class MapCalibrationLocateOptionsDefaultsTests
+{
+    [Fact]
+    public void ScaleMax_default_is_two_per_mithril_1153()
+    {
+        // mithril#1153: bumped 1.20 → 2.00 after two corroborating bundles four
+        // days apart on Map_HogansKeepBasement (engine 3.0.0.88 / 3.0.0.96)
+        // showed the true map-render scale was ~1.50 — outside the prior
+        // [0.20, 1.20] range. A future PR that reverts this without a fresh
+        // measurement and explicit cross-link to #1153 (or a successor that
+        // bounds the search differently, e.g. an adaptive coarse stage) fails
+        // here loudly.
+        new MapCalibrationLocateOptions().ScaleMax.Should().Be(2.00);
+    }
+
+    [Fact]
+    public void ScaleMin_default_is_unchanged_at_zero_point_two()
+    {
+        // mithril#1153 deliberately scoped to the upper bound — the lower
+        // bound stays at the mithril#1061 default. Pin so a casual symmetric
+        // widening would fail here.
+        new MapCalibrationLocateOptions().ScaleMin.Should().Be(0.20);
+    }
+
+    [Fact]
+    public void ScaleStep_default_is_unchanged_at_zero_point_zero_two()
+    {
+        new MapCalibrationLocateOptions().ScaleStep.Should().Be(0.02);
+    }
+
+    [Fact]
+    public void FallbackNccFloor_default_is_unchanged_at_zero_point_two()
+    {
+        // mithril#1153 explicitly does NOT touch the gate floor — that's a
+        // separate concern. Pin so a future change to either field is an
+        // intentional, separate-PR action.
+        new MapCalibrationLocateOptions().FallbackNccFloor.Should().Be(0.20);
+    }
+}

--- a/tests/Mithril.MapCalibration.Tests/MapCalibrationLocateOptionsV2MigrateTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/MapCalibrationLocateOptionsV2MigrateTests.cs
@@ -13,9 +13,12 @@ namespace Mithril.MapCalibration.Tests;
 public sealed class MapCalibrationLocateOptionsV2MigrateTests
 {
     [Fact]
-    public void Current_version_is_2()
+    public void Current_version_is_3()
     {
-        MapCalibrationLocateOptions.CurrentVersion.Should().Be(2);
+        // mithril#1153 bumped to v3 to lift persisted scaleMax 1.20 → 2.00 for
+        // existing installs. The pin here is the load-bearing signal that a
+        // future schema bump didn't quietly down-rev the version constant.
+        MapCalibrationLocateOptions.CurrentVersion.Should().Be(3);
     }
 
     [Fact]
@@ -47,9 +50,11 @@ public sealed class MapCalibrationLocateOptionsV2MigrateTests
     [Fact]
     public void Migrate_is_identity_when_already_at_current_version()
     {
+        // mithril#1153 bumped CurrentVersion 2 → 3; pin uses the new current
+        // sentinel so the test name remains accurate.
         var loaded = new MapCalibrationLocateOptions
         {
-            SchemaVersion = 2,
+            SchemaVersion = 3,
             RendererBlurEnabled = false,
             RendererBlurSlope = 2.5,
         };

--- a/tests/Mithril.MapCalibration.Tests/MapCalibrationLocateOptionsV3MigrateTests.cs
+++ b/tests/Mithril.MapCalibration.Tests/MapCalibrationLocateOptionsV3MigrateTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Mithril.MapCalibration.Detection;
+using Xunit;
+
+namespace Mithril.MapCalibration.Tests;
+
+/// <summary>
+/// mithril#1153 — covers the v2 → v3 migration on
+/// <see cref="MapCalibrationLocateOptions"/>. The migrate body lifts the
+/// persisted <see cref="MapCalibrationLocateOptions.ScaleMax"/> from the old
+/// default 1.20 to the new default 2.00 ONLY when it has not been explicitly
+/// customised — so a user who set their own value (e.g. 1.5 to work around the
+/// pre-#1153 failure mode) keeps their override.
+///
+/// <para>This migration is load-bearing: without it the constructor-default
+/// bump is a no-op for every existing install, because <c>JsonSettingsStore</c>
+/// writes scaleMax to disk and <c>AddMithrilVersionedSettings</c> only
+/// dispatches through <c>Migrate</c> when <c>SchemaVersion != CurrentVersion</c>.
+/// A real on-disk file from this dev's machine confirmed at PR time:
+/// <c>"schemaVersion": 2, "scaleMax": 1.2</c>.</para>
+/// </summary>
+public sealed class MapCalibrationLocateOptionsV3MigrateTests
+{
+    [Fact]
+    public void Migrate_v2_to_v3_lifts_prior_default_scaleMax_to_two()
+    {
+        var loaded = new MapCalibrationLocateOptions
+        {
+            SchemaVersion = 2,
+            ScaleMax = 1.20,  // mirrors a v2 file on disk for any pre-#1153 install
+        };
+
+        var migrated = MapCalibrationLocateOptions.Migrate(loaded);
+
+        migrated.ScaleMax.Should().Be(2.00,
+            "the v2 → v3 migration lifts the prior default 1.20 to the new default 2.00 for existing installs");
+        // Loader stamps the bumped SchemaVersion back after Migrate returns,
+        // so Migrate itself does not need to set it.
+        migrated.SchemaVersion.Should().Be(2);
+    }
+
+    [Fact]
+    public void Migrate_v2_to_v3_preserves_explicit_user_override()
+    {
+        var loaded = new MapCalibrationLocateOptions
+        {
+            SchemaVersion = 2,
+            ScaleMax = 1.50,  // a user who explicitly tuned their value
+        };
+
+        var migrated = MapCalibrationLocateOptions.Migrate(loaded);
+
+        // The migration ONLY lifts the value when it equals the OLD default
+        // (1.20) — any other value is treated as an explicit user choice and
+        // preserved as-is.
+        migrated.ScaleMax.Should().Be(1.50);
+    }
+
+    [Theory]
+    [InlineData(0.20)]   // ScaleMin floor — would be a deliberate degenerate override
+    [InlineData(1.00)]   // 1.00 — exactly 1× zoom intent
+    [InlineData(1.19)]   // just under the prior default
+    [InlineData(1.21)]   // just over the prior default
+    [InlineData(2.00)]   // already at the new default (e.g. an early adopter)
+    [InlineData(3.50)]   // explicit user widening past the new default
+    public void Migrate_v2_to_v3_only_resets_exact_prior_default(double explicitValue)
+    {
+        var loaded = new MapCalibrationLocateOptions
+        {
+            SchemaVersion = 2,
+            ScaleMax = explicitValue,
+        };
+
+        var migrated = MapCalibrationLocateOptions.Migrate(loaded);
+
+        migrated.ScaleMax.Should().Be(explicitValue,
+            "the v2 → v3 reset is gated exact-equal to the old 1.20 default — every other value is treated as a user choice");
+    }
+
+    [Fact]
+    public void Migrate_v1_to_v3_lifts_prior_default_scaleMax_cumulatively()
+    {
+        // A v1 JSON file (pre-mithril#1070) that omitted the RendererBlur*
+        // fields would have had scaleMax = 1.20 written explicitly (the
+        // shipping default at the time of v1). Loading such a file lands the
+        // v1 → v3 cumulative migration on this same body.
+        var loaded = new MapCalibrationLocateOptions
+        {
+            SchemaVersion = 1,
+            ScaleMax = 1.20,
+        };
+
+        var migrated = MapCalibrationLocateOptions.Migrate(loaded);
+
+        migrated.ScaleMax.Should().Be(2.00);
+        // The blur defaults arrive via the constructor (the v1 → v2 path is
+        // additive and relies on the v2-onwards constructor defaults for
+        // RendererBlur*; the v3 migrate inherits that behavior).
+        migrated.RendererBlurEnabled.Should().BeTrue();
+        migrated.RendererBlurIntercept.Should().Be(-1.5643);
+    }
+
+    [Fact]
+    public void Migrate_returns_same_reference_when_resetting_scaleMax()
+    {
+        // The migration mutates the loaded instance in place and returns it
+        // (cheap — no allocation). Pin so a future refactor that switches to
+        // a copy-and-return shape is an intentional change.
+        var loaded = new MapCalibrationLocateOptions
+        {
+            SchemaVersion = 2,
+            ScaleMax = 1.20,
+        };
+
+        var migrated = MapCalibrationLocateOptions.Migrate(loaded);
+
+        ReferenceEquals(loaded, migrated).Should().BeTrue();
+    }
+}

--- a/tools/MapCalibrationFromScreenshot/SparseLocateSpike.cs
+++ b/tools/MapCalibrationFromScreenshot/SparseLocateSpike.cs
@@ -25,7 +25,13 @@ internal static class SparseLocateSpike
 {
     private const double LoweRatio = 0.75;
     private const double ScaleMin = 0.30;
-    private const double ScaleMax = 1.20;
+    // mithril#1153: track the production default 2.00 (was 1.20). The spike's
+    // own ladder shape (ScaleStep=0.05, ScaleMin=0.30) is intentionally
+    // different from the production refiner — it's a coarser comparison sweep
+    // — but the ceiling must match production so the spike can actually
+    // reproduce Hogan's Basement-style >1.0× zoom captures it was built to
+    // investigate.
+    private const double ScaleMax = 2.00;
     private const double ScaleStep = 0.05;
 
     public static int Run()


### PR DESCRIPTION
## Summary

Bumps `MapCalibrationLocateOptions.ScaleMax` from **1.20 → 2.00** AND lifts the persisted on-disk value via a new v2→v3 schema migration so the bump reaches existing installs (not just fresh ones).

Two corroborating `Map_HogansKeepBasement` bundles four days apart showed the Sobel-padded-pyramid locator picking ladder-bottom degenerate regions because the true map-render scale (~1.50×) sat outside the prior search range `[0.20, 1.20]`. 2.00 covers the measured 1.495 with headroom.

> [!IMPORTANT]
> This PR is the **locator-stage fix** for #1153 — necessary but **not sufficient** for a clean auto-cal on the cited bundles. The locator now picks the right scale, but a downstream rect-handling invariant in `AutoCalibrationEngine` (`ClampToFrame` + `ImageOps.Resize` introduce a texture↔screenshot offset when the recovered scale > 1.0) keeps the same bundles at `-rejected-solve` at the solver stage. Filed as follow-up [mithril#1182](https://github.com/moumantai-gg/mithril/issues/1182).

Closes #1153 (locator-stage scope). Closes #1179 (duplicate, confirmed in the [issue comment](https://github.com/moumantai-gg/mithril/issues/1153#issuecomment-)).

## Measurement table

Replays via `ScaleMaxBumpVerificationTests` (skippable; dev-local bundles per [`map_calibration_replay_fixtures_dev_local`](https://github.com/moumantai-gg/mithril/blob/main/CLAUDE.md)). Both bundles' `03-screenshot-gray.png` hashes are SHA-256-pinned.

| Bundle | Engine | Capture | ScaleMax = 1.20 (prior) | ScaleMax = 2.00 (new) |
|---|---|---|---|---|
| `Map_HogansKeepBasement-20260612-233006-375-rejected-solve` | 3.0.0.88 | 1510×1313 | scale **0.140**, ncc **0.322**, origin (1048,891), 143×143 — ladder bottom | scale **1.460**, ncc **0.278**, origin (10,-82), 1495×1495 — true scale recovered |
| `Map_HogansKeepBasement-20260616-103608-261-rejected-solve` | 3.0.0.96 | 1510×1313 | scale **0.180**, ncc **0.266**, origin (838,430), 184×184 — ladder bottom | scale **1.427**, ncc **0.611**, origin (29,-50), 1462×1462 — true scale recovered |

Both new picks land in [1.4, 1.6] (well inside the manually-measured ~1.495 true scale per the issue body) and clear the `FallbackNccFloor=0.20`.

## What ships

**Production code:**
- `src/Mithril.MapCalibration.Detection/MapCalibrationLocateOptions.cs`:
  - `_scaleMax = 2.00` (was 1.20) with inline #1153 rationale.
  - `const int Version = 3` (was 2). v2→v3 `Migrate` body lifts persisted `_scaleMax` from 1.20 → 2.00 **only** when the loaded value equals the exact prior default (so a user who explicitly set a different value keeps it).
- `tools/MapCalibrationFromScreenshot/SparseLocateSpike.cs`: spike-tool `const ScaleMax` bumped to match production (its own ladder step stays intentionally different).

**Tests** (all 19 pass, plus the full slnx ~5800 tests):
- `MapCalibrationLocateOptionsDefaultsTests` — pins the new default + neighbouring unchanged constants (`ScaleMin`, `ScaleStep`, `FallbackNccFloor`).
- `MapCalibrationLocateOptionsV3MigrateTests` — 10 tests covering the v2→v3 reset-vs-preserve gate.
- `MapCalibrationLocateOptionsV2MigrateTests` — updated for the bumped `CurrentVersion`.
- `ScaleMaxBumpVerificationTests` — dev-local replay on the two Hogan's bundles. Now asserts the prior-default ladder-bottom failure mode (so a future refactor that lets 1.20 also recover trips loudly), uses bundle-specific NCC tolerance ±0.10 (instead of brittle `> 0.20`), and `Assert.Fail`s on a Bundles()↔CanonicalScreenshotSha256 dataset inconsistency.

**Docs:**
- `docs/planning/map-calibration-sparse-locate-fallback-1061/spec.md` — prose + knob table reflect new `ScaleMax = 2.00`.
- `docs/planning/calibration-1155-scene-class-profile/spec.md` line 270 — reframes the deferred-followup note to match the realised approach (static bump, not adaptive ladder).

## Code-review actions

Multi-angle code review (9 angles + sweep, 47 sub-agents) surfaced 11 unique findings. Actioned in commits on this branch:

| # | Finding | Action |
|---|---|---|
| 1 | Persisted JSON keeps `scaleMax: 1.20`, Migrate identity → fix is no-op for existing users | Bumped Version to 3 + conditional reset in Migrate; new `V3MigrateTests` |
| 2 | Downstream `ClampToFrame` + `ImageOps.Resize` misalign texture↔screenshot at scale > 1.0 | Out of scope; filed [#1182](https://github.com/moumantai-gg/mithril/issues/1182); flagged in this PR's caveat block |
| 3 | Prior-default 1.20 row logged but not asserted | Added `priorResult.Metrics.Scale < 0.30` + `RawFitRect.Width < 300` asserts |
| 4 | `BundleMatchesCanonicalHash` silently skips on missing-canonical-key | `Assert.Fail` with diagnostic message |
| 5 | NCC `> 0.20` brittle (06-12 margin only 0.078) | Bundle-specific tolerance ±0.10 |
| 6 | `~67%` arithmetic should be `~78%` (51 → 91 rungs) | Comment fixed |
| 7 | `TryLoadBaseTexture` duplicates `LiveMapViewProbeRealScreenshotBenchmark` | Acknowledged-deferred; not actioned |
| 8 | No CI regression coverage (dev-local-bundle gate) | Acknowledged-intentional per the [`map_calibration_replay_fixtures_dev_local`](https://github.com/moumantai-gg/mithril/blob/main/CLAUDE.md) convention; `V3MigrateTests` + `LocateOptionsDefaultsTests` are CI-runnable |
| 9 | `SparseLocateSpike.cs` hardcodes 1.20 | Bumped to 2.00 |
| 10 | 1155 spec line 270 calls #1153 "adaptive ladder" | Reframed as "static bump + deferred follow-ups" |
| 11 | 1061 spec lines 26, 125 still quote ScaleMax = 1.20 | Both updated with cross-link to this PR |

## Test plan

- [x] `dotnet build Mithril.slnx -c Debug` — green (0 warnings, 0 errors).
- [x] `dotnet test Mithril.slnx --no-build` — green across every project (Mithril.MapCalibration.Tests: 451, Mithril.Shared.Tests: 1238, etc.).
- [x] `dotnet test --filter "FullyQualifiedName~MapCalibrationLocateOptions|FullyQualifiedName~ScaleMaxBumpVerification"` — 19 pass (4 defaults pins, 3 V2 migrate, 10 V3 migrate, 2 bundle-replay).
- [x] Confirmed the v2→v3 migration scenario against this dev's actual persisted file (`%LocalAppData%/Mithril/Shell/map-calibration-locate.json` had `"schemaVersion": 2, "scaleMax": 1.2`).

— drafted by Claude (Opus 4.7), posted by @arthur-conde
